### PR TITLE
Change pywbem minimum to 0.12.6

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-# Additional pip requirements file for pywbem development dependencies.
+# Additional pip requirements file for pywbemtools development dependencies.
 #
 # The order of packages is significant, because pip processes them in the order
 # of appearance.
@@ -20,7 +20,10 @@ python-coveralls>=2.8.0; python_version == '2.7'
 
 # Unit test (no imports, invoked via py.test script)
 pytest>=3.3.0
-pytest-cov>=2.4.0
+
+# TODO:the <2.6 limitation is a temporary bypass because of import conflicts.
+# Remove when the conflicts are corrected. ks 14 Sept. 2018
+pytest-cov>=2.4.0,<2.6
 
 # Sphinx (no imports, invoked via sphinx-build script):
 Sphinx>=1.5.1
@@ -57,4 +60,3 @@ tornado<5.0; python_version <= '2.7'
 # Oct 2017.  See issue #80
 # TODO: retest this in the future so we can remove this limitation
 pyzmq==16.0.2
-

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -44,7 +44,7 @@ wheel===0.29.0
 
 # Direct dependencies for runtime (must be consistent with requirements.txt)
 
-pywbem===0.12.0
+pywbem===0.12.6
 
 pbr===1.10.0
 six===1.10.0

--- a/pywbemcli/_common.py
+++ b/pywbemcli/_common.py
@@ -275,6 +275,7 @@ def parse_wbemuri_str(wbemuri_str, namespace=None):
     if wbemuri_str and wbemuri_str[0] != ":":
         if re.match(r"^[a-zA-Z0-9_]+\.", wbemuri_str):
             wbemuri_str = ':%s' % wbemuri_str
+
     try:
         instance_name = CIMInstanceName.from_wbem_uri(wbemuri_str)
         if instance_name.namespace and namespace:

--- a/pywbemcli/_common.py
+++ b/pywbemcli/_common.py
@@ -268,7 +268,7 @@ def parse_wbemuri_str(wbemuri_str, namespace=None):
         ClickException: if the input wbemuri_str is an invalid wbemuri.
 
     """
-    # TODO documented in issue # 131
+    # TODO documented in issue #131
     # TODO remove this code when we resolve issue with pywbem issue #1359
     # Issue is that 0.13.0 does not allow the form classname.keybindings
     # without the : before the classname

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Pip requirements file for pywbem runtime dependencies.
+# Pip requirements file for pywbemtools runtime dependencies.
 #
 # The order of packages is significant, because pip processes them in the order
 # of appearance.
@@ -6,10 +6,9 @@
 # Make sure that the package versions in minimum-constraints.txt are also
 # the minimum versions required in requirements.txt and dev-requirements.txt.
 
-
 # Direct dependencies (except pip, setuptools, wheel):
 
-pywbem>=0.12.0
+pywbem>=0.12.6
 # git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
 
 pbr>=1.10.0

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -141,6 +141,10 @@ Options:
   -h, --help              Show this message and exit.
 """
 
+OK = True
+RUN = True
+FAIL = False
+
 MOCK_TEST_CASES = [
     # desc - Description of test
     # args - List of arguments or string of arguments
@@ -152,7 +156,7 @@ MOCK_TEST_CASES = [
      '--help',
      {'stdout': CLS_HELP,
       'test': 'lines'},
-     None, True],
+     None, OK],
     #
     # Enumerate subcommand and its options
     #
