### PR TITLE
Refactor pywbemcli executable tests

### DIFF
--- a/pywbemcli/_cmd_class.py
+++ b/pywbemcli/_cmd_class.py
@@ -42,10 +42,11 @@ from ._displaytree import display_class_tree
 # the default is True which is what we want.
 # TODO: We need to document all these defaults.
 includeclassqualifiers_option = [              # pylint: disable=invalid-name
-    click.option('--includequalifiers/--no_includequalifiers',
+    click.option('--no-qualifiers', is_flag=True,
                  required=False, default=True,
-                 help='Include qualifiers in the result. Default is to'
-                      ' include qualifiers')]
+                 help='Do not include qualifiers in the response.'
+                      'The default behavior is to include'
+                      'qualifiers in the returned class.')]
 
 deepinheritance_option = [              # pylint: disable=invalid-name
     click.option('-d', '--deepinheritance', is_flag=True, required=False,
@@ -324,7 +325,7 @@ def cmd_class_get(context, classname, options):
             classname,
             namespace=options['namespace'],
             LocalOnly=options['localonly'],
-            IncludeQualifiers=options['includequalifiers'],
+            IncludeQualifiers=options['no_qualifiers'],
             IncludeClassOrigin=options['includeclassorigin'],
             PropertyList=resolve_propertylist(options['propertylist']))
 
@@ -390,7 +391,7 @@ def cmd_class_enumerate(context, classname, options):
                 namespace=options['namespace'],
                 LocalOnly=options['localonly'],
                 DeepInheritance=options['deepinheritance'],
-                IncludeQualifiers=options['includequalifiers'],
+                IncludeQualifiers=options['no_qualifiers'],
                 IncludeClassOrigin=options['includeclassorigin'])
             if options['sort']:
                 results.sort(key=lambda x: x.classname)
@@ -544,7 +545,8 @@ def cmd_class_tree(context, classname, options):
             classname = None
 
         else:
