### PR TITLE
Fixes #95 Change output table formatting package to use tabulate

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -52,7 +52,7 @@ click===6.6
 click-spinner===0.1.6
 click-repl===0.1.0
 asciitree===0.3.3
-terminaltables===3.0.0
+tabulate===0.8.2
 prompt-toolkit===1.0.9
 
 

--- a/pywbemcli/_common.py
+++ b/pywbemcli/_common.py
@@ -24,20 +24,20 @@ from textwrap import fill
 from prompt_toolkit import prompt
 import click
 import six
-from terminaltables import AsciiTable
+import tabulate
 
 from pywbem import CIMInstanceName, CIMInstance, \
     CIMClass, CIMQualifierDeclaration, tocimobj, CIMProperty, CIMClassName
 from pywbem.cim_obj import mofstr
 from pywbem.cim_obj import NocaseDict
 
-TABLE_FORMATS = ['table', 'plain', 'simple', 'grid']
+TABLE_FORMATS = ['table', 'plain', 'simple', 'grid', 'rst']
 CIM_OBJECT_OUTPUT_FORMATS = ['mof', 'xml', 'txt', 'tree']
 
 # TODO: ks for some reason extending one list with another causes a problem
 # in click with the help.
-OUTPUT_FORMATS = ['table', 'plain', 'simple', 'grid', 'mof', 'xml', 'txt',
-                  'tree']
+OUTPUT_FORMATS = ['table', 'plain', 'simple', 'grid', 'rst', 'mof', 'xml',
+                  'txt', 'tree']
 GENERAL_OPTIONS_METAVAR = '[GENERAL-OPTIONS]'
 CMD_OPTS_TXT = '[COMMAND-OPTIONS]'
 
@@ -593,7 +593,8 @@ def display_cim_objects(context, objects, output_format=None, summary=False):
         Click context contained in ContextObj object.
 
       TODO This is not correct form for this doc.
-      objects(iterable of CIMInstance, CIMInstanceName, CIMClass, CIMClassName,or CIMQualifier):
+      objects(iterable of CIMInstance, CIMInstanceName, CIMClass, CIMClassName,
+      or CIMQualifier):
         Iterable of CIM Objects to be displayed or a single object.
 
       output_format(:term:`strng`):
@@ -897,56 +898,11 @@ def format_table(rows, headers, table_format='simple', title=None):
     if table_format not in TABLE_FORMATS:
         raise click.ClickException('Invalid table format %s.' % table_format)
 
-    # Future this line can be change to tabulate call.
-    result = _build_terminal_table(rows, headers, table_format=table_format)
+    result = tabulate.tabulate(rows, headers, tablefmt=table_format)
 
     if title:
         result = '%s\n%s' % (title, result)
     return result
-
-
-def _build_terminal_table(rows, headers, table_format='simple'):
-    """
-        Builds a table using the formatting characteristics of tabulate package
-        but using the terminaltable package since it supports folded cells.
-
-        This uses the formatting definitions of the tabulate package including:
-        plain, simple, grid to format tables that are similar to
-        tabulate.  In the future we may switch to tabulate when it supports
-        folded tables because it allows more output formats.
-
-        This is an internal function and is NOT intended to be used externally
-        since the format, etc. checking is in build_table, not here.
-
-        NOTE: This is a separate function because it can be replaced with
-        a call to tabulate in the future
-    """
-    if headers:
-        rows.insert(0, headers)
-
-    table = AsciiTable(rows)
-    # table with no borders
-    if table_format is None or table_format == 'plain':
-        table.inner_column_border = False
-        table.inner_heading_row_border = False
-        table.inner_row_border = False
-        table.outer_border = False
-    # table with only header/data separation border
-    elif table_format == 'simple' or table_format == 'table':
-        table.inner_heading_row_border = True
-        table.inner_column_border = False
-        table.outer_border = False
-    # table with borders around all cells
-    elif table_format == 'grid':
-        table.inner_column_border = True
-        table.outer_border = True
-        table.inner_row_border = True
-        table.inner_heading_row_border = True
-    else:
-        raise ValueError('Invalid table type %s. Folded tables have '
-                         ' limited formatting.' % table_format)
-
-    return(table.table)
 
 
 def fold_string(input_string, max_width):

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,5 @@ click>=6.6
 click-spinner>=0.1.6
 click-repl>=0.1.0
 asciitree>=0.3.3
