### PR TITLE
Fixes #33: Remove names subcommands

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -17,4 +17,7 @@ exclude =
 #disable_noqa
     
 ignore =
+    # unable to detect undefined names (when using wildcard import)
+    F403
+
 

--- a/design/help_overview.rst
+++ b/design/help_overview.rst
@@ -5,6 +5,18 @@ Overview of pywbemcli help with the multiple subcommands
 
 This is a display of the output of the pywbemcli commands define in this file. Each help output is presented as a section title with the command as sent to pywbemcli followed by the ouput returned by pywbemcli.
 
+*********************
+pywbemcli repl --help
+*********************
+
+::
+
+
+
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli repl --help`
+
 *****************
 pywbemcli  --help
 *****************
@@ -103,28 +115,11 @@ pywbemcli class --help
 
 ::
 
-    Usage: pywbemcli class [COMMAND-OPTIONS] COMMAND [ARGS]...
-    
-      Command Group to manage CIM Classes.
-    
-      In addition to the command-specific options shown in this help text, the
-      general options (see 'pywbemcli --help') can also be specified before the
-      command. These are NOT retained after the command is executed.
-    
-    Options:
-      --help  Show this message and exit.
-    
-    Commands:
-      associators   Get the associated classes for the CLASSNAME.
-      delete        Delete the class defined by CLASSNAME from...
-      enumerate     Enumerate classes from the WBEMServer.
-      find          Find all classes that match the CLASSNAME...
-      get           get and display a single CIM class from the...
-      hierarchy     Display class inheritance hierarchy as a...
-      invokemethod  Invoke the class method named methodname in...
-      references    Get the reference classes for the CLASSNAME.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli class --help`
 
 **************************
 pywbemcli class get --help
@@ -132,30 +127,11 @@ pywbemcli class get --help
 
 ::
 
-    Usage: pywbemcli class get [COMMAND-OPTIONS] CLASSNAME
-    
-      get and display a single CIM class from the WBEM Server
-    
-    Options:
-      -l, --localonly                 Show only local properties of the class.
-      --includequalifiers / --no_includequalifiers
-                                      Include qualifiers in the result. Default is
-                                      to include qualifiers
-      -c, --includeclassorigin        Include classorigin in the result.
-      -p, --propertylist <property name>
-                                      Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
-      -n, --namespace <name>          Namespace to use for this operation. If
-                                      defined that namespace overrides the general
-                                      options namespace
-      --help                          Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli class get --help`
 
 ***********************************
 pywbemcli class invokemethod --help
@@ -163,33 +139,11 @@ pywbemcli class invokemethod --help
 
 ::
 
-    Usage: pywbemcli class invokemethod [COMMAND-OPTIONS] classname name
-    
-      Invoke the class method named methodname in the class classname
-    
-    Options:
-      -p, --parameter parameter  Optional multiple method parameters of form
-                                 name=value
-      -n, --namespace <name>     Namespace to use for this operation. If defined
-                                 that namespace overrides the general options
-                                 namespace
-      --help                     Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
 
-****************************
-pywbemcli class names --help
-****************************
-
-::
-
-
-
-**STDER:** Usage: pywbemcli class [COMMAND-OPTIONS] COMMAND [ARGS]...
-
-Error: No such command "names".
-
-**ERROR:** cmd `pywbemcli class names --help`
+**ERROR:** cmd `pywbemcli class invokemethod --help`
 
 ********************************
 pywbemcli class enumerate --help
@@ -197,39 +151,11 @@ pywbemcli class enumerate --help
 
 ::
 
-    Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME
-    
-      Enumerate classes from the WBEMServer.
-    
-      Enumerates the classes (or classnames) from the WBEMServer starting either
-      at the top of the class hierarchy or from  the position in the class
-      hierarch defined by `classname` argument if provided.
-    
-      The output format is defined by the output_format global option.
-    
-      The includeclassqualifiers, includeclassorigin options define optional
-      information to be included in the output.
-    
-      The deepinheritance option defines whether the complete hiearchy is
-      retrieved or just the next level in the hiearchy.
-    
-    Options:
-      -d, --deepinheritance           Return complete subclass hierarchy for this
-                                      class if set. Otherwise retrieve only the
-                                      next hierarchy level.
-      -l, --localonly                 Show only local properties of the class.
-      --includequalifiers / --no_includequalifiers
-                                      Include qualifiers in the result. Default is
-                                      to include qualifiers
-      -c, --includeclassorigin        Include classorigin in the result.
-      -o, --names_only                Show only local properties of the class.
-      -s, --sort                      Sort into alphabetical order by classname.
-      -n, --namespace <name>          Namespace to use for this operation. If
-                                      defined that namespace overrides the general
-                                      options namespace
-      --help                          Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli class enumerate --help`
 
 **********************************
 pywbemcli class associators --help
