### PR TITLE
Add code to ignore python warnings for test execute pywbemcli

### DIFF
--- a/tests/live_unit/test_pegasus.py
+++ b/tests/live_unit/test_pegasus.py
@@ -25,7 +25,6 @@ from __future__ import print_function, absolute_import
 import unittest
 import re
 from subprocess import Popen, PIPE
-import shlex
 import six
 
 
@@ -42,14 +41,13 @@ class ClientTest(unittest.TestCase):
 class TestsContainer(ClientTest):
     """Container class for all tests"""
 
-    def execute_cmd(self, cmd_str, shell=None):  # pylint: disable=no-self-use
+    def execute_cmd(self, cmd_str):  # pylint: disable=no-self-use
         """Execute the command defined by cmd_str and return results."""
         if self.verbose:
             print('cmd %s' % cmd_str)
-        args = shlex.split(cmd_str)
-        if self.verbose:
-            print('args %s' % args)
-        proc = Popen(args, stdout=PIPE, stderr=PIPE, shell=shell)
+        # Disable python warnings for pywbemcli call.See issue #42
+        command = 'export PYTHONWARNINGS="" && %s' % cmd_str
+        proc = Popen(command, shell=True, stdout=PIPE, stderr=PIPE)
         std_out, std_err = proc.communicate()
         exitcode = proc.returncode
         if six.PY3:


### PR DESCRIPTION
Issue #42. Add code to test execution of pywbemcli to ignore warnings
because of importwarning from sphinxcontrib

This change sets PYTHONWARNING to "" for tests that directly call the pywbemcli executable so that
the importwarning from sphinxcontrib is not generated.

This means that we have no real test for python warnings at the level of execution of the pybemcli script itself.

Set as high priority since this issue is breaking the CI environment.