### PR TITLE
(Review 3) Fixes #117: Remove prompt toolkit version limitation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,4 @@ click-spinner>=0.1.6
 click-repl>=0.1.0
 asciitree>=0.3.3
 tabulate>=0.8.2
-# Issue # 117 prompt_toolkit is available but is incompatible.
-#   The repl cmd fails
-prompt-toolkit>=1.0.15,<2.0.0
+prompt-toolkit>=1.0.15


### PR DESCRIPTION
This removes the limitation on the prompt toolkit import max version that was imposed and documented in issue #117 
This also includes rebase from two other issues that we discovered and for which we created prs

1. Limit click import versions

2. fixes for test_instances_subcmd