### PR TITLE
WIP Adds support for pywbem_mock

### DIFF
--- a/pywbemcli/_cmd_connection.py
+++ b/pywbemcli/_cmd_connection.py
@@ -238,7 +238,7 @@ def cmd_connection_export(context):
     context.spinner.stop()
     svr = context.pywbem_server
 
-    export_statement(PywbemServer.server_envvar, svr.server_uri)
+    export_statement(PywbemServer.server_envvar, svr.server_url)
 
     if_export_statement(PywbemServer.defaultnamespace_envvar,
                         svr.default_namespace)
@@ -313,7 +313,7 @@ def show_connection_information(context, svr, separate_line=True):
                '%sUser: %s%sPassword: %s%sTimeout: %s%sNoverify: %s%s'
                'Certfile: %s%sKeyfile: %s%suse_pull_ops: %s'
                % (svr.name, sep,
-                  svr.server_uri, sep,
+                  svr.server_url, sep,
                   svr.default_namespace, sep,
                   svr.user, sep,
                   svr.password, sep,
@@ -406,7 +406,7 @@ def cmd_connection_list(context):
     rows = []
 
     for name, svr in six.iteritems(pywbemcli_servers):
-        row = [name, svr.server_uri, svr.default_namespace, svr.user,
+        row = [name, svr.server_url, svr.default_namespace, svr.user,
                svr.password, svr.timeout, svr.noverify, svr.certfile,
                svr.keyfile]
         rows.append(row)

--- a/pywbemcli/_context_obj.py
+++ b/pywbemcli/_context_obj.py
@@ -53,8 +53,10 @@ class ContextObj(object):
         self._spinner = click_spinner.Spinner()
 
     def __repr__(self):
-        return 'ContextObj(pywbem_server=%s, outputformat=%s, verbose=%s' % \
-               (self.pywbem_server, self.output_format, self.verbose)
+        return 'ContextObj(pywbem_server=%s, outputformat=%s, ' \
+               'pull_max_cnt=%s, use_pull=%s, timestats=%s, verbose=%s' % \
+               (self.pywbem_server, self.output_format, self.pull_max_cnt,
+                self.use_pull, self.timestats, self.verbose)
 
     @property
     def output_format(self):
@@ -82,7 +84,7 @@ class ContextObj(object):
         return self._use_pull
 
     @property
-    def max_pull_cnt(self):
+    def pull_max_cnt(self):
         """
         :term:`string`: Maximum number of objects to be returne for pull op.
         """
@@ -246,7 +248,7 @@ class ContextObj(object):
                 # get the password if it is required.  This may involve a
                 # prompt.
                 self._pywbem_server.get_password(self)
-                self._pywbem_server.create_connection()
+                self._pywbem_server.create_connection(self.verbose)
                 PYWBEM_SERVER_OBJ = self._pywbem_server
         else:
             self._pywbem_server = PYWBEM_SERVER_OBJ

--- a/pywbemcli/config.py
+++ b/pywbemcli/config.py
@@ -40,7 +40,7 @@ However, they should be used from the ``pywbemcli`` namespace.
 
 __all__ = ['DEFAULT_CONNECTION_TIMEOUT', 'DEFAULT_OUTPUT_FORMAT',
            'DEFAULT_NAMESPACE', 'PYWBEMCLI_PROMPT', 'PYWBEMCLI_HISTORY_FILE',
-           'DEFAULT_MAXPULLCNT', 'MAX_TIMEOUT']
+           'DEFAULT_MAXPULLCNT', 'MAX_TIMEOUT', 'DEFAULT_URL_SCHEME']
 
 from pywbem import DEFAULT_ITER_MAXOBJECTCOUNT
 
@@ -51,47 +51,40 @@ DEFAULT_CONNECTION_TIMEOUT = 30
 
 #: Specifies the default output format selected if no output format is
 #: defined on the cmd line, environment variable, or a config file.
-
 DEFAULT_OUTPUT_FORMAT = 'simple'
 
 #: Specifies the default namespace uses if no default namespace is defined
 #: on the cmd line, environment variable, or a config file.
-
 DEFAULT_NAMESPACE = 'root/cimv2'
 
 #: Specifies the default query language to be used for exedquery operations
 #: when a query language is not specified in the request or config
-
 DEFAULT_QUERY_LANGUAGE = 'DMTF:CQL'
 
 #: Characters for cmdline prompt when the pywbemcli repl is executing.
 #: The prompt is presented at the beginning of a line awaiting a command
 #: input.
 #: The prompt MUST BE Unicode (prompt-toolkit requirement)
-
 PYWBEMCLI_PROMPT = u'pywbemcli> '
 
 #: File path of history file for interactive mode.
 #: If the file name starts with tilde (which is handled by the shell, not by
 #: the file system), it is properly expanded.
-
 PYWBEMCLI_HISTORY_FILE = '~/.pywbemcli_history'
 
 #: Default uri scheme if none is provided.  Thus if a server uri without
 #: scheme component is provided, this is the default prepended to the
 #: uri.
 
-DEFAULT_URI_SCHEME = 'https'
+DEFAULT_URL_SCHEME = 'https'
 
 #: Default pull MaxObjectCount if none is provided.  This is the maximum
 #: number of objects per request that will be returned if the server
 #: uses the pull operations for EnumerateInstances, AssociatorInstances,
 #: etc. Set to the same default as used by pywbem.
-
 DEFAULT_MAXPULLCNT = DEFAULT_ITER_MAXOBJECTCOUNT
 
 #: Maximum allowed connection timeout in seconds.  The environment will not
 #: allow a connection timeout value larger than this on the command line or
 #: internal option for timeout.
-
 MAX_TIMEOUT = 300

--- a/pywbemcli/pywbemcli.py
+++ b/pywbemcli/pywbemcli.py
@@ -208,7 +208,7 @@ def cli(ctx, server, name, default_namespace, user, password, timeout, noverify,
                                          ca_certs=ca_certs,
                                          use_pull_ops=use_pull_ops,
                                          pull_max_cnt=pull_max_cnt,
-                                         enable_stats=timestats,
+                                         stats_enabled=timestats,
                                          verbose=verbose)
         else:
             if name:

--- a/tests/function/test_class_subcmd.py
+++ b/tests/function/test_class_subcmd.py
@@ -1,0 +1,101 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test the class subcommand
+"""
+
+from __future__ import absolute_import, print_function
+import pytest
+import os
+
+from .utils import execute_pywbemcli, call_pywbemcli_inline, assert_rc
+
+TEST_DIR = os.path.dirname(__file__)
+
+
+class TestClassGeneral(object):
+    """
+    Test class using pytest for the subcommands of the class subcommand
+    """
+    def test_help(self):
+        """Test 'pywbemcli --help'"""
+
+        # Invoke the command to be tested
+        rc, stdout, stderr = execute_pywbemcli(['class', '--help'])
+
+        assert_rc(0, rc, stdout, stderr)
+        assert stdout.startswith(
+            "Usage: pywbemcli class [COMMAND-OPTIONS]"), \
+            "stdout={!r}".format(stdout)
+
+        assert stderr == ""
+
+    # @pytest.mark.skip(reason="Unfinished test")
+    def test_class_error_no_server(self):
+        """Test 'pywbemcli ... class getclass' when no host is provided
+
+        This test runs against a real url so we set timeout to the mininum
+        to minimize test time since the expected result is a timeout exception.
+        """
+
+        # Invoke the command to be tested
+        rc, stdout, stderr = execute_pywbemcli(['-s', 'http://fred', '-t', '1',
+                                                'class', 'get', 'CIM_blah'])
+
+        assert_rc(1, rc, stdout, stderr)
+        print('stderr %s' % stderr)
+
+        assert stdout == ""
+        assert stderr.startswith(
+            "Error: ConnectionError"), \
+            "stderr={!r}".format(stderr)
+
+
+class TestClassEnumerate(object):
+    """
+    Test the options of the pywbemcli class enumerate' subcommand
+    """
+    def test_help(self):
+        """
+        Test 'pywbemcli class enumerate --help'
+        """
+
+        # Invoke the command to be tested
+        rc, stdout, stderr = execute_pywbemcli(['class', 'enumerate', '--help'])
+
+        assert_rc(0, rc, stdout, stderr)
+        print('stdout=%s' % stdout)
+        assert stdout.startswith(
+            "Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME\n"), \
+            "stdout={!r}".format(stdout)
+
+        assert stderr == ""
+
+    def test_enumerate_mock(self):
+        """
+        Test 'pywbemcli class enumerate
+        """
+        mock_mof_path = os.path.join(TEST_DIR, 'simple_mock_model.mof')
+        url = 'fake://file%s' % mock_mof_path
+
+        rc, stdout, stderr = call_pywbemcli_inline(
+            ['-s', url, 'class', 'enumerate']
+        )
+
+        assert_rc(0, rc, stdout, stderr)
+        assert stderr == ""
+        assert stdout.startswith(
+            '   [Description ( "Very CIM Class" )]\n'), \
+            "stderr={!r}".format(stderr)

--- a/tests/function/test_globals.py
+++ b/tests/function/test_globals.py
@@ -1,0 +1,35 @@
+"""
+Test global options that can be tested without a subcommand
+"""
+from __future__ import absolute_import, print_function
+
+import re
+
+from .utils import execute_pywbemcli, assert_rc
+
+
+class TestGlobalOptions(object):
+    """
+    All tests for the 'pywbmecl' command with global options that can be tested
+    without a subcommand.
+    """
+
+    def test_global_help(self):
+        """Test 'pywbemcli --help'"""
+
+        rc, stdout, stderr = execute_pywbemcli(['--help'])
+
+        assert_rc(0, rc, stdout, stderr)
+        assert stdout.startswith(
+            "Usage: pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS]...\n"), \
+            "stdout={!r}".format(stdout)
+        assert stderr == ""
+
+    def test_global_version(self):
+        """Test 'pywbemcli --version'"""
+
+        rc, stdout, stderr = execute_pywbemcli(['--version'])
+
+        assert_rc(0, rc, stdout, stderr)
+        assert re.match(r'^pywbemcli, version [0-9]+\.[0-9]+\.[0-9]+', stdout)
+        assert stderr == ""

--- a/tests/function/utils.py
+++ b/tests/function/utils.py
@@ -1,0 +1,313 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Utilities to exercise pywbemcli both as a separate executable and in line with
+a direct call.
+"""
+
+from __future__ import absolute_import, print_function
+
+import sys
+import os
+import re
+import tempfile
+from copy import copy
+from subprocess import Popen, PIPE
+import six
+
+from pywbemcli.pywbemcli import cli
+
+
+def execute_pywbemcli(args, env=None):
+    """
+    Invoke the 'pywbemcli' command as a child process.
+
+    This requires that the 'pywbemcli' command is installed in the current
+    Python environment.
+
+    Parameters:
+
+      args (iterable of :term:`string`): Command line arguments, without the
+        command name.
+        Each single argument must be its own item in the iterable; combining
+        the arguments into a string does not work.
+        The arguments may be binary strings encoded in UTF-8, or unicode
+        strings.
+
+      env (dict): Environment variables to be put into the environment when
+        calling the command. May be `None`. Dict key is the variable name as a
+        :term:`string`; dict value is the variable value as a :term:`string`
+        (without any shell escaping needed).
+
+    Returns:
+
+      tuple(rc, stdout, stderr): Output of the command, where:
+
+        * rc(int): Exit code of the command.
+        * stdout(:term:`unicode string`): Standard output of the command,
+          as a unicode string with newlines represented as '\\n'.
+          An empty string, if there was no data.
+        * stderr(:term:`unicode string`): Standard error of the command,
+          as a unicode string with newlines represented as '\\n'.
+          An empty string, if there was no data.
+    """
+
+    cli_cmd = u'pywbemcli'
+
+    if env is None:
+        env = {}
+    else:
+        env = copy(env)
+
+    # Unset pywbemcli env variables
+    if 'PYWBEMCLI_HOST' not in env:
+        env['PYWBEMCLI_HOST'] = None
+
+    env['PYTHONPATH'] = '.'  # Use local files
+    env['PYTHONWARNINGS'] = ''  # Disable for parsing output
+
+    # Put the env vars into the environment of the current Python process,
+    # from where they will be inherited into its child processes (-> shell ->
+    # cli command).
+    for name in env:
+        value = env[name]
+        if value is None:
+            if name in os.environ:
+                del os.environ[name]
+        else:
+            os.environ[name] = value
+
+    assert isinstance(args, (list, tuple))
+    cmd_args = [cli_cmd]
+    for arg in args:
+        if not isinstance(arg, six.text_type):
+            arg = arg.decode('utf-8')
+        cmd_args.append(arg)
+
+    # print('cmd_args %s' % cmd_args)
+
+    # Note that the click package on Windows writes '\n' at the Python level
+    # as '\r\n' at the level of the shell. Some other layer (presumably the
+    # Windows shell) contriubutes another such translation, so we end up with
+    # '\r\r\n' for each '\n'. Using universal_newlines=True undoes all of that.
+    proc = Popen(cmd_args, shell=False, stdout=PIPE, stderr=PIPE,
+                 universal_newlines=True)
+    stdout_str, stderr_str = proc.communicate()
+    rc = proc.returncode
+
+    if isinstance(stdout_str, six.binary_type):
+        stdout_str = stdout_str.decode('utf-8')
+    if isinstance(stderr_str, six.binary_type):
+        stderr_str = stderr_str.decode('utf-8')
+
+    return rc, stdout_str, stderr_str
+
+
+def call_pywbemcli_inline(args, env=None):
+    """
+    Invoke the Python code of the `pywbemcli` command in the current Python
+    process.
+
+    Does not require that the `pywbemcli` command is installed in the
+    current Python environment.
+
+    Parameters:
+
+      args (iterable of :term:`string`): Command line arguments, without the
+        command name.
+        Each single argument must be its own item in the iterable; combining
+        the arguments into a string as a single argument does not work.
+
+        ex. pywbemcli -s http://localhost class get CIM_blah becomes:
+            ['-s' 'http://fred', '-t', '1', 'class', 'get',  'CIM_blah']
+
+        The arguments may be binary strings encoded in UTF-8, or unicode
+        strings.
+
+      env (dict): Environment variables to be put into the environment when
+        calling the command. May be `None`. Dict key is the variable name as a
+        :term:`string`; dict value is the variable value as a :term:`string`,
+        (without any shell escaping needed).
+
+    Returns:
+
+      tuple(rc, stdout, stderr): Output of the command, where:
+
+        * rc(int): Exit code of the command.
+        * stdout(:term:`unicode string`): Standard output of the command,
+          as a unicode string with newlines represented as '\\n'.
+          An empty string, if there was no data.
+        * stderr(:term:`unicode string`): Standard error of the command,
+          as a unicode string with newlines represented as '\\n'.
+          An empty string, if there was no data.
+    """
+
+    cli_cmd = u'pywbemcli'
+
+    if env is None:
+        env = {}
+    else:
+        env = copy(env)
+
+    env['PYTHONPATH'] = '.'  # Use local files
+    env['PYTHONWARNINGS'] = ''  # Disable for parsing output
+
+    # Put the env vars into the environment of the current Python process.
+    # The cli command code runs in the current Python process.
+    for name in env:
+        value = env[name]
+        if value is None:
+            if name in os.environ:
+                del os.environ[name]
+        else:
+            os.environ[name] = value
+
+    assert isinstance(args, (list, tuple))
+    sys.argv = [cli_cmd]
+    for arg in args:
+        if not isinstance(arg, six.text_type):
+            arg = arg.decode('utf-8')
+        sys.argv.append(arg)
+
+    # print('sys.argv %s' % sys.argv)
+
+    # In Python 3.6, the string type must match the file mode
+    # (bytes/binary and str/text). sys.std* is open in text mode,
+    # so we need to open the temp file also in text mode.
+    with tempfile.TemporaryFile(mode='w+t') as tmp_stdout:
+        saved_stdout = sys.stdout
+        sys.stdout = tmp_stdout
+
+        with tempfile.TemporaryFile(mode='w+t') as tmp_stderr:
+            saved_stderr = sys.stderr
+            sys.stderr = tmp_stderr
+
+            exit_rcs = []  # Mutable object for storing sys.exit() rcs.
+
+            def local_exit(rc):
+                exit_rcs.append(rc)
+
+            saved_exit = sys.exit
+            sys.exit = local_exit
+
+            cli_rc = cli()
+
+            if len(exit_rcs) > 0:
+                # The click command function called sys.exit(). This should
+                # always be the case for pywbemcli.
+
+                # When --help is specified, click invokes the specified
+                # subcommand without args when run in py.test (for whatever
+                # reason...). As a consequence, sys.exit() is called an extra
+                # time. We use the rc passed into the first invocation.
+                rc = exit_rcs[0]
+            else:
+                # The click command function returned and did not call
+                # sys.exit(). That can be done with click, but should not be
+                # the case with pywbemcli. We still handle that, just in case.
+                rc = cli_rc
+
+            sys.exit = saved_exit
+
+            sys.stderr = saved_stderr
+            tmp_stderr.flush()
+            tmp_stderr.seek(0)
+            stderr_str = tmp_stderr.read()
+
+        sys.stdout = saved_stdout
+        tmp_stdout.flush()
+        tmp_stdout.seek(0)
+        stdout_str = tmp_stdout.read()
+
+    if isinstance(stdout_str, six.binary_type):
+        stdout_str = stdout_str.decode('utf-8')
+    if isinstance(stderr_str, six.binary_type):
+        stderr_str = stderr_str.decode('utf-8')
+
+    # Note that the click package on Windows writes '\n' at the Python level
+    # as '\r\n' at the level of the shell, so we need to undo that.
+    stdout_str = stdout_str.replace('\r\n', '\n')
+    stderr_str = stderr_str.replace('\r\n', '\n')
+
+    return rc, stdout_str, stderr_str
+
+
+def assert_rc(exp_rc, rc, stdout, stderr):
+    """
+    Assert that the specified return code is as expected.
+
+    The actual return code is compared with the expected return code,
+    and if they don't match, stdout and stderr are displayed as a means
+    to help debugging the issue.
+
+    Parameters:
+
+      exp_rc (int): expected return code.
+
+      rc (int): actual return code.
+
+      stdout (string): stdout of the command, for debugging purposes.
+
+      stderr (string): stderr of the command, for debugging purposes.
+    """
+
+    assert exp_rc == rc, \
+        "Unexpected exit code (expected {}, got {})\n" \
+        "  stdout:\n" \
+        "{}\n" \
+        "  stderr:\n" \
+        "{}". \
+        format(exp_rc, rc, stdout, stderr)
+
+
+def assert_patterns(exp_patterns, lines, meaning):
+    """
+    Assert that the specified lines match the specified patterns.
+
+    The patterns are matched against the complete line from begin to end,
+    even if no begin and end markers are specified in the patterns.
+
+    Parameters:
+
+      exp_patterns (iterable of string): regexp patterns defining the expected
+        value for each line.
+
+      lines (iterable of string): the lines to be matched.
+
+      meaning (string): A short descriptive text that identifies the meaning
+        of the lines that are matched, e.g. 'stderr'.
+    """
+
+    assert len(lines) == len(exp_patterns), \
+        "Unexpected number of lines in {}:\n" \
+        "  expected patterns:\n" \
+        "{}\n" \
+        "  actual lines:\n" \
+        "{}\n". \
+        format(meaning,
+               '\n'.join(exp_patterns),
+               '\n'.join(lines))
+
+    for i, line in enumerate(lines):
+        pattern = exp_patterns[i]
+        if not pattern.endswith('$'):
+            pattern += '$'
+        assert re.match(pattern, line), \
+            "Unexpected line {} in {}:\n" \
+            "  expected pattern:\n" \
+            "{}\n" \
+            "  actual line:\n" \
+            "{}\n". \
+            format(i, meaning, pattern, line)

--- a/tests/unit/test_pywbem_server.py
+++ b/tests/unit/test_pywbem_server.py
@@ -39,7 +39,7 @@ class PywbemServerTests(unittest.TestCase):
         pw = 'blah'
         svr = PywbemServer(server, ns, user=user, password=pw)
 
-        self.assertEqual(svr.server_uri, server)
+        self.assertEqual(svr.server_url, server)
         self.assertEqual(svr.default_namespace, ns)
         self.assertEqual(svr.user, user)
         self.assertEqual(svr.password, pw)
@@ -47,6 +47,9 @@ class PywbemServerTests(unittest.TestCase):
         print(svr)
 
     def test_all_parms(self):
+        """
+        Test that all of the input parameters are correctly putinto properties
+        """
         server = 'http://localhost'
         ns = 'root/cimv2'
         user = 'Fred'
@@ -61,7 +64,7 @@ class PywbemServerTests(unittest.TestCase):
                            noverify=noverify, certfile=certfile,
                            keyfile=keyfile, verbose=verbose)
 
