### PR TITLE
Fix issue with cli param in associators and fix doc

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -48,7 +48,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       attempts to retrieve the connection
                                       information from persistent storage. If the
                                       server option exists that is used as the
-                                      connection
+                                      connection name
       -d, --default_namespace TEXT    Default Namespace to use in the target
                                       WBEMServer if no namespace is defined in the
                                       subcommand(EnvVar:
@@ -184,18 +184,35 @@ The following defines the help output for the `pywbemcli class associators --hel
 
       Get the associated classes for CLASSNAME.
 
-      Get the classes(or classnames) that are associated with the CLASSNAME
+      Get the classes(or class names) that are associated with the CLASSNAME
       argument filtered by the --assocclass, --resultclass, --role and
-      --resultrole options.
+      --resultrole options and modified by the other options.
 
-      Results are displayed as defined by the output format global option.
+      Results are formatted as defined by the output format global option.
 
     Options:
-      -a, --assocclass <class name>   Filter by the associated class name
-                                      provided.
-      -c, --resultclass <class name>  Filter by the result class name provided.
-      -r, --role <role name>          Filter by the role name provided.
-      -R, --resultrole <role name>    Filter by the role name provided.
+      -a, --assocclass <class name>   Filter by the association class name
+                                      provided. Each returned class (or class
+                                      name) should be associated to the source
+                                      class through this class or its subclasses.
+                                      Optional.
+      -c, --resultclass <class name>  Filter by the association result class name
+                                      provided. Each returned class (or class
+                                      name) should be this class or one of its
+                                      subclasses. Optional
+      -r, --role <role name>          Filter by the role name provided. Each
+                                      returned class (or class name)should be
+                                      associated with the source class (CLASSNAME)
+                                      through an association with this role
+                                      (property name in the association that
+                                      matches this parameter). Optional.
+      -R, --resultrole <role name>    Filter by the result role name provided.
+                                      Each returned class (or class name)should be
+                                      associated with the source class (CLASSNAME)
+                                      through an association with returned object
+                                      having this role (property name in the
+                                      association that matches this parameter).
+                                      Optional.
       --no-qualifiers                 If set, request server to not include
                                       qualifiers in the returned class(s). The
                                       default behavior is to request include
@@ -284,6 +301,8 @@ The following defines the help output for the `pywbemcli class enumerate --help`
       The deepinheritance option defines whether the complete hiearchy is
       retrieved or just the next level in the hiearchy.
 
+      Results are formatted as defined by the output format global option.
+
     Options:
       -d, --deepinheritance     Return complete subclass hierarchy for this class
                                 if set. Otherwise retrieve only the next hierarchy
@@ -370,7 +389,7 @@ The following defines the help output for the `pywbemcli class get --help` subco
       The --includeclassorigin, --includeclassqualifiers, and --propertylist
       options determine what parts of the class definition are tetrieved.
 
-      The --output option determines the output format for the display.
+      Results are formatted as defined by the output format global option.
 
     Options:
       -l, --localonly                 Show only local properties of the class.
@@ -446,13 +465,21 @@ The following defines the help output for the `pywbemcli class references --help
 
       Get the reference classes for CLASSNAME.
 
-      Get the reference classes (or their classnames) for the CLASSNAME argument
-      filtered by the role and result class options and modified  by the other
+      Get the reference classes (or class names) for the CLASSNAME argument
+      filtered by the role and result class options and modified by the other
       options.
 
+      Results are displayed as defined by the output format global option.
+
     Options:
-      -R, --resultclass <class name>  Filter by the classname provided.
-      -r, --role <role name>          Filter by the role name provided.
+      -R, --resultclass <class name>  Filter by the result classname provided.
+                                      Each returned class (or classname) should be
+                                      this class or its subclasses. Optional.
+      -r, --role <role name>          Filter by the role name provided. Each
+                                      returned class (or classname) should refer
+                                      to the target instance through a property
+                                      with a name that matches the value of this
+                                      parameter. Optional.
       --no-qualifiers                 If set, request server to not include
                                       qualifiers in the returned class(s). The
                                       default behavior is to request include
@@ -505,8 +532,9 @@ The following defines the help output for the `pywbemcli class tree --help` subc
       if the --superclasses options is specified and a CLASSNAME is defined the
       class hiearchy of superclasses leading to CLASSNAME is displayed.
 
-      This is a separate subcommand because t is tied specifically to displaying
-      in a tree format.so that the --output-format global option is ignored.
+      This is a separate subcommand because it is tied specifically to
+      displaying in a tree format.so that the --output-format global option is
+      ignored.
 
     Options:
       -s, --superclasses      Display the superclasses to CLASSNAME as a tree.
@@ -749,13 +777,15 @@ The following defines the help output for the `pywbemcli connection select --hel
       Select a connection from defined connections.
 
       Selects a connection from the persistently stored set of named connections
-      if NAME exists in the store.
+      if NAME exists in the store. The name argument is optional.  If not
+      supplied, a list of connections from the connections definition file is
+      presented with a prompt for the user to select a name
 
       Examples:
 
          connection select <name>    # select the defined <name>
 
-         connection select       # presents select list to pick connection
+         connection select           # presents select list to pick connection
 
     Options:
       -h, --help  Show this message and exit.
@@ -890,19 +920,38 @@ The following defines the help output for the `pywbemcli instance associators --
       Get associated instances or names.
 
       Returns the associated instances or names (--names-only option) for the
-      INSTANCENAME argument filtered by the --assocclass, --resultclass, --role
-      and --resultrole options.
+      `INSTANCENAME` argument filtered by the --assocclass, --resultclass,
+      --role and --resultrole options.
 
       This may be executed interactively by providing only a classname and the
       interactive option. Pywbemcli presents a list of instances in the class
       from which one can be chosen as the target.
 
+      Results are formatted as defined by the output format global option.
+
     Options:
-      -a, --assocclass <class name>   Filter by the associated instancename
-                                      provided.
+      -a, --assocclass <class name>   Filter by the association class name
+                                      provided.Each returned instance (or instance
+                                      name) should be associated to the source
+                                      instance through this class or its
+                                      subclasses. Optional.
       -c, --resultclass <class name>  Filter by the result class name provided.
-      -R, --role <role name>          Filter by the role name provided.
-      -R, --resultrole <class name>   Filter by the result role name provided.
+                                      Each returned instance (or instance name)
+                                      should be a member of this class or one of
+                                      its subclasses. Optional
+      -r, --role <role name>          Filter by the role name provided. Each
+                                      returned instance (or instance name)should
+                                      be associated with the source instance
+                                      (INSTANCENAME) through an association with
+                                      this role (property name in the association
+                                      that matches this parameter). Optional.
+      -R, --resultrole <role name>    Filter by the result role name provided.
+                                      Each returned instance (or instance
+                                      name)should be associated with the source
+                                      instance name (`INSTANCENAME`) through an
+                                      association with returned object having this
+                                      role (property name in the association that
+                                      matches this parameter). Optional.
       -q, --includequalifiers         If set, requests server to include
                                       qualifiers in the returned instance(s).
       -c, --includeclassorigin        Include classorigin in the result.
@@ -921,7 +970,7 @@ The following defines the help output for the `pywbemcli instance associators --
                                       defined that namespace overrides the general
                                       options namespace
       -s, --sort                      Sort into alphabetical order by classname.
-      -i, --interactive               If set, INSTANCENAME argument must be a
+      -i, --interactive               If set, `INSTANCENAME` argument must be a
                                       class rather than an instance and user is
                                       presented with a list of instances of the
                                       class from which the instance to process is
@@ -1037,10 +1086,10 @@ The following defines the help output for the `pywbemcli instance delete --help`
       interactive option.
 
     Options:
-      -i, --interactive       If set, INSTANCENAME argument must be a class rather
-                              than an instance and user is presented with a list
-                              of instances of the class from which the instance to
-                              process is selected.
+      -i, --interactive       If set, `INSTANCENAME` argument must be a class
+                              rather than an instance and user is presented with a
+                              list of instances of the class from which the
+                              instance to process is selected.
       -n, --namespace <name>  Namespace to use for this operation. If defined that
                               namespace overrides the general options namespace
       -h, --help              Show this message and exit.
@@ -1068,6 +1117,8 @@ The following defines the help output for the `pywbemcli instance enumerate --he
 
       Displays the returned instances in mof, xml, or table formats or the
       instance names as a string or XML formats (--names-only option).
+
+      Results are formatted as defined by the output format global option.
 
     Options:
       -l, --localonly                 Show only local properties of the class.
@@ -1113,8 +1164,8 @@ The following defines the help output for the `pywbemcli instance get --help` su
 
       Get a single CIMInstance.
 
-      Gets the instance defined by INSTANCENAME where INSTANCENAME  must resolve
-      to the instance name of the desired instance. This may be supplied
+      Gets the instance defined by `INSTANCENAME` where `INSTANCENAME` must
+      resolve to the instance name of the desired instance. This may be supplied
       directly as an untyped wbem_uri formatted string or through the
       --interactive option. The wbemuri may contain the namespace or the
       namespace can be supplied with the --namespace option. If no namespace is
@@ -1123,6 +1174,8 @@ The following defines the help output for the `pywbemcli instance get --help` su
 
       This method may be executed interactively by providing only a classname
       and the interactive option (-i).
+
+      Results are formatted as defined by the output format global option.
 
     Options:
       -l, --localonly                 Show only local properties of the returned
@@ -1144,7 +1197,7 @@ The following defines the help output for the `pywbemcli instance get --help` su
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
                                       options namespace
-      -i, --interactive               If set, INSTANCENAME argument must be a
+      -i, --interactive               If set, `INSTANCENAME` argument must be a
                                       class rather than an instance and user is
                                       presented with a list of instances of the
                                       class from which the instance to process is
@@ -1194,7 +1247,7 @@ The following defines the help output for the `pywbemcli instance invokemethod -
                                   parameter to be included in the new instance.
                                   Array parameter values defined by comma-
                                   separated-values. EmbeddedInstance not allowed.
-      -i, --interactive           If set, INSTANCENAME argument must be a class
+      -i, --interactive           If set, `INSTANCENAME` argument must be a class
                                   rather than an instance and user is presented
                                   with a list of instances of the class from which
                                   the instance to process is selected.
@@ -1251,7 +1304,7 @@ The following defines the help output for the `pywbemcli instance modify --help`
                                       server uses the propertylist to limit
                                       changes made to the instance to properties
                                       in the propertylist.
-      -i, --interactive               If set, INSTANCENAME argument must be a
+      -i, --interactive               If set, `INSTANCENAME` argument must be a
                                       class rather than an instance and user is
                                       presented with a list of instances of the
                                       class from which the instance to process is
@@ -1286,6 +1339,8 @@ The following defines the help output for the `pywbemcli instance query --help` 
 
       The results of the query are displayed as mof or xml.
 
+      Results are formatted as defined by the output format global option.
+
     Options:
       -l, --querylanguage QUERY LANGUAGE
                                       Use the query language defined. (Default:
@@ -1312,20 +1367,29 @@ The following defines the help output for the `pywbemcli instance references --h
 
     Usage: pywbemcli instance references [COMMAND-OPTIONS] INSTANCENAME
 
-       Get the reference instances or names.
+      Get the reference instances or names.
 
-       Gets the reference instances or instance names(--names-only option) for a
-       target `INSTANCENAME` in the target WBEM server filtered by the  `role`
-       and `resultclass` options.
+      Gets the reference instances or instance names(--names-only option) for a
+      target `INSTANCENAME` in the target WBEM server filtered by the `role` and
+      `resultclass` options.
 
       This may be executed interactively by providing only a class name for
       `INSTANCENAME` and the `interactive` option(-i). Pywbemcli presents a list
-      of instances names in the class from which one can be chosen as the
+      of instances names in the class from which you can be chosen as the
       target.
+
+      Results are formatted as defined by the output format global option.
 
     Options:
       -R, --resultclass <class name>  Filter by the result class name provided.
-      -r, --role <role name>          Filter by the role name provided.
+                                      Each returned instance (or instance name)
+                                      should be a member of this class or its
+                                      subclasses. Optional
+      -r, --role <role name>          Filter by the role name provided. Each
+                                      returned instance (or instance name) should
+                                      refer to the target instance through a
+                                      property with aname that matches the value
+                                      of this parameter. Optional.
       -q, --includequalifiers         If set, requests server to include
                                       qualifiers in the returned instance(s).
       -c, --includeclassorigin        Include classorigin in the result.
@@ -1344,7 +1408,7 @@ The following defines the help output for the `pywbemcli instance references --h
                                       defined that namespace overrides the general
                                       options namespace
       -s, --sort                      Sort into alphabetical order by classname.
-      -i, --interactive               If set, INSTANCENAME argument must be a
+      -i, --interactive               If set, `INSTANCENAME` argument must be a
                                       class rather than an instance and user is
                                       presented with a list of instances of the
                                       class from which the instance to process is

--- a/pywbemcli/_cmd_class.py
+++ b/pywbemcli/_cmd_class.py
@@ -89,7 +89,8 @@ def class_get(context, classname, **options):
     The --includeclassorigin, --includeclassqualifiers, and --propertylist
     options determine what parts of the class definition are tetrieved.
 
-    The --output option determines the output format for the display.
+    Results are formatted as defined by the output format global option.
+
     """
     context.execute_cmd(lambda: cmd_class_get(context, classname, options))
 
@@ -178,6 +179,8 @@ def class_enumerate(context, classname, **options):
 
     The deepinheritance option defines whether the complete hiearchy is
     retrieved or just the next level in the hiearchy.
+
+    Results are formatted as defined by the output format global option.
     """
     context.execute_cmd(lambda: cmd_class_enumerate(context, classname,
                                                     options))
@@ -187,10 +190,15 @@ def class_enumerate(context, classname, **options):
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True)
 @click.option('-R', '--resultclass', type=str, required=False,
               metavar='<class name>',
-              help='Filter by the classname provided.')
+              help='Filter by the result classname provided. Each returned '
+                   'class (or classname) should be this class or its '
+                   'subclasses. Optional.')
 @click.option('-r', '--role', type=str, required=False,
               metavar='<role name>',
-              help='Filter by the role name provided.')
+              help='Filter by the role name provided. Each returned class '
+                   '(or classname) should refer to the target instance through '
+                   'a property with a name that matches the value of this '
+                   'parameter. Optional.')
 @add_options(includeclassqualifiers_option)
 @add_options(includeclassorigin_option)
 @add_options(propertylist_option)
@@ -203,9 +211,11 @@ def class_references(context, classname, **options):
     """
     Get the reference classes for CLASSNAME.
 
-    Get the reference classes (or their classnames) for the CLASSNAME argument
-    filtered by the role and result class options and modified  by the
+    Get the reference classes (or class names) for the CLASSNAME argument
+    filtered by the role and result class options and modified by the
     other options.
+
+    Results are displayed as defined by the output format global option.
     """
     context.execute_cmd(lambda: cmd_class_references(context, classname,
                                                      options))
@@ -215,16 +225,28 @@ def class_references(context, classname, **options):
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True)
 @click.option('-a', '--assocclass', type=str, required=False,
               metavar='<class name>',
-              help='Filter by the associated class name provided.')
+              help='Filter by the association class name provided. Each '
+                   'returned class (or class name) should be associated to the '
+                   'source class through this class or its subclasses. '
+                   'Optional.')
 @click.option('-c', '--resultclass', type=str, required=False,
               metavar='<class name>',
-              help='Filter by the result class name provided.')
+              help='Filter by the association result class name provided. Each '
+                   'returned class (or class name) should be this class or one '
+                   'of its subclasses. Optional')
 @click.option('-r', '--role', type=str, required=False,
               metavar='<role name>',
-              help='Filter by the role name provided.')
+              help='Filter by the role name provided. Each returned class '
+              '(or class name)should be associated with the source class '
+              '(CLASSNAME) through an association with this role (property '
+              'name in the association that matches this parameter). Optional.')
 @click.option('-R', '--resultrole', type=str, required=False,
               metavar='<role name>',
-              help='Filter by the role name provided.')
+              help='Filter by the result role name provided. Each returned '
+              'class (or class name)should be associated with the source class '
+              '(CLASSNAME) through an association with returned object having '
+              'this role (property name in the association that matches this '
+              'parameter). Optional.')
 @add_options(includeclassqualifiers_option)
 @add_options(includeclassorigin_option)
 @add_options(propertylist_option)
@@ -237,11 +259,11 @@ def class_associators(context, classname, **options):
     """
     Get the associated classes for CLASSNAME.
 
-    Get the classes(or classnames) that are associated with the CLASSNAME
+    Get the classes(or class names) that are associated with the CLASSNAME
     argument filtered by the --assocclass, --resultclass, --role and
-    --resultrole options.
+    --resultrole options and modified by the other options.
 
-    Results are displayed as defined by the output format global option.
+    Results are formatted as defined by the output format global option.
     """
     context.execute_cmd(lambda: cmd_class_associators(context, classname,
                                                       options))
@@ -301,7 +323,7 @@ def class_tree(context, classname, **options):
     if the --superclasses options is specified and a CLASSNAME is defined
     the class hiearchy of superclasses leading to CLASSNAME is displayed.
 
-    This is a separate subcommand because t is tied specifically to displaying
+    This is a separate subcommand because it is tied specifically to displaying
     in a tree format.so that the --output-format global option is ignored.
     """
     context.execute_cmd(lambda: cmd_class_tree(context, classname, options))

--- a/pywbemcli/_cmd_instance.py
+++ b/pywbemcli/_cmd_instance.py
@@ -55,7 +55,7 @@ deepinheritance_option = [              # pylint: disable=invalid-name
 
 interactive_option = [              # pylint: disable=invalid-name
     click.option('-i', '--interactive', is_flag=True, required=False,
-                 help='If set, INSTANCENAME argument must be a class rather '
+                 help='If set, `INSTANCENAME` argument must be a class rather '
                       'than an instance and user is presented with a list of '
                       'instances of the class from which the instance to '
                       'process is selected.')]
@@ -107,17 +107,18 @@ def instance_get(context, instancename, **options):
     """
     Get a single CIMInstance.
 
-    Gets the instance defined by INSTANCENAME where INSTANCENAME  must resolve
-    to the instance name of the desired instance. This may be supplied directly
-    as an untyped wbem_uri formatted string or through the --interactive
-    option. The wbemuri may contain the namespace or the namespace can be
-    supplied with the --namespace option. If no namespace is supplied, the
-    connection default namespace is used.  Any host name in the wbem_uri is
+    Gets the instance defined by `INSTANCENAME` where `INSTANCENAME` must
+    resolve to the instance name of the desired instance. This may be supplied
+    directly as an untyped wbem_uri formatted string or through the
+    --interactive option. The wbemuri may contain the namespace or the namespace
+    can be supplied with the --namespace option. If no namespace is supplied,
+    the connection default namespace is used.  Any host name in the wbem_uri is
     ignored.
 
     This method may be executed interactively by providing only a classname and
     the interactive option (-i).
 
+    Results are formatted as defined by the output format global option.
     """
     context.execute_cmd(lambda: cmd_instance_get(context, instancename,
                                                  options))
@@ -238,8 +239,6 @@ def instance_invokemethod(context, instancename, methodname, **options):
     Example:
 
     pywbmcli instance invokemethod  CIM_x.InstanceID='hi" methodx -p id=3
-
-
     """
     context.execute_cmd(lambda: cmd_instance_invokemethod(context,
                                                           instancename,
@@ -271,6 +270,9 @@ def instance_enumerate(context, classname, **options):
 
     Displays the returned instances in mof, xml, or table formats or the
     instance names as a string or XML formats (--names-only option).
+
+    Results are formatted as defined by the output format global option.
+
     """
     context.execute_cmd(lambda: cmd_instance_enumerate(context, classname,
                                                        options))
@@ -280,10 +282,15 @@ def instance_enumerate(context, classname, **options):
 @click.argument('instancename', type=str, metavar='INSTANCENAME', required=True)
 @click.option('-R', '--resultclass', type=str, required=False,
               metavar='<class name>',
-              help='Filter by the result class name provided.')
+              help='Filter by the result class name provided. Each returned '
+                   'instance (or instance name) should be a member of this '
+                   'class or its subclasses. Optional')
 @click.option('-r', '--role', type=str, required=False,
               metavar='<role name>',
-              help='Filter by the role name provided.')
+              help='Filter by the role name provided. Each returned instance '
+                   '(or instance name) should refer to the target instance '
+                   'through a property with aname that matches the value of '
+                   'this parameter. Optional.')
 @add_options(includequalifiers_option)
 @add_options(includeclassorigin_option)
 @add_options(propertylist_option)
@@ -301,9 +308,11 @@ def instance_references(context, instancename, **options):
     target `INSTANCENAME` in the target WBEM server filtered by the
     `role` and `resultclass` options.
 
-   This may be executed interactively by providing only a class name for
-   `INSTANCENAME` and the `interactive` option(-i). Pywbemcli presents a list of
-   instances names in the class from which one can be chosen as the target.
+    This may be executed interactively by providing only a class name for
+    `INSTANCENAME` and the `interactive` option(-i). Pywbemcli presents a list
+    of instances names in the class from which you can be chosen as the target.
+
+    Results are formatted as defined by the output format global option.
     """
     context.execute_cmd(lambda: cmd_instance_references(context, instancename,
                                                         options))
@@ -313,16 +322,28 @@ def instance_references(context, instancename, **options):
 @click.argument('instancename', type=str, metavar='INSTANCENAME', required=True)
 @click.option('-a', '--assocclass', type=str, required=False,
               metavar='<class name>',
-              help='Filter by the associated instancename provided.')
+              help='Filter by the association class name provided.Each '
+                   'returned instance (or instance name) should be associated '
+                   'to the source instance through this class or its '
+                   'subclasses. Optional.')
 @click.option('-c', '--resultclass', type=str, required=False,
               metavar='<class name>',
-              help='Filter by the result class name provided.')
-@click.option('-R', '--role', type=str, required=False,
+              help='Filter by the result class name provided. Each '
+                   'returned instance (or instance name) should be a member '
+                   'of this class or one of its subclasses. Optional')
+@click.option('-r', '--role', type=str, required=False,
               metavar='<role name>',
-              help='Filter by the role name provided.')
+              help='Filter by the role name provided. Each returned instance '
+              '(or instance name)should be associated with the source instance '
+              '(INSTANCENAME) through an association with this role (property '
+              'name in the association that matches this parameter). Optional.')
 @click.option('-R', '--resultrole', type=str, required=False,
-              metavar='<class name>',
-              help='Filter by the result role name provided.')
+              metavar='<role name>',
+              help='Filter by the result role name provided. Each returned '
+              'instance (or instance name)should be associated with the source '
+              ' instance name (`INSTANCENAME`) through an association with '
+              'returned object having this role (property name in the '
+              'association that matches this parameter). Optional.')
 @add_options(includequalifiers_option)
 @add_options(includeclassorigin_option)
 @add_options(propertylist_option)
@@ -337,12 +358,14 @@ def instance_associators(context, instancename, **options):
     Get associated instances or names.
 
     Returns the associated instances or names (--names-only option) for the
-    INSTANCENAME argument filtered by the --assocclass, --resultclass, --role
+    `INSTANCENAME` argument filtered by the --assocclass, --resultclass, --role
     and --resultrole options.
 
     This may be executed interactively by providing only a classname and the
     interactive option. Pywbemcli presents a list of instances in the class
     from which one can be chosen as the target.
+
+    Results are formatted as defined by the output format global option.
     """
     context.execute_cmd(lambda: cmd_instance_associators(context, instancename,
                                                          options))
@@ -366,6 +389,8 @@ def instance_query(context, query, **options):
     argument and query language options.
 
     The results of the query are displayed as mof or xml.
+
+    Results are formatted as defined by the output format global option.
 
     """
     context.execute_cmd(lambda: cmd_instance_query(context, query, options))
@@ -400,7 +425,6 @@ def instance_count(context, classname, **options):
 
     This operation can take a long time to execute since it enumerates all
     classes in the namespace.
-
     """
     context.execute_cmd(lambda: cmd_instance_count(context, classname, options))
 

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -66,6 +66,8 @@ CLS_ENUM_HELP = """Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME
   The deepinheritance option defines whether the complete hiearchy is
   retrieved or just the next level in the hiearchy.
 
+  Results are formatted as defined by the output format global option.
+
 Options:
   -d, --deepinheritance     Return complete subclass hierarchy for this class
                             if set. Otherwise retrieve only the next hierarchy
@@ -131,8 +133,9 @@ CLASS_TREE_HELP = """Usage: pywbemcli class tree [COMMAND-OPTIONS] CLASSNAME
   if the --superclasses options is specified and a CLASSNAME is defined the
   class hiearchy of superclasses leading to CLASSNAME is displayed.
 
-  This is a separate subcommand because t is tied specifically to displaying
-  in a tree format.so that the --output-format global option is ignored.
+  This is a separate subcommand because it is tied specifically to
+  displaying in a tree format.so that the --output-format global option is
+  ignored.
 
 Options:
   -s, --superclasses      Display the superclasses to CLASSNAME as a tree.
@@ -498,14 +501,14 @@ TEST_CASES = [
      {'stdout': ['Usage: pywbemcli class associators [COMMAND-OPTIONS] '
                  'CLASSNAME',
                  'Get the associated classes for CLASSNAME.',
-                 '-a, --assocclass <class name>   Filter by the associated '
+                 '-a, --assocclass <class name>   Filter by the association '
                  'class name',
-                 '-c, --resultclass <class name>  Filter by the result class '
-                 'name provided.',
+                 '-c, --resultclass <class name>  Filter by the association '
+                 'result class name',
                  '-r, --role <role name>          Filter by the role name '
                  'provided.',
-                 '-R, --resultrole <role name>    Filter by the role name '
-                 'provided.',
+                 '-R, --resultrole <role name>    Filter by the result role '
+                 'name provided.',
                  '--no-qualifiers',
                  '-c, --includeclassorigin', ],
       'test': 'in'},
@@ -521,8 +524,8 @@ TEST_CASES = [
      {'stdout': ['Usage: pywbemcli class references [COMMAND-OPTIONS] '
                  'CLASSNAME',
                  'Get the reference classes for CLASSNAME.',
-                 '-R, --resultclass <class name>  Filter by the classname '
-                 'provided.',
+                 '-R, --resultclass <class name>  Filter by the result '
+                 'classname provided.',
                  '-r, --role <role name>          Filter by the role name '
                  'provided.',
                  '--no-qualifiers',

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -68,6 +68,8 @@ INST_ENUM_HELP = """Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSN
   Displays the returned instances in mof, xml, or table formats or the
   instance names as a string or XML formats (--names-only option).
 
+  Results are formatted as defined by the output format global option.
+
 Options:
   -l, --localonly                 Show only local properties of the class.
   -d, --deepinheritance           If set, requests server to return properties
@@ -100,8 +102,8 @@ INST_GET_HELP = """Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME
 
   Get a single CIMInstance.
 
-  Gets the instance defined by INSTANCENAME where INSTANCENAME  must resolve
-  to the instance name of the desired instance. This may be supplied
+  Gets the instance defined by `INSTANCENAME` where `INSTANCENAME` must
+  resolve to the instance name of the desired instance. This may be supplied
   directly as an untyped wbem_uri formatted string or through the
   --interactive option. The wbemuri may contain the namespace or the
   namespace can be supplied with the --namespace option. If no namespace is
@@ -110,6 +112,8 @@ INST_GET_HELP = """Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME
 
   This method may be executed interactively by providing only a classname
   and the interactive option (-i).
+
+  Results are formatted as defined by the output format global option.
 
 Options:
   -l, --localonly                 Show only local properties of the returned
@@ -131,7 +135,7 @@ Options:
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace
-  -i, --interactive               If set, INSTANCENAME argument must be a
+  -i, --interactive               If set, `INSTANCENAME` argument must be a
                                   class rather than an instance and user is
                                   presented with a list of instances of the
                                   class from which the instance to process is
@@ -179,10 +183,10 @@ INST_DELETE_HELP = """Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANC
   interactive option.
 
 Options:
-  -i, --interactive       If set, INSTANCENAME argument must be a class rather
-                          than an instance and user is presented with a list
-                          of instances of the class from which the instance to
-                          process is selected.
+  -i, --interactive       If set, `INSTANCENAME` argument must be a class
+                          rather than an instance and user is presented with a
+                          list of instances of the class from which the
+                          instance to process is selected.
   -n, --namespace <name>  Namespace to use for this operation. If defined that
                           namespace overrides the general options namespace
   -h, --help              Show this message and exit.
@@ -221,20 +225,29 @@ Options:
 
 INST_REFERENCES_HELP = """Usage: pywbemcli instance references [COMMAND-OPTIONS] INSTANCENAME
 
-   Get the reference instances or names.
+  Get the reference instances or names.
 
-   Gets the reference instances or instance names(--names-only option) for a
-   target `INSTANCENAME` in the target WBEM server filtered by the  `role`
-   and `resultclass` options.
+  Gets the reference instances or instance names(--names-only option) for a
+  target `INSTANCENAME` in the target WBEM server filtered by the `role` and
+  `resultclass` options.
 
   This may be executed interactively by providing only a class name for
   `INSTANCENAME` and the `interactive` option(-i). Pywbemcli presents a list
-  of instances names in the class from which one can be chosen as the
+  of instances names in the class from which you can be chosen as the
   target.
+
+  Results are formatted as defined by the output format global option.
 
 Options:
   -R, --resultclass <class name>  Filter by the result class name provided.
-  -r, --role <role name>          Filter by the role name provided.
+                                  Each returned instance (or instance name)
+                                  should be a member of this class or its
+                                  subclasses. Optional
+  -r, --role <role name>          Filter by the role name provided. Each
+                                  returned instance (or instance name) should
+                                  refer to the target instance through a
+                                  property with aname that matches the value
+                                  of this parameter. Optional.
   -q, --includequalifiers         If set, requests server to include
                                   qualifiers in the returned instance(s).
   -c, --includeclassorigin        Include classorigin in the result.
@@ -253,7 +266,7 @@ Options:
                                   defined that namespace overrides the general
                                   options namespace
   -s, --sort                      Sort into alphabetical order by classname.
-  -i, --interactive               If set, INSTANCENAME argument must be a
+  -i, --interactive               If set, `INSTANCENAME` argument must be a
                                   class rather than an instance and user is
                                   presented with a list of instances of the
                                   class from which the instance to process is
@@ -297,7 +310,7 @@ Options:
                                   server uses the propertylist to limit
                                   changes made to the instance to properties
                                   in the propertylist.
-  -i, --interactive               If set, INSTANCENAME argument must be a
+  -i, --interactive               If set, `INSTANCENAME` argument must be a
                                   class rather than an instance and user is
                                   presented with a list of instances of the
                                   class from which the instance to process is
@@ -316,19 +329,38 @@ INST_ASSOCIATORS_HELP = """Usage: pywbemcli instance associators [COMMAND-OPTION
   Get associated instances or names.
 
   Returns the associated instances or names (--names-only option) for the
-  INSTANCENAME argument filtered by the --assocclass, --resultclass, --role
-  and --resultrole options.
+  `INSTANCENAME` argument filtered by the --assocclass, --resultclass,
+  --role and --resultrole options.
 
   This may be executed interactively by providing only a classname and the
   interactive option. Pywbemcli presents a list of instances in the class
   from which one can be chosen as the target.
 
+  Results are formatted as defined by the output format global option.
+
 Options:
-  -a, --assocclass <class name>   Filter by the associated instancename
-                                  provided.
+  -a, --assocclass <class name>   Filter by the association class name
+                                  provided.Each returned instance (or instance
+                                  name) should be associated to the source
+                                  instance through this class or its
+                                  subclasses. Optional.
   -c, --resultclass <class name>  Filter by the result class name provided.
-  -R, --role <role name>          Filter by the role name provided.
-  -R, --resultrole <class name>   Filter by the result role name provided.
+                                  Each returned instance (or instance name)
+                                  should be a member of this class or one of
+                                  its subclasses. Optional
+  -r, --role <role name>          Filter by the role name provided. Each
+                                  returned instance (or instance name)should
+                                  be associated with the source instance
+                                  (INSTANCENAME) through an association with
+                                  this role (property name in the association
+                                  that matches this parameter). Optional.
+  -R, --resultrole <role name>    Filter by the result role name provided.
+                                  Each returned instance (or instance
+                                  name)should be associated with the source
+                                  instance name (`INSTANCENAME`) through an
+                                  association with returned object having this
+                                  role (property name in the association that
+                                  matches this parameter). Optional.
   -q, --includequalifiers         If set, requests server to include
                                   qualifiers in the returned instance(s).
   -c, --includeclassorigin        Include classorigin in the result.
@@ -347,7 +379,7 @@ Options:
                                   defined that namespace overrides the general
                                   options namespace
   -s, --sort                      Sort into alphabetical order by classname.
-  -i, --interactive               If set, INSTANCENAME argument must be a
+  -i, --interactive               If set, `INSTANCENAME` argument must be a
                                   class rather than an instance and user is
                                   presented with a list of instances of the
                                   class from which the instance to process is
@@ -386,7 +418,7 @@ Options:
                               parameter to be included in the new instance.
                               Array parameter values defined by comma-
                               separated-values. EmbeddedInstance not allowed.
-  -i, --interactive           If set, INSTANCENAME argument must be a class
+  -i, --interactive           If set, `INSTANCENAME` argument must be a class
                               rather than an instance and user is presented
                               with a list of instances of the class from which
                               the instance to process is selected.


### PR DESCRIPTION
1. Fixed an issue in instance associators where we were using the same
short option (-R) for two options (changed one to -r).

2. Extended the documentation for associators and references to better
define the the role and class options functionality.

3.Added statement on formatting for output to a number of the
subcommands  in class and instance.

4. Modified the  tests to that these changes to help text pass the
tests.