### PR TITLE
Fix pywbemcli.py help doc issue

### DIFF
--- a/design/help_overview.rst
+++ b/design/help_overview.rst
@@ -15,20 +15,21 @@ The following defines the help output for the `pywbemcli  --help` subcommand
 ::
 
     Usage: pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS]...
-    
+
       Command line browser for WBEM Servers. This cli tool implements the
       CIM/XML client APIs as defined in pywbem to make requests to a WBEM
-      server. This browser uses subcommands to      * Explore the
-      characteristics of WBEM Servers based on using the       pywbem client
-      APIs.  It can manage/inspect CIM_Classes and       CIM_instanceson the
-      server.
-    
+      server. This browser uses subcommands to:
+
+          * Explore the characteristics of WBEM Servers based on using the
+            pywbem client APIs.  It can manage/inspect CIM_Classes and
+            CIM_instanceson the server.
+
           * In addition it can inspect namespaces and other server information
             and inspect and manage WBEM indication subscriptions.
-    
+
       The options shown above that can also be specified on any of the
       (sub-)commands as well as the command line.
-    
+
     Options:
       -s, --server TEXT               Hostname or IP address with scheme of the
                                       WBEMServer in  format
@@ -104,7 +105,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       processing.
       --version                       Show the version of this command and exit.
       --help                          Show this message and exit.
-    
+
     Commands:
       class       Command Group to manage CIM Classes.
       connection  Command group to manage WBEM connections.
@@ -113,7 +114,6 @@ The following defines the help output for the `pywbemcli  --help` subcommand
       qualifier   Command Group to manage CIM...
       repl        Enter interactive (REPL) mode (default) and...
       server      Command Group for WBEM server operations.
-
 
 
 .. _`pywbemcli class --help`:
@@ -129,16 +129,16 @@ The following defines the help output for the `pywbemcli class --help` subcomman
 ::
 
     Usage: pywbemcli class [COMMAND-OPTIONS] COMMAND [ARGS]...
-    
+
       Command Group to manage CIM Classes.
-    
+
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
       command. These are NOT retained after the command is executed.
-    
+
     Options:
       --help  Show this message and exit.
-    
+
     Commands:
       associators   Get the associated classes for the CLASSNAME.
       delete        Delete the class defined by CLASSNAME from...
@@ -148,7 +148,6 @@ The following defines the help output for the `pywbemcli class --help` subcomman
       hierarchy     Display class inheritance hierarchy as a...
       invokemethod  Invoke the class method named methodname in...
       references    Get the reference classes for the CLASSNAME.
-
 
 
 .. _`pywbemcli class associators --help`:
@@ -164,15 +163,15 @@ The following defines the help output for the `pywbemcli class associators --hel
 ::
 
     Usage: pywbemcli class associators [COMMAND-OPTIONS] CLASSNAME
-    
+
       Get the associated classes for the CLASSNAME.
-    
+
       Get the classes(or classnames) that are associated with the CLASSNAME
       argument filtered by the assocclass, resultclass, role and resultrole
       arguments options.
-    
+
       Results are displayed as defined by the output format global option.
-    
+
     Options:
       -a, --assocclass <class name>   Filter by the associated class name
                                       provided.
@@ -199,7 +198,6 @@ The following defines the help output for the `pywbemcli class associators --hel
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli class delete --help`:
 
 pywbemcli class delete --help
@@ -213,13 +211,13 @@ The following defines the help output for the `pywbemcli class delete --help` su
 ::
 
     Usage: pywbemcli class delete [COMMAND-OPTIONS] CLASSNAME
-    
+
       Delete the class defined by CLASSNAME from the WBEM Server. If the class
       has instances, the command is refused unless the --force option is used.
-    
+
       WARNING: Removing classes from a WBEM Server can cause damage to the
       server. Use this with caution.
-    
+
     Options:
       -f, --force             Force the delete request to be issued even if there
                               are instances in the server or subclasses to this
@@ -228,7 +226,6 @@ The following defines the help output for the `pywbemcli class delete --help` su
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       --help                  Show this message and exit.
-
 
 
 .. _`pywbemcli class enumerate --help`:
@@ -244,21 +241,21 @@ The following defines the help output for the `pywbemcli class enumerate --help`
 ::
 
     Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME
-    
+
       Enumerate classes from the WBEMServer.
-    
+
       Enumerates the classes (or classnames) from the WBEMServer starting either
       at the top of the class hierarchy or from  the position in the class
       hierarch defined by `classname` argument if provided.
-    
+
       The output format is defined by the output_format global option.
-    
+
       The includeclassqualifiers, includeclassorigin options define optional
       information to be included in the output.
-    
+
       The deepinheritance option defines whether the complete hiearchy is
       retrieved or just the next level in the hiearchy.
-    
+
     Options:
       -d, --deepinheritance           Return complete subclass hierarchy for this
                                       class if set. Otherwise retrieve only the
@@ -276,7 +273,6 @@ The following defines the help output for the `pywbemcli class enumerate --help`
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli class find --help`:
 
 pywbemcli class find --help
@@ -290,31 +286,30 @@ The following defines the help output for the `pywbemcli class find --help` subc
 ::
 
     Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME regex
-    
+
       Find all classes that match the CLASSNAME regex.
-    
+
       Find all of the classes in the namespace  of the defined WBEMServer that
       match the CLASSNAME  regular expression argument in the namespaces of the
       defined WBEMserver.
-    
+
       The CLASSNAME argument is required.
-    
+
       The CLASSNAME argument may be either a complete classname or a regular
       expression that can be matched to one or more classnames. To limit the
       filter to a single classname, terminate the classname with $.
-    
+
       The regular expression is anchored to the beginning of the classname and
       is case insensitive. Thus pywbem_ returns all classes that begin with
       PyWBEM_, pywbem_, etc.
-    
+
       The namespace option limits the search to the defined namespace
-    
+
     Options:
       -s, --sort              Sort into alphabetical order by classname.
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       --help                  Show this message and exit.
-
 
 
 .. _`pywbemcli class get --help`:
@@ -330,9 +325,9 @@ The following defines the help output for the `pywbemcli class get --help` subco
 ::
 
     Usage: pywbemcli class get [COMMAND-OPTIONS] CLASSNAME
-    
+
       get and display a single CIM class from the WBEM Server
-    
+
     Options:
       -l, --localonly                 Show only local properties of the class.
       --includequalifiers / --no_includequalifiers
