### PR TITLE
Modify  requirements to use click version 7

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -15,9 +15,11 @@ exclude =
 
 # remove the comment and it will ignore noga entries at least in files.
 #disable_noqa
-    
+
 ignore =
     # unable to detect undefined names (when using wildcard import)
-    F403
-
+    F403,
+    # line break after binary operator: is issued since 10/2018 in situations
+    # that are ok (e.g. within brackets).
+    W504
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -56,7 +56,6 @@ jupyter>=1.0.0
 # TODO: Follow up on resolution of this issue.
 tornado<5.0; python_version <= '2.7'
 
-# temporary fix to get around problem introduced by pyzmq 16.03 release 30
-# Oct 2017.  See issue #80
-# TODO: retest this in the future so we can remove this limitation
-pyzmq==16.0.2
+# Excluding pymq 16.0.3 to get around problem; see issue #80.
+pyzmq>=16.0.2,!=16.0.3
+

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -48,9 +48,9 @@ pywbem===0.12.6
 
 pbr===1.10.0
 six===1.10.0
-click===6.6
+click===7.0
 click-spinner===0.1.6
-click-repl===0.1.0
+click-repl===0.1.6
 asciitree===0.3.3
 tabulate===0.8.2
 prompt-toolkit===1.0.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,11 +13,9 @@ pywbem>=0.12.6
 
 pbr>=1.10.0
 six>=1.10.0
-# TODO: Issue #137 defined a problem where the click update to 7.0 causes
-#       failures
-click>=6.6,<7.0
-click-spinner>=0.1.6
-click-repl>=0.1.0
+click>=7.0
+click-spinner>=0.1.8
+click-repl>=0.1.6
 asciitree>=0.3.3
 tabulate>=0.8.2
 prompt-toolkit>=1.0.15

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,15 +39,5 @@ universal = 1
 [pbr]
 warnerrors = true
 
-[flake8]
-ignore =
-    # unable to detect undefined names (when using wildcard import)
-    F403
-exclude =
-    .git,
-    .tox,
-    __pycache__,
-    *.pyc,
-    docs/conf.py,
-    build_doc,
-    dist
+# flake8 config is in .flake8 file
+


### PR DESCRIPTION
The problems with the initial release have been fixed so click 7 now works with the repl.  The problem was actually  in the repl.  Set the minimum toclick v 7 also.

This pr was rebased to pr #148, the flake8 issue

There is one thing you may have an issue with.  I set the minimum contstraints to click 7.0 also.  They changed some message formats so it seemed easiest.  We had fixed the ones  that were already in the tests but they will probably keep popping up.  Which means I set the minimum based on our tests, not on an actual click code change that we require. 