### PR TITLE
Correct issues with output_format definition

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -199,6 +199,7 @@ The following defines the help output for the `pywbemcli class associators --hel
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
                                       options namespace
+      -S, --summary                   Return only summary of objects (count).
       -h, --help                      Show this message and exit.
 
 
@@ -281,6 +282,7 @@ The following defines the help output for the `pywbemcli class enumerate --help`
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
                                       options namespace
+      -S, --summary                   Return only summary of objects (count).
       -h, --help                      Show this message and exit.
 
 
@@ -429,6 +431,7 @@ The following defines the help output for the `pywbemcli class references --help
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
                                       options namespace
+      -S, --summary                   Return only summary of objects (count).
       -h, --help                      Show this message and exit.
 
 
@@ -818,6 +821,7 @@ The following defines the help output for the `pywbemcli instance associators --
                                       class and  user is provided with a list of
                                       instances of the  class from which the
                                       instance to delete is selected.
+      -S, --summary                   Return only summary of objects (count).
       -h, --help                      Show this message and exit.
 
 
@@ -971,6 +975,7 @@ The following defines the help output for the `pywbemcli instance enumerate --he
                                       options namespace
       -o, --names_only                Show only local properties of the class.
       -s, --sort                      Sort into alphabetical order by classname.
+      -S, --summary                   Return only summary of objects (count).
       -h, --help                      Show this message and exit.
 
 
@@ -1078,6 +1083,7 @@ The following defines the help output for the `pywbemcli instance query --help` 
                                       defined that namespace overrides the general
                                       options namespace
       -s, --sort                      Sort into alphabetical order by classname.
+      -S, --summary                   Return only summary of objects (count).
       -h, --help                      Show this message and exit.
 
 
@@ -1129,6 +1135,7 @@ The following defines the help output for the `pywbemcli instance references --h
                                       class and  user is provided with a list of
                                       instances of the  class from which the
                                       instance to delete is selected.
+      -S, --summary                   Return only summary of objects (count).
       -h, --help                      Show this message and exit.
 
 
@@ -1188,7 +1195,7 @@ The following defines the help output for the `pywbemcli qualifier enumerate --h
     Options:
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
-      -s, --sort              Sort into alphabetical order by classname.
+      -S, --summary           Return only summary of objects (count).
       -h, --help              Show this message and exit.
 
 

--- a/pywbemcli/_context_obj.py
+++ b/pywbemcli/_context_obj.py
@@ -59,7 +59,9 @@ class ContextObj(object):
     @property
     def output_format(self):
         """
-        :term:`string`: String defining the output format requested.
+        :term:`string`: String defining the output format requested.  This may
+        be None meaning that the default format should be used or may be
+        one of the values in the TABLE_FORMATS variable.
         """
         return self._output_format
 

--- a/pywbemcli/pywbemcli.py
+++ b/pywbemcli/pywbemcli.py
@@ -170,8 +170,8 @@ def cli(ctx, server, name, default_namespace, user, password, timeout, noverify,
 
     if ctx.obj is None:
         # Apply the documented option defaults.
-        if output_format is None:
-            output_format = DEFAULT_OUTPUT_FORMAT
+        # default for output_format is applied in processing since it depends
+        # on request (ex. mof for get class vs table for many)
         if default_namespace is None:
             default_namespace = DEFAULT_NAMESPACE
 

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -81,7 +81,7 @@ class ContainerMeta(type):
             """
             def test(self):  # pylint: disable=missing-docstring
                 cmd_opt = '-s http://localhost -u fred -p pw -k keyfile.txt ' \
-                          '-c certfile.txt -d root/blah'
+                          '-c certfile.txt -d root/cimv2'
                 command = 'pywbemcli %s %s' % (cmd_opt, cmd_str)
                 # Disable python warnings for pywbemcli call.See issue #42
                 command = 'export PYTHONWARNINGS="" && %s' % command


### PR DESCRIPTION
1. Changed output format definition to not set default until output.
This simplifies the issue between the mof structured displays and the
table displays.
2. Cleaned up code around display of paths to cover issue were the
classname return from enumerate classes is unicode, not CIMClassName.

3. Add new display function in common for display of paths including
classnames, instancenames associatornames, referencenames. This allows
displaying as table or just text output.

4. Minor fix to test_connection to use valid namespace for local tests.

5. Fix display cimobjects summary (-S) to correctly show the returned
with the count

6. Add table output to class find.