@@ -353,7 +348,6 @@ The following defines the help output for the `pywbemcli class get --help` subco
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli class hierarchy --help`:
 
 pywbemcli class hierarchy --help
@@ -367,20 +361,19 @@ The following defines the help output for the `pywbemcli class hierarchy --help`
 ::
 
     Usage: pywbemcli class hierarchy [COMMAND-OPTIONS] CLASSNAME
-    
+
       Display class inheritance hierarchy as a tree.
-    
+
       The classname option, if it exists defines the topmost class of the
       hierarchy to include in the display. This is a separate subcommand because
       it is tied specifically to displaying in a tree format.
-    
+
     Options:
       -s, --superclasses      Display the superclasses to CLASSNAME.  In this case
                               CLASSNAME is required
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       --help                  Show this message and exit.
-
 
 
 .. _`pywbemcli class invokemethod --help`:
@@ -396,9 +389,9 @@ The following defines the help output for the `pywbemcli class invokemethod --he
 ::
 
     Usage: pywbemcli class invokemethod [COMMAND-OPTIONS] classname name
-    
+
       Invoke the class method named methodname in the class classname
-    
+
     Options:
       -p, --parameter parameter  Optional multiple method parameters of form
                                  name=value
@@ -406,7 +399,6 @@ The following defines the help output for the `pywbemcli class invokemethod --he
                                  that namespace overrides the general options
                                  namespace
       --help                     Show this message and exit.
-
 
 
 .. _`pywbemcli class references --help`:
@@ -422,13 +414,13 @@ The following defines the help output for the `pywbemcli class references --help
 ::
 
     Usage: pywbemcli class references [COMMAND-OPTIONS] CLASSNAME
-    
+
       Get the reference classes for the CLASSNAME.
-    
+
       Get the reference classes (or their classnames) for the CLASSNAME argument
       filtered by the role and result class options and modified  by the other
       options.
-    
+
     Options:
       -r, --resultclass <class name>  Filter by the classname provided.
       -x, --role <role name>          Filter by the role name provided.
@@ -452,7 +444,6 @@ The following defines the help output for the `pywbemcli class references --help
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli connection --help`:
 
 pywbemcli connection --help
@@ -466,18 +457,18 @@ The following defines the help output for the `pywbemcli connection --help` subc
 ::
 
     Usage: pywbemcli connection [COMMAND-OPTIONS] COMMAND [ARGS]...
-    
+
       Command group to manage WBEM connections.
-    
+
       These command allow viewing and setting connection information.
-    
+
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
       command. These are NOT retained after the command is executed.
-    
+
     Options:
       --help  Show this message and exit.
-    
+
     Commands:
       create  Create a new named connection from the input...
       delete  Show the current connection information, i.e.
@@ -487,7 +478,6 @@ The following defines the help output for the `pywbemcli connection --help` subc
       set     Set current connection into repository.
       show    Show the current connection information, i.e.
       test    Execute a simple wbem request to test that...
-
 
 
 .. _`pywbemcli connection create --help`:
@@ -503,28 +493,28 @@ The following defines the help output for the `pywbemcli connection create --hel
 ::
 
     Usage: pywbemcli connection create [COMMAND-OPTIONS] name SERVER
-    
+
       Create a new named connection from the input parameters.
-    
+
       This subcommand creates and saves a new named connection from the input
       parameters.
-    
+
       The name and server arguments MUST exist. They define the server uri and
       the unique name under which this server connection information will be
       stored. All other properties are optional.
-    
+
       It does NOT automatically set the pywbemcli to use that connection. Use
       `connection select` to set a particular stored connection definition as
       the current connection.
-    
+
       This is the alternative means of defining a new WBEM server to be accessed
       to supplying the parameters on the command line. and using the connection
       set command to put it into the connection repository.
-    
+
       Defines a new connection that can be referenced by the name argument in
       the future.  This connection object is capable of managing all of the
       properties defined for WBEMConnections.
-    
+
     Options:
       -d, --default_namespace TEXT  Default Namespace to use in the target
                                     WBEMServer if no namespace is defined in the
@@ -553,7 +543,6 @@ The following defines the help output for the `pywbemcli connection create --hel
       --help                        Show this message and exit.
 
 
-
 .. _`pywbemcli connection delete --help`:
 
 pywbemcli connection delete --help
@@ -567,13 +556,12 @@ The following defines the help output for the `pywbemcli connection delete --hel
 ::
 
     Usage: pywbemcli connection delete [COMMAND-OPTIONS] name
-    
+
       Show the current connection information, i.e. all the variables that make
       up the current connection
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli connection export --help`:
@@ -589,15 +577,14 @@ The following defines the help output for the `pywbemcli connection export --hel
 ::
 
     Usage: pywbemcli connection export [COMMAND-OPTIONS]
-    
+
       Export  the current connection information.
-    
+
       Creates an export statement for each connection variable and outputs the
       statement to the conole.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli connection list --help`:
@@ -613,13 +600,12 @@ The following defines the help output for the `pywbemcli connection list --help`
 ::
 
     Usage: pywbemcli connection list [COMMAND-OPTIONS]
-    
+
       Execute a simple wbem request to test that the connection exists and is
       working.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli connection select --help`:
@@ -635,12 +621,11 @@ The following defines the help output for the `pywbemcli connection select --hel
 ::
 
     Usage: pywbemcli connection select [COMMAND-OPTIONS] name
-    
+
       Select a connection from the current defined connections
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli connection set --help`:
@@ -656,16 +641,15 @@ The following defines the help output for the `pywbemcli connection set --help` 
 ::
 
     Usage: pywbemcli connection set [COMMAND-OPTIONS] name
-    
+
       Set current connection into repository.
-    
+
       Sets the current wbem connection information into the repository of
       connections. If the name does not already exist in the connection
       information, the provided name is used.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli connection show --help`:
@@ -681,13 +665,12 @@ The following defines the help output for the `pywbemcli connection show --help`
 ::
 
     Usage: pywbemcli connection show [COMMAND-OPTIONS] name
-    
+
       Show the current connection information, i.e. all the variables that make
       up the current connection
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli connection test --help`:
@@ -703,13 +686,12 @@ The following defines the help output for the `pywbemcli connection test --help`
 ::
 
     Usage: pywbemcli connection test [COMMAND-OPTIONS]
-    
+
       Execute a simple wbem request to test that the connection exists and is
       working.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli help --help`:
@@ -725,12 +707,11 @@ The following defines the help output for the `pywbemcli help --help` subcommand
 ::
 
     Usage: pywbemcli help [OPTIONS]