@@ -160,84 +164,84 @@ MOCK_TEST_CASES = [
      ['enumerate', '--help'],
      {'stdout': CLS_ENUM_HELP,
       'test': 'lines'},
-     None, True],
+     None, OK],
     ['class subcommand enumerate  -h response.',
      ['enumerate', '-h'],
      {'stdout': CLS_ENUM_HELP,
       'test': 'lines'},
-     None, True],
+     None, OK],
     ['class subcommand enumerate CIM_Foo',
      ['enumerate', 'CIM_Foo'],
-     {'stdout': '   [Description ( "Simple CIM Class" )]',
+     {'stdout': '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand enumerate CIM_Foo local only',
      ['enumerate', 'CIM_Foo', '-l'],
      {'stdout':
-      '   [Description ( "Simple CIM Class" )]',
+      '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand enumerate CIM_Foo localonly',
      ['enumerate', 'CIM_Foo', '--localonly'],
      {'stdout':
-      '   [Description ( "Simple CIM Class" )]',
+      '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand enumerate CIM_Foo -d',
      ['enumerate', 'CIM_Foo', '-d'],
      {'stdout':
-      '   [Description ( "Simple CIM Class" )]',
+      '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand enumerate CIM_Foo --deepinheritance',
      ['enumerate', 'CIM_Foo', '--deepinheritance'],
      {'stdout':
-      '   [Description ( "Simple CIM Class" )]',
+      '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand enumerate CIM_Foo -c',
      ['enumerate', 'CIM_Foo', '-c'],
      {'stdout':
-      '   [Description ( "Simple CIM Class" )]',
+      '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand enumerate CIM_Foo --includeclassorigin',
      ['enumerate', 'CIM_Foo', '--includeclassorigin'],
      {'stdout':
-      '   [Description ( "Simple CIM Class" )]',
+      '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand enumerate CIM_Foo -o names only',
      ['enumerate', 'CIM_Foo', '-o'],
      {'stdout': 'CIM_Foo',
       'test': 'startswith'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand enumerate CIM_Foo --names_only',
      ['enumerate', 'CIM_Foo', '--names_only'],
      {'stdout': 'CIM_Foo',
       'test': 'startswith'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand enumerate CIM_Foo summary',
      ['enumerate', 'CIM_Foo', '-S'],
-     {'stdout': '1 CIMClass(s) returned',
+     {'stdout': '2 CIMClass(s) returned',
       'test': 'startswith'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand enumerate CIM_Foo summary',
      ['enumerate', 'CIM_Foo', '--summary'],
-     {'stdout': '1 CIMClass(s) returned',
+     {'stdout': '2 CIMClass(s) returned',
       'test': 'startswith'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand enumerate CIM_Foo names and deepinheritance',
      ['enumerate', 'CIM_Foo', '-do'],
-     {'stdout': ['CIM_Foo', 'CIM_Foo_sub', 'CIM_Foo_sub2', 'CIM_Foo_sub_sub'],
+     {'stdout': ['CIM_Foo_sub', 'CIM_Foo_sub2', 'CIM_Foo_sub_sub'],
       'test': 'patterns'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
 
     ['class subcommand enumerate CIM_Foo include qualifiers',
      ['enumerate', 'CIM_Foo'],
      {'stdout': ['Key ( true )', '[Description (', 'class CIM_Foo'],
       'test': 'in'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     #
     # Test class get
     #
@@ -245,7 +249,7 @@ MOCK_TEST_CASES = [
      ['get', '--help'],
      {'stdout': 'Usage: pywbemcli class get [COMMAND-OPTIONS] CLASSNAME',
       'test': 'startswith'},
-     None, True],
+     None, OK],
 
     # subcommand get localonly option
     ['class subcommand get not localonly. Tests for property names',
@@ -253,7 +257,7 @@ MOCK_TEST_CASES = [
      {'stdout': ['string cimfoo_sub2;', 'InstanceID', 'IntegerProp', 'Fuzzy',
                  'Key ( true )', 'IN ( false )'],
       'test': 'in'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand get localonly. Tests whole response',
      ['get', 'CIM_Foo_sub2', '-l'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
@@ -262,7 +266,7 @@ MOCK_TEST_CASES = [
                  '',
                  '};', '', ],
       'test': 'patterns'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand get localonly. Tests whole response',
      ['get', 'CIM_Foo_sub2', '--localonly'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
@@ -271,7 +275,7 @@ MOCK_TEST_CASES = [
                  '',
                  '};', '', ],
       'test': 'patterns'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     # includequalifiers. Test the flag that excludes qualifiers
     ['class subcommand get without qualifiers, . Tests whole response',
      ['get', 'CIM_Foo_sub2', '--no-qualifiers'],
@@ -286,7 +290,7 @@ MOCK_TEST_CASES = [
                  '   uint32 DeleteNothing();', '',
                  '};', '', ],
       'test': 'lines'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     # test class get with propert list
     ['class subcommand get with propertylist, . Tests whole response',
      ['get', 'CIM_Foo_sub2', '-p', 'InstanceID'],
@@ -312,7 +316,7 @@ MOCK_TEST_CASES = [
                  '   uint32 DeleteNothing();', '',
                  '};', '', ],
       'test': 'lines'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand get with empty propertylist, . Tests whole response',
      ['get', 'CIM_Foo_sub2', '-p', '""'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {', '',
@@ -334,7 +338,7 @@ MOCK_TEST_CASES = [
                  '   uint32 DeleteNothing();', '',
                  '};', '', ],
       'test': 'lines'},
-     SIMPLE_MOCK_FILE, True],
+     SIMPLE_MOCK_FILE, OK],
     # TODO include class origin. TODO not returning class origin correctly.
     ['class subcommand get with propertylist and classorigin,',
      ['get', 'CIM_Foo_sub2', '-p', 'InstanceID', '-c'],
@@ -360,7 +364,7 @@ MOCK_TEST_CASES = [
                  '   uint32 DeleteNothing();', '',
                  '};', '', ],
       'test': 'lines'},
-     SIMPLE_MOCK_FILE, False],
+     SIMPLE_MOCK_FILE, FAIL],
     #
     # find subcommand
     #
@@ -368,13 +372,13 @@ MOCK_TEST_CASES = [
      ['find', '-h'],
      {'stdout': CLASS_FIND_HELP,
       'test': 'lines'},
-     None, False],
+     None, OK],
 
     ['class subcommand find  --help',
      ['find', '--help'],
      {'stdout': CLASS_FIND_HELP,
       'test': 'lines'},
-     None, False],
+     None, OK],
     # TODO Add detailed tests for find
     #
     # subcommand "class tree"
@@ -383,44 +387,53 @@ MOCK_TEST_CASES = [
      ['tree', '--help'],
      {'stdout': CLASS_TREE_HELP,
       'test': 'lines'},
-     None, True],
-    # TODO this test occasionally includeing | in output as if spinner not
-    # stopped. For now removed the extra spaces.
+     None, OK],
+
+    # Order inconsistent on output. so we just test that some of the lines are
+    # in the output
+    # root
+    #  +-- CIM_Foo
+    #      +-- CIM_Foo_sub2
+    #      +-- CIM_Foo_sub
+    #          +-- CIM_Foo_sub_sub
+    # or
+    # root
+    #  +-- CIM_Foo
+    #      +-- CIM_Foo_sub
+    #      |   +-- CIM_Foo_sub_sub
+    #      +-- CIM_Foo_sub2
     ['class subcommand tree top down. Order uncertain so use "in" test ',
      ['tree'],
      {'stdout': ['root',
                  ' +-- CIM_Foo',
-                 '+-- CIM_Foo_sub2',
-                 '+-- CIM_Foo_sub',
-                 '+-- CIM_Foo_sub_sub', ],
-      'test': 'in'},
-     SIMPLE_MOCK_FILE, True],
+                 '     +-- CIM_Foo_sub2',
+                 '     +-- CIM_Foo_sub',
+                 '[| ]*  +-- CIM_Foo_sub_sub', ],  # account for ordering issue
+      'test': 'regex'},
+     SIMPLE_MOCK_FILE, OK],
 
     # TODO The following test fails right now completely.
     ['class subcommand tree top down starting at defined class ',
      ['tree', 'CIM_Foo_sub'],
-     {'stdout': ['root',
-                 ' +-- CIM_Foo',
-                 '     +-- CIM_Foo_sub2',
-                 '     +-- CIM_Foo_sub',
-                 '         +-- CIM_Foo_sub_sub', ],
+     {'stdout': ['CIM_Foo_sub',
+                 ' +-- CIM_Foo_sub_sub', ],
       'test': 'lines'},
-     SIMPLE_MOCK_FILE, False],
-    ['class subcommand tree bottom up',
+     SIMPLE_MOCK_FILE, OK],
+    ['class subcommand tree bottom up. Ordering guaranteed here',
      ['tree', '-s', 'CIM_Foo_sub_sub'],
      {'stdout': ['root',
                  ' +-- CIM_Foo',
                  '     +-- CIM_Foo_sub',
                  '         +-- CIM_Foo_sub_sub', ],
       'test': 'lines'},
-     SIMPLE_MOCK_FILE, False],
+     SIMPLE_MOCK_FILE, OK],
     ['class subcommand tree with invalid class',
      ['tree', '-s', 'CIM_Foo_subx'],
-     {'stderr': 'Error: CIMError: 6: Class CIM_Foo_subx not found in namespace '
-                'root/cimv2.',
+     {'stderr': ['CIMError:', 'Class CIM_Foo_subx not found in namespace',
+                 'root/cimv2.'],
       'rc': 1,
-      'test': 'lines'},
-     SIMPLE_MOCK_FILE, True],
+      'test': 'regex'},
+     SIMPLE_MOCK_FILE, OK],
     #
     # associators subcommand tests
     #
@@ -440,7 +453,7 @@ MOCK_TEST_CASES = [
                  '--no-qualifiers',
                  '-c, --includeclassorigin', ],
       'test': 'in'},
-     None, True],
+     None, OK],
 
     # TODO add detailed associators tests.  Need new mock file with
     # associations to do this
@@ -459,7 +472,7 @@ MOCK_TEST_CASES = [
                  '--no-qualifiers',
                  '-c, --includeclassorigin', ],
       'test': 'in'},
-     None, True],
+     None, OK],
     # TODO add detailed reference tests
     #
     # invokemethod subcommand tests
@@ -472,7 +485,7 @@ MOCK_TEST_CASES = [
                  '-p, --parameter parameter  Optional multiple method '
                  'parameters of form', ],
       'test': 'in'},
-     None, True],
+     None, OK],
     # TODO add detailed invokemethod tests. Requires invokemethod in
     # mock repo
 ]
@@ -550,7 +563,7 @@ class TestClassEnumerate(object):
             [
                 ["Class parameter"],
                 ['CIM_Foo'],
-                '   [Description ( "Simple CIM Class" )]\n',
+                '   [Description ( "Subclass of CIM_Foo" )]\n',
                 None
             ]
         ]

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -131,7 +131,18 @@ class TestParseWbemUri(object):
                 namespace=u'root/cimv2',
                 keys={'k1': 'v1'},
                 host=u'10.11.12.13:5989'),
-            None, False
+            None, True
+        ),
+        (
+            "class and keybinding only",
+            'CIM_Foo.k1="v1"',
+            None,
+            dict(
+                classname=u'CIM_Foo',
+                namespace=None,
+                keys={'k1': 'v1'},
+                host=None,),
+            None, True
         ),
     ]
 
@@ -182,6 +193,7 @@ class TestParseWbemUri(object):
             else:
 
                 # The code to be tested
+                print('BEFORE uri=%s' % uri)
                 obj = parse_wbemuri_str(uri)
 
         if exp_attrs:

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -488,8 +488,8 @@ MOCK_TEST_CASES = [
     #
     ['Verify instance subcommand enumerate error, invalid classname fails',
      ['enumerate', 'CIM_Foox'],
-     {'stderr': 'Error: CIMError: 5: Class CIM_Foox not found in namespace'
-                ' root/cimv2',
+     {'stderr': 'Error: CIMError: 6: Class CIM_Foox not found in namespace'
+                ' root/cimv2.',
       'rc': 1,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],


### PR DESCRIPTION

See the commit messages for the gory details.

The invokemethod tests fail with 0.12.0.  Changed to 0.12.6 and the
tests work.  Note that we went to 0.12.6 because we changed messages in the mocker between 0.12.5 and 0.12.6 and that is causing test errors.  That change got us into other issues that required changing tests.  

UPDATE: Subsequent to initial creation of the which we rebased on pr#132, we hit more issues in the tests so found it easier to pull the two together into a single pr rather than trying to fix two of them and play with rebase..  This is that pr.  I will mark the other one as obsolete.  This pr has both the fix for pywbem version in requirements.txt and mininum_constraints.txt and the change to dev-requirements for pytest-cov:

pytest-cov>=2.4.0,<2.6

The majority of the changes, however are the changes to the test files, mostly for class but some for instance in part because of the changes to pywbem_mock for 0.12.6 but also to a) make the tests compares more general and avoid issues with changes to pywbem_mock, b)enable a couple of tests that were marked False, c) Change the tests to use the pattern of 3 variables OK, RUN, FAIL to mark tests.