### PR TITLE
Ks/fix args documentation

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -544,6 +544,7 @@ The following defines the help output for the `pywbemcli connection delete --hel
       Delete connection information from the persistent store for the connection
       defined by NAME.
 
+
     Options:
       -h, --help  Show this message and exit.
 
@@ -611,6 +612,7 @@ The following defines the help output for the `pywbemcli connection new --help` 
       Create a new named WBEM connection.
 
       This subcommand creates and saves a new named connection from the input
+
       arguments (NAME and URI) and options
 
       The new connection that can be referenced by the name argument in the

--- a/pywbemcli/_cmd_server.py
+++ b/pywbemcli/_cmd_server.py
@@ -135,7 +135,11 @@ def server_test_pull(context):
     """
     Test existence of pull opeations.
 
-    Test whether the pull operations exist on the WBEM server.
+    Test whether the pull WBEMConnection methods (ex. OpenEnumerateInstances)
+    exist on the WBEM server.
+
+    This command tests all of the pull operations and reports any that
+    return a NOT_SUPPORTED response.
     """
     context.execute_cmd(lambda: cmd_server_test_pull(context))
 


### PR DESCRIPTION
Minor fixes to pywbmemcli documentation, mostly setting case correctly on some of the comments in the
code that get to the documentation and making the first line of the group documentation strings short so the lines do not end in ... .