### PR TITLE
 Add mock tests for instance subcommand

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -1079,8 +1079,8 @@ The following defines the help output for the `pywbemcli instance get --help` su
                                       instance.
       -q, --includequalifiers         If set, requests server to include
                                       qualifiers in the returned instance(s).
-      -c, --includeclassorigin        Include Class Origin in the returned
-                                      instance.
+      -c, --includeclassorigin        Include class origin attribute in returned
+                                      instance(s).
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
                                       not included a Null property list is defined

--- a/pywbemcli/_cmd_instance.py
+++ b/pywbemcli/_cmd_instance.py
@@ -80,7 +80,7 @@ def instance_group():
               help='Show only local properties of the returned instance.')
 @add_options(includequalifiers_option)
 @click.option('-c', '--includeclassorigin', is_flag=True, required=False,
-              help='Include Class Origin in the returned instance.')
+              help='Include class origin attribute in returned instance(s).')
 @add_options(propertylist_option)
 @add_options(namespace_option)
 @add_options(interactive_option)
@@ -423,6 +423,7 @@ def cmd_instance_create(context, classname, options):
 
         # properties is a tuple of name,value pairs
         new_inst = create_ciminstance(class_, properties, property_list)
+
         # TODO: Future Possibly create log of instance created.
         context.conn.CreateInstance(new_inst, namespace=options['namespace'])
 

--- a/pywbemcli/_cmd_instance.py
+++ b/pywbemcli/_cmd_instance.py
@@ -404,7 +404,7 @@ def cmd_instance_delete(context, instancename, options):
     try:
         context.conn.DeleteInstance(instancepath)
 
-        click.echo('Deleted %s', instancepath)
+        click.echo('Deleted %s' % instancepath)
 
     except Error as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
@@ -616,10 +616,10 @@ def cmd_instance_count(context, classname, options):
         # Sum the number of instances with the defined classname.
         # this counts only classes with that specific classname and not
         # subclasses
-        count = sum(1 for inst in inst_names if (inst.classname == classname))
+        count = sum(1 for inst in inst_names if (inst.classname == classname_))
 
         if count != 0:
-            display_tuple = (classname, count)
+            display_tuple = (classname_, count)
             display_data.append(display_tuple)
 
     # If sort set, resort by count size

--- a/pywbemcli/_common.py
+++ b/pywbemcli/_common.py
@@ -104,7 +104,7 @@ def pick_instance(context, objectname, namespace=None):
                                                                   namespace)
 
     if not instance_names:
-        click.echo('No instance paths found for %s', objectname)
+        click.echo('No instance paths found for %s' % objectname)
         return None
 
     try:
@@ -145,18 +145,17 @@ def pick_from_list(context, options, title):
         index += 1
         click.echo('%s: %s' % (index, str_))
     selection = None
+    msg = 'Input integer between 0 and %s or Ctrl-C to exit selection: ' % index
     while True:
         try:
-            selection = int(prompt(
-                'Select an entry by index or hit enter to exit command>'))
+            selection = int(prompt(msg))
             if selection >= 0 and selection <= index:
                 return selection
         except ValueError:
             pass
         except KeyboardInterrupt:
             raise ValueError
-        click.echo('%s Invalid. Input integer between 0 and %s or Ctrl-C to '
-                   'stop selection.' % (selection, index))
+        click.echo('%s Invalid. %s' % (selection, msg))
     context.spinner.start()
 
 
@@ -232,6 +231,7 @@ def objects_sort(objects):
     return rtn_objs
 
 
+<<<<<<< HEAD
 def parse_wbemuri_str(wbemuri_str, namespace=None):
     """
     Parse a string that is a wbemuri into a CIMInstanceName object.

--- a/pywbemcli/_common.py
+++ b/pywbemcli/_common.py
@@ -51,21 +51,26 @@ def output_format_is_table(output_format):
 # separate function.
 def resolve_propertylist(propertylist):
     """
-    Correct property list received from options.  Click options produces an
+    resolve property list received from options.  Click options produces an
     empty list when there is no property list.  Pywbem requires None
     when there is no propertylist
 
     Further, property lists can be input as a comma separated list so this
-    function also splits these.
+    function also splits any string with embedded commas.
     """
     # If no property list, return None which means all properties
+    # print('\nRESOLVE_PL=%s repl=%r, len=%s, 0=%s' % (propertylist,
+    # propertylist, len(propertylist), propertylist[0]))
+    # TODO determine how to produce an empty string in property list.
+    # Right now '""' on cmd line produces '""' here which is defined as
+    # a string with len 1
     if not propertylist:
         propertylist = None
 
-    # if cmdline was a single empty string, we set to empty list
-    # This means send no propertylist and is a special case for the
-    # cim/xml and pywbem interface.
-    elif len(propertylist) == 1 and not propertylist[0]:
+    # If propertylist is a single empty string, we set to empty list.
+    elif len(propertylist) == 0:
+        propertylist = []
+    elif len(propertylist) == 1 and propertylist[0] == '"':
         propertylist = []
 
     # expand any comma separated entries in the list
@@ -78,6 +83,7 @@ def resolve_propertylist(propertylist):
                 pl.append(item)
         propertylist = pl
 
+    # print('RESOLVEDPL %r' % propertylist)
     return propertylist
 
 
@@ -231,7 +237,6 @@ def objects_sort(objects):
     return rtn_objs
 
 
-<<<<<<< HEAD
 def parse_wbemuri_str(wbemuri_str, namespace=None):
     """
     Parse a string that is a wbemuri into a CIMInstanceName object.