@@ -237,42 +163,11 @@ pywbemcli class associators --help
 
 ::
 
-    Usage: pywbemcli class associators [COMMAND-OPTIONS] CLASSNAME
-    
-      Get the associated classes for the CLASSNAME.
-    
-      Get the classes(or classnames) that are associated with the CLASSNAME
-      argument filtered by the assocclass, resultclass, role and resultrole
-      arguments options.
-    
-      Results are displayed as defined by the output format global option.
-    
-    Options:
-      -a, --assocclass <class name>   Filter by the associated class name
-                                      provided.
-      -c, --resultclass <class name>  Filter by the result class name provided.
-      -r, --role <role name>          Filter by the role name provided.
-      -R, --resultrole <role name>    Filter by the role name provided.
-      --includequalifiers / --no_includequalifiers
-                                      Include qualifiers in the result. Default is
-                                      to include qualifiers
-      -c, --includeclassorigin        Include classorigin in the result.
-      -p, --propertylist <property name>
-                                      Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
-      -o, --names_only                Show only local properties of the class.
-      -s, --sort                      Sort into alphabetical order by classname.
-      -n, --namespace <name>          Namespace to use for this operation. If
-                                      defined that namespace overrides the general
-                                      options namespace
-      --help                          Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli class associators --help`
 
 *********************************
 pywbemcli class references --help
@@ -280,37 +175,11 @@ pywbemcli class references --help
 
 ::
 
-    Usage: pywbemcli class references [COMMAND-OPTIONS] CLASSNAME
-    
-      Get the reference classes for the CLASSNAME.
-    
-      Get the reference classes (or their classnames) for the CLASSNAME argument
-      filtered by the role and result class options and modified  by the other
-      options.
-    
-    Options:
-      -r, --resultclass <class name>  Filter by the classname provided.
-      -x, --role <role name>          Filter by the role name provided.
-      --includequalifiers / --no_includequalifiers
-                                      Include qualifiers in the result. Default is
-                                      to include qualifiers
-      -c, --includeclassorigin        Include classorigin in the result.
-      -p, --propertylist <property name>
-                                      Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
-      -o, --names_only                Show only local properties of the class.
-      -s, --sort                      Sort into alphabetical order by classname.
-      -n, --namespace <name>          Namespace to use for this operation. If
-                                      defined that namespace overrides the general
-                                      options namespace
-      --help                          Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli class references --help`
 
 ***************************
 pywbemcli class find --help
@@ -318,33 +187,11 @@ pywbemcli class find --help
 
 ::
 
-    Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME regex
-    
-      Find all classes that match the CLASSNAME regex.
-    
-      Find all of the classes in the namespace  of the defined WBEMServer that
-      match the CLASSNAME  regular expression argument in the namespaces of the
-      defined WBEMserver.
-    
-      The CLASSNAME argument is required.
-    
-      The CLASSNAME argument may be either a complete classname or a regular
-      expression that can be matched to one or more classnames. To limit the
-      filter to a single classname, terminate the classname with $.
-    
-      The regular expression is anchored to the beginning of the classname and
-      is case insensitive. Thus pywbem_ returns all classes that begin with
-      PyWBEM_, pywbem_, etc.
-    
-      The namespace option limits the search to the defined namespace
-    
-    Options:
-      -s, --sort              Sort into alphabetical order by classname.
-      -n, --namespace <name>  Namespace to use for this operation. If defined that
-                              namespace overrides the general options namespace
-      --help                  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli class find --help`
 
 ********************************
 pywbemcli class hierarchy --help
@@ -352,22 +199,11 @@ pywbemcli class hierarchy --help
 
 ::
 
-    Usage: pywbemcli class hierarchy [COMMAND-OPTIONS] CLASSNAME
-    
-      Display class inheritance hierarchy as a tree.
-    
-      The classname option, if it exists defines the topmost class of the
-      hierarchy to include in the display. This is a separate subcommand because
-      it is tied specifically to displaying in a tree format.
-    
-    Options:
-      -s, --superclasses      Display the superclasses to CLASSNAME.  In this case
-                              CLASSNAME is required
-      -n, --namespace <name>  Namespace to use for this operation. If defined that
-                              namespace overrides the general options namespace
-      --help                  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli class hierarchy --help`
 
 *****************************
 pywbemcli instance get --help
