### PR TITLE
(Review 1) Fix issue in test_instances_subcmd.py

### DIFF
--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -538,11 +538,9 @@ MOCK_TEST_CASES = [
     ['Verify instance subcommand enumerate error, no classname fails',
      ['enumerate'],
      {'stderr':
-      ['Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME',
-       '',
-       'Error: Missing argument "classname".'],
+      ['Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME', ],
       'rc': 2,
-      'test': 'lines'},
+      'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
     #
@@ -662,11 +660,9 @@ MOCK_TEST_CASES = [
     ['instance subcommand get error. no classname',
      ['get'],
      {'stderr':
-      ['Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME',
-       '',
-       'Error: Missing argument "instancename".'],
+      ['Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME', ],
       'rc': 2,
-      'test': 'lines'},
+      'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance subcommand get error. no classname',
@@ -787,9 +783,7 @@ MOCK_TEST_CASES = [
                  'namespace "root/cimv2" in WEB ',
                  "server: PYWBEMCLIFakedConnection\\(url=",
                  'http://FakedUrl',
-                 "creds=None, default_namespace=",
-                 "'root/cimv2'\\)"
-                 ],
+                 "creds=None, default_namespace=", ],
       'rc': 1,
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
@@ -962,21 +956,17 @@ MOCK_TEST_CASES = [
     ['Verify instance subcommand delete, missing instance name',
      ['delete'],
      {'stderr':
-      ['Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME',
-       '',
-       'Error: Missing argument "instancename".'],
+      ['Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME', ],
       'rc': 2,
-      'test': 'lines'},
+      'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance subcommand delete, instance name not in repo',
      ['delete'],
      {'stderr':
-      ['Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME',
-       '',
-       'Error: Missing argument "instancename".'],
+      ['Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME', ],
       'rc': 2,
-      'test': 'lines'},
+      'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
     #
@@ -1075,11 +1065,9 @@ MOCK_TEST_CASES = [
     ['Verify instance subcommand references, no instance name',
      ['references'],
      {'stderr': ['Usage: pywbemcli instance references [COMMAND-OPTIONS] '
-                 'INSTANCENAME',
-                 '',
-                 'Error: Missing argument "instancename".'],
+                 'INSTANCENAME', ],
       'rc': 2,
-      'test': 'lines'},
+      'test': 'in'},
      ASSOC_MOCK_FILE, OK],
 
     ['Verify instance subcommand references, invalid instance name',
@@ -1120,11 +1108,9 @@ MOCK_TEST_CASES = [
     ['Verify instance subcommand associators, no instance name',
      ['associators'],
      {'stderr': ['Usage: pywbemcli instance associators [COMMAND-OPTIONS] '
-                 'INSTANCENAME',
-                 '',
-                 'Error: Missing argument "instancename".'],
+                 'INSTANCENAME', ],
       'rc': 2,
-      'test': 'lines'},
+      'test': 'in'},
      ASSOC_MOCK_FILE, OK],
 
     ['Verify instance subcommand associators, invalid instance name',


### PR DESCRIPTION
There were several test casesin test_instance_subcmd.py that started to fail over the weekend, notabably a set of changes to in  where the code
capitilized INSTANCENAME in the error reason and added that a line to the usage about
"Try pywbem .... -h".  This simply corrects the text in the test so that the test passes.

It was an issue in a change in Click where they changed the Usage message text for errors that involve missing required arguments between version 6.6 and 6.7 of Click.

We were testing for the exact message output and that changed. Since we must now assume that messages might change in the future, It would seem logical to generalize the test and protect ourselves against changes to message format by testing just for the most general part of the usage message in addition to the result code. That is the change made.