### PR TITLE
Using M2Crypto master branch to pick up sslv2_method fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 six # MIT
 pbr>=1.8 # Apache-2.0
-pywbem # gpl
+-e git+https://gitlab.com/m2crypto/m2crypto.git@master#egg=M2Crypto
 click # BSD
 click-spinner>=0.1.5 # MIT
 click-repl # MIT


### PR DESCRIPTION
Please review.

This is a temporary circumvention for the M2Crypto import issue described in issue #14. It should be merged to get going again.