@@ -375,39 +211,11 @@ pywbemcli instance get --help
 
 ::
 
-    Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME
-    
-      Get a single CIMInstance.
-    
-      Gets the instance defined by instancename.
-    
-      This may be executed interactively by providing only a classname and the
-      interactive option.
-    
-    Options:
-      -l, --localonly                 Show only local properties of the returned
-                                      instance.
-      -q, --includequalifiers         Include qualifiers in the result.
-      -c, --includeclassorigin        Include Class Origin in the returned
-                                      instance.
-      -p, --propertylist <property name>
-                                      Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
-      -n, --namespace <name>          Namespace to use for this operation. If
-                                      defined that namespace overrides the general
-                                      options namespace
-      -i, --interactive               If set, instancename argument must be a
-                                      class and  user is provided with a list of
-                                      instances of the  class from which the
-                                      instance to delete is selected.
-      --help                          Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli instance get --help`
 
 ********************************
 pywbemcli instance delete --help
@@ -415,21 +223,11 @@ pywbemcli instance delete --help
 
 ::
 
-    Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME
-    
-      Delete a single instance defined by instancename from the WBEM server.
-      This may be executed interactively by providing only a classname and the
-      interactive option.
-    
-    Options:
-      -i, --interactive       If set, instancename argument must be a class and
-                              user is provided with a list of instances of the
-                              class from which the instance to delete is selected.
-      -n, --namespace <name>  Namespace to use for this operation. If defined that
-                              namespace overrides the general options namespace
-      --help                  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli instance delete --help`
 
 ********************************
 pywbemcli instance create --help
@@ -437,27 +235,11 @@ pywbemcli instance create --help
 
 ::
 
-    Usage: pywbemcli instance create [COMMAND-OPTIONS] classname
-    
-      Create an instance of classname.
-    
-    Options:
-      -x, --property property         Optional multiple property definitions of
-                                      form name=value
-      -p, --propertylist <property name>
-                                      Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
-      -n, --namespace <name>          Namespace to use for this operation. If
-                                      defined that namespace overrides the general
-                                      options namespace
-      --help                          Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli instance create --help`
 
 **************************************
 pywbemcli instance invokemethod --help
@@ -465,22 +247,11 @@ pywbemcli instance invokemethod --help
 
 ::
 
-    Usage: pywbemcli instance invokemethod [COMMAND-OPTIONS] name name
-    
-      Invoke the method defined by instancename and methodname with parameters.
-    
-      This issues an instance level invokemethod request and displays the
-      results.
-    
-    Options:
-      -p, --parameter parameter  Optional multiple method parameters of form
-                                 name=value
-      -n, --namespace <name>     Namespace to use for this operation. If defined
-                                 that namespace overrides the general options
-                                 namespace
-      --help                     Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli instance invokemethod --help`
 
 *******************************
 pywbemcli instance query --help
@@ -488,41 +259,11 @@ pywbemcli instance query --help
 
 ::
 
