### PR TITLE
Fix error in flake8 noqa definitions

### DIFF
--- a/pywbemcli/__init__.py
+++ b/pywbemcli/__init__.py
@@ -18,16 +18,16 @@ from __future__ import absolute_import
 
 import sys
 
-from ._cmd_class import *       # noqa: F403, F401
-from ._cmd_instance import *       # noqa: F403, F401
-from ._cmd_qualifier import *       # noqa: F403, F401
-from ._cmd_server import *       # noqa: F403, F401
-from ._cmd_connection import *   # noqa: F403, F401
-from ._common import *   # noqa: F403, F401
-from ._pywbem_server import *   # noqa: F403, F401
-from ._context_obj import *   # noqa: F403, F401
-from ._connection_repository import *   # noqa: F403, F401
-from .pywbemcli import *       # noqa: F403, F401
+from ._cmd_class import *       # noqa: F403,F401
+from ._cmd_instance import *       # noqa: F403,F401
+from ._cmd_qualifier import *       # noqa: F403,F401
+from ._cmd_server import *       # noqa: F403,F401
+from ._cmd_connection import *   # noqa: F403,F401
+from ._common import *   # noqa: F403,F401
+from ._pywbem_server import *   # noqa: F403,F401
+from ._context_obj import *   # noqa: F403,F401
+from ._connection_repository import *   # noqa: F403,F401
+from .pywbemcli import *       # noqa: F403,F401
 from .config import *  # noqa: F403,F401
 from ._pywbemcli_operations import *  # noqa: F403,F401
 


### PR DESCRIPTION
We are including space after comma in some flake8 noqa defintions.
That is not allowed all of a sudden so generates a number of flake8
issues with __init__.py