-            # get the complete subclass hierarchy
+            # get the subclass hierarchy either complete or starting at the
+            # optional CLASSNAME
             classes = context.conn.EnumerateClasses(
                 ClassName=classname,
                 namespace=options['namespace'],
@@ -554,6 +556,7 @@ def cmd_class_tree(context, classname, options):
 
     # display the list of classes as a tree. The classname is the top
     # of the tree.
+    context.spinner.stop()
     display_class_tree(classes, classname)
 
 

--- a/pywbemcli/_common.py
+++ b/pywbemcli/_common.py
@@ -638,7 +638,6 @@ def display_cim_objects(context, objects, output_format=None, summary=False):
         return
 
     # display a single item.
-    assert isinstance(objects, (CIMInstance, CIMClass, CIMQualifierDeclaration))
     object_ = objects
     if output_format in TABLE_FORMATS:
         if isinstance(object_, CIMInstance):

--- a/pywbemcli/_displaytree.py
+++ b/pywbemcli/_displaytree.py
@@ -80,7 +80,7 @@ def display_class_tree(classes, top_class=None):
     # build dictionary of classname : superclassname
     cn_supercn = {cl.classname: cl.superclass for cl in classes}
 
-    # if top_Class is none, create artifical root
+    # if top_class is none, create artifical root
     if top_class is None:
         for cn in cn_supercn:
             if not cn_supercn[cn]:

--- a/pywbemcli/_pywbemcli_operations.py
+++ b/pywbemcli/_pywbemcli_operations.py
@@ -294,12 +294,12 @@ class BuildRepositoryMixin(object):  # pylint: disable=too-few-public-methods
     """
     def build_repository(self, conn, file_path_list, verbose):
         """
-        Build the repository from the input url.
+        Build the repository from the file_path list
         """
         for file_path in file_path_list:
             ext = os.path.splitext(file_path)[1]
             if not os.path.exists(file_path):
-                raise ValueError('File name %s does not exit' % file_path)
+                raise ValueError('File name %s does not exist' % file_path)
             if ext == '.mof':
                 conn.compile_mof_file(file_path)
             elif ext == '.py':

--- a/tests/unit/cli_test_extensions.py
+++ b/tests/unit/cli_test_extensions.py
@@ -1,0 +1,198 @@
+"""
+The class in this file defines a common base for the pytests executed
+through pywbemcli execution
+
+"""
+
+from __future__ import absolute_import, print_function
+import re
+import pytest
+import os
+import six
+
+from .utils import execute_pywbemcli, assert_rc, assert_patterns, assert_lines
+
+TEST_DIR = os.path.dirname(__file__)
+
+
+class CLITestsBase(object):
+    """
+        Standard methods used for all tests
+        TODO these should be moved to common file since we want to create
+        a test file for each major subcommand.
+    """
+    def mock_subcmd_test(self, desc, subcmd, args, env, exp_response,
+                         mock_file, condition):
+        """
+        Standard test for pywbemcli commands using pytest
+
+        Parameters:
+          desc (:term:`string`):
+            Description of the test
+
+          subcmd (:term:`string`):
+            pywbemcli subcommand inserted for this test.  This is the first
+            level subcommand (ex. class).
+
+          args (:term:`py:iterable` of :term:`string`):
+            Arguments to be inserted into the command line after the
+            subcommand name. This must be a list of the individual works
+            to be appended after the subcmd.
+
+          exp_response ( (dict): Keyword arguments for the expected response.):
+            Includes the following keys:
+
+               'stdout' or 'stderr' - Defines which return is expected (the
+               expected response). The value is a string or iterable defining
+               the data expected in the response. The data definition in
+               this dictionary entry must be compatible with the definition
+               of expected data for the test selected.
+               Only one of these keys may exist.
+
+               'test' - if it exists defines the test used to compare the
+               returned data with the expected returned data defined as the
+               value of 'stdout'/'stderr'
+
+               The tests define are:
+
+                 'startswith' - Expected Response must be a single string
+                 The returned text defined starts with the defined string
+
+                 'lines' -  Expected response may be either a list of strings or
+                 single string
+
+                 Compares for exact match between the expected response and the
+                 returned data line by line. The number of lines and the data
+                 in each line must match.  If the expected response is a single
+                 string is is split into lines separated at each new line
+                 before the match
+
+                 'patterns' - Expected response must be same as lines test
+                 except that each line in the expected response is treated as
+                 a regex expression and a regex match is executed for each line.
+
+                 'regex' - Expected response is a single string or list of
+                 strings. Each string is considered a regex expression.
+
+                 'in' - Expected response is string or list of strings.
+                 Tests the complete response to determine if each entry
+                 in expected response is in the response data as a single test.
+
+                 Executes a single regex search of the entire
+                 response data to match with each entry in the expected
+                 response
+
+               'rc' expected exit_code from pywbemcli.  If None, code 0
+               is expected.
+
+               'mock' If this key exists, the value is a list of files that
+               represent the mock data. In this case, the connection is
+               made with the --mock_server input parameter and the name
+               of the mock files as data.
+
+          mock_file (:term:`string` or None):
+            If this is a string, this test will be executed using the
+            --mock_server pywbemcl option with this file as the name of the
+            objects to be compiled. This should be just a file name and
+            this method assumes it is in the testsuite directory.
+
+            If None, test is executed without the --mock-server input parameter
+            and defines an artificial server name  Used to test subcommands
+            and options that do not communicate with a server.  It is faster
+            than installing the mock repository
+
+          condition (None or False):
+            If False, the test is skipped
+        """
+        if not condition:
+            pytest.skip("Condition for test case %s not met" % desc)
+
+        if isinstance(args, six.string_types):
+            args = args.split(" ")
+
+        cmd_line = ['-s', 'http:/blah']
+        if mock_file:
+            cmd_line.extend(['--mock_server',
+                             os.path.join(TEST_DIR, mock_file)])
+
+        cmd_line.append(subcmd)
+
+        if args:
+            cmd_line.extend(args)
+
+        rc, stdout, stderr = execute_pywbemcli(cmd_line)
+
+        exp_rc = exp_response['rc'] if 'rc' in exp_response else 0
+        assert_rc(exp_rc, rc, stdout, stderr)
+
+        test_value = None
+        component = None
+        if 'stdout' in exp_response:
+            test_value = exp_response['stdout']
+            rtn_value = stdout
+            component = 'stdout'
+        elif 'stderr' in exp_response:
+            test_value = exp_response['stderr']
+            rtn_value = stderr
+            component = 'stderr'
+        else:
+            assert False, 'Expected "stdout" or "stderr" key. One of keys ' \
+                          'required in exp_response.'
+
+        if test_value:
+            if 'test' in exp_response:
+                test = exp_response['test']
+                # test that rtn_value starts with test_value
+                if test == 'startswith':
+                    assert isinstance(test_value, six.string_types)
+                    assert rtn_value.startswith(test_value), \
+                        "{}\n{}={!r}".format(desc, component, rtn_value)
+                # test that lines match between test_value and rtn_value
+                # base on regex match
+                elif test == 'patterns':
+                    if isinstance(test_value, six.string_types):
+                        test_value = test_value.splitlines()
+                    assert isinstance(test_value, (list, tuple))
+                    assert_patterns(test_value, rtn_value.splitlines(),
+                                    "{}\n{}={!r}".format(desc, component,
+                                                         rtn_value))
+                # test that each line in the test value matches the
+                # corresponding line in the rtn_value exactly
+                elif test == 'lines':
+                    if isinstance(test_value, six.string_types):
+                        test_value = test_value.splitlines()
+                    if isinstance(test_value, (list, tuple)):
+                        assert_lines(test_value, rtn_value.splitlines(),
+                                     "{}\n{}={!r}".format(desc, component,
+                                                          rtn_value))
+                    else:
+                        assert(isinstance(test_value, six.string_types))
+                        assert_lines(test_value.splitlines(),
+                                     rtn_value.splitlines(),
+                                     "{}\n{}={!r}".format(desc, component,
+                                                          rtn_value))
+                # test with a regex search that all values in list exist in
+                # the return
+                elif test == 'regex':
+                    if isinstance(test_value, (tuple, list)):
+                        rtn_value = rtn_value.join("\n")
+                    elif isinstance(test_value, six.string_types):
+                        rtn_value = [rtn_value]
+                    else:
+                        assert False, "regex expected response must be string" \
+                                      "or list of strings. %s found" % \
+                                      type(rtn_value)
+
+                    for regex in test_value:
+                        assert isinstance(regex, six.string_types)
+                        match_result = re.search(regex, rtn_value)
+                        assert not match_result, \
+                            "{}\n{}={!r}".format(desc, re, rtn_value)
+                elif test == 'in':
+                    if isinstance(test_value, six.string_types):
+                        test_value = [test_value]
+                    for test_str in test_value:
+                        assert test_str in rtn_value, \
+                            "{}\n{}={!r}".format(desc, test_str, rtn_value)
+                else:
+                    assert 'test %s is invalid. Skipped' % test

--- a/tests/unit/simple_mock_model.mof
+++ b/tests/unit/simple_mock_model.mof
@@ -67,6 +67,16 @@ class CIM_Foo_sub : CIM_Foo {
     string cimfoo_sub;
 };
 
+    [Description ("Subclass of CIM_Foo_sub")]
+class CIM_Foo_sub_sub : CIM_Foo_sub {
+    string cimfoo_sub_sub;
+        [Description("Sample method with input and output parameters")]
+    uint32 Method1(
+        [IN ( false), OUT, Description("Response param 2")]
+      string OutputParam2);
+};
+
+
 class CIM_Foo_sub2 : CIM_Foo {
     string cimfoo_sub2;
 };

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -83,6 +83,93 @@ Options:
   -h, --help                Show this message and exit.
 """
 
+CLASS_FIND_HELP = """Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME-REGEX
+
+  Find all classes that match CLASSNAME-REGEX.
+
+  Find all classes in the namespace(s) of the target WBEMServer that match
+  the CLASSNAME-REGEX regular expression argument. The CLASSNAME-REGEX
+  argument is required.
+
+  The CLASSNAME-REGEX argument may be either a complete classname or a
+  regular expression that can be matched to one or more classnames. To limit
+  the filter to a single classname, terminate the classname with $.
+
+  The regular expression is anchored to the beginning of the classname and
+  is case insensitive. Thus, `pywbem_` returns all classes that begin with
+  `PyWBEM_`, `pywbem_`, etc.
+
+  The namespace option limits the search to the defined namespace. Otherwise
+  all namespaces in the target server are searched.
+
+  Output is in table format if table output specified. Otherwise it is in
+  the form <namespace>:<classname>
+
+Options:
+  -s, --sort              Sort into alphabetical order by classname.
+  -n, --namespace <name>  Namespace to use for this operation. If defined that
+                          namespace overrides the general options namespace
+  -h, --help              Show this message and exit.
+"""
+
+CLASS_TREE_HELP = """Usage: pywbemcli class tree [COMMAND-OPTIONS] CLASSNAME
+
+  Display CIM class inheritance hierarchy tree.
+
+  Displays a tree of the class hiearchy to show superclasses and subclasses.
+
+  CLASSNAMe is an optional argument that defines the starting point for the
+  hiearchy display
+
+  If the --superclasses option not specified the hiearchy starting either at
+  the top most classes of the class hiearchy or at the class defined by
+  CLASSNAME is displayed.
+
+  if the --superclasses options is specified and a CLASSNAME is defined the
+  class hiearchy of superclasses leading to CLASSNAME is displayed.
+
+  This is a separate subcommand because t is tied specifically to displaying
+  in a tree format.so that the --output-format global option is ignored.
+
+Options:
+  -s, --superclasses      Display the superclasses to CLASSNAME as a tree.
+                          When this option is set, the CLASSNAME argument is
+                          required
+  -n, --namespace <name>  Namespace to use for this operation. If defined that
+                          namespace overrides the general options namespace
+  -h, --help              Show this message and exit.
+"""
+
+CLASS_FIND_HELP = """Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME-REGEX
+
+  Find all classes that match CLASSNAME-REGEX.
+
+  Find all classes in the namespace(s) of the target WBEMServer that match
+  the CLASSNAME-REGEX regular expression argument. The CLASSNAME-REGEX
+  argument is required.
+
+  The CLASSNAME-REGEX argument may be either a complete classname or a
+  regular expression that can be matched to one or more classnames. To limit
+  the filter to a single classname, terminate the classname with $.
+
+  The regular expression is anchored to the beginning of the classname and
+  is case insensitive. Thus, `pywbem_` returns all classes that begin with
+  `PyWBEM_`, `pywbem_`, etc.
+
+  The namespace option limits the search to the defined namespace. Otherwise
+  all namespaces in the target server are searched.
+
+  Output is in table format if table output specified. Otherwise it is in
+  the form <namespace>:<classname>
+
+Options:
+  -s, --sort              Sort into alphabetical order by classname.
+  -n, --namespace <name>  Namespace to use for this operation. If defined that
+                          namespace overrides the general options namespace
+  -h, --help              Show this message and exit.
+
+"""
+
 MOCK_TEST_CASES = [
     # desc - Description of test
     # args - List of arguments or string of arguments
@@ -303,30 +390,30 @@ MOCK_TEST_CASES = [
                  '};', '', ],
       'test': 'lines'},
      SIMPLE_MOCK_FILE, False],
