### PR TITLE
Fixes #16: Add delete class to pywbemcli

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Andreas Maier <andy-maier@users.noreply.github.com>
+Andreas Maier <maiera@de.ibm.com>
 Karl Schopmeyer <k.schopmeyer@swbell.net>
 kschopmeyer <k.schopmeyer@swbell.net>


### PR DESCRIPTION
While we do not want to add the create and modify class operations, the
delete class seems logical and simple. Probably will not be used much
but I already found a use for in in tests.