-    
+
       Show help message for interactive mode.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli instance --help`:
@@ -746,20 +727,20 @@ The following defines the help output for the `pywbemcli instance --help` subcom
 ::
 
     Usage: pywbemcli instance [COMMAND-OPTIONS] COMMAND [ARGS]...
-    
+
       Command Group to manage CIM instances.
-    
+
       This incudes functions to get, enumerate, create, modify, and delete
       instances in a namspace and additional functions to get more general
       information on instances (ex. counts) within the namespace
-    
+
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
       command. These are NOT retained after the command is executed.
-    
+
     Options:
       --help  Show this message and exit.
-    
+
     Commands:
       associators   Get the associated instances or instance...
       count         Get number of instances for each class in...
@@ -770,7 +751,6 @@ The following defines the help output for the `pywbemcli instance --help` subcom
       invokemethod  Invoke the method defined by instancename and...
       query         Execute the query defined by the query...
       references    Get the reference instances or instance...
-
 
 
 .. _`pywbemcli instance associators --help`:
@@ -786,14 +766,14 @@ The following defines the help output for the `pywbemcli instance associators --
 ::
 
     Usage: pywbemcli instance associators [COMMAND-OPTIONS] INSTANCENAME
-    
+
       Get the associated instances or instance names.
-    
+
       Returns the associated instances or names (names-only option) for the
       INSTANCENAME argument filtered by the assocclass, resultclass, role and
       resultrole arguments. This may be executed interactively by providing only
       a classname and the interactive option.
-    
+
     Options:
       -a, --assocclass <class name>   Filter by the associated instancename
                                       provided.
@@ -822,7 +802,6 @@ The following defines the help output for the `pywbemcli instance associators --
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli instance count --help`:
 
 pywbemcli instance count --help
@@ -836,30 +815,29 @@ The following defines the help output for the `pywbemcli instance count --help` 
 ::
 
     Usage: pywbemcli instance count [COMMAND-OPTIONS] CLASSNAME regex
-    
+
       Get number of instances for each class in namespace.
-    
+
       The size of the response may be limited by CLASSNAME argument which
       defines a classname regular expression so that only those classes are
       counted
-    
+
       The CLASSNAME argument is optional.
-    
+
       The CLASSNAME argument may be either a complete classname or a regular
       expression that can be matched to one or more classnames. To limit the
       filter to a single classname, terminate the classname with $.
-    
+
       The regular expression is anchored to the beginning of the classname and
       is case insensitive. Thus pywbem_ returns all classes that begin with
       PyWBEM_, pywbem_, etc.
-    
+
     Options:
       -s, --sort              Sort by instance count. Otherwise sorted by
                               classname
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       --help                  Show this message and exit.
-
 
 
 .. _`pywbemcli instance create --help`:
@@ -875,9 +853,9 @@ The following defines the help output for the `pywbemcli instance create --help`
 ::
 
     Usage: pywbemcli instance create [COMMAND-OPTIONS] classname
-    
+
       Create an instance of classname.
-    
+
     Options:
       -x, --property property         Optional multiple property definitions of
                                       form name=value
@@ -895,7 +873,6 @@ The following defines the help output for the `pywbemcli instance create --help`
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli instance delete --help`:
 
 pywbemcli instance delete --help
@@ -909,11 +886,11 @@ The following defines the help output for the `pywbemcli instance delete --help`
 ::
 
     Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME
-    
+
       Delete a single instance defined by instancename from the WBEM server.
       This may be executed interactively by providing only a classname and the
       interactive option.
-    
+
     Options:
       -i, --interactive       If set, instancename argument must be a class and
                               user is provided with a list of instances of the
@@ -921,7 +898,6 @@ The following defines the help output for the `pywbemcli instance delete --help`
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       --help                  Show this message and exit.
-
 
 
 .. _`pywbemcli instance enumerate --help`:
@@ -937,13 +913,13 @@ The following defines the help output for the `pywbemcli instance enumerate --he
 ::
 
     Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME
-    
+
       Enumerate instances or instance names from the WBEMServer starting either
       at the top  of the hiearchy (if no classname provided) or from the
       classname argument provided.
-    
+
       Displays the returned instances or names
-    
+
     Options:
       -l, --localonly                 Show only local properties of the class.
       -d, --deepinheritance           Return properties in subclasses of defined
@@ -967,7 +943,6 @@ The following defines the help output for the `pywbemcli instance enumerate --he
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli instance get --help`:
 
 pywbemcli instance get --help
@@ -981,14 +956,14 @@ The following defines the help output for the `pywbemcli instance get --help` su
 ::
 
     Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME
-    
+
       Get a single CIMInstance.
-    
+
       Gets the instance defined by instancename.
-    
+
       This may be executed interactively by providing only a classname and the
       interactive option.
-    
+
     Options:
       -l, --localonly                 Show only local properties of the returned
                                       instance.
@@ -1013,7 +988,6 @@ The following defines the help output for the `pywbemcli instance get --help` su
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli instance invokemethod --help`:
 
 pywbemcli instance invokemethod --help
@@ -1027,12 +1001,12 @@ The following defines the help output for the `pywbemcli instance invokemethod -
 ::
 
     Usage: pywbemcli instance invokemethod [COMMAND-OPTIONS] name name
-    
+
       Invoke the method defined by instancename and methodname with parameters.
-    
+
       This issues an instance level invokemethod request and displays the
       results.
-    
+
     Options:
       -p, --parameter parameter  Optional multiple method parameters of form
                                  name=value
@@ -1044,7 +1018,6 @@ The following defines the help output for the `pywbemcli instance invokemethod -
                                  that namespace overrides the general options
                                  namespace
       --help                     Show this message and exit.
-
 
 
 .. _`pywbemcli instance query --help`:
@@ -1060,9 +1033,9 @@ The following defines the help output for the `pywbemcli instance query --help` 
 ::
 
     Usage: pywbemcli instance query [COMMAND-OPTIONS] <query string>
-    
+
       Execute the query defined by the query argument.
-    
+
     Options:
       -l, --querylanguage <query language>
                                       Use the query language defined. (Default:
@@ -1072,7 +1045,6 @@ The following defines the help output for the `pywbemcli instance query --help` 
                                       options namespace
       -s, --sort                      Sort into alphabetical order by classname.
       --help                          Show this message and exit.
-
 
 
 .. _`pywbemcli instance references --help`:
@@ -1088,14 +1060,14 @@ The following defines the help output for the `pywbemcli instance references --h
 ::
 
     Usage: pywbemcli instance references [COMMAND-OPTIONS] INSTANCENAME
-    
+
       Get the reference instances or instance names.
-    
+
       For the INSTANCENAME argument provided return instances or instance names
       (names-only option) filtered by the role and result class options. This
       may be executed interactively by providing only a classname and the
       interactive option.
-    
+
     Options:
       -r, --resultclass <class name>  Filter by the result class name provided.
       -o, --role <role name>          Filter by the role name provided.
@@ -1121,7 +1093,6 @@ The following defines the help output for the `pywbemcli instance references --h
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli qualifier --help`:
 
 pywbemcli qualifier --help
