### PR TITLE
fixes #78 Resync appveyor.yml with current version from pywbem

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,11 @@ configuration:
 
 install:
 
+  - git --version
   - if %APPVEYOR_REPO_BRANCH%.==manual-ci-run. set _NEED_REBASE=true
+  # This Git version requires user configuration in rebase step
+  - if %_NEED_REBASE%.==true. git config user.name "dummy"
+  - if %_NEED_REBASE%.==true. git config user.email "dummy@dummy"
   - if %_NEED_REBASE%.==true. git fetch origin master
   - if %_NEED_REBASE%.==true. git branch master FETCH_HEAD
   - if %_NEED_REBASE%.==true. git rebase master
@@ -44,75 +48,111 @@ install:
   - if %APPVEYOR_REPO_BRANCH%.==manual-ci-run. set _MANUAL_CI_RUN=true
   - if %APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH%.==manual-ci-run. set _MANUAL_CI_RUN=true
 
+  # Verify that the commands used in this file are available
+  - where where
+  - where choco
+  - choco --version
+
   # Set PACKAGE_LEVEL for make
   - set PACKAGE_LEVEL=%configuration%
 
-  # Examine the environment
-  - echo %PATH%
-  - echo %INCLUDE%
-  - echo %LIB%
+  # Examine the initial environment
+  - ver
+  - 'echo "%PATH%"'
+  - 'echo "%PYTHONPATH%"'
+  - 'echo "%INCLUDE%"'
+  - 'echo "%LIB%"'
+  - choco source list
   - dir C:\
   - dir
+  - set
 
-  # Show OS-level packages available for installation via "choco"
-  # Note: "choco" is a Windows installer, similar to "yum" on RHEL.
-  - choco source list
-
-  # Add Python
-  #- reg ADD HKCU\Software\Python\PythonCore\%PYTHON_VERSION%\InstallPath /ve /d "%PYTHON_HOME%" /t REG_SZ /f
-  #- reg ADD HKLM\Software\Python\PythonCore\%PYTHON_VERSION%\InstallPath /ve /d "%PYTHON_HOME%" /t REG_SZ /f
-  - set PATH=%PYTHON_HOME%;%PYTHON_HOME%\Scripts;%PATH%
-
-  ## Install pip via get-pip.py - disabled because pip is already installed
-  #- ps: (new-object System.Net.WebClient).Downloadfile('https://bootstrap.pypa.io/get-pip.py', 'C:\Users\appveyor\get-pip.py')
-  #- ps: Start-Process -FilePath "C:\Python27\python.exe" -ArgumentList "C:\Users\appveyor\get-pip.py" -Wait -Passthru
+  # Remove Python 2.7 from PATH.
+  # Note that YAML interprets some characters in a special way (including '!' and '#')
+  # so we have to use single quotes to protect some CMD commands from YAML.
+  # Note that for some reason, "setlocal EnableDelayedExpansion" needs to be on the
+  # same line as the command you want to execute under that setting. Using !abc! variable
+  # expansion requires EnableDelayedExpansion.
+  - 'set $line=%PATH%'
+  - 'set $line=%$line: =#%'
+  - 'set $line=%$line:;= %'
+  - 'set $line=%$line:)=^^)%'
+  - 'setlocal EnableDelayedExpansion & for %%a in (%$line%) do echo %%a | find /i "Python27" || set $newpath=!$newpath!;%%a'
+  - 'set $newpath=%$newpath:#= %'
+  - 'set $newpath=%$newpath:^^=%'
+  - 'set PATH=%$newpath%'
 
   # Add CygWin
   - set PATH=C:\cygwin\bin;%PATH%
 
-  ## Example for installing an OS-level package via "choco":
-  #
-  #- choco install -y <package-name>
-  #- set PATH=<package-path>;%PATH%
+  # Verify that the commands provided by CygWin and used in this file are available
+  - where wget
+  - wget --version
+  - where unzip
+  - unzip --help
+  - where 7z
+  - 7z --help
 