--- a/pywbemcli/_common_options.py
+++ b/pywbemcli/_common_options.py
@@ -29,12 +29,13 @@ import click
 propertylist_option = [                      # pylint: disable=invalid-name
     click.option('-p', '--propertylist', multiple=True, type=str,
                  default=None, metavar='<property name>',
-                 help='Define a propertylist for the request. If not included '
+                 help='Define a propertylist for the request. If not defined '
                       'a Null property list is defined and the server '
-                      'returns all properties. If defined as empty string '
-                      'the server returns no properties.'
-                      ' ex: -p propertyname1 -p propertyname2 or '
-                      '-p propertyname1,propertyname2')]
+                      'returns all properties. Multiple properties may be '
+                      'defined either a comma separated list defing the option '
+                      'multipletimes (ex: -p pn1 -p pn22 or -p pn1,pn2). '
+                      'If defined as empty string the server returns no '
+                      'properties.')]
 
 names_only_option = [                      # pylint: disable=invalid-name
     click.option('-o', '--names_only', is_flag=True, required=False,

--- a/tests/unit/cli_test_extensions.py
+++ b/tests/unit/cli_test_extensions.py
@@ -110,7 +110,8 @@ class CLITestsBase(object):
         if isinstance(args, six.string_types):
             args = args.split(" ")
 
-        cmd_line = ['-s', 'http:/blah']
+        # TODO -s option not needed if mock file
+        cmd_line = ['-s', 'http://blah']
         if mock_file:
             cmd_line.extend(['--mock-server',
                              os.path.join(TEST_DIR, mock_file)])
@@ -119,6 +120,8 @@ class CLITestsBase(object):
 
         if args:
             cmd_line.extend(args)
+
+        # print('\nCMDLINE %s' % cmd_line)
 
         rc, stdout, stderr = execute_pywbemcli(cmd_line)
 

--- a/tests/unit/simple_assoc_mock_model.mof
+++ b/tests/unit/simple_assoc_mock_model.mof
@@ -1,0 +1,121 @@
+Qualifier Association : boolean = false,
+    Scope(association),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Description : string = null,
+    Scope(any),
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+Qualifier In : boolean = true,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Key : boolean = false,
+    Scope(property, reference),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Out : boolean = false,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+class TST_Person{
+        [Key, Description ("This is key prop")]
+    string name;
+    string extraProperty = "defaultvalue";
+};
+
+class TST_Personsub : TST_Person{
+    string secondProperty = "empty";
+    uint32 counter;
+};
+
+[Association, Description(" Lineage defines the relationship "
+    "between parents and children.") ]
+class TST_Lineage {
+    [key] string InstanceID;
+    TST_Person ref parent;
+    TST_Person ref child;
+};
+
+[Association, Description(" Family gathers person to family.") ]
+class TST_MemberOfFamilyCollection {
+   [key] TST_Person ref family;
+   [key] TST_Person ref member;
+};
+
+[ Description("Collection of Persons into a Family") ]
+class TST_FamilyCollection {
+        [Key, Description ("This is key prop and family name")]
+    string name;
+};
+
+instance of TST_Person as $Mike { name = "Mike"; };
+instance of TST_Person as $Saara { name = "Saara"; };
+instance of TST_Person as $Sofi { name = "Sofi"; };
+instance of TST_Person as $Gabi{ name = "Gabi"; };
+
+instance of TST_PersonSub as $Mikesub{ name = "Mikesub";
+                            secondProperty = "one" ;
+                            counter = 1; };
+
+instance of TST_PersonSub as $Saarasub { name = "Saarasub";
+                            secondProperty = "two" ;
+                            counter = 2; };
+
+instance of TST_PersonSub as $Sofisub{ name = "Sofisub";
+                            secondProperty = "three" ;
+                            counter = 3; };
+
+instance of TST_PersonSub as $Gabisub{ name = "Gabisub";
+                            secondProperty = "four" ;
+                            counter = 4; };
+
+instance of TST_Lineage as $MikeSofi
+{
+    InstanceID = "MikeSofi";
+    parent = $Mike;
+    child = $Sofi;
+};
+
+instance of TST_Lineage as $MikeGabi
+{
+    InstanceID = "MikeGabi";
+    parent = $Mike;
+    child = $Gabi;
+};
+
+instance of TST_Lineage  as $SaaraSofi
+{
+    InstanceID = "SaaraSofi";
+    parent = $Saara;
+    child = $Sofi;
+};
+
+instance of TST_FamilyCollection as $Family1
+{
+    name = "family1";
+};
+
+instance of TST_FamilyCollection as $Family2
+{
+    name = "Family2";
+};
+
+
+instance of TST_MemberOfFamilyCollection as $SofiMember
+{
+    family = $Family1;
+    member = $Sofi;
+};
+
+instance of TST_MemberOfFamilyCollection as $GabiMember
+{
+    family = $Family1;
+    member = $Gabi;
+};
+
+instance of TST_MemberOfFamilyCollection as $MikeMember
+{
+    family = $Family2;
+    member = $Mike;
+};

--- a/tests/unit/simple_mock_invokemethod.py
+++ b/tests/unit/simple_mock_invokemethod.py
@@ -1,0 +1,29 @@
+"""
+mocker test script that install a callback to be executed. This is based on
+the CIM_Foo class in the simple_mock_model.mof test file
+
+"""
+
+RETURN_VALUE = 0
+RETURN_PARAMS = None
+
+
+def fuzzy_callback(self, conn, methodname, object_name, **params):
+    # pylint: disable=attribute-defined-outside-init, unused-argument
+    # pylint: disable=invalid-name
+    """
+    InvokeMethod callback.  This is a simple callback that just tests
+    methodname and then returns returnvalue and params from the
+    TestInvokeMethod object attributes.
+    """
+    print('fuzzy_callback conn=%s, methodname=%s, object_name=%s, params=%r'
+          (conn, methodname, object_name, params))
+
+    global RETURN_VALUE
+    global RETURN_PARAMS
+    return (RETURN_VALUE, RETURN_PARAMS)
+
+
+global CONN
+# This method expected to use the global namespace
+CONN.add_method_callback('CIM_Foo', 'Fuzzy', fuzzy_callback)  # noqa: F821

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -51,31 +51,35 @@ Commands:
   references    Get the reference instances or names.
 """
 
+# pylint: disable=line-too-long
 INST_ENUM_HELP = """Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME
 
   Enumerate instances or names of CLASSNAME.
 
-  Enumerate instances or instance names from the WBEMServer starting either
-  at the top  of the hierarchy (if no CLASSNAME provided) or from the
-  CLASSNAME argument if provided.
+  Enumerate instances or instance names (the --name_only option) from the
+  WBEMServer starting either at the top  of the hierarchy (if no CLASSNAME
+  provided) or from the CLASSNAME argument if provided.
 
-  Displays the returned instances or names
+  Displays the returned instances (mof, xml, or table formats) or names
 
 Options:
   -l, --localonly                 Show only local properties of the class.
-  -d, --deepinheritance           Return properties in subclasses of defined
-                                  target.  If not specified only properties in
+  -d, --deepinheritance           If set, requests server to return properties
+                                  in subclasses of the target instances class.
+                                  If option not specified only properties from
                                   target class are returned
-  -q, --includequalifiers         Include qualifiers in the result.
+  -q, --includequalifiers         If set, requests server to include
+                                  qualifiers in the returned instance(s).
   -c, --includeclassorigin        Include ClassOrigin in the result.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
-                                  not included a Null property list is defined
-                                  and the server returns all properties. If
-                                  defined as empty string the server returns
-                                  no properties. ex: -p propertyname1 -p
-                                  propertyname2 or -p
-                                  propertyname1,propertyname2
+                                  not defined a Null property list is defined
+                                  and the server returns all properties.
+                                  Multiple properties may be defined either a
+                                  comma separated list defing the option
+                                  multipletimes (ex: -p pn1 -p pn22 or -p
+                                  pn1,pn2). If defined as empty string the
+                                  server returns no properties.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace
@@ -85,20 +89,40 @@ Options:
   -h, --help                      Show this message and exit.
 """
 
-ENUM_INST_RESP = """instance of CIM_Foo {
-   InstanceID = "CIM_Foo1";
-   IntegerProp = 1;
-};
+INST_GET_HELP = """Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME
 
-instance of CIM_Foo {
-   InstanceID = "CIM_Foo2";
-   IntegerProp = 2;
-};
+  Get a single CIMInstance.
 
-instance of CIM_Foo {
-   InstanceID = "CIM_Foo3";
-};
+  Gets the instance defined by INSTANCENAME.
 
+  This may be executed interactively by providing only a classname and the
+  interactive option (-i).
+
+Options:
+  -l, --localonly                 Show only local properties of the returned
+                                  instance.
+  -q, --includequalifiers         If set, requests server to include
+                                  qualifiers in the returned instance(s).
+  -c, --includeclassorigin        Include class origin attribute in returned
+                                  instance(s).
+  -p, --propertylist <property name>
+                                  Define a propertylist for the request. If
+                                  not defined a Null property list is defined
+                                  and the server returns all properties.
+                                  Multiple properties may be defined either a
+                                  comma separated list defing the option
+                                  multipletimes (ex: -p pn1 -p pn22 or -p
+                                  pn1,pn2). If defined as empty string the
+                                  server returns no properties.
+  -n, --namespace <name>          Namespace to use for this operation. If
+                                  defined that namespace overrides the general
+                                  options namespace
+  -i, --interactive               If set, INSTANCENAME argument must be a
+                                  class rather than an instance and user is
+                                  presented with a list of instances of the
+                                  class from which the instance to process is
+                                  selected.
+  -h, --help                      Show this message and exit.
 """
 
 INST_CREATE_HELP = """Usage: pywbemcli instance create [COMMAND-OPTIONS] CLASSNAME
@@ -114,15 +138,17 @@ INST_CREATE_HELP = """Usage: pywbemcli instance create [COMMAND-OPTIONS] CLASSNA
 Options:
   -P, --property property         Optional property definitions of form
                                   name=value.Multiple definitions allowed, one
-                                  for each property
+                                  for each property to be included in the new
+                                  instance.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
-                                  not included a Null property list is defined
-                                  and the server returns all properties. If
-                                  defined as empty string the server returns
-                                  no properties. ex: -p propertyname1 -p
-                                  propertyname2 or -p
-                                  propertyname1,propertyname2
+                                  not defined a Null property list is defined
+                                  and the server returns all properties.
+                                  Multiple properties may be defined either a
+                                  comma separated list defing the option
+                                  multipletimes (ex: -p pn1 -p pn22 or -p
+                                  pn1,pn2). If defined as empty string the
+                                  server returns no properties.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace
@@ -133,14 +159,16 @@ INST_DELETE_HELP = """Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANC
 
   Delete a single CIM instance.
 
-  Delete the instanced defined by INSTANCENAME from the WBEM server. This
-  may be executed interactively by providing only a class name and the
+  Delete the instanced defined by INSTANCENAME from the WBEM server.
+
+  This may be executed interactively by providing only a class name and the
   interactive option.
 
 Options:
-  -i, --interactive       If set, INSTANCENAME argument must be a class and
-                          user is provided with a list of instances of the
-                          class from which the instance to delete is selected.
+  -i, --interactive       If set, INSTANCENAME argument must be a class rather
+                          than an instance and user is presented with a list
+                          of instances of the class from which the instance to
+                          process is selected.
   -n, --namespace <name>  Namespace to use for this operation. If defined that
                           namespace overrides the general options namespace
   -h, --help              Show this message and exit.
@@ -178,40 +206,42 @@ Options:
 
 INST_REFERENCES_HELP = """Usage: pywbemcli instance references [COMMAND-OPTIONS] INSTANCENAME
 
-  Get the reference instances or names.
+   Get the reference instances or names.
 
-  Gets the reference instances or instance names(--names-only option) for a
-  target instance name in the target WBEM server.
+   Gets the reference instances or instance names(--names-only option) for a
+   target `INSTANCENAME` in the target WBEM server filtered by the  `role`
+   and `resultclass` options.
 
-  For the INSTANCENAME argument provided return instances or instance names
-  filtered by the --role and --resultclass options.
-
-  This may be executed interactively by providing only a class name and the
-  interactive option(-i). Pywbemcli presents a list of instances names in
-  the class from which one can be chosen as the target.
+  This may be executed interactively by providing only a class name for
+  `INSTANCENAME` and the `interactive` option(-i). Pywbemcli presents a list
+  of instances names in the class from which one can be chosen as the
+  target.
 
 Options:
   -R, --resultclass <class name>  Filter by the result class name provided.
   -r, --role <role name>          Filter by the role name provided.
-  -q, --includequalifiers         Include qualifiers in the result.
+  -q, --includequalifiers         If set, requests server to include
+                                  qualifiers in the returned instance(s).
   -c, --includeclassorigin        Include classorigin in the result.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
-                                  not included a Null property list is defined
-                                  and the server returns all properties. If
-                                  defined as empty string the server returns
-                                  no properties. ex: -p propertyname1 -p
-                                  propertyname2 or -p
-                                  propertyname1,propertyname2
+                                  not defined a Null property list is defined
+                                  and the server returns all properties.
+                                  Multiple properties may be defined either a
+                                  comma separated list defing the option
+                                  multipletimes (ex: -p pn1 -p pn22 or -p
+                                  pn1,pn2). If defined as empty string the
+                                  server returns no properties.
   -o, --names_only                Show only local properties of the class.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace
   -s, --sort                      Sort into alphabetical order by classname.
   -i, --interactive               If set, INSTANCENAME argument must be a
-                                  class and  user is provided with a list of
-                                  instances of the  class from which the
-                                  instance to delete is selected.
+                                  class rather than an instance and user is
+                                  presented with a list of instances of the
+                                  class from which the instance to process is
+                                  selected.
   -S, --summary                   Return only summary of objects (count).
   -h, --help                      Show this message and exit.
 """
@@ -234,48 +264,84 @@ Options:
   -c, --resultclass <class name>  Filter by the result class name provided.
   -R, --role <role name>          Filter by the role name provided.
   -R, --resultrole <class name>   Filter by the result role name provided.
-  -q, --includequalifiers         Include qualifiers in the result.
+  -q, --includequalifiers         If set, requests server to include
+                                  qualifiers in the returned instance(s).
   -c, --includeclassorigin        Include classorigin in the result.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
-                                  not included a Null property list is defined
-                                  and the server returns all properties. If
-                                  defined as empty string the server returns
-                                  no properties. ex: -p propertyname1 -p
-                                  propertyname2 or -p
-                                  propertyname1,propertyname2
+                                  not defined a Null property list is defined
+                                  and the server returns all properties.
+                                  Multiple properties may be defined either a
+                                  comma separated list defing the option
+                                  multipletimes (ex: -p pn1 -p pn22 or -p
+                                  pn1,pn2). If defined as empty string the
+                                  server returns no properties.
   -o, --names_only                Show only local properties of the class.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace
   -s, --sort                      Sort into alphabetical order by classname.
   -i, --interactive               If set, INSTANCENAME argument must be a
-                                  class and  user is provided with a list of
-                                  instances of the  class from which the
-                                  instance to delete is selected.
+                                  class rather than an instance and user is
+                                  presented with a list of instances of the
+                                  class from which the instance to process is
+                                  selected.
   -S, --summary                   Return only summary of objects (count).
   -h, --help                      Show this message and exit.
 """
 
+ENUM_INST_RESP = """instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo2";
+   IntegerProp = 2;
+};
+
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo3";
+};
+
+"""
+
 REF_INSTS = """instance of TST_Lineage {
    InstanceID = "MikeSofi";
-   parent = "/root/cimv2:TST_Person.name=\"Mike\"";
-   child = "/root/cimv2:TST_Person.name=\"Sofi\"";
+   parent = "/root/cimv2:TST_Person.name=\\\"Mike\\\"";
+   child = "/root/cimv2:TST_Person.name=\\\"Sofi\\\"";
 };
 
 instance of TST_Lineage {
    InstanceID = "MikeGabi";
-   parent = "/root/cimv2:TST_Person.name=\"Mike\"";
-   child = "/root/cimv2:TST_Person.name=\"Gabi\"";
+   parent = "/root/cimv2:TST_Person.name=\\\"Mike\\\"";
+   child = "/root/cimv2:TST_Person.name=\\\"Gabi\\\"";
 };
 
 instance of TST_MemberOfFamilyCollection {
-   family = "/root/cimv2:TST_FamilyCollection.name=\"Family2\"";
-   member = "/root/cimv2:TST_Person.name=\"Mike\"";
+   family = "/root/cimv2:TST_FamilyCollection.name=\\\"Family2\\\"";
+   member = "/root/cimv2:TST_Person.name=\\\"Mike\\\"";
 };
+
 """
 
-OK = False
+ASSOC_INSTS = """instance of TST_Person {
+   name = "Sofi";
+};
+
+instance of TST_Person {
+   name = "Gabi";
+};
+
+instance of TST_FamilyCollection {
+   name = "Family2";
+};
+
+"""
+
+# pylint: enable=line-too-long
+
+OK = True
 RUN = True
 FAIL = False
 
@@ -285,107 +351,242 @@ MOCK_TEST_CASES = [
     #
     #   instance --help
     #
-    ['instance subcommand help response',
+    ['Verify instance subcommand help response',
      '--help',
      {'stdout': INST_HELP,
       'test': 'lines'},
      None, OK],
+
     #
-    #  Instance Enumerate subcommand
+    #  Instance Enumerate subcommand good responses
     #
-    ['instance subcommand enumerate  --help response',
+    ['Verify instance subcommand enumerate  --help response',
      ['enumerate', '--help'],
      {'stdout': INST_ENUM_HELP,
       'test': 'lines'},
      None, OK],
-    ['instance subcommand enumerate CIM_Foo',
+
+    ['Verify instance subcommand enumerate CIM_Foo',
      ['enumerate', 'CIM_Foo'],
      {'stdout': ENUM_INST_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
-    ['instance subcommand enumerate names CIM_Foo -o',
+
+    ['Verify instance subcommand enumerate names CIM_Foo -o',
      ['enumerate', 'CIM_Foo', '-o'],
      {'stdout': ['root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
                  'root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"',
                  'root/cimv2:CIM_Foo.InstanceID="CIM_Foo3"', ],
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
-    #
-    #  instance get subcommand
-    #
-    ['instance subcommand enumerate deepinheritance CIM_Foo -d',
+
+    ['Verify instance subcommand enumerate deepinheritance CIM_Foo -d',
      ['enumerate', 'CIM_Foo', '-d'],
      {'stdout': ENUM_INST_RESP,
       'test': 'lines'},
-     SIMPLE_MOCK_FILE, False],
+     SIMPLE_MOCK_FILE, OK],
 
     #
     # instance enumerate error returns
     #
-    ['instance subcommand enumerate error. invalid classname',
+    ['Verify instance subcommand enumerate error, invalid classname fails',
      ['enumerate', 'CIM_Foox'],
      {'stderr': 'Error: CIMError: 5: Class CIM_Foox not found in namespace'
                 ' root/cimv2',
       'rc': 1,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
-    ['instance subcommand enumerate error. no classname',
+
+    ['Verify instance subcommand enumerate error, no classname fails',
      ['enumerate'],
      {'stderr':
-         ['Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME',
-          '',
-          'Error: Missing argument "classname".'],
+      ['Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME',
+       '',
+       'Error: Missing argument "classname".'],
       'rc': 2,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    #
+    #  instance get subcommand
+    #
+
+    ['Verify instance subcommand get with instancename returns data',
+     ['get', '--help'],
+     {'stdout': INST_GET_HELP,
+      'rc': 0,
+      'test': 'lines'},
+     None, OK],
+
+    ['Verify instance subcommand get with instancename returns data',
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"'],
+     {'stdout': ['instance of CIM_Foo {',
+                 '   InstanceID = "CIM_Foo1";',
+                 '   IntegerProp = 1;',
+                 '};',
+                 ''],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance subcommand get with instancename local_only returns data',
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '-l'],
+     {'stdout': ['instance of CIM_Foo {',
+                 '   InstanceID = "CIM_Foo1";',
+                 '   IntegerProp = 1;',
+                 '};',
+                 ''],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+
+    ['Verify instance subcommand get with instancename --localonly returns '
+     ' data',
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--localonly'],
+     {'stdout': ['instance of CIM_Foo {',
+                 '   InstanceID = "CIM_Foo1";',
+                 '   IntegerProp = 1;',
+                 '};',
+                 ''],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance subcommand get with instancename prop list -p returns '
+     ' one property',
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '-p', 'InstanceID'],
+     {'stdout': ['instance of CIM_Foo {',
+                 '   InstanceID = "CIM_Foo1";',
+                 '};',
+                 ''],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance subcommand get with instancename prop list '
+     '--propertylist returns property',
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--propertylist', 'InstanceID'],
+     {'stdout': ['instance of CIM_Foo {',
+                 '   InstanceID = "CIM_Foo1";',
+                 '};',
+                 ''],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance subcommand get with instancename prop list -p  '
+     ' InstanceID,IntegerProp returns 2 properties',
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '-p', 'InstanceID,IntegerProp'],
+     {'stdout': ['instance of CIM_Foo {',
+                 '   InstanceID = "CIM_Foo1";',
+                 '   IntegerProp = 1;',
+                 '};',
+                 ''],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance subcommand get with instancename prop list -p '
+     ' multiple instances of option returns 2 properties',
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '-p', 'InstanceID',
+      '-p', 'IntegerProp'],
+     {'stdout': ['instance of CIM_Foo {',
+                 '   InstanceID = "CIM_Foo1";',
+                 '   IntegerProp = 1;',
+                 '};',
+                 ''],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance subcommand get with instancename empty  prop list '
+     'returns  empty instance',
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '-p', '""'],
+     {'stdout': ['instance of CIM_Foo {',
+                 '};',
+                 ''],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, FAIL],
+    # TODO: This should return an empty instance not the statement Return empty
+
+    #
+    #  get subcommand errors
+    #
+    ['instance subcommand get error. no classname',
+     ['get'],
+     {'stderr':
+      ['Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME',
+       '',
+       'Error: Missing argument "instancename".'],
+      'rc': 2,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance subcommand get error. no classname',
+     ['get', 'CIM_Foo.InstanceID="CIM_blah"'],
+     {'stderr':
+      ['Error: CIMError: 6: Instance not found in repository namespace '
+       'root/cimv2. Path=root/cimv2:CIM_Foo.InstanceID="CIM_blah"'],
+      'rc': 1,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
     #
     #  instance create subcommand
     #
-    # TODO  tests
-    ['instance subcommand create, --help response',
+    ['Verify instance subcommand create, --help response',
      ['create', '--help'],
      {'stdout': INST_CREATE_HELP,
       'rc': 0,
       'test': 'lines'},
      None, OK],
-    # TODO create valid instance tests
-    # TODO create invaid instance tests
+
+    ['Verify instance subcommand create, new instance of CIM_Foo',
+     ['create', 'CIM_Foo', '-P', 'InstanceID=blah'],
+     {'stdout': "",
+      'rc': 0,
+      'test': 'lines'},
+     None, FAIL],
+
+    # TODO create more valid create instance tests
+    # TODO create invaid create instance tests
 
     #
     #  instance delete subcommand
     #
-    ['instance subcommand delete, --help response',
+    ['Verify instance subcommand delete, --help response',
      ['delete', '--help'],
      {'stdout': INST_DELETE_HELP,
       'rc': 0,
       'test': 'lines'},
      None, OK],
-    # TODO This test fails because we are incorrectly parsing the instance ID
-    # fix with issue on moving to wbemurl from hand coded parser
-    ['instance subcommand delete, valid delete',
-     ['delete', 'CIM_Foo.InstanceID="CIM_Foo1"'],
-     {'stdout': "Deleted",
-      'rc': 2,
-      'test': 'lines'},
-     SIMPLE_MOCK_FILE, False],
 
-    ['instance subcommand delete, missing instance name',
+    ['Verify instance subcommand delete, valid delete',
+     ['delete', 'CIM_Foo.InstanceID="CIM_Foo1"'],
+     {'stdout': ''
+         'Deleted root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance subcommand delete, missing instance name',
      ['delete'],
      {'stderr':
-         ['Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME',
-          '',
-          'Error: Missing argument "instancename".'],
+      ['Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME',
+       '',
+       'Error: Missing argument "instancename".'],
       'rc': 2,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['instance subcommand delete, instance name not in repo',
+    ['Verify instance subcommand delete, instance name not in repo',
      ['delete'],
      {'stderr':
-         ['Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME',
-          '',
-          'Error: Missing argument "instancename".'],
+      ['Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME',
+       '',
+       'Error: Missing argument "instancename".'],
       'rc': 2,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
@@ -393,33 +594,33 @@ MOCK_TEST_CASES = [
     #
     #  instance references subcommand
     #
-    ['instance subcommand references, --help response',
+    ['Verify instance subcommand references, --help response',
      ['references', '--help'],
      {'stdout': INST_REFERENCES_HELP,
       'rc': 0,
       'test': 'lines'},
      None, OK],
-    # TODO  add valid references test
-    ['instance subcommand references, returns data',
+
+    ['Verify instance subcommand references, returns data',
      ['references', 'TST_Person.name="Mike"'],
      {'stdout': REF_INSTS,
       'rc': 0,
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['instance subcommand references -o, returns data',
+    ['Verify instance subcommand references -o, returns data',
      ['references', 'TST_Person.name="Mike"', '-o'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeSofi"',
                  '//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeGabi"',
                  '//FakedUrl/root/cimv2:TST_MemberOfFamilyCollection.family'
-                 '="/root/cimv2:TST_FamilyCollection.name=\"Family2\"",member'
-                 '="/root/cimv2:TST_Person.name=\"Mike\""'],
+                 '="/root/cimv2:TST_FamilyCollection.name=\\"Family2\\"",member'
+                 '="/root/cimv2:TST_Person.name=\\"Mike\\""'],
       'rc': 0,
       'test': 'lines'},
-     ASSOC_MOCK_FILE, RUN],
+     ASSOC_MOCK_FILE, OK],
 
     # TODO add invalid references tests
-    ['instance subcommand references, no instance name',
+    ['Verify instance subcommand references, no instance name',
      ['references'],
      {'stderr': ['Usage: pywbemcli instance references [COMMAND-OPTIONS] '
                  'INSTANCENAME',
@@ -429,7 +630,7 @@ MOCK_TEST_CASES = [
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['instance subcommand references, invalid instance name',
+    ['Verify instance subcommand references, invalid instance name',
      ['references', 'TST_Blah.blah="abc"'],
      {'stdout': ['Return empty.'],
       'rc': 0,
@@ -439,25 +640,58 @@ MOCK_TEST_CASES = [
     #
     #  instance associators subcommand
     #
-    ['instance subcommand associators, --help response',
+    ['Verify instance subcommand associators, --help response',
      ['associators', '--help'],
      {'stdout': INST_ASSOCIATORS_HELP,
       'rc': 0,
       'test': 'lines'},
      None, OK],
     # TODO  add valid associators tests
-    # TODO add invalid associators tests
 
+    ['Verify instance subcommand associators, returns data',
+     ['associators', 'TST_Person.name="Mike"'],
+     {'stdout': ASSOC_INSTS,
+      'rc': 0,
+      'test': 'lines'},
+     ASSOC_MOCK_FILE, OK],
+
+    ['Verify instance subcommand associators -o, returns data',
+     ['associators', 'TST_Person.name="Mike"', '-o'],
+     {'stdout': ['//FakedUrl/root/cimv2:TST_Person.name="Sofi"',
+                 '//FakedUrl/root/cimv2:TST_Person.name="Gabi"',
+                 '//FakedUrl/root/cimv2:TST_FamilyCollection.name="Family2"'],
+      'rc': 0,
+      'test': 'lines'},
+     ASSOC_MOCK_FILE, OK],
+
+    # TODO add invalid associators tests
+    ['Verify instance subcommand associators, no instance name',
+     ['associators'],
+     {'stderr': ['Usage: pywbemcli instance associators [COMMAND-OPTIONS] '
+                 'INSTANCENAME',
+                 '',
+                 'Error: Missing argument "instancename".'],
+      'rc': 2,
+      'test': 'lines'},
+     ASSOC_MOCK_FILE, OK],
+
+    ['Verify instance subcommand associators, invalid instance name',
+     ['associators', 'TST_Blah.blah="abc"'],
+     {'stdout': ['Return empty.'],
+      'rc': 0,
+      'test': 'lines'},
+     ASSOC_MOCK_FILE, OK],
     #
     #  instance count subcommand
     #
-    ['instance subcommand count, --help response',
+    ['Verify instance subcommand count, --help response',
      ['count', '--help'],
      {'stdout': INST_COUNT_HELP,
       'rc': 0,
       'test': 'lines'},
      None, OK],
-    ['instance subcommand count, Return table of instances',
+
+    ['Verify instance subcommand count, Return table of instances',
      ['count', 'CIM_'],
      {'stdout': ['Count of instances per class',
                  'Class      count',
@@ -467,14 +701,23 @@ MOCK_TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
+    ['Verify instance subcommand count, --sort. Return table of instances',
+     ['count', 'CIM_'],
+     {'stdout': ['Count of instances per class',
+                 'Class      count',
+                 '-------  -------',
+                 'CIM_Foo        3', ],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+    # TODO add subclass instances to the test.
+
     #
     #  instance invokemethod subcommand
     #
 
     #
-    #  instance query subcommand
-    #
-    # We have not implemented this command
+    #  instance query subcommand. We have not implemented this command
 
 ]
 

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -1,0 +1,498 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests the class subcommand
+"""
+import os
+import pytest
+from .cli_test_extensions import CLITestsBase
+
+TEST_DIR = os.path.dirname(__file__)
+
+SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
+ASSOC_MOCK_FILE = 'simple_assoc_mock_model.mof'
+
+INST_HELP = """Usage: pywbemcli instance [COMMAND-OPTIONS] COMMAND [ARGS]...
+
+  Command group to manage CIM instances.
+
+  This incudes functions to get, enumerate, create, modify, and delete
+  instances in a namspace and additional functions to get more general
+  information on instances (ex. counts) within the namespace
+
+  In addition to the command-specific options shown in this help text, the
+  general options (see 'pywbemcli --help') can also be specified before the
+  command. These are NOT retained after the command is executed.
+
+Options:
+  -h, --help  Show this message and exit.
+
+Commands:
+  associators   Get associated instances or names.
+  count         Get instance count for classes.
+  create        Create an instance of classname.
+  delete        Delete a single CIM instance.
+  enumerate     Enumerate instances or names of CLASSNAME.
+  get           Get a single CIMInstance.
+  invokemethod  Invoke a CIM method.
+  query         Execute an execquery request.
+  references    Get the reference instances or names.
+"""
+
+INST_ENUM_HELP = """Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME
+
+  Enumerate instances or names of CLASSNAME.
+
+  Enumerate instances or instance names from the WBEMServer starting either
+  at the top  of the hierarchy (if no CLASSNAME provided) or from the
+  CLASSNAME argument if provided.
+
+  Displays the returned instances or names
+
+Options:
+  -l, --localonly                 Show only local properties of the class.
+  -d, --deepinheritance           Return properties in subclasses of defined
+                                  target.  If not specified only properties in
+                                  target class are returned
+  -q, --includequalifiers         Include qualifiers in the result.
+  -c, --includeclassorigin        Include ClassOrigin in the result.
+  -p, --propertylist <property name>
+                                  Define a propertylist for the request. If
+                                  not included a Null property list is defined
+                                  and the server returns all properties. If
+                                  defined as empty string the server returns
+                                  no properties. ex: -p propertyname1 -p
+                                  propertyname2 or -p
+                                  propertyname1,propertyname2
+  -n, --namespace <name>          Namespace to use for this operation. If
+                                  defined that namespace overrides the general
+                                  options namespace
+  -o, --names_only                Show only local properties of the class.
+  -s, --sort                      Sort into alphabetical order by classname.
+  -S, --summary                   Return only summary of objects (count).
+  -h, --help                      Show this message and exit.
+"""
+
+ENUM_INST_RESP = """instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo2";
+   IntegerProp = 2;
+};
+
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo3";
+};
+
+"""
+
+INST_CREATE_HELP = """Usage: pywbemcli instance create [COMMAND-OPTIONS] CLASSNAME
+
+  Create an instance of classname.
+
+  Creates an instance of the class `CLASSNAME` with the properties defined
+  in the property option.
+
+  The propertylist option limits the created instance to the properties in
+  the list. This parameter is NOT passed to the server
+
+Options:
+  -P, --property property         Optional property definitions of form
+                                  name=value.Multiple definitions allowed, one
+                                  for each property
+  -p, --propertylist <property name>
+                                  Define a propertylist for the request. If
+                                  not included a Null property list is defined
+                                  and the server returns all properties. If
+                                  defined as empty string the server returns
+                                  no properties. ex: -p propertyname1 -p
+                                  propertyname2 or -p
+                                  propertyname1,propertyname2
+  -n, --namespace <name>          Namespace to use for this operation. If
+                                  defined that namespace overrides the general
+                                  options namespace
+  -h, --help                      Show this message and exit.
+"""
+
+INST_DELETE_HELP = """Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME
+
+  Delete a single CIM instance.
+
+  Delete the instanced defined by INSTANCENAME from the WBEM server. This
+  may be executed interactively by providing only a class name and the
+  interactive option.
+
+Options:
+  -i, --interactive       If set, INSTANCENAME argument must be a class and
+                          user is provided with a list of instances of the
+                          class from which the instance to delete is selected.
+  -n, --namespace <name>  Namespace to use for this operation. If defined that
+                          namespace overrides the general options namespace
+  -h, --help              Show this message and exit.
+"""
+
+INST_COUNT_HELP = """Usage: pywbemcli instance count [COMMAND-OPTIONS] CLASSNAME-REGEX
+
+  Get instance count for classes.
+
+  Displays the count of instances for the classes defined by the `CLASSNAME-
+  REGEX` argument in one or more namespaces.
+
+  The size of the response may be limited by CLASSNAME-REGEX argument which
+  defines a regular expression based on the desired class names so that only
+  classes that match the regex are counted. The CLASSNAME-regex argument is
+  optional.
+
+  The CLASSNAME-regex argument may be either a complete classname or a
+  regular expression that can be matched to one or more classnames. To limit
+  the filter to a single classname, terminate the classname with $.
+
+  The CLASSNAME-REGEX regular expression is anchored to the beginning of the
+  classname and is case insensitive. Thus `pywbem_` returns all classes that
+  begin with `PyWBEM_`, `pywbem_`, etc.
+
+  This operation can take a long time to execute.
+
+Options:
+  -s, --sort              Sort by instance count. Otherwise sorted by
+                          classname
+  -n, --namespace <name>  Namespace to use for this operation. If defined that
+                          namespace overrides the general options namespace
+  -h, --help              Show this message and exit.
+"""
+
+INST_REFERENCES_HELP = """Usage: pywbemcli instance references [COMMAND-OPTIONS] INSTANCENAME
+
+  Get the reference instances or names.
+
+  Gets the reference instances or instance names(--names-only option) for a
+  target instance name in the target WBEM server.
+
+  For the INSTANCENAME argument provided return instances or instance names
+  filtered by the --role and --resultclass options.
+
+  This may be executed interactively by providing only a class name and the
+  interactive option(-i). Pywbemcli presents a list of instances names in
+  the class from which one can be chosen as the target.
+
+Options:
+  -R, --resultclass <class name>  Filter by the result class name provided.
+  -r, --role <role name>          Filter by the role name provided.
+  -q, --includequalifiers         Include qualifiers in the result.
+  -c, --includeclassorigin        Include classorigin in the result.
+  -p, --propertylist <property name>
+                                  Define a propertylist for the request. If
+                                  not included a Null property list is defined
+                                  and the server returns all properties. If
+                                  defined as empty string the server returns
+                                  no properties. ex: -p propertyname1 -p
+                                  propertyname2 or -p
+                                  propertyname1,propertyname2
+  -o, --names_only                Show only local properties of the class.
+  -n, --namespace <name>          Namespace to use for this operation. If
+                                  defined that namespace overrides the general
+                                  options namespace
+  -s, --sort                      Sort into alphabetical order by classname.
+  -i, --interactive               If set, INSTANCENAME argument must be a
+                                  class and  user is provided with a list of
+                                  instances of the  class from which the
+                                  instance to delete is selected.
+  -S, --summary                   Return only summary of objects (count).
+  -h, --help                      Show this message and exit.
+"""
+
+INST_ASSOCIATORS_HELP = """Usage: pywbemcli instance associators [COMMAND-OPTIONS] INSTANCENAME
+
+  Get associated instances or names.
+
+  Returns the associated instances or names (--names-only option) for the
+  INSTANCENAME argument filtered by the --assocclass, --resultclass, --role
+  and --resultrole options.
+
+  This may be executed interactively by providing only a classname and the
+  interactive option. Pywbemcli presents a list of instances in the class
+  from which one can be chosen as the target.
+
+Options:
+  -a, --assocclass <class name>   Filter by the associated instancename
+                                  provided.
+  -c, --resultclass <class name>  Filter by the result class name provided.
+  -R, --role <role name>          Filter by the role name provided.
+  -R, --resultrole <class name>   Filter by the result role name provided.
+  -q, --includequalifiers         Include qualifiers in the result.
+  -c, --includeclassorigin        Include classorigin in the result.
+  -p, --propertylist <property name>
+                                  Define a propertylist for the request. If
+                                  not included a Null property list is defined
+                                  and the server returns all properties. If
+                                  defined as empty string the server returns
+                                  no properties. ex: -p propertyname1 -p
+                                  propertyname2 or -p
+                                  propertyname1,propertyname2
+  -o, --names_only                Show only local properties of the class.
+  -n, --namespace <name>          Namespace to use for this operation. If
+                                  defined that namespace overrides the general
+                                  options namespace
+  -s, --sort                      Sort into alphabetical order by classname.
+  -i, --interactive               If set, INSTANCENAME argument must be a
+                                  class and  user is provided with a list of
+                                  instances of the  class from which the
+                                  instance to delete is selected.
+  -S, --summary                   Return only summary of objects (count).
+  -h, --help                      Show this message and exit.
+"""
+
+REF_INSTS = """instance of TST_Lineage {
+   InstanceID = "MikeSofi";
+   parent = "/root/cimv2:TST_Person.name=\"Mike\"";
+   child = "/root/cimv2:TST_Person.name=\"Sofi\"";
+};
+
+instance of TST_Lineage {
+   InstanceID = "MikeGabi";
+   parent = "/root/cimv2:TST_Person.name=\"Mike\"";
+   child = "/root/cimv2:TST_Person.name=\"Gabi\"";
+};
+
+instance of TST_MemberOfFamilyCollection {
+   family = "/root/cimv2:TST_FamilyCollection.name=\"Family2\"";
+   member = "/root/cimv2:TST_Person.name=\"Mike\"";
+};
+"""
+
+OK = False
+RUN = True
+FAIL = False
+
+MOCK_TEST_CASES = [
+    # desc, args, exp_response, mock, condition
+
+    #
+    #   instance --help
+    #
+    ['instance subcommand help response',
+     '--help',
+     {'stdout': INST_HELP,
+      'test': 'lines'},
+     None, OK],
+    #
+    #  Instance Enumerate subcommand
+    #
+    ['instance subcommand enumerate  --help response',
+     ['enumerate', '--help'],
+     {'stdout': INST_ENUM_HELP,
+      'test': 'lines'},
+     None, OK],
+    ['instance subcommand enumerate CIM_Foo',
+     ['enumerate', 'CIM_Foo'],
+     {'stdout': ENUM_INST_RESP,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+    ['instance subcommand enumerate names CIM_Foo -o',
+     ['enumerate', 'CIM_Foo', '-o'],
+     {'stdout': ['root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
+                 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"',
+                 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo3"', ],
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+    #
+    #  instance get subcommand
+    #
+    ['instance subcommand enumerate deepinheritance CIM_Foo -d',
+     ['enumerate', 'CIM_Foo', '-d'],
+     {'stdout': ENUM_INST_RESP,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, False],
+
+    #
+    # instance enumerate error returns
+    #
+    ['instance subcommand enumerate error. invalid classname',
+     ['enumerate', 'CIM_Foox'],
+     {'stderr': 'Error: CIMError: 5: Class CIM_Foox not found in namespace'
+                ' root/cimv2',
+      'rc': 1,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+    ['instance subcommand enumerate error. no classname',
+     ['enumerate'],
+     {'stderr':
+         ['Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME',
+          '',
+          'Error: Missing argument "classname".'],
+      'rc': 2,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    #
+    #  instance create subcommand
+    #
+    # TODO  tests
+    ['instance subcommand create, --help response',
+     ['create', '--help'],
+     {'stdout': INST_CREATE_HELP,
+      'rc': 0,
+      'test': 'lines'},
+     None, OK],
+    # TODO create valid instance tests
+    # TODO create invaid instance tests
+
+    #
+    #  instance delete subcommand
+    #
+    ['instance subcommand delete, --help response',
+     ['delete', '--help'],
+     {'stdout': INST_DELETE_HELP,
+      'rc': 0,
+      'test': 'lines'},
+     None, OK],
+    # TODO This test fails because we are incorrectly parsing the instance ID
+    # fix with issue on moving to wbemurl from hand coded parser
+    ['instance subcommand delete, valid delete',
+     ['delete', 'CIM_Foo.InstanceID="CIM_Foo1"'],
+     {'stdout': "Deleted",
+      'rc': 2,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, False],
+
+    ['instance subcommand delete, missing instance name',
+     ['delete'],
+     {'stderr':
+         ['Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME',
+          '',
+          'Error: Missing argument "instancename".'],
+      'rc': 2,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['instance subcommand delete, instance name not in repo',
+     ['delete'],
+     {'stderr':
+         ['Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME',
+          '',
+          'Error: Missing argument "instancename".'],
+      'rc': 2,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    #
+    #  instance references subcommand
+    #
+    ['instance subcommand references, --help response',
+     ['references', '--help'],
+     {'stdout': INST_REFERENCES_HELP,
+      'rc': 0,
+      'test': 'lines'},
+     None, OK],
+    # TODO  add valid references test
+    ['instance subcommand references, returns data',
+     ['references', 'TST_Person.name="Mike"'],
+     {'stdout': REF_INSTS,
+      'rc': 0,
+      'test': 'lines'},
+     ASSOC_MOCK_FILE, OK],
+
+    ['instance subcommand references -o, returns data',
+     ['references', 'TST_Person.name="Mike"', '-o'],
+     {'stdout': ['//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeSofi"',
+                 '//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeGabi"',
+                 '//FakedUrl/root/cimv2:TST_MemberOfFamilyCollection.family'
+                 '="/root/cimv2:TST_FamilyCollection.name=\"Family2\"",member'
+                 '="/root/cimv2:TST_Person.name=\"Mike\""'],
+      'rc': 0,
+      'test': 'lines'},
+     ASSOC_MOCK_FILE, RUN],
+
+    # TODO add invalid references tests
+    ['instance subcommand references, no instance name',
+     ['references'],
+     {'stderr': ['Usage: pywbemcli instance references [COMMAND-OPTIONS] '
+                 'INSTANCENAME',
+                 '',
+                 'Error: Missing argument "instancename".'],
+      'rc': 2,
+      'test': 'lines'},
+     ASSOC_MOCK_FILE, OK],
+
+    ['instance subcommand references, invalid instance name',
+     ['references', 'TST_Blah.blah="abc"'],
+     {'stdout': ['Return empty.'],
+      'rc': 0,
+      'test': 'lines'},
+     ASSOC_MOCK_FILE, OK],
+
+    #
+    #  instance associators subcommand
+    #
+    ['instance subcommand associators, --help response',
+     ['associators', '--help'],
+     {'stdout': INST_ASSOCIATORS_HELP,
+      'rc': 0,
+      'test': 'lines'},
+     None, OK],
+    # TODO  add valid associators tests
+    # TODO add invalid associators tests
+
+    #
+    #  instance count subcommand
+    #
+    ['instance subcommand count, --help response',
+     ['count', '--help'],
+     {'stdout': INST_COUNT_HELP,
+      'rc': 0,
+      'test': 'lines'},
+     None, OK],
+    ['instance subcommand count, Return table of instances',
+     ['count', 'CIM_'],
+     {'stdout': ['Count of instances per class',
+                 'Class      count',
+                 '-------  -------',
+                 'CIM_Foo        3', ],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    #
+    #  instance invokemethod subcommand
+    #
+
+    #
+    #  instance query subcommand
+    #
+    # We have not implemented this command
+
+]
+
+
+class TestSubcmdMock(CLITestsBase):
+    """
+    Test all of the class subcommand variations.
+    """
+    subcmd = 'instance'
+    # mock_mof_file = 'simple_mock_model.mof'
+
+    @pytest.mark.parametrize(
+        "desc, args, exp_response, mock, condition",
+        MOCK_TEST_CASES)
+    def test_execute_pywbemcli(self, desc, args, exp_response, mock, condition):
+        """
+        Execute pybemcli with the defined input and test output.
+        """
+        env = None
+        self.mock_subcmd_test(desc, self.subcmd, args, env, exp_response,
+                              mock, condition)


### PR DESCRIPTION
There are some TODO tests but this is a first cut at the tests for the instance group.  However, it cannot be complete until we get some depend prs incorporated includ #121, #120, #119, #118.

Creates a new test and adds tests for the subcommands in the instance
command group.