### PR TITLE
Added repr as an output format for objects. Based on #158

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,8 @@ pywbemcli v0.5.0.dev0
 
 Released: Not yet
 
+This is the initial release of pywbemcli command line tool.
+
 Incompatible changes
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -28,8 +30,6 @@ Enhancements
 
 * Add input argument to _common.format_table to define sort of the
   rows of the table as a function of the formatting.
-
-This is the initial release of pywbemcli command line tool.
 
 Bug fixes
 ^^^^^^^^^

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -80,13 +80,13 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       trust/extracted/openssl/ca-bundle.trust.crt
                                       /etc/ssl/certs
                                       /etc/ssl/certificates
-      -o, --output-format [table|plain|simple|grid|rst|mof|xml|txt|tree]
+      -o, --output-format [table|plain|simple|grid|rst|mof|xml|txt|repr|tree]
                                       Output format (Default: simple). pywbemcli
                                       may override the format choice depending on
                                       the operation since not all formats apply to
                                       all output data types. For CIM structured
                                       objects (ex. CIMInstance), the default
-                                      output format is mof
+                                      output format is mof.
       --use-pull_ops [yes|no|either]  Determines whether the pull operations are
                                       used forthe EnumerateInstances,
                                       associatorinstances,referenceinstances, and

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -44,7 +44,7 @@ wheel==0.29.0
 
 # Direct dependencies for runtime (must be consistent with requirements.txt)
 
-pywbem==0.13.0
+pywbem==0.14.3
 
 pbr==1.10.0
 six==1.10.0

--- a/pywbemcli/_cmd_class.py
+++ b/pywbemcli/_cmd_class.py
@@ -498,6 +498,7 @@ def cmd_class_find(context, classname, options):
             ns_rows.sort(key=lambda x: x[1])
             rows.extend(ns_rows)
 
