### PR TITLE
Second pr -fixes #137 Fix failures in repl when click upgraded to 7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,8 @@ pywbem>=0.12.6
 
 pbr>=1.10.0
 six>=1.10.0
-click>=6.6
+# Issue # 137 defined a problem where the click update to 7.0 causes failures
+click>=6.6,<=6.7
 click-spinner>=0.1.6
 click-repl>=0.1.0
 asciitree>=0.3.3

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -539,8 +539,9 @@ MOCK_TEST_CASES = [
      ['enumerate'],
      {'stderr':
       ['Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME',
+       'Try "pywbemcli instance enumerate -h" for help.',
        '',
-       'Error: Missing argument "classname".'],
+       'Error: Missing argument "CLASSNAME".'],
       'rc': 2,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
@@ -663,8 +664,9 @@ MOCK_TEST_CASES = [
      ['get'],
      {'stderr':
       ['Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME',
+       'Try "pywbemcli instance get -h" for help.',
        '',
-       'Error: Missing argument "instancename".'],
+       'Error: Missing argument "INSTANCENAME".'],
       'rc': 2,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
@@ -963,8 +965,9 @@ MOCK_TEST_CASES = [
      ['delete'],
      {'stderr':
       ['Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME',
+       'Try "pywbemcli instance delete -h" for help.',
        '',
-       'Error: Missing argument "instancename".'],
+       'Error: Missing argument "INSTANCENAME".'],
       'rc': 2,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
@@ -973,11 +976,12 @@ MOCK_TEST_CASES = [
      ['delete'],
      {'stderr':
       ['Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME',
+       'Try "pywbemcli instance delete -h" for help.',
        '',
-       'Error: Missing argument "instancename".'],
+       'Error: Missing argument "INSTANCENAME".'],
       'rc': 2,
       'test': 'lines'},
-     SIMPLE_MOCK_FILE, OK],
+     SIMPLE_MOCK_FILE, RUN],
 
     #
     #  instance references subcommand
@@ -1076,8 +1080,9 @@ MOCK_TEST_CASES = [
      ['references'],
      {'stderr': ['Usage: pywbemcli instance references [COMMAND-OPTIONS] '
                  'INSTANCENAME',
+                 'Try "pywbemcli instance references -h" for help.',
                  '',
-                 'Error: Missing argument "instancename".'],
+                 'Error: Missing argument "INSTANCENAME".'],
       'rc': 2,
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
@@ -1121,8 +1126,9 @@ MOCK_TEST_CASES = [
      ['associators'],
      {'stderr': ['Usage: pywbemcli instance associators [COMMAND-OPTIONS] '
                  'INSTANCENAME',
+                 'Try "pywbemcli instance associators -h" for help.',
                  '',
-                 'Error: Missing argument "instancename".'],
+                 'Error: Missing argument "INSTANCENAME".'],
       'rc': 2,
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],


### PR DESCRIPTION
Bypass issues with upgrade to click 7.0 that causes failure each time a subcommand is executed in the REPL by forcing click 6.7 as maximum value