@@ -1135,25 +1106,24 @@ The following defines the help output for the `pywbemcli qualifier --help` subco
 ::
 
     Usage: pywbemcli qualifier [COMMAND-OPTIONS] COMMAND [ARGS]...
-    
+
       Command Group to manage CIM QualifierDeclarations.
-    
+
       Includes the capability to get and enumerate qualifier declarations.
-    
+
       This does not provide the capability to create or delete CIM
       QualifierDeclarations
-    
+
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
       command. These are NOT retained after the command is executed.
-    
+
     Options:
       --help  Show this message and exit.
-    
+
     Commands:
       enumerate  Enumerate CIMQualifierDeclaractions.
       get        Display CIMQualifierDeclaration.
-
 
 
 .. _`pywbemcli qualifier enumerate --help`:
@@ -1169,18 +1139,17 @@ The following defines the help output for the `pywbemcli qualifier enumerate --h
 ::
 
     Usage: pywbemcli qualifier enumerate [COMMAND-OPTIONS]
-    
+
       Enumerate CIMQualifierDeclaractions.
-    
+
       Displays all of the CIMQualifierDeclaration objects in the defined
       namespace in the current WBEM Server
-    
+
     Options:
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       -s, --sort              Sort into alphabetical order by classname.
       --help                  Show this message and exit.
-
 
 
 .. _`pywbemcli qualifier get --help`:
@@ -1196,17 +1165,16 @@ The following defines the help output for the `pywbemcli qualifier get --help` s
 ::
 
     Usage: pywbemcli qualifier get [COMMAND-OPTIONS] NAME
-    
+
       Display CIMQualifierDeclaration.
-    
+
       Displays a single CIMQualifierDeclaration for the defined namespace in the
       current WBEMServer
-    
+
     Options:
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       --help                  Show this message and exit.
-
 
 
 .. _`pywbemcli repl --help`:
@@ -1222,13 +1190,12 @@ The following defines the help output for the `pywbemcli repl --help` subcommand
 ::
 
     Usage: pywbemcli repl [OPTIONS]
-    
+
       Enter interactive (REPL) mode (default) and load any existing history
       file.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli server --help`:
@@ -1244,16 +1211,16 @@ The following defines the help output for the `pywbemcli server --help` subcomma
 ::
 
     Usage: pywbemcli server [COMMAND-OPTIONS] COMMAND [ARGS]...
-    
+
       Command Group for WBEM server operations.
-    
+
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
       command. These are NOT retained after the command is executed.
-    
+
     Options:
       --help  Show this message and exit.
-    
+
     Commands:
       brand       Display interop namespace name in the WBEM...
       connection  Display information on the connection used by...
@@ -1262,7 +1229,6 @@ The following defines the help output for the `pywbemcli server --help` subcomma
       namespaces  Display the namespaces in the WBEM server
       profiles    Display profiles in the WBEM Server.
       test_pull   Test whether pull opeations exist on the WBEM...
-
 
 
 .. _`pywbemcli server brand --help`:
@@ -1278,12 +1244,11 @@ The following defines the help output for the `pywbemcli server brand --help` su
 ::
 
     Usage: pywbemcli server brand [COMMAND-OPTIONS]
-    
+
       Display interop namespace name in the WBEM Server.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli server connection --help`:
@@ -1299,12 +1264,11 @@ The following defines the help output for the `pywbemcli server connection --hel
 ::
 
     Usage: pywbemcli server connection [COMMAND-OPTIONS]
-    
+
       Display information on the connection used by this server.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli server info --help`:
@@ -1320,12 +1284,11 @@ The following defines the help output for the `pywbemcli server info --help` sub
 ::
 
     Usage: pywbemcli server info [COMMAND-OPTIONS]
-    
+
       Display the brand information on theWBEM Server.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli server interop --help`:
@@ -1341,12 +1304,11 @@ The following defines the help output for the `pywbemcli server interop --help` 
 ::
 
     Usage: pywbemcli server interop [COMMAND-OPTIONS]
-    
+
       Display the interop namespace name in the WBEM Server.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli server namespaces --help`:
@@ -1362,13 +1324,12 @@ The following defines the help output for the `pywbemcli server namespaces --hel
 ::
 
     Usage: pywbemcli server namespaces [COMMAND-OPTIONS]
-    
+
       Display the namespaces in the WBEM server
-    
+
     Options:
       -s, --sort  Sort into alphabetical order by classname.
       --help      Show this message and exit.
-
 
 
 .. _`pywbemcli server profiles --help`:
@@ -1384,19 +1345,18 @@ The following defines the help output for the `pywbemcli server profiles --help`
 ::
 
     Usage: pywbemcli server profiles [COMMAND-OPTIONS]
-    
+
       Display profiles in the WBEM Server.
-    
+
       This display may be filtered by the optional organization and profile name
       options
