### PR TITLE
fixes #69 Fix m2crypto to version 0.26.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@
 
 six==1.10.0 # MIT     Fix this to version 1.10. See issue # 67
 pbr>=1.8 # Apache-2.0
-M2Crypto>=0.26.0
-
+M2Crypto==0.26.0    # MIT - nail to 0.26.0 per issue # 69
 click>=6.6 # BSD
 click-spinner>=0.1.6 # MIT
 click-repl>=0.1.0 # MIT


### PR DESCRIPTION
Because of install issue raised by M2Crypto update to version 0.27.0, we
are forcing fixed issue of 0.26.0 for the moment.