### PR TITLE
Fix error in cmd_server.py

### DIFF
--- a/pywbemcli/_cmd_server.py
+++ b/pywbemcli/_cmd_server.py
@@ -39,7 +39,7 @@ def print_profile_info(org_vm, inst):
 
 
 @cli.group('server', options_metavar=CMD_OPTS_TXT)
-def class_group():
+def server_group():
     """
     Command Group for WBEM server operations.
 
@@ -50,7 +50,7 @@ def class_group():
     pass
 
 
-@class_group.command('namespaces', options_metavar=CMD_OPTS_TXT)
+@server_group.command('namespaces', options_metavar=CMD_OPTS_TXT)
 @add_options(sort_option)
 @click.pass_obj
 def server_namespaces(context, **options):
@@ -61,7 +61,7 @@ def server_namespaces(context, **options):
     context.execute_cmd(lambda: cmd_server_namespaces(context, options))
 
 
-@class_group.command('interop', options_metavar=CMD_OPTS_TXT)
+@server_group.command('interop', options_metavar=CMD_OPTS_TXT)
 @click.pass_obj
 def server_interop(context):
     """
@@ -71,7 +71,7 @@ def server_interop(context):
     context.execute_cmd(lambda: cmd_server_interop(context))
 
 
-@class_group.command('brand', options_metavar=CMD_OPTS_TXT)
+@server_group.command('brand', options_metavar=CMD_OPTS_TXT)
 @click.pass_obj
 def server_brand(context):
     """
@@ -81,7 +81,7 @@ def server_brand(context):
     context.execute_cmd(lambda: cmd_server_brand(context))
 
 
-@class_group.command('info', options_metavar=CMD_OPTS_TXT)
+@server_group.command('info', options_metavar=CMD_OPTS_TXT)
 @click.pass_obj
 def server_info(context):
     """
@@ -90,7 +90,7 @@ def server_info(context):
     context.execute_cmd(lambda: cmd_server_info(context))
 
 
-@class_group.command('profiles', options_metavar=CMD_OPTS_TXT)
+@server_group.command('profiles', options_metavar=CMD_OPTS_TXT)
 @click.option('-o', '--organization', type=str, required=False,
               metavar='<org name>',
               help='Filter by the defined organization. (ex. -o DMTF')
@@ -108,7 +108,7 @@ def server_profiles(context, **options):
     context.execute_cmd(lambda: cmd_server_profiles(context, options))
 
 
-@class_group.command('connection', options_metavar=CMD_OPTS_TXT)
+@server_group.command('connection', options_metavar=CMD_OPTS_TXT)
 @click.pass_obj
 def server_connection(context):
     """
@@ -117,7 +117,7 @@ def server_connection(context):
     context.execute_cmd(lambda: cmd_server_connection(context))
 
 
-@class_group.command('test_pull', options_metavar=CMD_OPTS_TXT)
+@server_group.command('test_pull', options_metavar=CMD_OPTS_TXT)
 @click.pass_obj
 def server_test_pull(context):
     """


### PR DESCRIPTION
Wrong name on server subcmd definitions.  They are server not class subcommands