### PR TITLE
Add password logic to get password only if needed

### DIFF
--- a/pywbemcli/_connection_repository.py
+++ b/pywbemcli/_connection_repository.py
@@ -24,13 +24,13 @@ from __future__ import absolute_import
 
 import os
 import pickle
-import json
+import copy
 
 CONNECTIONS_FILE = 'pywbemcliservers.p'
 CONNECTIONS_LOADED = False
 PYWBEMCLI_SERVERS = {}
 
-# TODO make this into a class to clean up the code.
+# TODO make this into a class to clean up the code. This is a temp hack
 
 
 def get_pywbemcli_servers():
@@ -47,6 +47,20 @@ def get_pywbemcli_servers():
     return PYWBEMCLI_SERVERS
 
 
+def server_definitions_create_new(name, svr_definition):
+    """Add a new connection to the repository and save it"""
+    pywbemcli_servers = get_pywbemcli_servers()
+    pywbemcli_servers[name] = svr_definition
+    server_definitions_file_save()
+
+
+def server_definitions_delete(name):
+    """Add a new connection to the repository and save it"""
+    pywbemcli_servers = get_pywbemcli_servers()
+    del pywbemcli_servers[name]
+    server_definitions_file_save()
+
+
 def server_definitions_file_save():
     """Dump the connections pickle file if one has been loaded.
     If the dictionary is empty, it attempts to delete the file.
@@ -55,97 +69,11 @@ def server_definitions_file_save():
         if len(PYWBEMCLI_SERVERS) == 0:
             if os.path.isfile(CONNECTIONS_FILE):
                 os.remove(CONNECTIONS_FILE)
-        else:
+            # clear the wbem_server attribute
+            dict_copy = copy.deepcopy(PYWBEMCLI_SERVERS)
+            for name, svr in dict_copy.iteritems():
+                # TODO we are accessing protected member here
+                svr._wbem_server = None
+
             with open(CONNECTIONS_FILE, "wb") as fh:
-                pickle.dump(PYWBEMCLI_SERVERS, fh)
-
-
-class DictPersistJSON(dict):
-    """
-    A persistent dictionary that writes to a python file
-    """
-    # pylint: disable=super-init-not-called
-    def __init__(self, filename, *args, **kwargs):
-        self.filename = filename
-        self._load()
-        self.update(*args, **kwargs)
-
-    def _load(self):
-        """
-        Load the file if it is found.
-        """
-        if os.path.isfile(self.filename) and os.path.getsize(self.filename) > 0:
-            with open(self.filename, 'r') as fh:
-                self.update(json.load(fh))
-
-    def _dump(self):
-        """
-        Dump the current dictionary to filename as JSON data
-        """
-        with open(self.filename, 'w') as fh:
-            json.dump(self, fh)
-
-    def __getitem__(self, key):
-        """
-        Get a single item from the dictionary based on the key provided.
-        """
-        return dict.__getitem__(self, key)
-
-    def __setitem__(self, key, val):
-        """
-            Set the value defined into the key entry in the dictionary
-            and save the dictionary
-        """
-        dict.__setitem__(self, key, val)
-        self._dump()
-
-    def __repr__(self):
-        """ repr function for the dictionary object"""
-        dictrepr = dict.__repr__(self)
-        return '%s(%s)' % (type(self).__name__, dictrepr)
-
-    def update(self, *args, **kwargs):
-        """
-        General update for the dictionary.
-        """
-        for k, v in dict(*args, **kwargs).items():
-            self[k] = v
-        self._dump()
-
-
-class Connections(object):
-    """
-    This is a singleton object that creates an instance the first time the
-    constructor is called by attempting to read from a file.
-    """
-
-    def __init__(self):
-        """ If not already loaded, load the pickle file"""
-        self.loaded = False
-        self.connections_file = 'pywbemcliservers.p'
-        self.pywbem_servers = self.load()
-
-    def save(self):
-        """Save any existing pickle file"""
-        if self.loaded:
-            pickle.dump(self.pywbem_servers, open(self.connections_file, "wb"))
-
-    def load(self):
-        """
-        Install any current connection file. If
-        """
-        if self.loaded is False:
-            if os.path.isfile(self.connections_file):
-                self.loaded = True
-                self.pywbem_servers = \
-                    pickle.load(open(self.connections_file, 'rb'))
-            else:
-                return {}
-
-    def keys(self):
-        """TODO"""
-        pass
-
-    def value(self, key):
-        """TODO"""
-        pass
+                pickle.dump(dict_copy, fh)

--- a/pywbemcli/_context_obj.py
+++ b/pywbemcli/_context_obj.py
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Common Functions applicable across multiple components of pywbemcli
+Click Context object. This is the common object for click command calls
+
+It contains data that is set in the top level and used in subcommand calls
 """
 
 from __future__ import absolute_import, unicode_literals