-    Usage: pywbemcli instance query [COMMAND-OPTIONS] <query string>
-    
-      Execute the query defined by the query argument.
-    
-    Options:
-      -l, --querylanguage <query language>
-                                      Use the query language defined. (Default:
-                                      DMTF:CQL.
-      -n, --namespace <name>          Namespace to use for this operation. If
-                                      defined that namespace overrides the general
-                                      options namespace
-      -s, --sort                      Sort into alphabetical order by classname.
-      --help                          Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
 
-*******************************
-pywbemcli instance names --help
-*******************************
-
-::
-
-    Usage: pywbemcli instance names [COMMAND-OPTIONS] [CLASSNAME]
-    
-      Get and display a list of instance names of the classname argument.
-    
-      This is equivalent to pywbemcli instance enumerate -o
-    
-    Options:
-      -n, --namespace <name>  Namespace to use for this operation. If defined that
-                              namespace overrides the general options namespace
-      -s, --sort              Sort into alphabetical order by classname.
-      --help                  Show this message and exit.
-
-
+**ERROR:** cmd `pywbemcli instance query --help`
 
 ***********************************
 pywbemcli instance enumerate --help
@@ -530,37 +271,11 @@ pywbemcli instance enumerate --help
 
 ::
 
-    Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME
-    
-      Enumerate instances or instance names from the WBEMServer starting either
-      at the top  of the hiearchy (if no classname provided) or from the
-      classname argument provided.
-    
-      Displays the returned instances or names
-    
-    Options:
-      -l, --localonly                 Show only local properties of the class.
-      -d, --deepinheritance           Return properties in subclasses of defined
-                                      target.  If not specified only properties in
-                                      target class are returned
-      -q, --includequalifiers         Include qualifiers in the result.
-      -c, --includeclassorigin        Include ClassOrigin in the result.
-      -p, --propertylist <property name>
-                                      Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
-      -n, --namespace <name>          Namespace to use for this operation. If
-                                      defined that namespace overrides the general
-                                      options namespace
-      -o, --names_only                Show only local properties of the class.
-      -s, --sort                      Sort into alphabetical order by classname.
-      --help                          Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli instance enumerate --help`
 
 *******************************
 pywbemcli instance count --help
@@ -568,32 +283,11 @@ pywbemcli instance count --help
 
 ::
 
-    Usage: pywbemcli instance count [COMMAND-OPTIONS] CLASSNAME regex
-    
-      Get number of instances for each class in namespace.
-    
-      The size of the response may be limited by CLASSNAME argument which
-      defines a classname regular expression so that only those classes are
-      counted
-    
-      The CLASSNAME argument is optional.
-    
-      The CLASSNAME argument may be either a complete classname or a regular
-      expression that can be matched to one or more classnames. To limit the
-      filter to a single classname, terminate the classname with $.
-    
-      The regular expression is anchored to the beginning of the classname and
-      is case insensitive. Thus pywbem_ returns all classes that begin with
-      PyWBEM_, pywbem_, etc.
-    
-    Options:
-      -s, --sort              Sort by instance count. Otherwise sorted by
-                              classname
-      -n, --namespace <name>  Namespace to use for this operation. If defined that
-                              namespace overrides the general options namespace
-      --help                  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli instance count --help`
 
 ************************************
 pywbemcli instance references --help
@@ -601,40 +295,11 @@ pywbemcli instance references --help
 
 ::
 
-    Usage: pywbemcli instance references [COMMAND-OPTIONS] INSTANCENAME
-    
-      Get the reference instances or instance names.
-    
-      For the INSTANCENAME argument provided return instances or instance names
-      (names-only option) filtered by the role and result class options. This
-      may be executed interactively by providing only a classname and the
-      interactive option.
-    
-    Options:
-      -r, --resultclass <class name>  Filter by the result class name provided.
-      -o, --role <role name>          Filter by the role name provided.
-      -q, --includequalifiers         Include qualifiers in the result.
-      -c, --includeclassorigin        Include classorigin in the result.
-      -p, --propertylist <property name>
-                                      Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
-      -o, --names_only                Show only local properties of the class.
-      -n, --namespace <name>          Namespace to use for this operation. If
-                                      defined that namespace overrides the general
-                                      options namespace
-      -s, --sort                      Sort into alphabetical order by classname.
-      -i, --interactive               If set, instancename argument must be a
-                                      class and  user is provided with a list of
-                                      instances of the  class from which the
-                                      instance to delete is selected.
-      --help                          Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli instance references --help`
 
 *************************************
 pywbemcli instance associators --help
@@ -642,43 +307,11 @@ pywbemcli instance associators --help
 
 ::
 
-    Usage: pywbemcli instance associators [COMMAND-OPTIONS] INSTANCENAME
-    
-      Get the associated instances or instance names.
-    
-      Returns the associated instances or names (names-only option) for the
-      INSTANCENAME argument filtered by the assocclass, resultclass, role and
-      resultrole arguments. This may be executed interactively by providing only
-      a classname and the interactive option.
-    
-    Options:
-      -a, --assocclass <class name>   Filter by the associated instancename
-                                      provided.
-      -r, --resultclass <class name>  Filter by the result class name provided.
-      -x, --role <role name>          Filter by the role name provided.
-      -o, --resultrole <class name>   Filter by the result role name provided.
-      -q, --includequalifiers         Include qualifiers in the result.
-      -c, --includeclassorigin        Include classorigin in the result.
-      -p, --propertylist <property name>
-                                      Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
-      -o, --names_only                Show only local properties of the class.
-      -n, --namespace <name>          Namespace to use for this operation. If
-                                      defined that namespace overrides the general
-                                      options namespace
-      -s, --sort                      Sort into alphabetical order by classname.
-      -i, --interactive               If set, instancename argument must be a
-                                      class and  user is provided with a list of
-                                      instances of the  class from which the
-                                      instance to delete is selected.
-      --help                          Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli instance associators --help`
 
 **************************
 pywbemcli qualifier --help
@@ -686,27 +319,11 @@ pywbemcli qualifier --help
 
 ::
 
-    Usage: pywbemcli qualifier [COMMAND-OPTIONS] COMMAND [ARGS]...
-    
-      Command Group to manage CIM QualifierDeclarations.
-    
-      Includes the capability to get and enumerate qualifier declarations.
-    
-      This does not provide the capability to create or delete CIM
-      QualifierDeclarations
-    
-      In addition to the command-specific options shown in this help text, the
-      general options (see 'pywbemcli --help') can also be specified before the
-      command. These are NOT retained after the command is executed.
-    
-    Options:
-      --help  Show this message and exit.
-    
-    Commands:
-      enumerate  Enumerate CIMQualifierDeclaractions.
-      get        Display CIMQualifierDeclaration.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli qualifier --help`
 
 ************************************
 pywbemcli qualifier enumerate --help
@@ -714,20 +331,11 @@ pywbemcli qualifier enumerate --help
 
 ::
 
-    Usage: pywbemcli qualifier enumerate [COMMAND-OPTIONS]
-    
-      Enumerate CIMQualifierDeclaractions.
-    
-      Displays all of the CIMQualifierDeclaration objects in the defined
-      namespace in the current WBEM Server
-    
-    Options:
-      -n, --namespace <name>  Namespace to use for this operation. If defined that
-                              namespace overrides the general options namespace
-      -s, --sort              Sort into alphabetical order by classname.
-      --help                  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli qualifier enumerate --help`
 
 ******************************
 pywbemcli qualifier get --help
@@ -735,19 +343,11 @@ pywbemcli qualifier get --help
 
 ::
 
-    Usage: pywbemcli qualifier get [COMMAND-OPTIONS] NAME
-    
-      Display CIMQualifierDeclaration.
-    
-      Displays a single CIMQualifierDeclaration for the defined namespace in the
-      current WBEMServer
-    
-    Options:
-      -n, --namespace <name>  Namespace to use for this operation. If defined that
-                              namespace overrides the general options namespace
-      --help                  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli qualifier get --help`
 
 ***********************
 pywbemcli server --help
@@ -755,26 +355,11 @@ pywbemcli server --help
 
 ::
 
-    Usage: pywbemcli server [COMMAND-OPTIONS] COMMAND [ARGS]...
-    
-      Command Group for WBEM server operations.
-    
-      In addition to the command-specific options shown in this help text, the
-      general options (see 'pywbemcli --help') can also be specified before the
-      command. These are NOT retained after the command is executed.
-    
-    Options:
-      --help  Show this message and exit.
-    
-    Commands:
-      brand       Display the interop namespace name in the...
-      connection  Display information on the connection used by...
-      info        Display the brand information on the current...
-      interop     Display the interop namespace name in the...
-      namespaces  Display the set of namespaces in the current...
-      profiles    Display profiles on the current WBEM Server.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli server --help`
 
 *****************************
 pywbemcli server brand --help
@@ -782,14 +367,11 @@ pywbemcli server brand --help
 
 ::
 
-    Usage: pywbemcli server brand [COMMAND-OPTIONS]
-    
-      Display the interop namespace name in the WBEM Server.
-    
-    Options:
-      --help  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli server brand --help`
 
 **********************************
 pywbemcli server connection --help
@@ -797,14 +379,11 @@ pywbemcli server connection --help
 
 ::
 
-    Usage: pywbemcli server connection [COMMAND-OPTIONS]
-    
-      Display information on the connection used by this server.
-    
-    Options:
-      --help  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli server connection --help`
 
 ****************************
 pywbemcli server info --help
@@ -812,14 +391,11 @@ pywbemcli server info --help
 
 ::
 
-    Usage: pywbemcli server info [COMMAND-OPTIONS]
-    
-      Display the brand information on the current WBEM Server.
-    
-    Options:
-      --help  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli server info --help`
 
 **********************************
 pywbemcli server namespaces --help
@@ -827,15 +403,11 @@ pywbemcli server namespaces --help
 
 ::
 
-    Usage: pywbemcli server namespaces [COMMAND-OPTIONS]
-    
-      Display the set of namespaces in the current WBEM server
-    
-    Options:
-      -s, --sort  Sort into alphabetical order by classname.
-      --help      Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli server namespaces --help`
 
 *******************************
 pywbemcli server interop --help
@@ -843,14 +415,11 @@ pywbemcli server interop --help
 
 ::
 
-    Usage: pywbemcli server interop [COMMAND-OPTIONS]
-    
-      Display the interop namespace name in the WBEM Server.
-    
-    Options:
-      --help  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli server interop --help`
 
 ********************************
 pywbemcli server profiles --help
@@ -858,21 +427,11 @@ pywbemcli server profiles --help
 
 ::
 
-    Usage: pywbemcli server profiles [COMMAND-OPTIONS]
-    
-      Display profiles on the current WBEM Server.
-    
-      This display may be filtered by the optional organization and profile name
-      options
-    
-    Options:
-      -o, --organization <org name>   Filter by the defined organization. (ex. -o
-                                      DMTF
-      -n, --profilename <profile name>
-                                      Filter by the profile name. (ex. -n Array
-      --help                          Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli server profiles --help`
 
 ***************************
 pywbemcli connection --help
@@ -880,30 +439,11 @@ pywbemcli connection --help
 
 ::
 
-    Usage: pywbemcli connection [COMMAND-OPTIONS] COMMAND [ARGS]...
-    
-      Command group to manage WBEM connections.
-    
-      These command allow viewing and setting connection information.
-    
-      In addition to the command-specific options shown in this help text, the
-      general options (see 'pywbemcli --help') can also be specified before the
-      command. These are NOT retained after the command is executed.
-    
-    Options:
-      --help  Show this message and exit.
-    
-    Commands:
-      create  Create a new named connection from the input...
-      delete  Show the current connection information, i.e.
-      export  Export the current connection information.
-      list    Execute a simple wbem request to test that...
-      select  Select a connection from the current defined...
-      set     Set current connection into repository.
-      show    Show the current connection information, i.e.
-      test    Execute a simple wbem request to test that...
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli connection --help`
 
 ********************************
 pywbemcli connection show --help
@@ -911,15 +451,11 @@ pywbemcli connection show --help
 
 ::
 
-    Usage: pywbemcli connection show [COMMAND-OPTIONS] name
-    
-      Show the current connection information, i.e. all the variables that make
-      up the current connection
-    
-    Options:
-      --help  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli connection show --help`
 
 **********************************
 pywbemcli connection export --help
@@ -927,17 +463,11 @@ pywbemcli connection export --help
 
 ::
 
-    Usage: pywbemcli connection export [COMMAND-OPTIONS]
-    
-      Export  the current connection information.
-    
-      Creates an export statement for each connection variable and outputs the
-      statement to the conole.
-    
-    Options:
-      --help  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli connection export --help`
 
 ********************************
 pywbemcli connection show --help
@@ -945,15 +475,11 @@ pywbemcli connection show --help
 
 ::
 
-    Usage: pywbemcli connection show [COMMAND-OPTIONS] name
-    
-      Show the current connection information, i.e. all the variables that make
-      up the current connection
-    
-    Options:
-      --help  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli connection show --help`
 
 *******************************
 pywbemcli connection set --help
@@ -961,18 +487,11 @@ pywbemcli connection set --help
 
 ::
 
-    Usage: pywbemcli connection set [COMMAND-OPTIONS] name
-    
-      Set current connection into repository.
-    
-      Sets the current wbem connection information into the repository of
-      connections. If the name does not already exist in the connection
-      information, the provided name is used.
-    
-    Options:
-      --help  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli connection set --help`
 
 ********************************
 pywbemcli connection test --help
@@ -980,15 +499,11 @@ pywbemcli connection test --help
 
 ::
 
-    Usage: pywbemcli connection test [COMMAND-OPTIONS]
-    
-      Execute a simple wbem request to test that the connection exists and is
-      working.
-    
-    Options:
-      --help  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli connection test --help`
 
 **********************************
 pywbemcli connection select --help
@@ -996,14 +511,11 @@ pywbemcli connection select --help
 
 ::
 
-    Usage: pywbemcli connection select [COMMAND-OPTIONS] name
-    
-      Select a connection from the current defined connections
-    
-    Options:
-      --help  Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli connection select --help`
 
 **********************************
 pywbemcli connection create --help
@@ -1011,57 +523,11 @@ pywbemcli connection create --help
 
 ::
 
-    Usage: pywbemcli connection create [COMMAND-OPTIONS] name SERVER
-    
-      Create a new named connection from the input parameters.
-    
-      This subcommand creates and saves a new named connection from the input
-      parameters.
-    
-      The name and server arguments MUST exist. They define the server uri and
-      the unique name under which this server connection information will be
-      stored. All other properties are optional.
-    
-      It does NOT automatically set the pywbemcli to use that connection. Use
-      `connection select` to set a particular stored connection definition as
-      the current connection.
-    
-      This is the alternative means of defining a new WBEM server to be accessed
-      to supplying the parameters on the command line. and using the connection
-      set command to put it into the connection repository.
-    
-      Defines a new connection that can be referenced by the name argument in
-      the future.  This connection object is capable of managing all of the
-      properties defined for WBEMConnections.
-    
-    Options:
-      -d, --default_namespace TEXT  Default Namespace to use in the target
-                                    WBEMServer if no namespace is defined in the
-                                    subcommand (Default: root/cimv2).
-      -u, --user TEXT               User name for the WBEM Server connection.
-      -p, --password TEXT           Password for the WBEM Server. Will be
-                                    requested as part  of initialization if user
-                                    name exists and it is not  provided by this
-                                    option.
-      -t, --timeout TEXT            Operation timeout for the WBEM Server in
-                                    seconds. Default: 30
-      -n, --noverify                If set, client does not verify server
-                                    certificate.
-      -c, --certfile TEXT           Server certfile. Ignored if noverify flag set.
-      -k, --keyfile TEXT            Client private key file.
-      --ca_certs TEXT               File or directory containing certificates that
-                                    will be matched against a certificate received
-                                    from the WBEM server. Set the --no-verify-cert
-                                    option to bypass client verification of the
-                                    WBEM server certificate. Default: Searches for
-                                    matching certificates in the following system
-                                    directories: /etc/pki/ca-
-                                    trust/extracted/openssl/ca-bundle.trust.crt
-                                    /etc/ssl/certs
-                                    /etc/ssl/certificates
-      --help                        Show this message and exit.
 
 
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli connection create --help`
 
 **********************************
 pywbemcli connection delete --help
@@ -1069,13 +535,9 @@ pywbemcli connection delete --help
 
 ::
 
-    Usage: pywbemcli connection delete [COMMAND-OPTIONS] name
-    
-      Show the current connection information, i.e. all the variables that make
-      up the current connection
-    
-    Options:
-      --help  Show this message and exit.
 
 
-1 ERRORS encountered in output
+**STDER:** Error: No defined connection. Use -s option to define a connection
+
+**ERROR:** cmd `pywbemcli connection delete --help`
+37 ERRORS encountered in output

--- a/pywbemcli/__init__.py
+++ b/pywbemcli/__init__.py
@@ -18,17 +18,17 @@ from __future__ import absolute_import
 
 import sys
 
-from ._cmd_class import *       # noqa: F403, F401
-from ._cmd_instance import *       # noqa: F403, F401
-from ._cmd_qualifier import *       # noqa: F403, F401
-from ._cmd_server import *       # noqa: F403, F401
-from ._cmd_connection import *   # noqa: F403, F401
-from ._common import *   # noqa: F403, F401
-from ._pywbem_server import *   # noqa: F403, F401
-from ._context_obj import *   # noqa: F403, F401
-from ._connection_repository import *   # noqa: F403, F401
-from .pywbemcli import *       # noqa: F403, F401
-from .config import *  # noqa: F403,F401
+from ._cmd_class import *       # noqa: F401
+from ._cmd_instance import *       # noqa: F401
+from ._cmd_qualifier import *       # noqa: F401
+from ._cmd_server import *       # noqa: F401
+from ._cmd_connection import *   # noqa: F401
+from ._common import *   # noqa: F401
+from ._pywbem_server import *   # noqa: F401
+from ._context_obj import *   # noqa: F401
+from ._connection_repository import *   # noqa: F401
+from .pywbemcli import *       # noqa: F401
+from .config import *  # noqa: F401
 
 from ._version import __version__  # noqa: F401
 

--- a/pywbemcli/_cmd_instance.py
+++ b/pywbemcli/_cmd_instance.py
@@ -151,20 +151,6 @@ def instance_invokemethod(context, instancename, methodname, **options):
                                                           options))
 
 
