### PR TITLE
Add tests for the qualifier group

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -123,7 +123,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
       connection  Command group to manage WBEM connections.
       help        Show help message for interactive mode.
       instance    Command group to manage CIM instances.
-      qualifier   Commands to view QualifierDeclarations.
+      qualifier   Command group to view QualifierDeclarations.
       repl        Enter interactive (REPL) mode (default).
       server      Command Group for WBEM server operations.
 
@@ -1239,7 +1239,7 @@ The following defines the help output for the `pywbemcli qualifier --help` subco
 
     Usage: pywbemcli qualifier [COMMAND-OPTIONS] COMMAND [ARGS]...
 
-      Commands to view QualifierDeclarations.
+      Command group to view QualifierDeclarations.
 
       Includes the capability to get and enumerate CIM qualifier declarations
       defined in the WBEM Server.

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -197,12 +197,13 @@ The following defines the help output for the `pywbemcli class associators --hel
       -c, --includeclassorigin        Include classorigin in the result.
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
+                                      not defined a Null property list is defined
+                                      and the server returns all properties.
+                                      Multiple properties may be defined either a
+                                      comma separated list defing the option
+                                      multipletimes (ex: -p pn1 -p pn22 or -p
+                                      pn1,pn2). If defined as empty string the
+                                      server returns no properties.
       -o, --names_only                Show only local properties of the class.
       -s, --sort                      Sort into alphabetical order by classname.
       -n, --namespace <name>          Namespace to use for this operation. If
@@ -373,12 +374,13 @@ The following defines the help output for the `pywbemcli class get --help` subco
       -c, --includeclassorigin        Include classorigin in the result.
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
+                                      not defined a Null property list is defined
+                                      and the server returns all properties.
+                                      Multiple properties may be defined either a
+                                      comma separated list defing the option
+                                      multipletimes (ex: -p pn1 -p pn22 or -p
+                                      pn1,pn2). If defined as empty string the
+                                      server returns no properties.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
                                       options namespace
@@ -446,12 +448,13 @@ The following defines the help output for the `pywbemcli class references --help
       -c, --includeclassorigin        Include classorigin in the result.
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
+                                      not defined a Null property list is defined
+                                      and the server returns all properties.
+                                      Multiple properties may be defined either a
+                                      comma separated list defing the option
+                                      multipletimes (ex: -p pn1 -p pn22 or -p
+                                      pn1,pn2). If defined as empty string the
+                                      server returns no properties.
       -o, --names_only                Show only local properties of the class.
       -s, --sort                      Sort into alphabetical order by classname.
       -n, --namespace <name>          Namespace to use for this operation. If
@@ -871,12 +874,13 @@ The following defines the help output for the `pywbemcli instance associators --
       -c, --includeclassorigin        Include classorigin in the result.
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
+                                      not defined a Null property list is defined
+                                      and the server returns all properties.
+                                      Multiple properties may be defined either a
+                                      comma separated list defing the option
+                                      multipletimes (ex: -p pn1 -p pn22 or -p
+                                      pn1,pn2). If defined as empty string the
+                                      server returns no properties.
       -o, --names_only                Show only local properties of the class.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
@@ -962,12 +966,13 @@ The following defines the help output for the `pywbemcli instance create --help`
                                       instance.
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
+                                      not defined a Null property list is defined
+                                      and the server returns all properties.
+                                      Multiple properties may be defined either a
+                                      comma separated list defing the option
+                                      multipletimes (ex: -p pn1 -p pn22 or -p
+                                      pn1,pn2). If defined as empty string the
+                                      server returns no properties.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
                                       options namespace
@@ -1038,12 +1043,13 @@ The following defines the help output for the `pywbemcli instance enumerate --he
       -c, --includeclassorigin        Include ClassOrigin in the result.
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
+                                      not defined a Null property list is defined
+                                      and the server returns all properties.
+                                      Multiple properties may be defined either a
+                                      comma separated list defing the option
+                                      multipletimes (ex: -p pn1 -p pn22 or -p
+                                      pn1,pn2). If defined as empty string the
+                                      server returns no properties.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
                                       options namespace