+        context.spinner.stop()
         if context.output_format in TABLE_FORMATS:
             headers = ['Namespace', 'Classname']
             click.echo(format_table(rows, headers,

--- a/pywbemcli/_common.py
+++ b/pywbemcli/_common.py
@@ -57,7 +57,7 @@ CIM_OBJECT_OUTPUT_FORMATS = ['mof', 'xml', 'txt', 'tree']
 # TODO: ks for some reason extending one list with another causes a problem
 # in click with the help.
 OUTPUT_FORMATS = ['table', 'plain', 'simple', 'grid', 'rst', 'mof', 'xml',
-                  'txt', 'tree']
+                  'txt', 'repr', 'tree']
 GENERAL_OPTIONS_METAVAR = '[GENERAL-OPTIONS]'
 CMD_OPTS_TXT = '[COMMAND-OPTIONS]'
 
@@ -765,11 +765,16 @@ def display_cim_objects(context, objects, output_format=None, summary=False):
             raise click.ClickException('Output Format %s not supported. '
                                        'Default to\n%r' %
                                        (output_format, object_))
+    elif output_format == 'repr':
+        try:
+            click.echo(repr(object_))
+        except AttributeError:
+            raise click.ClickException('"repr" display of %r failed' % object_)
     elif output_format == 'txt':
         try:
             click.echo(object_)
         except AttributeError:
-            raise click.ClickException('"xt" display of %r failed' % object_)
+            raise click.ClickException('"txt" display of %r failed' % object_)
     elif output_format == 'tree':
         raise click.ClickException('Tree output format not allowed')
     else:

--- a/pywbemcli/pywbemcli.py
+++ b/pywbemcli/pywbemcli.py
@@ -111,7 +111,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    'the format choice depending on the operation since not '
                    'all formats apply to all output data types. For CIM '
                    'structured objects (ex. CIMInstance), the default output '
-                   'format is mof'
+                   'format is mof.'
               .format(of=DEFAULT_OUTPUT_FORMAT))
 @click.option('--use-pull_ops', envvar=PywbemServer.use_pull_envvar,
               type=click.Choice(['yes', 'no', 'either']),

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 
 # Direct dependencies (except pip, setuptools, wheel):
 
-pywbem>=0.13.0
+pywbem>=0.14.3
 # git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
 
 pbr>=1.10.0

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -524,7 +524,7 @@ TEST_CASES = [
 
     ['Verify class subcommand tree with invalid class',
      ['tree', '-s', 'CIM_Foo_subx'],
-     {'stderr': ['CIMError:', 'not found'],
+     {'stderr': ['CIMError:'],
       'rc': 1,
       'test': 'regex'},
 
@@ -602,14 +602,14 @@ TEST_CASES = [
 
     ['Verify class subcommand invokemethod fails Invalid Class',
      ['invokemethod', 'CIM_Foox', 'Fuzzy', '-p', 'TestInOutParameter="blah"'],
-     {'stderr': ["Error: CIMError: 6", "CIM_ERR_NOT_FOUND"],
+     {'stderr': ["Error: CIMError: 6"],
       'rc': 1,
       'test': 'in'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
     ['Verify class subcommand invokemethod fails Invalid Method',
      ['invokemethod', 'CIM_Foo', 'Fuzzyx', '-p', 'TestInOutParameter=blah'],
-     {'stderr': ["Error: CIMError: 17", "CIM_ERR_METHOD_NOT_FOUND"],
+     {'stderr': ["Error: CIMError: 17"],
       'rc': 1,
       'test': 'in'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
@@ -617,7 +617,7 @@ TEST_CASES = [
 
     ['Verify class subcommand invokemethod fails Method not registered',
      ['invokemethod', 'CIM_Foo', 'Fuzzy'],
-     {'stderr': ["Error: CIMError: 17", "CIM_ERR_METHOD_NOT_FOUND"],
+     {'stderr': ["Error: CIMError: 17"],
       'rc': 1,
       'test': 'in'},
      [SIMPLE_MOCK_FILE], OK],

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -591,7 +591,7 @@ TEST_CASES = [
     #
     ['Verify instance subcommand enumerate error, invalid classname fails',
      ['enumerate', 'CIM_Foox'],
-     {'stderr': ["Error: CIMError: 6", "CIM_ERR_NOT_FOUND"],
+     {'stderr': ["Error: CIMError: 6"],
       'rc': 1,
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
@@ -826,7 +826,11 @@ TEST_CASES = [
     ['Verify instance subcommand create, new instance invalid ns',
      ['create', 'PyWBEM_AllTypes', '-P', 'InstanceID=test_instance', '-n',
       'blah'],
+<<<<<<< HEAD
      {'stderr': ["Error: Exception 3", "CIM_ERR_INVALID_NAMESPACE"],
+=======
+     {'stderr': ["Error: Exception 3"],
+>>>>>>> 76f5fb3... Fix a number of test issues resulting primarily from changes to
       'rc': 1,
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
@@ -834,7 +838,11 @@ TEST_CASES = [
 
     ['Verify instance subcommand create, new instance invalid class',
      ['create', 'CIM_blah', '-P', 'InstanceID=test_instance'],
+<<<<<<< HEAD
      {'stderr': ["Error:", "CIMClass", "does not exist"],
+=======
+     {'stderr': ["Error:", "CIMClass"],
+>>>>>>> 76f5fb3... Fix a number of test issues resulting primarily from changes to
       'rc': 1,
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
@@ -1237,7 +1245,11 @@ TEST_CASES = [
       'TestInOutParameter=blah'],
      {'stderr': ["Error: CIMError: 17"],
       'rc': 1,
+<<<<<<< HEAD
       'test': 'in'},
+=======
+      'test': 'regex'},
+>>>>>>> 76f5fb3... Fix a number of test issues resulting primarily from changes to
      [SIMPLE_MOCK_FILE], OK],
 
     # TODO expand the number of invokemethod tests to include all options

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -826,11 +826,7 @@ TEST_CASES = [
     ['Verify instance subcommand create, new instance invalid ns',
      ['create', 'PyWBEM_AllTypes', '-P', 'InstanceID=test_instance', '-n',
       'blah'],
-<<<<<<< HEAD
      {'stderr': ["Error: Exception 3", "CIM_ERR_INVALID_NAMESPACE"],
-=======
-     {'stderr': ["Error: Exception 3"],
->>>>>>> 76f5fb3... Fix a number of test issues resulting primarily from changes to
       'rc': 1,
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
@@ -838,11 +834,7 @@ TEST_CASES = [
 
     ['Verify instance subcommand create, new instance invalid class',
      ['create', 'CIM_blah', '-P', 'InstanceID=test_instance'],
-<<<<<<< HEAD
-     {'stderr': ["Error:", "CIMClass", "does not exist"],
-=======
      {'stderr': ["Error:", "CIMClass"],
->>>>>>> 76f5fb3... Fix a number of test issues resulting primarily from changes to
       'rc': 1,
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
@@ -1245,11 +1237,7 @@ TEST_CASES = [
       'TestInOutParameter=blah'],
      {'stderr': ["Error: CIMError: 17"],
       'rc': 1,
-<<<<<<< HEAD
       'test': 'in'},
-=======
-      'test': 'regex'},
->>>>>>> 76f5fb3... Fix a number of test issues resulting primarily from changes to
      [SIMPLE_MOCK_FILE], OK],
 
     # TODO expand the number of invokemethod tests to include all options

--- a/tests/unit/test_qualdecl_subcmd.py
+++ b/tests/unit/test_qualdecl_subcmd.py
@@ -266,11 +266,7 @@ TEST_CASES = [
 
     ['Verify qualifier subcommand enumerate invalid namespace Fails',
      ['enumerate', '--namespace', 'root/blah'],
-<<<<<<< HEAD
      {'stderr': ["Error: CIMError: 3", "CIM_ERR_INVALID_NAMESPACE"],
-=======
-     {'stderr': ["Error: CIMError: 3"],
->>>>>>> 76f5fb3... Fix a number of test issues resulting primarily from changes to
       'rc': 1,
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
@@ -286,6 +282,20 @@ TEST_CASES = [
                  '0           0  GetQualifier'],
       'rc': 0,
       'test': 'in'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify qualifier subcommand -o repr get Description produces repr out',
+     {'args': ['get', 'Description'],
+      'global': ['-o', 'repr']},
+     {'stdout': "CIMQualifierDeclaration(name='Description', value=None, "
+                "type='string', is_array=False, array_size=None, "
+                "scopes=NocaseDict({'CLASS': False, 'ASSOCIATION': False, "
+                "'INDICATION': False, 'PROPERTY': False, 'REFERENCE': False, "
+                "'METHOD': False, 'PARAMETER': False, 'ANY': True}), "
+                "tosubclass=True, overridable=True, translatable=True, "
+                "toinstance=None)",
+      'rc': 0,
+      'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 ]
 

--- a/tests/unit/test_qualdecl_subcmd.py
+++ b/tests/unit/test_qualdecl_subcmd.py
@@ -235,7 +235,7 @@ TEST_CASES = [
 
     ['Verify qualifier subcommand get invalid qual decl name .',
      ['get', 'NoSuchQualDecl'],
-     {'stderr': ["Error: CIMError: 6", "not found"],
+     {'stderr': ["Error: CIMError: 6"],
       'rc': 1,
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
@@ -266,7 +266,11 @@ TEST_CASES = [
 
     ['Verify qualifier subcommand enumerate invalid namespace Fails',
      ['enumerate', '--namespace', 'root/blah'],
+<<<<<<< HEAD
      {'stderr': ["Error: CIMError: 3", "CIM_ERR_INVALID_NAMESPACE"],
+=======
+     {'stderr': ["Error: CIMError: 3"],
+>>>>>>> 76f5fb3... Fix a number of test issues resulting primarily from changes to
       'rc': 1,
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],


### PR DESCRIPTION
This allows us to display output in a format consistent with python
objects.

**NOTE:** We also integrated the change to set minimum and current pywbem to 0.14.3 to this PR since until we integrate that change, no tests will pass

We also fixed a couple of minor errors.

This pr was based on #158 but that one has  been integrated into master.