### PR TITLE
Fix issues with output formatting

### DIFF
--- a/pywbemcli/_cmd_connection.py
+++ b/pywbemcli/_cmd_connection.py
@@ -128,7 +128,7 @@ def connection_save(context, name):
 @click.option('-t', '--timeout', type=click.IntRange(0, MAX_TIMEOUT),
               help="Operation timeout for the WBEM Server in seconds. "
                    "Default: " + "%s" % DEFAULT_CONNECTION_TIMEOUT)
-@click.option('-n', '--noverify', type=str, is_flag=True,
+@click.option('-n', '--noverify', is_flag=True,
               help='If set, client does not verify server certificate.')
 @click.option('-c', '--certfile', type=str,
               help="Server certfile. Ignored if noverify flag set. ")

--- a/pywbemcli/_cmd_qualifier.py
+++ b/pywbemcli/_cmd_qualifier.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 import click
 from pywbem import Error
 from .pywbemcli import cli
-from ._common import display_cim_objects, CMD_OPTS_TXT
+from ._common import display_cim_objects, CMD_OPTS_TXT, output_format_is_table
 from ._common_options import sort_option, namespace_option, add_options
 
 
@@ -35,7 +35,7 @@ def qualifier_group():
     Includes the capability to get and enumerate CIM qualifier declarations
     defined in the WBEM Server.
 
-    This does not provide the capability to create or delete CIM
+    pywbemcli does not provide the capability to create or delete CIM
     QualifierDeclarations
 
     In addition to the command-specific options shown in this help text, the
@@ -76,6 +76,14 @@ def qualifier_enumerate(context, **options):
 ####################################################################
 #   Qualifier declaration command processing functions
 #####################################################################
+
+
+def qual_outputformat(output_format):
+    """ If output format is table type, force to mof"""
+
+    return 'mof' if output_format_is_table(output_format) else output_format
+
+
 def cmd_qualifier_get(context, name, options):
     """
     Execute the command for get qualifier and display result
@@ -84,7 +92,8 @@ def cmd_qualifier_get(context, name, options):
         qual_decl = context.conn.GetQualifier(name,
                                               namespace=options['namespace'])
 
-        display_cim_objects(context, qual_decl, context.output_format)
+        display_cim_objects(context, qual_decl,
+                            qual_outputformat(context.output_format))
 
     except Error as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
@@ -101,7 +110,8 @@ def cmd_qualifier_enumerate(context, options):
         if options['sort']:
             qual_decls.sort(key=lambda x: x.name)
 
-        display_cim_objects(context, qual_decls, context.output_format)
+        display_cim_objects(context, qual_decls,
+                            qual_outputformat(context.output_format))
 
     except Error as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))

--- a/pywbemcli/pywbemcli.py
+++ b/pywbemcli/pywbemcli.py
@@ -84,7 +84,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
               help="Operation timeout for the WBEM Server in seconds. "
                    "(EnvVar: PYWBEMCLI_TIMEOUT). "
                    "Default: " + "%s" % DEFAULT_CONNECTION_TIMEOUT)
-@click.option('-n', '--noverify', type=str, is_flag=True,
+@click.option('-n', '--noverify', is_flag=True,
               envvar=PywbemServer.noverify_envvar,
               help='If set, client does not verify server certificate.')
 @click.option('-c', '--certfile', type=str, envvar=PywbemServer.certfile_envvar,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-six>=1.10.0 # MIT
+six==1.10.0 # MIT     Fix this to version 1.10. See issue # 67
 pbr>=1.8 # Apache-2.0
 M2Crypto>=0.26.0
 


### PR DESCRIPTION
Formatter must consider object type and format request since there are
two basic types of formatters (cim structs and tables) and not all of
them apply to all objects.

This change:
1. Forces class and qualifier decl output to be mof if output_formatdefault set since default is simple table. It also adds error tests in some cases where output formatting cannot be
accomplished for the object type
2. Initiates definition of a table format for classes. 

It also corrects an error in that both is_flag and type str were set for
some click options. It removes the type parameter