### PR TITLE
Fixed determination of package version for Linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -187,7 +187,8 @@ install:
 
 # commands to run builds & tests
 script:
-  - if [[ -n $_MANUAL_CI_RUN ]]; then make build; fi
+# make build is always run in order to verify the package version determination
+  - make build
   - make builddoc
   - make check
   - make test


### PR DESCRIPTION
This change fixes an error introduced in PR #1289, that failed on Linux.
For details, see the commit message.
Ready for review and merge.