### PR TITLE
Update requirements.txt to only use version 1 of prompt-toolkit

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -621,7 +621,6 @@ The following defines the help output for the `pywbemcli connection new --help` 
       Create a new named WBEM connection.
 
       This subcommand creates and saves a new named connection from the input
-
       arguments (NAME and URI) and options
 
       The new connection that can be referenced by the name argument in the

--- a/pywbemcli/pywbemcli.py
+++ b/pywbemcli/pywbemcli.py
@@ -293,6 +293,7 @@ The following can be entered in interactive mode:
                               <pywbemcli-cmd>.
   help                        Show this help message.
   :?, :h, :help               Show help message about interactive mode.
+  <up-arrow, down-arrow>      View pwbemcli command history:
 """)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,6 @@ click-spinner>=0.1.6
 click-repl>=0.1.0
 asciitree>=0.3.3
 tabulate>=0.8.2
-prompt-toolkit>=1.0.9
+# Issue # 117 prompt_toolkit is available but is incompatible.
+#   The repl cmd fails
+prompt-toolkit>=1.0.15,<2.0.0


### PR DESCRIPTION
Ready for review. New prompt-toolkit 2 is incompatible so we limited ourself to v 1.

See commit for details

I also added to help for repl that up and down arrows show history.

Added comment to requirements.txt  referenceing the issue number.