@@ -1083,12 +1089,13 @@ The following defines the help output for the `pywbemcli instance get --help` su
                                       instance(s).
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
+                                      not defined a Null property list is defined
+                                      and the server returns all properties.
+                                      Multiple properties may be defined either a
+                                      comma separated list defing the option
+                                      multipletimes (ex: -p pn1 -p pn22 or -p
+                                      pn1,pn2). If defined as empty string the
+                                      server returns no properties.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
                                       options namespace
@@ -1205,12 +1212,13 @@ The following defines the help output for the `pywbemcli instance references --h
       -c, --includeclassorigin        Include classorigin in the result.
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
-                                      not included a Null property list is defined
-                                      and the server returns all properties. If
-                                      defined as empty string the server returns
-                                      no properties. ex: -p propertyname1 -p
-                                      propertyname2 or -p
-                                      propertyname1,propertyname2
+                                      not defined a Null property list is defined
+                                      and the server returns all properties.
+                                      Multiple properties may be defined either a
+                                      comma separated list defing the option
+                                      multipletimes (ex: -p pn1 -p pn22 or -p
+                                      pn1,pn2). If defined as empty string the
+                                      server returns no properties.
       -o, --names_only                Show only local properties of the class.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general

--- a/pywbemcli/_cmd_qualifier.py
+++ b/pywbemcli/_cmd_qualifier.py
@@ -32,7 +32,7 @@ from ._common_options import namespace_option, add_options, \
 @cli.group('qualifier', options_metavar=CMD_OPTS_TXT)
 def qualifier_group():
     """
-    Commands to view QualifierDeclarations.
+    Command group to view QualifierDeclarations.
 
     Includes the capability to get and enumerate CIM qualifier declarations
     defined in the WBEM Server.

--- a/pywbemcli/_common_options.py
+++ b/pywbemcli/_common_options.py
@@ -29,12 +29,13 @@ import click
 propertylist_option = [                      # pylint: disable=invalid-name
     click.option('-p', '--propertylist', multiple=True, type=str,
                  default=None, metavar='<property name>',
-                 help='Define a propertylist for the request. If not defined '
-                      'a Null property list is defined and the server '
-                      'returns all properties. Multiple properties may be '
-                      'defined either a comma separated list defing the option '
-                      'multipletimes (ex: -p pn1 -p pn22 or -p pn1,pn2). '
-                      'If defined as empty string the server returns no '
+                 help='Define a propertylist for the request. If option '
+                      'not specified a Null property list is created and the '
+                      'server returns all properties. Multiple properties may '
+                      'be defined with either a comma separated list defing '
+                      'the option multiple times. '
+                      '(ex: -p pn1 -p pn22 or -p pn1,pn2). '
+                      'If defined as empty string the server should return no '
                       'properties.')]
 
 names_only_option = [                      # pylint: disable=invalid-name

--- a/pywbemcli/_context_obj.py
+++ b/pywbemcli/_context_obj.py
@@ -214,7 +214,7 @@ class ContextObj(object):
             title = None
 
         rows.append(row)
-        click.echo(format_table(rows, header=hdr, title=title))
+        click.echo(format_table(rows, hdr, title=title))
 
     def connect_wbem_server(self):
         """

--- a/tests/unit/cli_test_extensions.py
+++ b/tests/unit/cli_test_extensions.py
@@ -34,10 +34,20 @@ class CLITestsBase(object):
             pywbemcli subcommand inserted for this test.  This is the first
             level subcommand (ex. class).
 
-          args (:term:`py:iterable` of :term:`string`):
-            Arguments to be inserted into the command line after the
-            subcommand name. This must be a list of the individual works
-            to be appended after the subcmd.
+          args (:term: dict or list or string):
+
+            if it is a dictionary arguments to be inserted into the command
+            line after the subcommand name. This is a dictionary with two
+            possible key names
+
+              * args: defines local aruments to append to the command after
+                    the subcommand name
+
+              * globals: defines global arguments that will be inserted
+                  into the command line before the subcommand name.
+
+            If it is a list or string it s the set of arguments  to append
+            after the subcommand name
 
           exp_response ( (dict): Keyword arguments for the expected response.):
             Includes the following keys:
@@ -107,19 +117,36 @@ class CLITestsBase(object):
         if not condition:
             pytest.skip("Condition for test case %s not met" % desc)
 
-        if isinstance(args, six.string_types):
-            args = args.split(" ")
+        global_args = []
+        local_args = []
+        if isinstance(args, dict):
+            global_args = args.get("global", None)
+            local_args = args.get("args", None)
+        elif isinstance(args, six.string_types):
+            local_args = args.split(" ")
+        elif isinstance(args, (list, tuple)):
+            local_args = args
+        else:
+            assert "Invalid args input to test %r" % args
 
-        # TODO -s option not needed if mock file
-        cmd_line = ['-s', 'http://blah']
+        if isinstance(local_args, six.string_types):
+            local_args = local_args.split(" ")
+
+        if isinstance(global_args, six.string_types):
+            global_args = global_args.split(" ")
+
+        cmd_line = ['-s', 'http:/blah']
+        if global_args:
+            cmd_line.extend(global_args)
+
         if mock_file:
             cmd_line.extend(['--mock-server',
                              os.path.join(TEST_DIR, mock_file)])
 
         cmd_line.append(subcmd)
 
-        if args:
-            cmd_line.extend(args)
+        if local_args:
+            cmd_line.extend(local_args)
 
         # print('\nCMDLINE %s' % cmd_line)
 

--- a/tests/unit/cli_test_extensions.py
+++ b/tests/unit/cli_test_extensions.py
@@ -34,9 +34,9 @@ class CLITestsBase(object):
             pywbemcli subcommand inserted for this test.  This is the first
             level subcommand (ex. class).
 
-          args (:term: dict or list or string):
+          args (:term: dict, list of term"`string` or term"`string`):
 
-            if it is a dictionary arguments to be inserted into the command
+            If it is a dictionary arguments to be inserted into the command
             line after the subcommand name. This is a dictionary with two
             possible key names
 

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -73,13 +73,14 @@ Options:
   -c, --includeclassorigin        Include ClassOrigin in the result.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
-                                  not defined a Null property list is defined
-                                  and the server returns all properties.
-                                  Multiple properties may be defined either a
-                                  comma separated list defing the option
-                                  multipletimes (ex: -p pn1 -p pn22 or -p
-                                  pn1,pn2). If defined as empty string the
-                                  server returns no properties.
+                                  option not specified a Null property
+                                  list is created and the server returns all
+                                  properties. Multiple properties may be
+                                  defined with either a comma separated list
+                                  defing the option multiple times. (ex: -p
+                                  pn1 -p pn22 or -p pn1,pn2). If defined as
+                                  empty string the server should return no
+                                  properties.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace
@@ -107,13 +108,14 @@ Options:
                                   instance(s).
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
-                                  not defined a Null property list is defined
-                                  and the server returns all properties.
-                                  Multiple properties may be defined either a
-                                  comma separated list defing the option
-                                  multipletimes (ex: -p pn1 -p pn22 or -p
-                                  pn1,pn2). If defined as empty string the
-                                  server returns no properties.
+                                  option not specified a Null property
+                                  list is created and the server returns all
+                                  properties. Multiple properties may be
+                                  defined with either a comma separated list
+                                  defing the option multiple times. (ex: -p
+                                  pn1 -p pn22 or -p pn1,pn2). If defined as
+                                  empty string the server should return no
+                                  properties.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace
@@ -142,13 +144,14 @@ Options:
                                   instance.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
-                                  not defined a Null property list is defined
-                                  and the server returns all properties.
-                                  Multiple properties may be defined either a
-                                  comma separated list defing the option
-                                  multipletimes (ex: -p pn1 -p pn22 or -p
-                                  pn1,pn2). If defined as empty string the
-                                  server returns no properties.
+                                  option not specified a Null property
+                                  list is created and the server returns all
+                                  properties. Multiple properties may be
+                                  defined with either a comma separated list
+                                  defing the option multiple times. (ex: -p
+                                  pn1 -p pn22 or -p pn1,pn2). If defined as
+                                  empty string the server should return no
+                                  properties.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace
@@ -225,13 +228,14 @@ Options:
   -c, --includeclassorigin        Include classorigin in the result.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
-                                  not defined a Null property list is defined
-                                  and the server returns all properties.
-                                  Multiple properties may be defined either a
-                                  comma separated list defing the option
-                                  multipletimes (ex: -p pn1 -p pn22 or -p
-                                  pn1,pn2). If defined as empty string the
-                                  server returns no properties.
+                                  option not specified a Null property
+                                  list is created and the server returns all
+                                  properties. Multiple properties may be
+                                  defined with either a comma separated list
+                                  defing the option multiple times. (ex: -p
+                                  pn1 -p pn22 or -p pn1,pn2). If defined as
+                                  empty string the server should return no
+                                  properties.
   -o, --names_only                Show only local properties of the class.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
@@ -269,13 +273,14 @@ Options:
   -c, --includeclassorigin        Include classorigin in the result.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
-                                  not defined a Null property list is defined
-                                  and the server returns all properties.
-                                  Multiple properties may be defined either a
-                                  comma separated list defing the option
-                                  multipletimes (ex: -p pn1 -p pn22 or -p
-                                  pn1,pn2). If defined as empty string the
-                                  server returns no properties.
+                                  option not specified a Null property
+                                  list is created and the server returns all
+                                  properties. Multiple properties may be
+                                  defined with either a comma separated list
+                                  defing the option multiple times. (ex: -p
+                                  pn1 -p pn22 or -p pn1,pn2). If defined as
+                                  empty string the server should return no
+                                  properties.
   -o, --names_only                Show only local properties of the class.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
@@ -601,20 +606,49 @@ MOCK_TEST_CASES = [
       'test': 'lines'},
      None, OK],
 
-    ['Verify instance subcommand references, returns data',
+    ['Verify instance subcommand references, returns instances',
      ['references', 'TST_Person.name="Mike"'],
      {'stdout': REF_INSTS,
       'rc': 0,
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references -o, returns data',
+    ['Verify instance subcommand references -o, returns paths',
      ['references', 'TST_Person.name="Mike"', '-o'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeSofi"',
                  '//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeGabi"',
                  '//FakedUrl/root/cimv2:TST_MemberOfFamilyCollection.family'
                  '="/root/cimv2:TST_FamilyCollection.name=\\"Family2\\"",member'
                  '="/root/cimv2:TST_Person.name=\\"Mike\\""'],
+      'rc': 0,
+      'test': 'lines'},
+     ASSOC_MOCK_FILE, OK],
+
+    ['Verify instance subcommand references -o, returns paths with resultclass '
+     'valid returns paths',
+     ['references', 'TST_Person.name="Mike"', '-o',
+      '--resultclass', 'TST_Lineage'],
+     {'stdout': ['//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeSofi"',
+                 '//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeGabi"', ],
+      'rc': 0,
+      'test': 'lines'},
+     ASSOC_MOCK_FILE, OK],
+
+    ['Verify instance subcommand references -o, returns paths with resultclass '
+     'short formvalid returns paths',
+     ['references', 'TST_Person.name="Mike"', '-o',
+      '-R', 'TST_Lineage'],
+     {'stdout': ['//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeSofi"',
+                 '//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeGabi"', ],
+      'rc': 0,
+      'test': 'lines'},
+     ASSOC_MOCK_FILE, OK],
+
+    ['Verify instance subcommand references -o, returns paths with resultclass '
+     'not a real ref returns no paths',
+     ['references', 'TST_Person.name="Mike"', '-o',
+      '--resultclass', 'TST_Lineagex'],
+     {'stdout': [],
       'rc': 0,
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
@@ -648,7 +682,7 @@ MOCK_TEST_CASES = [
      None, OK],
     # TODO  add valid associators tests
 
-    ['Verify instance subcommand associators, returns data',
+    ['Verify instance subcommand associators, returns iinstances',
      ['associators', 'TST_Person.name="Mike"'],
      {'stdout': ASSOC_INSTS,
       'rc': 0,

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -73,8 +73,8 @@ Options:
   -c, --includeclassorigin        Include ClassOrigin in the result.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
-                                  option not specified a Null property
-                                  list is created and the server returns all
+                                  option not specified a Null property list is
+                                  created and the server returns all
                                   properties. Multiple properties may be
                                   defined with either a comma separated list
                                   defing the option multiple times. (ex: -p
@@ -108,8 +108,8 @@ Options:
                                   instance(s).
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
-                                  option not specified a Null property
-                                  list is created and the server returns all
+                                  option not specified a Null property list is
+                                  created and the server returns all
                                   properties. Multiple properties may be
                                   defined with either a comma separated list
                                   defing the option multiple times. (ex: -p
@@ -144,8 +144,8 @@ Options:
                                   instance.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
-                                  option not specified a Null property
-                                  list is created and the server returns all
+                                  option not specified a Null property list is
+                                  created and the server returns all
                                   properties. Multiple properties may be
                                   defined with either a comma separated list
                                   defing the option multiple times. (ex: -p
@@ -228,8 +228,8 @@ Options:
   -c, --includeclassorigin        Include classorigin in the result.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
-                                  option not specified a Null property
-                                  list is created and the server returns all
+                                  option not specified a Null property list is
+                                  created and the server returns all
                                   properties. Multiple properties may be
                                   defined with either a comma separated list
                                   defing the option multiple times. (ex: -p
@@ -273,8 +273,8 @@ Options:
   -c, --includeclassorigin        Include classorigin in the result.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
-                                  option not specified a Null property
-                                  list is created and the server returns all
+                                  option not specified a Null property list is
+                                  created and the server returns all
                                   properties. Multiple properties may be
                                   defined with either a comma separated list
                                   defing the option multiple times. (ex: -p

--- a/tests/unit/test_qualdecl_subcmd.py
+++ b/tests/unit/test_qualdecl_subcmd.py
@@ -160,6 +160,16 @@ QD_TBL_OUT = """Qualifier Declarations
 +-------------+---------+---------+---------+-------------+-----------------+
 """
 
+QD_STATS_OUT = """Qualifier In : boolean = true,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+  Count    Exc    Time    ReqLen    ReplyLen  Operation
+-------  -----  ------  --------  ----------  ------------
+      1      0       0         0           0  GetQualifier
+
+"""
+
 OK = True
 RUN = True
 FAIL = False
@@ -255,6 +265,21 @@ MOCK_TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
+    ['Verify qualifier subcommand -T (statistics) gets stats output',
+     {'args': ['get', 'IN'],
+      'global': ['-T']},
+     {'stdout': QD_STATS_OUT,
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify qualifier subcommand --timestats gets stats output',
+     {'args': ['get', 'IN'],
+      'global': ['--timestats']},
+     {'stdout': QD_STATS_OUT,
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
 ]
 
 

--- a/tests/unit/test_qualdecl_subcmd.py
+++ b/tests/unit/test_qualdecl_subcmd.py
@@ -1,0 +1,282 @@
+# Copyright 2017 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests the qualifier grop of  subcommands
+"""
+import os
+import pytest
+from .cli_test_extensions import CLITestsBase
+
+TEST_DIR = os.path.dirname(__file__)
+
+# A mof file that defines basic qualifier decls, classes, and instances
+# but not tied to the DMTF classes.
+SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
+
+QD_HELP = """Usage: pywbemcli qualifier [COMMAND-OPTIONS] COMMAND [ARGS]...
+
+  Command group to view QualifierDeclarations.
+
+  Includes the capability to get and enumerate CIM qualifier declarations
+  defined in the WBEM Server.
+
+  pywbemcli does not provide the capability to create or delete CIM
+  QualifierDeclarations
+
+  In addition to the command-specific options shown in this help text, the
+  general options (see 'pywbemcli --help') can also be specified before the
+  command. These are NOT retained after the command is executed.
+
+Options:
+  -h, --help  Show this message and exit.
+
+Commands:
+  enumerate  Enumerate CIMQualifierDeclaractions.
+  get        Display CIMQualifierDeclaration.
+"""
+
+QD_ENUM_HELP = """Usage: pywbemcli qualifier enumerate [COMMAND-OPTIONS]
+
+  Enumerate CIMQualifierDeclaractions.
+
+  Displays all of the CIMQualifierDeclaration objects in the defined
+  namespace in the current WBEM Server
+
+Options:
+  -n, --namespace <name>  Namespace to use for this operation. If defined that
+                          namespace overrides the general options namespace
+  -S, --summary           Return only summary of objects (count).
+  -h, --help              Show this message and exit.
+"""
+
+QD_GET_HELP = """Usage: pywbemcli qualifier get [COMMAND-OPTIONS] QUALIFIERNAME
+
+  Display CIMQualifierDeclaration.
+
+  Displays CIMQualifierDeclaration QUALIFIERNAME for the defined namespace
+  in the current WBEMServer
+
+Options:
+  -n, --namespace <name>  Namespace to use for this operation. If defined that
+                          namespace overrides the general options namespace
+  -h, --help              Show this message and exit.
+"""
+
+QD_ENUM_MOCK = """Qualifier Abstract : boolean = false,
+    Scope(class, association, indication),
+    Flavor(EnableOverride, Restricted);
+
+Qualifier Aggregate : boolean = false,
+    Scope(reference),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Association : boolean = false,
+    Scope(association),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Description : string,
+    Scope(any),
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+Qualifier In : boolean = true,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Indication : boolean = false,
+    Scope(class, indication),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Key : boolean = false,
+    Scope(property, reference),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Out : boolean = false,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Override : string,
+    Scope(property, reference, method),
+    Flavor(EnableOverride, Restricted);
+
+"""
+
+QD_GET_MOCK = """Qualifier Description : string,
+    Scope(any),
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+"""
+# pylint: disable=line-too-long
+QD_GET_MOCK_XML = """<QUALIFIER.DECLARATION ISARRAY="false" NAME="Description" OVERRIDABLE="true" TOSUBCLASS="true" TRANSLATABLE="true" TYPE="string">
+    <SCOPE ASSOCIATION="true" CLASS="true" INDICATION="true" METHOD="true" PARAMETER="true" PROPERTY="true" REFERENCE="true"/>
+</QUALIFIER.DECLARATION>
+
+"""  # noqa: E501
+
+QD_TBL_OUT = """Qualifier Declarations
++-------------+---------+---------+---------+-------------+-----------------+
+| Name        | Type    | Value   | Array   | Scopes      | Flavors         |
++=============+=========+=========+=========+=============+=================+
+| Abstract    | boolean | False   | False   | CLASS       | EnableOverride  |
+|             |         |         |         | ASSOCIATION | Restricted      |
+|             |         |         |         | INDICATION  |                 |
++-------------+---------+---------+---------+-------------+-----------------+
+| Aggregate   | boolean | False   | False   | REFERENCE   | DisableOverride |
+|             |         |         |         |             | ToSubclass      |
++-------------+---------+---------+---------+-------------+-----------------+
+| Association | boolean | False   | False   | ASSOCIATION | DisableOverride |
+|             |         |         |         |             | ToSubclass      |
++-------------+---------+---------+---------+-------------+-----------------+
+| Description | string  |         | False   | ANY         | EnableOverride  |
+|             |         |         |         |             | ToSubclass      |
+|             |         |         |         |             | Translatable    |
++-------------+---------+---------+---------+-------------+-----------------+
+| In          | boolean | True    | False   | PARAMETER   | DisableOverride |
+|             |         |         |         |             | ToSubclass      |
++-------------+---------+---------+---------+-------------+-----------------+
+| Indication  | boolean | False   | False   | CLASS       | DisableOverride |
+|             |         |         |         | INDICATION  | ToSubclass      |
++-------------+---------+---------+---------+-------------+-----------------+
+| Key         | boolean | False   | False   | PROPERTY    | DisableOverride |
+|             |         |         |         | REFERENCE   | ToSubclass      |
++-------------+---------+---------+---------+-------------+-----------------+
+| Out         | boolean | False   | False   | PARAMETER   | DisableOverride |
+|             |         |         |         |             | ToSubclass      |
++-------------+---------+---------+---------+-------------+-----------------+
+| Override    | string  |         | False   | PROPERTY    | EnableOverride  |
+|             |         |         |         | REFERENCE   | Restricted      |
+|             |         |         |         | METHOD      |                 |
++-------------+---------+---------+---------+-------------+-----------------+
+"""
+
+OK = True
+RUN = True
+FAIL = False
+MOCK_TEST_CASES = [
+    # desc - Description of test
+    # args - Dictionary defining input to the command. There are two possible
+    #        keywords:
+    #        args: List of arguments or string of arguments to append to the
+    #            command line after the subcommand
+    #        globals - List of arguments or string of arguments to prepend to
+    #            the subcommand name.  This allows including global options on
+    #            each command.
+    # exp_response - Dictionary of expected responses,
+    # mock - None or name of files (mof or .py),
+    # condition - If True, the test is executed,  Otherwise it is skipped.
+
+    ['Verify qualifier subcommand help response',
+     '--help',
+     {'stdout': QD_HELP,
+      'test': 'lines'},
+     None, OK],
+
+    ['Verify qualifier subcommand enumerate  --help response',
+     ['enumerate', '--help'],
+     {'stdout': QD_ENUM_HELP,
+      'test': 'lines'},
+     None, OK],
+
+    ['Verify qualifier subcommand enumerate  -h response.',
+     ['enumerate', '-h'],
+     {'stdout': QD_ENUM_HELP,
+      'test': 'lines'},
+     None, OK],
+
+    ['Verify qualifier subcommand get  -h response.',
+     ['get', '-h'],
+     {'stdout': QD_GET_HELP,
+      'test': 'lines'},
+     None, OK],
+
+    ['Verify qualifier subcommand enumerate returns qual decls.',
+     ['enumerate'],
+     {'stdout': QD_ENUM_MOCK,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify qualifier subcommand enumerate with namespace returns qual decls.',
+     ['enumerate', '--namespace', 'root/cimv2'],
+     {'stdout': QD_ENUM_MOCK,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify qualifier subcommand enumerate summary returns qual decls.',
+     ['enumerate', '--summary'],
+     {'stdout': '9 CIMQualifierDeclaration(s) returned',
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify qualifier subcommand get  Description',
+     ['get', 'Description'],
+     {'stdout': QD_GET_MOCK,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify qualifier subcommand get invalid qual decl name .',
+     ['get', 'NoSuchQualDecl'],
+     {'stderr': "Error: CIMError: 6: Qualifier declaration NoSuchQualDecl not "
+                "found in namespace root/cimv2.",
+      'rc': 1,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify qualifier subcommand get  Description outputformat xml',
+     {'args': ['get', 'Description'],
+      'global': ['--output-format', 'xml']},
+     {'stdout': QD_GET_MOCK_XML,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify qualifier subcommand -o grid enumerate produces table out',
+     {'args': ['enumerate'],
+      'global': ['-o', 'grid']},
+     {'stdout': QD_TBL_OUT,
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify qualifier subcommand enumerate invalid namespace Fails',
+     ['enumerate', '--namespace', 'root/blah'],
+     {'stderr': "Error: CIMError: 3: Namespace root/blah not found for "
+                "qualifiers",
+      'rc': 1,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+]
+
+
+class TestSubcmdQualifiers(CLITestsBase):
+    """
+    Test all of the qualifiers subcommand variations.
+    """
+    subcmd = 'qualifier'
+
+    @pytest.mark.parametrize(
+        "desc, args, exp_response, mock, condition",
+        MOCK_TEST_CASES)
+    def test_qualdecl(self, desc, args, exp_response, mock, condition):
+        """
+        Common test method for those subcommands and options in the
+        class subcmd that can be tested.  This includes:
+
+          * Subcommands like help that do not require access to a server
+
+          * Subcommands that can be tested with a single execution of a
+            pywbemcli command.
+        """
+        env = None
+        self.mock_subcmd_test(desc, self.subcmd, args, env, exp_response,
+                              mock, condition)


### PR DESCRIPTION
Ready for review and commit.

This pr  adds a new test file test_qualifier_subcmds.py to test the qualifier command group.

These tests use calls to pywbemcli to test the help responses of the
group and subcommands as well as the standard mock to test data
responses for each subcommand and its options. This is the same pattern as test_class_subcmds.py and test_instance_subcmds.py

This extends the mock_subcmd_test method to allow for the inclusion of
global command options like --output-format. It allows a dictionary for the args parameter as well as the current list or string.  If the dictionary is supplied it can contain 2 keys (args - for the normal agurments and global for those arguments that are to be prepended to the command line ahead of the subcommand group name.  This allows testing, for example, --output-format, etc. parameters.

It makes one small change to the qualifier subcommands to standardize
the first line of the help text.