--- a/pywbemcli/pywbemcli.py
+++ b/pywbemcli/pywbemcli.py
@@ -111,10 +111,18 @@ def cli(ctx, server, name, default_namespace, user, password, timeout, noverify,
     """
     Command line browser for WBEM Servers. This cli tool implements the
     CIM/XML client APIs as defined in pywbem to make requests to a WBEM
-    server.
+    server. This browser uses subcommands to
+    \b
+        * Explore the characteristics of WBEM Servers based on using the
+          pywbem client APIs.  It can manage/inspect CIM_Classes and
+          CIM_instanceson the server.
+
+    \b
+        * In addition it can inspect namespaces and other server information
+          and inspect and manage WBEM indication subscriptions.
 
     The options shown above that can also be specified on any of the
-    (sub-)commands.
+    (sub-)commands as well as the command line.
     """
 
     # in interactive mode, global options specified in cmd line are used as
@@ -123,7 +131,9 @@ def cli(ctx, server, name, default_namespace, user, password, timeout, noverify,
     # specified and is why global options don't define defaults in the
     # decorators that define them.
 
+    # Temp solution to get the persistent file of connections
     pywbemcli_servers = get_pywbemcli_servers()
+
     if ctx.obj is None:
         # Apply the documented option defaults.
         if output_format is None:

--- a/tests/unit/test_connection_repository.py
+++ b/tests/unit/test_connection_repository.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+
+# (C) Copyright 2017 IBM Corp.
+# (C) Copyright 2017 Inova Development Inc.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+    Execute and test the validity of the help output from pywbemcli
+"""
+
+from __future__ import absolute_import, print_function
+
+import os
+import unittest
+import shlex
+from re import findall
+from subprocess import Popen, PIPE
+import six
+
+from pywbemcli._connection_repository import CONNECTIONS_FILE
+
+SCRIPT_DIR = os.path.dirname(__file__)
+REPO_FILE = os.path.join(SCRIPT_DIR, CONNECTIONS_FILE)
+
+# TODO ks remove the print statements in some of the tests after we do
+# correct persistence
+
+
+class ConnectionRepositoryTest(unittest.TestCase):
+    """
+    Execute shell tests to determine that connection persistence
+    works
+    """
+    def setUp(self):
+        """
+        Setup for the test
+        """
+        print('test file is %s' % REPO_FILE)
+        if os.path.isfile(REPO_FILE):
+            os.remove(REPO_FILE)
+
+    def tearDown(self):
+        """
+        Delete any leftover pickle file
+        """
+        if os.path.isfile(REPO_FILE):
+            os.remove(REPO_FILE)
+
+    def do_test(self, command, err=None, result_regex=None):
+        """
+        Execute the command defined.  If err is not none, confirm that
+        error received.
+        Return stdout
+        """
+        args = shlex.split(command)
+        proc = Popen(args, stdout=PIPE, stderr=PIPE)
+        out, err = proc.communicate()
+        exitcode = proc.returncode
+        if six.PY3:
+            out = out.decode()
+            err = err.decode()
+
+        if not err:
+            if exitcode != 0:
+                print('exitcode %s, err %s' % (exitcode, err))
+            self.assertEqual(exitcode, 0, ('ExitCode Err, cmd="%s" '
+                                           'exitcode %s' %
+                                           (command, exitcode)))
+
+            self.assertEqual(err, "", 'stderr not empty. returned %s'
+                             % (err))
+        if result_regex:
+            for item in result_regex:
+                match_result = findall(item, out)
+                self.assertIsNotNone(match_result,
+                                     "Expecting some result")
+        return out
+
+    def test_simple_script(self):
+        """
+        Test a simple script that just shows current connections
+        """
+        result = ['WBEMServer uri: http://localhost']
+        out = self.do_test('pywbemcli -s http://localhost connection show',
+                           err=False, result_regex=result)
+        print(out)
+
+    def test_create_delete(self):
+        """
+        Test the creation of a connection and deletion
+        """
+        out = self.do_test('pywbemcli -s http://localhost '
+                           'connection create blah http://junkhost',
+                           err=False, result_regex=['blah', 'http://junkhost'])
+        print(out)
+
+        out = self.do_test('pywbemcli -s http://localhost '
+                           'connection list',
+                           err=False, result_regex=['blah', 'http://junkhost'])
+        print(out)
+
+        out = self.do_test('pywbemcli -s http://localhost '
+                           'connection delete blah',
+                           err=False,)
+        print('Did delete out = %s' % out)
+
+        out = self.do_test('pywbemcli -s http://localhost '
+                           'connection list',
+                           err=False,)
+        print('list after delete\n%s' % out)
+        # self.assertEqual(findall('blah', out), [])
+
+
+if __name__ == '__main__':
+
+    unittest.main()

--- a/tests/unit/test_helpmsgs.py
+++ b/tests/unit/test_helpmsgs.py
@@ -95,7 +95,7 @@ class ContainerMeta(type):
             results
             """
             def test(self):  # pylint: disable=missing-docstring
-                command = 'pywbemcli %s --help' % (cmd_str)
+                command = 'pywbemcli -s http://blah %s --help' % (cmd_str)
                 args = shlex.split(command)
                 proc = Popen(args, stdout=PIPE, stderr=PIPE)
                 out, err = proc.communicate()


### PR DESCRIPTION
Cleanup password handling and use of context.

1. We were miss using the ctx.obj in that we were causing a
WBEMConnection to be created for each subcommand.

2. Added the function to get the password from a prompt when it is
required

3. Reorganized code to move all the code associated with the Click
context object into its own file.  Also all the WBEMConnection code is
not in that same file since it is only used in the context of this
ContextObj class

4. Moved code and data associated with the wbem connection into a
separate object (PywbemServer) that centralizes functionality and
data concerning WBEMConnection and WBEMServer and prepares for being
able to create multiple of these and name them so that the user can
persistently define connections and also maintain a base of
multiple connections persistently.

Add connection functionality to passwork pr. This is really
part of another issue but extends the whole use of the
PywbemServer class to be able to change connection in the
interactive mode. In order to make sense of this I put it into
this pr

Update the help_overview to reflect new commands. The merge
from issue #24 should have fixed the issues Andreas found in
the horrible formatting of the help_overview document in the
design directory.

Add temporary persistence functionality for the connections.
This is simplistic in that it uses a global dictionary
and pickles the dictionary for persistence.  This code
is in a separate file.

Adds to tests for persistence by executing pywbemcli
connection subcommands

Change assci table to separate header from lines

Add the help overview to the docs.

Extend changes.rst. Temp test in test_helpmsgs.py

Move logic for save connection info to its own file

Add test for connection_repository persistence by
createing test that executes pywbemcli and the
connection subcommands