-        self.assertEqual(svr.server_uri, server)
+        self.assertEqual(svr.server_url, server)
         self.assertEqual(svr.default_namespace, ns)
         self.assertEqual(svr.user, user)
         self.assertEqual(svr.password, pw)
@@ -70,6 +73,9 @@ class PywbemServerTests(unittest.TestCase):
         self.assertEqual(svr.keyfile, keyfile)
 
     def test_all_connect(self):
+        """
+        Test the create_connection method.
+        """
         server = 'http://localhost'
         ns = 'root/cimv2'
         user = 'Fred'
@@ -84,7 +90,7 @@ class PywbemServerTests(unittest.TestCase):
                            noverify=noverify, certfile=certfile,
                            keyfile=keyfile, verbose=verbose)
 
-        self.assertEqual(svr.server_uri, server)
+        self.assertEqual(svr.server_url, server)
         self.assertEqual(svr.default_namespace, ns)
         self.assertEqual(svr.user, user)
         self.assertEqual(svr.password, pw)
@@ -93,7 +99,7 @@ class PywbemServerTests(unittest.TestCase):
         self.assertEqual(svr.keyfile, keyfile)
 
         # connect and test connection results
-        svr.create_connection()
+        svr.create_connection(False)
         self.assertEqual(svr.conn.url, server)
         self.assertEqual(svr.wbem_server.conn.url, svr.conn.url)
 


### PR DESCRIPTION
Note that this pr is built on pr #88 test/function subdirectory since the goal was that the mock capability was to be used as the basis for most of the function level tests.


WIP today because the tests themselves have not been added. this code consists of just
the infrastructure components.

This pr rebased to pr ks/#xxx-create_funct_tests which adds
the tests/function directory the utils.py file that provides
functions to execute pywbemcli both as a script and as
in line code  and some initital tests. 

Addsupport for pywbem_mock by using a specific scheme in the host url to define a mock request.  If the scheme is 'fake' we assume that the netloc component is a keyword defining what is in the path and that the path is the data used to define the setup for the mock. Usually this will be a mof file with the mof to be compiled.

This also fixes an issue where we were using uri for the variable names
and it is really url.  Renamed the variables.