-    
+
     Options:
       -o, --organization <org name>   Filter by the defined organization. (ex. -o
                                       DMTF
       -n, --profilename <profile name>
                                       Filter by the profile name. (ex. -n Array
       --help                          Show this message and exit.
-
 
 
 .. _`pywbemcli server test_pull --help`:
@@ -1412,10 +1372,9 @@ The following defines the help output for the `pywbemcli server test_pull --help
 ::
 
     Usage: pywbemcli server test_pull [COMMAND-OPTIONS]
-    
+
       Test whether pull opeations exist on the WBEM server.
-    
+
     Options:
       --help  Show this message and exit.
-
 

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -15,20 +15,21 @@ The following defines the help output for the `pywbemcli  --help` subcommand
 ::
 
     Usage: pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS]...
-    
+
       Command line browser for WBEM Servers. This cli tool implements the
       CIM/XML client APIs as defined in pywbem to make requests to a WBEM
-      server. This browser uses subcommands to      * Explore the
-      characteristics of WBEM Servers based on using the       pywbem client
-      APIs.  It can manage/inspect CIM_Classes and       CIM_instanceson the
-      server.
-    
+      server. This browser uses subcommands to:
+
+          * Explore the characteristics of WBEM Servers based on using the
+            pywbem client APIs.  It can manage/inspect CIM_Classes and
+            CIM_instanceson the server.
+
           * In addition it can inspect namespaces and other server information
             and inspect and manage WBEM indication subscriptions.
-    
+
       The options shown above that can also be specified on any of the
       (sub-)commands as well as the command line.
-    
+
     Options:
       -s, --server TEXT               Hostname or IP address with scheme of the
                                       WBEMServer in  format
@@ -104,7 +105,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       processing.
       --version                       Show the version of this command and exit.
       --help                          Show this message and exit.
-    
+
     Commands:
       class       Command Group to manage CIM Classes.
       connection  Command group to manage WBEM connections.
@@ -113,7 +114,6 @@ The following defines the help output for the `pywbemcli  --help` subcommand
       qualifier   Command Group to manage CIM...
       repl        Enter interactive (REPL) mode (default) and...
       server      Command Group for WBEM server operations.
-
 
 
 .. _`pywbemcli class --help`:
@@ -129,16 +129,16 @@ The following defines the help output for the `pywbemcli class --help` subcomman
 ::
 
     Usage: pywbemcli class [COMMAND-OPTIONS] COMMAND [ARGS]...
-    
+
       Command Group to manage CIM Classes.
-    
+
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
       command. These are NOT retained after the command is executed.
-    
+
     Options:
       --help  Show this message and exit.
-    
+
     Commands:
       associators   Get the associated classes for the CLASSNAME.
       delete        Delete the class defined by CLASSNAME from...
@@ -148,7 +148,6 @@ The following defines the help output for the `pywbemcli class --help` subcomman
       hierarchy     Display class inheritance hierarchy as a...
       invokemethod  Invoke the class method named methodname in...
       references    Get the reference classes for the CLASSNAME.
-
 
 
 .. _`pywbemcli class associators --help`:
@@ -164,15 +163,15 @@ The following defines the help output for the `pywbemcli class associators --hel
 ::
 
     Usage: pywbemcli class associators [COMMAND-OPTIONS] CLASSNAME
-    
+
       Get the associated classes for the CLASSNAME.
-    
+
       Get the classes(or classnames) that are associated with the CLASSNAME
       argument filtered by the assocclass, resultclass, role and resultrole
       arguments options.
-    
+
       Results are displayed as defined by the output format global option.
-    
+
     Options:
       -a, --assocclass <class name>   Filter by the associated class name
                                       provided.
@@ -199,7 +198,6 @@ The following defines the help output for the `pywbemcli class associators --hel
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli class delete --help`:
 
 pywbemcli class delete --help
@@ -213,13 +211,13 @@ The following defines the help output for the `pywbemcli class delete --help` su
 ::
 
     Usage: pywbemcli class delete [COMMAND-OPTIONS] CLASSNAME
-    
+
       Delete the class defined by CLASSNAME from the WBEM Server. If the class
       has instances, the command is refused unless the --force option is used.
-    
+
       WARNING: Removing classes from a WBEM Server can cause damage to the
       server. Use this with caution.
-    
+
     Options:
       -f, --force             Force the delete request to be issued even if there
                               are instances in the server or subclasses to this
@@ -228,7 +226,6 @@ The following defines the help output for the `pywbemcli class delete --help` su
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       --help                  Show this message and exit.
-
 
 
 .. _`pywbemcli class enumerate --help`:
@@ -244,21 +241,21 @@ The following defines the help output for the `pywbemcli class enumerate --help`
 ::
 
     Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME
-    
+
       Enumerate classes from the WBEMServer.
-    
+
       Enumerates the classes (or classnames) from the WBEMServer starting either
       at the top of the class hierarchy or from  the position in the class
       hierarch defined by `classname` argument if provided.
-    
+
       The output format is defined by the output_format global option.
-    
+
       The includeclassqualifiers, includeclassorigin options define optional
       information to be included in the output.
-    
+
       The deepinheritance option defines whether the complete hiearchy is
       retrieved or just the next level in the hiearchy.
-    
+
     Options:
       -d, --deepinheritance           Return complete subclass hierarchy for this
                                       class if set. Otherwise retrieve only the
@@ -276,7 +273,6 @@ The following defines the help output for the `pywbemcli class enumerate --help`
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli class find --help`:
 
 pywbemcli class find --help
@@ -290,31 +286,30 @@ The following defines the help output for the `pywbemcli class find --help` subc
 ::
 
     Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME regex
-    
+
       Find all classes that match the CLASSNAME regex.
-    
+
       Find all of the classes in the namespace  of the defined WBEMServer that
       match the CLASSNAME  regular expression argument in the namespaces of the
       defined WBEMserver.
-    
+
       The CLASSNAME argument is required.
-    
+
       The CLASSNAME argument may be either a complete classname or a regular
       expression that can be matched to one or more classnames. To limit the
       filter to a single classname, terminate the classname with $.
-    
+
       The regular expression is anchored to the beginning of the classname and
       is case insensitive. Thus pywbem_ returns all classes that begin with
       PyWBEM_, pywbem_, etc.
-    
+
       The namespace option limits the search to the defined namespace
-    
+
     Options:
       -s, --sort              Sort into alphabetical order by classname.
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       --help                  Show this message and exit.
-
 
 
 .. _`pywbemcli class get --help`:
@@ -330,9 +325,9 @@ The following defines the help output for the `pywbemcli class get --help` subco
 ::
 
     Usage: pywbemcli class get [COMMAND-OPTIONS] CLASSNAME
-    
+
       get and display a single CIM class from the WBEM Server
-    
+
     Options:
       -l, --localonly                 Show only local properties of the class.
       --includequalifiers / --no_includequalifiers
@@ -353,7 +348,6 @@ The following defines the help output for the `pywbemcli class get --help` subco
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli class hierarchy --help`:
 
 pywbemcli class hierarchy --help
@@ -367,20 +361,19 @@ The following defines the help output for the `pywbemcli class hierarchy --help`
 ::
 
     Usage: pywbemcli class hierarchy [COMMAND-OPTIONS] CLASSNAME
-    
+
       Display class inheritance hierarchy as a tree.
-    
+
       The classname option, if it exists defines the topmost class of the
       hierarchy to include in the display. This is a separate subcommand because
       it is tied specifically to displaying in a tree format.
-    
+
     Options:
       -s, --superclasses      Display the superclasses to CLASSNAME.  In this case
                               CLASSNAME is required
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       --help                  Show this message and exit.
-
 
 
 .. _`pywbemcli class invokemethod --help`:
@@ -396,9 +389,9 @@ The following defines the help output for the `pywbemcli class invokemethod --he
 ::
 
     Usage: pywbemcli class invokemethod [COMMAND-OPTIONS] classname name
-    
+
       Invoke the class method named methodname in the class classname
-    
+
     Options:
       -p, --parameter parameter  Optional multiple method parameters of form
                                  name=value
@@ -406,7 +399,6 @@ The following defines the help output for the `pywbemcli class invokemethod --he
                                  that namespace overrides the general options
                                  namespace
       --help                     Show this message and exit.
-
 
 
 .. _`pywbemcli class references --help`:
@@ -422,13 +414,13 @@ The following defines the help output for the `pywbemcli class references --help
 ::
 
     Usage: pywbemcli class references [COMMAND-OPTIONS] CLASSNAME
-    
+
       Get the reference classes for the CLASSNAME.
-    
+
       Get the reference classes (or their classnames) for the CLASSNAME argument
       filtered by the role and result class options and modified  by the other
       options.
-    
+
     Options:
       -r, --resultclass <class name>  Filter by the classname provided.
       -x, --role <role name>          Filter by the role name provided.
@@ -452,7 +444,6 @@ The following defines the help output for the `pywbemcli class references --help
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli connection --help`:
 
 pywbemcli connection --help
@@ -466,18 +457,18 @@ The following defines the help output for the `pywbemcli connection --help` subc
 ::
 
     Usage: pywbemcli connection [COMMAND-OPTIONS] COMMAND [ARGS]...
-    
+
       Command group to manage WBEM connections.
-    
+
       These command allow viewing and setting connection information.
-    
+
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
       command. These are NOT retained after the command is executed.
-    
+
     Options:
       --help  Show this message and exit.
-    
+
     Commands:
       create  Create a new named connection from the input...
       delete  Show the current connection information, i.e.
@@ -487,7 +478,6 @@ The following defines the help output for the `pywbemcli connection --help` subc
       set     Set current connection into repository.
       show    Show the current connection information, i.e.
       test    Execute a simple wbem request to test that...
-
 
 
 .. _`pywbemcli connection create --help`:
@@ -503,28 +493,28 @@ The following defines the help output for the `pywbemcli connection create --hel
 ::
 
     Usage: pywbemcli connection create [COMMAND-OPTIONS] name SERVER
-    
+
       Create a new named connection from the input parameters.
-    
+
       This subcommand creates and saves a new named connection from the input
       parameters.
-    
+
       The name and server arguments MUST exist. They define the server uri and
       the unique name under which this server connection information will be
       stored. All other properties are optional.
-    
+
       It does NOT automatically set the pywbemcli to use that connection. Use
       `connection select` to set a particular stored connection definition as
       the current connection.
-    
+
       This is the alternative means of defining a new WBEM server to be accessed
       to supplying the parameters on the command line. and using the connection
       set command to put it into the connection repository.
-    
+
       Defines a new connection that can be referenced by the name argument in
       the future.  This connection object is capable of managing all of the
       properties defined for WBEMConnections.
-    
+
     Options:
       -d, --default_namespace TEXT  Default Namespace to use in the target
                                     WBEMServer if no namespace is defined in the
@@ -553,7 +543,6 @@ The following defines the help output for the `pywbemcli connection create --hel
       --help                        Show this message and exit.
 
 
-
 .. _`pywbemcli connection delete --help`:
 
 pywbemcli connection delete --help
@@ -567,13 +556,12 @@ The following defines the help output for the `pywbemcli connection delete --hel
 ::
 
     Usage: pywbemcli connection delete [COMMAND-OPTIONS] name
-    
+
       Show the current connection information, i.e. all the variables that make
       up the current connection
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli connection export --help`:
@@ -589,15 +577,14 @@ The following defines the help output for the `pywbemcli connection export --hel
 ::
 
     Usage: pywbemcli connection export [COMMAND-OPTIONS]
-    
+
       Export  the current connection information.
-    
+
       Creates an export statement for each connection variable and outputs the
       statement to the conole.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli connection list --help`:
@@ -613,13 +600,12 @@ The following defines the help output for the `pywbemcli connection list --help`
 ::
 
     Usage: pywbemcli connection list [COMMAND-OPTIONS]
-    
+
       Execute a simple wbem request to test that the connection exists and is
       working.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli connection select --help`:
@@ -635,12 +621,11 @@ The following defines the help output for the `pywbemcli connection select --hel
 ::
 
     Usage: pywbemcli connection select [COMMAND-OPTIONS] name
-    
+
       Select a connection from the current defined connections
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli connection set --help`:
@@ -656,16 +641,15 @@ The following defines the help output for the `pywbemcli connection set --help` 
 ::
 
     Usage: pywbemcli connection set [COMMAND-OPTIONS] name
-    
+
       Set current connection into repository.
-    
+
       Sets the current wbem connection information into the repository of
       connections. If the name does not already exist in the connection
       information, the provided name is used.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli connection show --help`:
@@ -681,13 +665,12 @@ The following defines the help output for the `pywbemcli connection show --help`
 ::
 
     Usage: pywbemcli connection show [COMMAND-OPTIONS] name
-    
+
       Show the current connection information, i.e. all the variables that make
       up the current connection
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli connection test --help`:
@@ -703,13 +686,12 @@ The following defines the help output for the `pywbemcli connection test --help`
 ::
 
     Usage: pywbemcli connection test [COMMAND-OPTIONS]
-    
+
       Execute a simple wbem request to test that the connection exists and is
       working.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli help --help`:
@@ -725,12 +707,11 @@ The following defines the help output for the `pywbemcli help --help` subcommand
 ::
 
     Usage: pywbemcli help [OPTIONS]
-    
+
       Show help message for interactive mode.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli instance --help`:
@@ -746,20 +727,20 @@ The following defines the help output for the `pywbemcli instance --help` subcom
 ::
 
     Usage: pywbemcli instance [COMMAND-OPTIONS] COMMAND [ARGS]...
-    
+
       Command Group to manage CIM instances.
-    
+
       This incudes functions to get, enumerate, create, modify, and delete
       instances in a namspace and additional functions to get more general
       information on instances (ex. counts) within the namespace
-    
+
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
       command. These are NOT retained after the command is executed.
-    
+
     Options:
       --help  Show this message and exit.
-    
+
     Commands:
       associators   Get the associated instances or instance...
       count         Get number of instances for each class in...
@@ -770,7 +751,6 @@ The following defines the help output for the `pywbemcli instance --help` subcom
       invokemethod  Invoke the method defined by instancename and...
       query         Execute the query defined by the query...
       references    Get the reference instances or instance...
-
 
 
 .. _`pywbemcli instance associators --help`:
@@ -786,14 +766,14 @@ The following defines the help output for the `pywbemcli instance associators --
 ::
 
     Usage: pywbemcli instance associators [COMMAND-OPTIONS] INSTANCENAME
-    
+
       Get the associated instances or instance names.
-    
+
       Returns the associated instances or names (names-only option) for the
       INSTANCENAME argument filtered by the assocclass, resultclass, role and
       resultrole arguments. This may be executed interactively by providing only
       a classname and the interactive option.
-    
+
     Options:
       -a, --assocclass <class name>   Filter by the associated instancename
                                       provided.
@@ -822,7 +802,6 @@ The following defines the help output for the `pywbemcli instance associators --
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli instance count --help`:
 
 pywbemcli instance count --help
@@ -836,30 +815,29 @@ The following defines the help output for the `pywbemcli instance count --help` 
 ::
 
     Usage: pywbemcli instance count [COMMAND-OPTIONS] CLASSNAME regex
-    
+
       Get number of instances for each class in namespace.
-    
+
       The size of the response may be limited by CLASSNAME argument which
       defines a classname regular expression so that only those classes are
       counted
-    
+
       The CLASSNAME argument is optional.
-    
+
       The CLASSNAME argument may be either a complete classname or a regular
       expression that can be matched to one or more classnames. To limit the
       filter to a single classname, terminate the classname with $.
-    
+
       The regular expression is anchored to the beginning of the classname and
       is case insensitive. Thus pywbem_ returns all classes that begin with
       PyWBEM_, pywbem_, etc.
-    
+
     Options:
       -s, --sort              Sort by instance count. Otherwise sorted by
                               classname
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       --help                  Show this message and exit.
-
 
 
 .. _`pywbemcli instance create --help`:
@@ -875,9 +853,9 @@ The following defines the help output for the `pywbemcli instance create --help`
 ::
 
     Usage: pywbemcli instance create [COMMAND-OPTIONS] classname
-    
+
       Create an instance of classname.
-    
+
     Options:
       -x, --property property         Optional multiple property definitions of
                                       form name=value
@@ -895,7 +873,6 @@ The following defines the help output for the `pywbemcli instance create --help`
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli instance delete --help`:
 
 pywbemcli instance delete --help
@@ -909,11 +886,11 @@ The following defines the help output for the `pywbemcli instance delete --help`
 ::
 
     Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME
-    
+
       Delete a single instance defined by instancename from the WBEM server.
       This may be executed interactively by providing only a classname and the
       interactive option.
-    
+
     Options:
       -i, --interactive       If set, instancename argument must be a class and
                               user is provided with a list of instances of the
@@ -921,7 +898,6 @@ The following defines the help output for the `pywbemcli instance delete --help`
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       --help                  Show this message and exit.
-
 
 
 .. _`pywbemcli instance enumerate --help`:
@@ -937,13 +913,13 @@ The following defines the help output for the `pywbemcli instance enumerate --he
 ::
 
     Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME
-    
+
       Enumerate instances or instance names from the WBEMServer starting either
       at the top  of the hiearchy (if no classname provided) or from the
       classname argument provided.
-    
+
       Displays the returned instances or names
-    
+
     Options:
       -l, --localonly                 Show only local properties of the class.
       -d, --deepinheritance           Return properties in subclasses of defined
@@ -967,7 +943,6 @@ The following defines the help output for the `pywbemcli instance enumerate --he
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli instance get --help`:
 
 pywbemcli instance get --help
@@ -981,14 +956,14 @@ The following defines the help output for the `pywbemcli instance get --help` su
 ::
 
     Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME
-    
+
       Get a single CIMInstance.
-    
+
       Gets the instance defined by instancename.
-    
+
       This may be executed interactively by providing only a classname and the
       interactive option.
-    
+
     Options:
       -l, --localonly                 Show only local properties of the returned
                                       instance.
@@ -1013,7 +988,6 @@ The following defines the help output for the `pywbemcli instance get --help` su
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli instance invokemethod --help`:
 
 pywbemcli instance invokemethod --help
@@ -1027,12 +1001,12 @@ The following defines the help output for the `pywbemcli instance invokemethod -
 ::
 
     Usage: pywbemcli instance invokemethod [COMMAND-OPTIONS] name name
-    
+
       Invoke the method defined by instancename and methodname with parameters.
-    
+
       This issues an instance level invokemethod request and displays the
       results.
-    
+
     Options:
       -p, --parameter parameter  Optional multiple method parameters of form
                                  name=value
@@ -1044,7 +1018,6 @@ The following defines the help output for the `pywbemcli instance invokemethod -
                                  that namespace overrides the general options
                                  namespace
       --help                     Show this message and exit.
-
 
 
 .. _`pywbemcli instance query --help`:
@@ -1060,9 +1033,9 @@ The following defines the help output for the `pywbemcli instance query --help` 
 ::
 
     Usage: pywbemcli instance query [COMMAND-OPTIONS] <query string>
-    
+
       Execute the query defined by the query argument.
-    
+
     Options:
       -l, --querylanguage <query language>
                                       Use the query language defined. (Default:
@@ -1072,7 +1045,6 @@ The following defines the help output for the `pywbemcli instance query --help` 
                                       options namespace
       -s, --sort                      Sort into alphabetical order by classname.
       --help                          Show this message and exit.
-
 
 
 .. _`pywbemcli instance references --help`:
@@ -1088,14 +1060,14 @@ The following defines the help output for the `pywbemcli instance references --h
 ::
 
     Usage: pywbemcli instance references [COMMAND-OPTIONS] INSTANCENAME
-    
+
       Get the reference instances or instance names.
-    
+
       For the INSTANCENAME argument provided return instances or instance names
       (names-only option) filtered by the role and result class options. This
       may be executed interactively by providing only a classname and the
       interactive option.
-    
+
     Options:
       -r, --resultclass <class name>  Filter by the result class name provided.
       -o, --role <role name>          Filter by the role name provided.
@@ -1121,7 +1093,6 @@ The following defines the help output for the `pywbemcli instance references --h
       --help                          Show this message and exit.
 
 
-
 .. _`pywbemcli qualifier --help`:
 
 pywbemcli qualifier --help
@@ -1135,25 +1106,24 @@ The following defines the help output for the `pywbemcli qualifier --help` subco
 ::
 
     Usage: pywbemcli qualifier [COMMAND-OPTIONS] COMMAND [ARGS]...
-    
+
       Command Group to manage CIM QualifierDeclarations.
-    
+
       Includes the capability to get and enumerate qualifier declarations.
-    
+
       This does not provide the capability to create or delete CIM
       QualifierDeclarations
-    
+
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
       command. These are NOT retained after the command is executed.
-    
+
     Options:
       --help  Show this message and exit.
-    
+
     Commands:
       enumerate  Enumerate CIMQualifierDeclaractions.
       get        Display CIMQualifierDeclaration.
-
 
 
 .. _`pywbemcli qualifier enumerate --help`:
@@ -1169,18 +1139,17 @@ The following defines the help output for the `pywbemcli qualifier enumerate --h
 ::
 
     Usage: pywbemcli qualifier enumerate [COMMAND-OPTIONS]
-    
+
       Enumerate CIMQualifierDeclaractions.
-    
+
       Displays all of the CIMQualifierDeclaration objects in the defined
       namespace in the current WBEM Server
-    
+
     Options:
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       -s, --sort              Sort into alphabetical order by classname.
       --help                  Show this message and exit.
-
 
 
 .. _`pywbemcli qualifier get --help`:
@@ -1196,17 +1165,16 @@ The following defines the help output for the `pywbemcli qualifier get --help` s
 ::
 
     Usage: pywbemcli qualifier get [COMMAND-OPTIONS] NAME
-    
+
       Display CIMQualifierDeclaration.
-    
+
       Displays a single CIMQualifierDeclaration for the defined namespace in the
       current WBEMServer
-    
+
     Options:
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       --help                  Show this message and exit.
-
 
 
 .. _`pywbemcli repl --help`:
@@ -1222,13 +1190,12 @@ The following defines the help output for the `pywbemcli repl --help` subcommand
 ::
 
     Usage: pywbemcli repl [OPTIONS]
-    
+
       Enter interactive (REPL) mode (default) and load any existing history
       file.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli server --help`:
@@ -1244,16 +1211,16 @@ The following defines the help output for the `pywbemcli server --help` subcomma
 ::
 
     Usage: pywbemcli server [COMMAND-OPTIONS] COMMAND [ARGS]...
-    
+
       Command Group for WBEM server operations.
-    
+
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
       command. These are NOT retained after the command is executed.
-    
+
     Options:
       --help  Show this message and exit.
-    
+
     Commands:
       brand       Display interop namespace name in the WBEM...
       connection  Display information on the connection used by...
@@ -1262,7 +1229,6 @@ The following defines the help output for the `pywbemcli server --help` subcomma
       namespaces  Display the namespaces in the WBEM server
       profiles    Display profiles in the WBEM Server.
       test_pull   Test whether pull opeations exist on the WBEM...
-
 
 
 .. _`pywbemcli server brand --help`:
@@ -1278,12 +1244,11 @@ The following defines the help output for the `pywbemcli server brand --help` su
 ::
 
     Usage: pywbemcli server brand [COMMAND-OPTIONS]
-    
+
       Display interop namespace name in the WBEM Server.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli server connection --help`:
@@ -1299,12 +1264,11 @@ The following defines the help output for the `pywbemcli server connection --hel
 ::
 
     Usage: pywbemcli server connection [COMMAND-OPTIONS]
-    
+
       Display information on the connection used by this server.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli server info --help`:
@@ -1320,12 +1284,11 @@ The following defines the help output for the `pywbemcli server info --help` sub
 ::
 
     Usage: pywbemcli server info [COMMAND-OPTIONS]
-    
+
       Display the brand information on theWBEM Server.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli server interop --help`:
@@ -1341,12 +1304,11 @@ The following defines the help output for the `pywbemcli server interop --help` 
 ::
 
     Usage: pywbemcli server interop [COMMAND-OPTIONS]
-    
+
       Display the interop namespace name in the WBEM Server.
-    
+
     Options:
       --help  Show this message and exit.
-
 
 
 .. _`pywbemcli server namespaces --help`:
@@ -1362,13 +1324,12 @@ The following defines the help output for the `pywbemcli server namespaces --hel
 ::
 
     Usage: pywbemcli server namespaces [COMMAND-OPTIONS]
-    
+
       Display the namespaces in the WBEM server
-    
+
     Options:
       -s, --sort  Sort into alphabetical order by classname.
       --help      Show this message and exit.
-
 
 
 .. _`pywbemcli server profiles --help`:
@@ -1384,19 +1345,18 @@ The following defines the help output for the `pywbemcli server profiles --help`
 ::
 
     Usage: pywbemcli server profiles [COMMAND-OPTIONS]
-    
+
       Display profiles in the WBEM Server.
-    
+
       This display may be filtered by the optional organization and profile name
       options
-    
+
     Options:
       -o, --organization <org name>   Filter by the defined organization. (ex. -o
                                       DMTF
       -n, --profilename <profile name>
                                       Filter by the profile name. (ex. -n Array
       --help                          Show this message and exit.
-
 
 
 .. _`pywbemcli server test_pull --help`:
@@ -1412,10 +1372,9 @@ The following defines the help output for the `pywbemcli server test_pull --help
 ::
 
     Usage: pywbemcli server test_pull [COMMAND-OPTIONS]
-    
+
       Test whether pull opeations exist on the WBEM server.
-    
+
     Options:
       --help  Show this message and exit.
-
 

--- a/pywbemcli/pywbemcli.py
+++ b/pywbemcli/pywbemcli.py
@@ -132,7 +132,8 @@ def cli(ctx, server, name, default_namespace, user, password, timeout, noverify,
     """
     Command line browser for WBEM Servers. This cli tool implements the
     CIM/XML client APIs as defined in pywbem to make requests to a WBEM
-    server. This browser uses subcommands to
+    server. This browser uses subcommands to:
+
     \b
         * Explore the characteristics of WBEM Servers based on using the
           pywbem client APIs.  It can manage/inspect CIM_Classes and

--- a/tools/click_help_capture.py
+++ b/tools/click_help_capture.py
@@ -84,15 +84,21 @@ def rst_headline(title, level):
 
 def print_rst_verbatum_text(text_str):
     """
-    Print the text on input surrounded by the back quotes defining
-    veratum text
+    Print the text on input proceeded by the rst literal block indicator
     """
     print('::\n')
     # indent text for rst. rst requires that block monospace test be
     # indented and preceeded by line with just '::' and followed by
-    # empty line. This indents by two char the complete test_str except
-    # the first line
-    print('%s\n' % indent(text_str, 4))
+    # empty line. Indent all lines with text
+
+    lines = text_str.split('\n')
+    new_lines = []
+    for line in lines:
+        if line:
+            new_lines.append(indent(line, 4))
+        else:
+            new_lines.append(line)
+    print('%s' % '\n'.join(new_lines))
 
 
 HELP_DICT = {}
@@ -134,7 +140,7 @@ def get_subcmd_group_names(script_name, cmd):
                            ' from %s call. stderr %s' % (script_name,
                                                          exitcode,
                                                          std_err))
-    if len(std_err):
+    if std_err:
         raise RuntimeError('Error. expected stderr (%s)returned from '
                            '%s call.' % (script_name, std_err))
 
@@ -145,7 +151,7 @@ def get_subcmd_group_names(script_name, cmd):
     group_list = []
     group_state = False
     for line in lines:
-        if group_state and len(line):
+        if group_state and line:
             # split line into list of words and get first word as subcommand
             words = line.split()
             group_list.append(words[0])


### PR DESCRIPTION
A missing empty line in the cli comment for pywbemcli was
causing formatting issues with help output. Added
space and rebuilt the help output

Correct issue with creating help info for docs

We were indenting all lines from the help.  This meant that empty
lines end up with spaces. Added code to clear any line that
only have spaces.