-@instance_group.command('names', options_metavar=CMD_OPTS_TXT)
-@click.argument('classname', required=False,)
-@add_options(namespace_option)
-@add_options(sort_option)
-@click.pass_obj
-def instance_names(context, classname, **options):
-    """
-    Get and display a list of instance names of the classname argument.
-
-    This is equivalent to pywbemcli instance enumerate -o
-    """
-    context.execute_cmd(lambda: cmd_instance_names(context, classname, options))
-
-
 @instance_group.command('enumerate', options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True)
 @click.option('-l', '--localonly', is_flag=True, required=False,
@@ -415,24 +401,6 @@ def cmd_instance_invokemethod(context, instancename, methodname,
         params = create_params(cim_method, options['parameter'])
 
         context.conn.InvokeMethod(instancepath, methodname, params)
-
-    except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
-
-
-def cmd_instance_names(context, classname, options):
-    """
-    get and display a the instancenames of the instances of the class
-    classname
-    """
-    try:
-        inst_names = context.conn.EnumerateInstanceNames(
-            classname,
-            namespace=options['namespace'])
-
-        if options['sort']:
-            inst_names.sort()
-        display_cim_objects(context, inst_names, context.output_format)
 
     except Error as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))

--- a/tests/unit/test_helpmsgs.py
+++ b/tests/unit/test_helpmsgs.py
@@ -37,6 +37,8 @@ import six
 #    it simple until code stabilizes.
 TESTS_MAP = {  # pylint: disable=invalid-name
     'top': ["", ['--server', '--default_namespace']],
+
+    'repl': ["repl", ["REPL"]],
     "class": ["class", ['get', 'invokemethod']],
     "classget": ["class get", ['localonly', 'propertylist']],
     "classenum": ["class enumerate", []],
@@ -53,7 +55,6 @@ TESTS_MAP = {  # pylint: disable=invalid-name
     "instdelete": ["instance delete", []],
     "instinvok": ["instance invokemethod", []],
     "instquery": ["instance query", []],
-    "instnames": ["instance names", []],
     "instenum": ["instance enumerate", []],
     "instcount": ["instance count", []],
     "instref": ["instance references", []],

--- a/tools/help_overview.py
+++ b/tools/help_overview.py
@@ -138,11 +138,12 @@ print('This is a display of the output of the pywbemcli commands define in '
     'command as sent to pywbemcli followed by the ouput returned by '
     'pywbemcli.'     )
 
+help_cmd("repl")ma
+
 help_cmd("")
 help_cmd("class")
 help_cmd("class get")
 help_cmd("class invokemethod")
-help_cmd("class names")
 help_cmd("class enumerate")
 help_cmd("class associators")
 help_cmd("class references")
@@ -154,7 +155,6 @@ help_cmd("instance delete")
 help_cmd("instance create")
 help_cmd("instance invokemethod")
 help_cmd("instance query")
-help_cmd("instance names")
 help_cmd("instance enumerate")
 help_cmd("instance count")
 help_cmd("instance references")

--- a/tools/help_overview.py
+++ b/tools/help_overview.py
@@ -138,7 +138,7 @@ print('This is a display of the output of the pywbemcli commands define in '
     'command as sent to pywbemcli followed by the ouput returned by '
     'pywbemcli.'     )
 
-help_cmd("repl")ma
+help_cmd("repl")
 
 help_cmd("")
 help_cmd("class")


### PR DESCRIPTION
Removes instance name command from subcommands since this functionality is covered by the enumerate with an option.

Removed from tests also.

Removed one noqa message.

Reguires pr#44 to complete tests.