### PR TITLE
Fixes #80. Revert dev-requirements to pyzmq 16.0.2

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -40,4 +40,9 @@ twine>=1.8.1  # Apache-2.0
 jupyter>=1.0.0 # BSD
 notebook>=4.3.1
 
+# temporary fix to get around problem introduced by pyzmq 16.03 release 30
+# Oct 2017.  See issue #80
+# TODO retest this in the future so we can remove this limitation
+pyzmq==16.0.2
+
 


### PR DESCRIPTION
Wheel install of pyzmq 16.03 fails so we will use the old one for now.

Note that the final error message comes from ccache during the compile process so this could even be a ccache issue.  However, I don't really care right now.  16.0.2 works and the next morning 16.0.3 fails. We go back to 16.0.2 for now.

Marked as priority since blocks everything