-terminaltables>=3.0.0
+tabulate>=0.8.2
 prompt-toolkit>=1.0.9
-

--- a/tests/unit/test_tableformat.py
+++ b/tests/unit/test_tableformat.py
@@ -32,10 +32,14 @@ except ImportError:
 
 from pywbemcli._common import format_table, fold_string
 
-VERBOSE = True
+VERBOSE = False
+
+# TODO ks rewrite this test for pytest.  Note that the capture IO
+#      may be different in that they have fixtures such as capsys
+#      to capture output that may eplace StringIO used below.
 
 
-class TableTests(unittest.TestCase):
+class BaseTableTests(unittest.TestCase):
     """Base class for testing table output"""
     @staticmethod
     def create_simple_table(table_format=None, title=True):
@@ -85,8 +89,8 @@ class TableTests(unittest.TestCase):
             line += 1
 
 
-class FormatTableTests(TableTests):
-    """Tests on the asciitable module"""
+class FormatTableTests(BaseTableTests):
+    """Tests on the table_format function in _common.py"""
     def test_table_simple_hdr(self):
         """Test a simple table with header"""
 
@@ -100,20 +104,20 @@ class FormatTableTests(TableTests):
             print(actual)
 
         expected = ('test simple table\n'
-                    ' col1       col2        col3        \n'
-                    '------------------------------------\n'
-                    ' row1col1   row1col2    row1col3    \n'
-                    ' row2col1   row2col2    row2col3    \n'
-                    ' row3 col1  row3  col2  row3   col3 \n'
-                    ' 0          999         9999999     \n'
-                    ' 1.1432     1.2         0           \n')
+                    'col1       col2        col3\n'
+                    '---------  ----------  -----------\n'
+                    'row1col1   row1col2    row1col3\n'
+                    'row2col1   row2col2    row2col3\n'
+                    'row3 col1  row3  col2  row3   col3\n'
+                    '0          999         9999999\n'
+                    '1.1432     1.2         0\n')
 
         self.compare_results(actual, expected)
 
         self.assertEqual(actual, expected,
                          'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
 
-    def test_table_simple_print_no_header(self):
+    def test_table_simple_no_hdr(self):
         """Test print a simple table no header"""
 
         captured_output = StringIO()          # Create StringIO object
@@ -125,13 +129,13 @@ class FormatTableTests(TableTests):
         if VERBOSE:
             print(actual)
 
-        expected = (' col1       col2        col3        \n'
-                    '------------------------------------\n'
-                    ' row1col1   row1col2    row1col3    \n'
-                    ' row2col1   row2col2    row2col3    \n'
-                    ' row3 col1  row3  col2  row3   col3 \n'
-                    ' 0          999         9999999     \n'
-                    ' 1.1432     1.2         0           \n')
+        expected = ('col1       col2        col3\n'
+                    '---------  ----------  -----------\n'
+                    'row1col1   row1col2    row1col3\n'
+                    'row2col1   row2col2    row2col3\n'
+                    'row3 col1  row3  col2  row3   col3\n'
+                    '0          999         9999999\n'
+                    '1.1432     1.2         0\n')
 
         self.compare_results(actual, expected)
 
@@ -153,18 +157,18 @@ class FormatTableTests(TableTests):
             print(actual)
 
         expected = ('test simple table\n'
-                    ' col1       col2        col3        \n'
-                    ' row1col1   row1col2    row1col3    \n'
-                    ' row2col1   row2col2    row2col3    \n'
-                    ' row3 col1  row3  col2  row3   col3 \n'
-                    ' 0          999         9999999     \n'
-                    ' 1.1432     1.2         0           \n')
+                    'col1       col2        col3\n'
+                    'row1col1   row1col2    row1col3\n'
+                    'row2col1   row2col2    row2col3\n'
+                    'row3 col1  row3  col2  row3   col3\n'
+                    '0          999         9999999\n'
+                    '1.1432     1.2         0\n')
 
         self.compare_results(actual, expected)
         self.assertEqual(actual, expected,
                          'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
 
-    def test_table_grid_print(self):
+    def test_table_grid(self):
         """Test printing a plain table with borders and header"""
         captured_output = StringIO()          # Create StringIO object
         sys.stdout = captured_output                   # and redirect stdout.
@@ -180,7 +184,7 @@ class FormatTableTests(TableTests):
         expected = ('test simple table\n'
                     '+-----------+------------+-------------+\n'
                     '| col1      | col2       | col3        |\n'
-                    '+-----------+------------+-------------+\n'
+                    '+===========+============+=============+\n'
                     '| row1col1  | row1col2   | row1col3    |\n'
                     '+-----------+------------+-------------+\n'
                     '| row2col1  | row2col2   | row2col3    |\n'
@@ -196,6 +200,35 @@ class FormatTableTests(TableTests):
         self.assertEqual(actual, expected,
                          'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
 
+    def test_table_rst_hdr(self):
+        """Test a none table borders with header"""
+
+        captured_output = StringIO()          # Create StringIO object
+        sys.stdout = captured_output                   # and redirect stdout.
+
+        table = self.create_simple_table(table_format='rst', title=True)
+        print(table)
+
+        sys.stdout = sys.__stdout__
+        actual = captured_output.getvalue()
+        if VERBOSE:
+            print(actual)
+
+        expected = ('test simple table\n'
+                    '=========  ==========  ===========\n'
+                    'col1       col2        col3\n'
+                    '=========  ==========  ===========\n'
+                    'row1col1   row1col2    row1col3\n'
+                    'row2col1   row2col2    row2col3\n'
+                    'row3 col1  row3  col2  row3   col3\n'
+                    '0          999         9999999\n'
+                    '1.1432     1.2         0\n'
+                    '=========  ==========  ===========\n')
+
+        self.compare_results(actual, expected)
+        self.assertEqual(actual, expected,
+                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+
     def test_folded_cell_plain(self):
         """Test building a folded cell table plain with header"""
         actual = self.create_folded_table(table_format='plain', title=True)
@@ -204,13 +237,13 @@ class FormatTableTests(TableTests):
             print(actual)
 
         expected = ('test folded table\n'
-                    ' col1       col2      col3      \n'
-                    ' row1col1   row2col2  this is a \n'
-                    '                      folded    \n'
-                    '                      cell      \n'
-                    ' this is a  row2col2  row2col3  \n'
-                    ' folded                         \n'
-                    ' cell                           ')
+                    'col1       col2      col3\n'
+                    'row1col1   row2col2  this is a\n'
+                    '                     folded\n'
+                    '                     cell\n'
+                    'this is a  row2col2  row2col3\n'
+                    'folded\n'
+                    'cell')
 
         self.compare_results(actual, expected)
         self.assertEqual(actual, expected,
@@ -230,14 +263,14 @@ class FormatTableTests(TableTests):
             print(actual)
 
         expected = ('test folded table\n'
-                    ' col1       col2      col3      \n'
-                    '--------------------------------\n'
-                    ' row1col1   row2col2  this is a \n'
-                    '                      folded    \n'
-                    '                      cell      \n'
-                    ' this is a  row2col2  row2col3  \n'
-                    ' folded                         \n'
-                    ' cell                           \n')
+                    'col1       col2      col3\n'
+                    '---------  --------  ---------\n'
+                    'row1col1   row2col2  this is a\n'
+                    '                     folded\n'
+                    '                     cell\n'
+                    'this is a  row2col2  row2col3\n'
+                    'folded\n'
+                    'cell\n')
 
         self.compare_results(actual, expected)
         self.assertEqual(actual, expected,
@@ -253,7 +286,7 @@ class FormatTableTests(TableTests):
         expected = ('test folded table\n'
                     '+-----------+----------+-----------+\n'
                     '| col1      | col2     | col3      |\n'
-                    '+-----------+----------+-----------+\n'
+                    '+===========+==========+===========+\n'
                     '| row1col1  | row2col2 | this is a |\n'
                     '|           |          | folded    |\n'
                     '|           |          | cell      |\n'


### PR DESCRIPTION
Simple change to use package we always wanted to use for table formatting and to fix minor changes in tests because the two packages formatted table output slightly differently.

See commit message for more information