-    ['class subcommand find --help, . ',
-     ['find', '--help'],
-     {'stdout': ['Usage: pywbemcli class find [COMMAND-OPTIONS] '
-                 'CLASSNAME-REGEX',
-                 'Find all classes that match CLASSNAME-REGEX.',
-                 '-s, --sort              Sort into alphabetical order by '
-                 'classname.'],
-      'test': 'in'},
-     None, True],
     #
     # find subcommand
     #
-    # TODO find subcommand. This one requires server so we need another
-    # mof example that has namespace in it
+    ['class subcommand find -h, ',
+     ['find', '-h'],
+     {'stdout': CLASS_FIND_HELP,
+      'test': 'lines'},
+     None, False],
+
+    ['class subcommand find  --help',
+     ['find', '--help'],
+     {'stdout': CLASS_FIND_HELP,
+      'test': 'lines'},
+     None, False],
+    # TODO Add detailed tests for find
     #
     # subcommand "class tree"
     #
-    ['class subcommand get  --help response',
+    ['class subcommand tree --help response',
      ['tree', '--help'],
-     {'stdout': ['Usage: pywbemcli class tree [COMMAND-OPTIONS]',
-                 '--superclasses', ],
-      'test': 'in'},
+     {'stdout': CLASS_TREE_HELP,
+      'test': 'lines'},
      None, True],
-    # TODO this test occasiona\ly includeing | in output as if spinner not
+    # TODO this test occasionally includeing | in output as if spinner not
     # stopped. For now removed the extra spaces.
     ['class subcommand tree top down. Order uncertain so use "in" test ',
      ['tree'],
@@ -426,7 +513,7 @@ MOCK_TEST_CASES = [
 # other tests.  Test lo on top level
 
 
-class TestSubcmdMock(CLITestsBase):
+class TestSubcmdClass(CLITestsBase):
     """
     Test all of the class subcommand variations.
     """
@@ -437,6 +524,13 @@ class TestSubcmdMock(CLITestsBase):
         MOCK_TEST_CASES)
     def test_class(self, desc, args, exp_response, mock, condition):
         """
+        Common test method for those subcommands and options in the
+        class subcmd that can be tested.  This includes:
+
+          * Subcommands like help that do not require access to a server
+
+          * Subcommands that can be tested with a single execution of a
+            pywbemcli command.
         """
         env = None
         self.mock_subcmd_test(desc, self.subcmd, args, env, exp_response,
@@ -447,19 +541,6 @@ class TestClassGeneral(object):
     """
     Test class using pytest for the subcommands of the class subcommand
     """
-    def test_help(self):
-        """Test 'pywbemcli --help'"""
-
-        # Invoke the command to be tested
-        rc, stdout, stderr = execute_pywbemcli(['class', '--help'])
-
-        assert_rc(0, rc, stdout, stderr)
-        assert stdout.startswith(
-            "Usage: pywbemcli class [COMMAND-OPTIONS]"), \
-            "stdout={!r}".format(stdout)
-
-        assert stderr == ""
-
     # @pytest.mark.skip(reason="Unfinished test")
     def test_class_error_no_server(self):
         """Test 'pywbemcli ... class getclass' when no host is provided
@@ -484,21 +565,6 @@ class TestClassEnumerate(object):
     """
     Test the options of the pywbemcli class enumerate' subcommand
     """
-    def test_help(self):
-        """
-        Test 'pywbemcli class enumerate --help'
-        """
-
-        # Invoke the command to be tested
-        rc, stdout, stderr = execute_pywbemcli(['class', 'enumerate', '--help'])
-
-        assert_rc(0, rc, stdout, stderr)
-        assert stdout.startswith(
-            "Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME\n"), \
-            "stdout={!r}".format(stdout)
-
-        assert stderr == ""
-
     # TODO remap this to use the same test_funct decorator as pywbem when
     # that code is committed.
     @pytest.mark.parametrize(

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -139,7 +139,7 @@ def assert_rc(exp_rc, rc, stdout, stderr):
         format(exp_rc, rc, stdout, stderr)
 
 
-def assert_patterns(exp_patterns, lines, meaning):
+def assert_patterns(exp_patterns, act_lines, meaning):
     """
     Assert that the specified lines match the specified patterns.
 
@@ -151,30 +151,66 @@ def assert_patterns(exp_patterns, lines, meaning):
       exp_patterns (iterable of string): regexp patterns defining the expected
         value for each line.
 
-      lines (iterable of string): the lines to be matched.
+      act_lines (iterable of string): the lines to be matched.
 
       meaning (string): A short descriptive text that identifies the meaning
         of the lines that are matched, e.g. 'stderr'.
     """
-
-    assert len(lines) == len(exp_patterns), \
+    assert len(act_lines) == len(exp_patterns), \
         "Unexpected number of lines in {}:\n" \
-        "  expected patterns:\n" \
+        "Expected lines cnt={}:\n" \
         "{}\n" \
-        "  actual lines:\n" \
+        "Actual lines cnt={}:\n" \
         "{}\n". \
-        format(meaning,
-               '\n'.join(exp_patterns),
-               '\n'.join(lines))
+        format(meaning, len(act_lines),
+               '\n'.join(exp_patterns), len(exp_patterns),
+               '\n'.join(act_lines))
 
-    for i, line in enumerate(lines):
-        pattern = exp_patterns[i]
-        if not pattern.endswith('$'):
-            pattern += '$'
-        assert re.match(pattern, line), \
+    for i, act_line in enumerate(act_lines):
+        exp_line = exp_patterns[i]
+        # if not exp_line.endswith('$'):
+        #    exp_line += '$'
+        assert re.match(exp_line, act_line), \
             "Unexpected line {} in {}:\n" \
-            "  expected pattern:\n" \
+            "  expected line vs. actual line:\n" \
             "{}\n" \
-            "  actual line:\n" \
             "{}\n". \
-            format(i, meaning, pattern, line)
+            format(i, meaning, exp_line, act_line)
+
+
+def assert_lines(exp_lines, act_lines, meaning):
+    """
+    Assert that the specified lines match exactly the lines specified in
+    exp_lines. This does not require that the pattern lines escape any
+    special characters, etc.
+
+    The exp_lines are matched against the complete line from begin to end. The
+    test stops at the first difference
+
+    Parameters:
+
+      exp_lines (iterable of string): the expected string for each line.
+
+      act_lines (iterable of string): the lines to be matched.
+
+      meaning (string): A short descriptive text that identifies the meaning
+        of the lines that are matched, e.g. 'stderr'.
+    """
+    assert len(act_lines) == len(exp_lines), \
+        "Unexpected number of lines in {}:\n" \
+        "Expected lines cnt={}:\n" \
+        "{}\n" \
+        "Actual lines cnt={}:\n" \
+        "{}\n". \
+        format(meaning, len(act_lines),
+               '\n'.join(exp_lines), len(exp_lines),
+               '\n'.join(act_lines))
+
+    for i, act_line in enumerate(act_lines):
+        exp_line = exp_lines[i]
+        assert exp_line == act_line, \
+            "Unexpected line {} in {}:\n" \
+            "  expected line vs. actual line:\n" \
+            "{}\n" \
+            "{}\n". \
+            format(i, meaning, exp_line, act_line)


### PR DESCRIPTION
Refactor the pywbemcli executable tests to create a common
base class for the tests largely using the mock environment
and modify the test for class to use this environment.

All tests are defined through parameters to the single method
that executes the test.

This turned out to be cleaner and more consistent that using
the wrapper function at this point.

The limits with this approach are:

1. The mock environment has to be created for each test which takes
time.

2. Only a single subcommand can be executed within a single test because
the repl today only support entering a single command at at time. Thus
tests like class delete can only confirm a good response, not that the
class was actually deleted in the mock environment.

Note that these tests are not complete today but include a number of
TODOs and test with the condition marked false.

In addition we found a couple of errors in the current code that we fixed
including:

1. On the class tree command, we were not stopping the spinner before
calling the display method.

2. We were using the click form
click.option('--includequalifiers/--no_includequalifiers'
to define the option for include qualifiers.  First it was
giving some problems and second it was just more complex
that we need since the real option is just to not include
qualifiers so I modified that to a simple flag with the name
--no-qualifiers for the getclass, etc. subcommands in the
class group.

3. We had the EnumerateInstances options DeepInheritance
mispelled as Deepinheritance so fixed that both for instance
and class subcommands.