-  ## Example for manually installing OS-level prereqs:
-  #
-  ## Preparation
-  #- echo set _PWD=%%%%~dp0>tmp_prereq_dir.bat
-  #- call tmp_prereq_dir.bat
-  #- rm tmp_prereq_dir.bat
-  #- set _PREREQ_DIR=prereqs
-  #- set _PREREQ_ABSDIR=%_PWD%%_PREREQ_DIR%
-  #- echo Installing OS-level prereqs into: %_PREREQ_ABSDIR%
-  #- mkdir %_PREREQ_DIR%
-  #
-  ## Install libxml2
-  #- set _PKGFILE=libxml2-2.7.8.win32.zip
-  #- set _PKGDIR=libxml2-2.7.8.win32
-  #- wget -q -P %_PREREQ_DIR% ftp://ftp.zlatkovic.com/libxml/%_PKGFILE%
-  #- unzip -q -d %_PREREQ_DIR% %_PREREQ_DIR%/%_PKGFILE%
-  #- set INCLUDE=%_PREREQ_ABSDIR%\%_PKGDIR%\include;%INCLUDE%
-  #- set LIB=%_PREREQ_ABSDIR%\%_PKGDIR%\lib;%LIB%
-  #- set PATH=%_PREREQ_ABSDIR%\%_PKGDIR%\bin;%PATH%
+  # Add Python
+  - reg ADD HKCU\Software\Python\PythonCore\%PYTHON_VERSION%\InstallPath /ve /d "%PYTHON_HOME%" /t REG_SZ /f
+  - reg ADD HKLM\Software\Python\PythonCore\%PYTHON_VERSION%\InstallPath /ve /d "%PYTHON_HOME%" /t REG_SZ /f
+  - set PATH=%PYTHON_HOME%;%PYTHON_HOME%\Scripts;%PATH%
+
+  ## Install InnoSetup - disabled because it is not needed
+  #- choco install -y InnoSetup
+  #- set PATH="C:\Program Files (x86)\Inno Setup 5";%PATH%
+
+  ## Install pip - disabled because pip is already installed
+  #- ps: (new-object System.Net.WebClient).Downloadfile('https://bootstrap.pypa.io/get-pip.py', 'C:\Users\appveyor\get-pip.py')
+  #- ps: Start-Process -FilePath "C:\Python27\python.exe" -ArgumentList "C:\Users\appveyor\get-pip.py" -Wait -Passthru
+
+  # Examine the final environment
+  - 'echo "%PATH%"'
+  - 'echo "%PYTHONPATH%"'
+  - 'echo "%INCLUDE%"'
+  - 'echo "%LIB%"'
 
   # Install tox
+  - where pip
+  - pip --version
   - pip install tox==2.0.0
 
   # Verify that the commands used in tox.ini are available
+  - where tox
   - tox --version
+  - where make
   - make --version
-  - sh --version
-
-  # Verify that the commands used in Makefile are available
-  - bash --version
-  - rm --version
-  - mv --version
-  - find --version
-  - tee --version
+  - where pip
   - pip --version
+  - where python
   - python --version
 
-# This is not a C# project, build stuff at the test step instead:
+
+  # Verify that the commands used in makefile are available
+  - where sh
+  - sh --version
+  - where bash
+  - bash --version
+  - where rm
+  - rm --version
+  - where mv
+  - mv --version
+  - where xargs
+  - xargs --version
+  - where grep
+  - grep --version
+  - where sed
+  - sed --version
+  - where tar
+  - tar --version
+  - where find
+  - find --version
+
+  # Verify that the commands used in the pywbem testsuite are available
+  - where xmllint
+  - xmllint --version
+
+# Not a C# project, build stuff at the test step instead.
 build: false
 
 before_test:


### PR DESCRIPTION
This changes appveyor.yml to exactly what is in the current
pywbem/appveyor.yml and attempts to get the appveyor tests running.

We had a problem defined in issue #78 but in the mean time apparenly the appveyor account also gone inactive. That was restarted