### PR TITLE
fix issues with the table formatter for cim instance properties based on #158

### DIFF
--- a/pywbemcli/_cmd_class.py
+++ b/pywbemcli/_cmd_class.py
@@ -501,8 +501,8 @@ def cmd_class_find(context, classname, options):
         if context.output_format in TABLE_FORMATS:
             headers = ['Namespace', 'Classname']
             click.echo(format_table(rows, headers,
-                                    table_format=context.output_format,
-                                    title='Find class %s' % classname))
+                                    title='Find class %s' % classname,
+                                    table_format=context.output_format))
         else:
             # Display function to display classnames returned with
             # their namespaces in the form <namespace>:<classname>

--- a/pywbemcli/_cmd_instance.py
+++ b/pywbemcli/_cmd_instance.py
@@ -804,8 +804,8 @@ def cmd_instance_count(context, classname, options):
             rows.append([item[0], item[1]])
     context.spinner.stop()
     click.echo(format_table(rows, headers,
-                            table_format=context.output_format,
-                            title='Count of instances per class'))
+                            title='Count of instances per class',
+                            table_format=context.output_format))
 
 
 def cmd_instance_query(context, query, options):

--- a/pywbemcli/_common.py
+++ b/pywbemcli/_common.py
@@ -29,12 +29,30 @@ import tabulate
 
 from pywbem import CIMInstanceName, CIMInstance, CIMClass, \
     CIMQualifierDeclaration, CIMProperty, CIMClassName, cimvalue, \
-    CIM_ERR_METHOD_NOT_FOUND, CIMError
+    CIM_ERR_METHOD_NOT_FOUND, CIMError, CIMFloat, CIMInt
 from pywbem.cim_obj import mofstr
 from pywbem.cim_obj import NocaseDict
 
+from .config import USE_TERMINAL_WIDTH, DEFAULT_TABLE_WIDTH
+
+# Same as in pywbem.cimobj.py
+try:
+    from builtins import type as builtin_type
+except ImportError:  # py2
+    from __builtin__ import type as builtin_type
+
+# Same as in pwbem.cimtypes.py
+if six.PY2:
+    # pylint: disable=invalid-name,undefined-variable
+    _Longint = long  # noqa: F821
+else:
+    # pylint: disable=invalid-name
+    _Longint = int
+
+
 TABLE_FORMATS = ['table', 'plain', 'simple', 'grid', 'rst']
 CIM_OBJECT_OUTPUT_FORMATS = ['mof', 'xml', 'txt', 'tree']
+
 
 # TODO: ks for some reason extending one list with another causes a problem
 # in click with the help.
@@ -42,6 +60,8 @@ OUTPUT_FORMATS = ['table', 'plain', 'simple', 'grid', 'rst', 'mof', 'xml',
                   'txt', 'tree']
 GENERAL_OPTIONS_METAVAR = '[GENERAL-OPTIONS]'
 CMD_OPTS_TXT = '[COMMAND-OPTIONS]'
+
+DEFAULT_MAX_CELL_WIDTH = 100
 
 
 def output_format_is_table(output_format):
@@ -294,11 +314,9 @@ def parse_wbemuri_str(wbemuri_str, namespace=None):
     # TODO remove this code when we resolve issue with pywbem issue #1359
     # Issue is that 0.13.0 does not allow the form classname.keybindings
     # without the : before the classname
-    # print('PARSE_WBEMURI_STR1 %s' % wbemuri_str)
     if wbemuri_str and wbemuri_str[0] != ":":
         if re.match(r"^[a-zA-Z0-9_]+\.", wbemuri_str):
             wbemuri_str = ':%s' % wbemuri_str
-    # print('PARSE_WBEMURI_STR2 %s' % wbemuri_str)
 
     try:
         instance_name = CIMInstanceName.from_wbem_uri(wbemuri_str)
@@ -578,7 +596,7 @@ def get_cimtype(objects):
         test_object = object
     else:
         cim_type = 'unknown'
-        return
+        return None
 
     if isinstance(test_object, tuple):
         # associator or reference class level return is tuple
@@ -651,8 +669,8 @@ def display_cim_objects_summary(context, objects):
         if output_format_is_table(output_format):
             rows = [[len(objects), cim_type]]
             click.echo(format_table(rows, ['Count', 'CIM Type'],
-                                    table_format=context.output_format,
-                                    title='Summary of %s returned' % cim_type))
+                                    title='Summary of %s returned' % cim_type,
+                                    table_format=output_format))
             return
         click.echo('%s %s(s) returned' % (len(objects), cim_type))
     else:
@@ -708,44 +726,29 @@ def display_cim_objects(context, objects, output_format=None, summary=False):
         display_cim_objects_summary(context, objects)
         return
     # default when displaying cim objects is mof
-    if output_format is None:
-        output_format = 'mof'
+    output_format = context.output_format or 'mof'
 
     if isinstance(objects, (list, tuple)):
+        # Table format output is processed as a group
         if output_format in TABLE_FORMATS:
-            if isinstance(objects[0], CIMInstance):
-                print_insts_as_table(context, objects)
-            elif isinstance(objects[0], CIMClass):
-                print_classes_as_table(context, objects)
-            elif isinstance(objects[0], CIMQualifierDeclaration):
-                print_qual_decls_as_table(context, objects)
-            elif isinstance(objects[0], (CIMClassName, CIMInstanceName,
-                                         six.string_types)):
-                print_paths_as_table(context, objects)
-            else:
-                raise click.ClickException("Cannot print %s as table" %
-                                           type(objects[0]))
+            _print_objects_as_table(context, objects)
         else:
-            # recursively call to display each object
+            # Recursively call to display each object
             for obj in objects:
-                display_cim_objects(context, obj, output_format=output_format)
+                display_cim_objects(context, obj,
+                                    output_format=context.output_format)
         return
 
-    # display a single item.
+    # Display a single item.
     object_ = objects
+    # This allows passing single objects to the table formatter (i.e. not lists)
     if output_format in TABLE_FORMATS:
-        if isinstance(object_, CIMInstance):
-            print_insts_as_table(context, object_)
-        elif isinstance(object_, CIMClass):
-            print_classes_as_table(context, [object_])
-        else:
-            raise click.ClickException('No table formatter for %s' %
-                                       type(object_))
+        _print_objects_as_table(context, [object_])
     elif output_format == 'mof':
         try:
             click.echo(object_.tomof())
         except AttributeError:
-            # insert space between instance names for readability
+            # insert NL between instance names for readability
             if isinstance(object_, CIMInstanceName):
                 click.echo("")
                 click.echo(object_)
@@ -774,195 +777,447 @@ def display_cim_objects(context, objects, output_format=None, summary=False):
                                    output_format)
 
 
-def print_class_as_table(context, class_, max_cell_width=20):
-    """
-    TODO: Future add code here to display a class as a table.  The temp output
-    so we could create the function is to just output as mof
-    """
-    click.echo(class_.tomof())
-
-
-def print_classes_as_table(context, classes, max_cell_width=20):
+#######################################################################
+#
+#  The following code formats and outputs CIM Objects in table format
+#
+#######################################################################
+def _print_classes_as_table(classes, table_width, table_format):
     """
     TODO: Future extend to display classes as a table, showing the
     properties for each class. This will display the properties that exist in
-    subclasses
+    subclasses. The temp output
+    so we could create the function is to just output as mof
     """
     # pylint: disable=unused-argument
 
     for class_ in classes:
-        print_class_as_table(context, class_, max_cell_width=20)
+        click.echo(class_.tomof())
 
 
-def print_paths_as_table(context, objects, max_cell_width=20):
+def _print_paths_as_table(objects, table_width, table_format):
+    # pylint: disable=unused-argument
     """
     Display paths as a table. This include CIMInstanceName, ClassPath,
     and unicode (the return type for enumerateClasses).
     """
-    headers = ['path']
+    cim_type = get_cimtype(objects)
+    if objects:
+        if isinstance(cim_type, six.stringtypes):
+            headers = ['path']
+            rows = [obj for obj in objects]
+        elif isinstance(cim_type, CIMClass, CIMInstanceName):
+            headers = ['host', 'namespace', 'keybindings']
+            rows = [[obj.host, obj.namespace, obj.keybindings]
+                    for obj in objects]
+        else:
+            raise click.ClickException("{0} invalid type ({1})for path display".
+                                       format(objects[0], cim_type))
 
-    rows = [[obj] for obj in objects]
-
-    title = '%s paths' % get_cimtype(objects)
+    title = '{} paths'.format(cim_type)
     click.echo(format_table(rows, headers, title=title,
-                            table_format=context.output_format))
+                            table_format=table_format))
 
 
-def print_qual_decls_as_table(context, qual_decls, max_cell_width=20):
+def _print_qual_decls_as_table(qual_decls, table_width, table_format):
     """
-    Display the elements of qualifier declarations as a table
+    Display the elements of qualifier declarations as a table with a
+    row for each qualifier declaration and a column for each of the attributes
+    of the qualifier declaration (name, type, Value, Array, Scopes, Flavors.
+
+    The function displays all of the qualifier declarations in the
     """
     rows = []
     headers = ['Name', 'Type', 'Value', 'Array', 'Scopes', 'Flavors']
+    max_column_width = (table_width / len(headers)) - 4
     for q in qual_decls:
         scopes = '\n'.join([key for key in q.scopes if q.scopes[key]])
-        # TODO this is messy code.  Should we use something like:
-        flavors = 'EnableOverride' if q.overridable else 'DisableOverride'
-        flavors = q.overridable and 'EnableOverride' or 'DisableOverride'
-        flavors += '\n'
-        flavors += q.tosubclass and 'ToSubclass' or 'Restricted'
+        flavors = []
+        flavors.append('EnableOverride' if q.overridable else 'DisableOverride')
+        # flavors = q.overridable and 'EnableOverride' or 'DisableOverride'
+        # flavors += ','
+        flavors.append('ToSubclass' if q.tosubclass else 'Restricted')
         if q.translatable:
-            flavors += '\nTranslatable'
+            flavors.append('Translatable')
+        if sum([len(i) for i in flavors]) > max_column_width:
+            sep = "\n"
+        else:
+            sep = ", "
+        flavors = sep.join(flavors)
 
         row = [q.name, q.type, q.value, q.is_array, scopes, flavors]
         rows.append(row)
 
     click.echo(format_table(rows, headers, title='Qualifier Declarations',
-                            table_format=context.output_format))
+                            table_format=table_format))
 
 
-# TODO: Future provide way to set up max table and cell width more logically
-def print_insts_as_table(context, objects, include_classes=False,
-                         max_cell_width=20):
+def _format_instances_as_rows(insts, max_cell_width=DEFAULT_MAX_CELL_WIDTH,
+                              include_classes=False):
     """
-    If possible display the list of instances as a table.
-    Currently this only works for instances where the table is a column
-    per property.
+    Format the list of instances properties into as a list of the property
+    values for each instance( a row of the table) gathered into a list of
+    the rows.
 
-    This cannot display properties with embedded instances. They are ignored
+    Include_classes for each instance if True. Sets the classname as the first
+    column.
 
-    include_classes if True sets the classname as the first column.
+    max_width if not None folds col entries longer than the defined
+    max_cell_width. If max_width is None, the data length is ignored.
 
-    max_width if not None folds col entries longer than the defined length.
-    If max_width is None, the data length is ignored. The property names used
-    as the col headers are ignored.
+    Formatting is consistent with mof output for each value.
+
+    NOTE: This is a separate function to allow testing of the table formatting
+    independently of print output.
+
+    Returns:
+        list of strings where each string is a row in the table and each
+        item in a row is a cell entry
     """
+    # Avoid crash deeper in code if max_cell_width is None.
+    if max_cell_width is None:
+        max_cell_width = DEFAULT_MAX_CELL_WIDTH
     lines = []
-    title = None
     prop_names = []
 
     # find instance with max number of properties
-    for inst in objects:
+    for inst in insts:
         pn = inst.keys()
         if len(pn) > len(prop_names):
             prop_names = pn
+
+    for inst in insts:
+        if not isinstance(inst, CIMInstance):
+            raise ValueError('Only  Accepts CIMInstance. not type %s' %
+                             type(inst))
+
+        # Insert classname as first col if flag set
+        line = [inst.classname] if include_classes else []
+
+        # get value for each property in this object
+        for name in prop_names:
+            # Account for possible instances without all properties
+            if name not in inst.properties:
+                val_str = ''
+            else:
+                value = inst.get(name)
+                p = inst.properties[name]
+                if value is None:
+                    val_str = u''
+                else:
+                    val_str, _ = _value_tomof(p.value, p.type, indent=0,
+                                              maxline=max_cell_width,
+                                              line_pos=0, end_space=0,
+                                              avoid_splits=False)
+            line.append(val_str)
+        lines.append(line)
+
+    return lines
+
+
+def _print_instances_as_table(insts, table_width, table_format,
+                              include_classes=False):
+    """
+    Print the properties of the instances defined in insts as a table where
+    each row is an instance and each column is a property value.  The properties
+    are formatted similar to mof output. All properties in the instance are
+    included.
+
+    The header line consists of property names.
+    """
+
+    if table_width is None:
+        table_width = DEFAULT_TABLE_WIDTH
+
+    # Find instance with max number of prop names to determine number
+    # of columns
+    prop_names = []
+    for inst in insts:
+        pn = inst.keys()
+        if len(pn) > len(prop_names):
+            prop_names = pn
+
+    # Try to estimate max cell width from number of cols
+    # This allows folding long data.  However it is incomplete in
+    # that we do not fold the property name.  Further, the actual output
+    # width of a column involves the tabulate outputter, output_format
+    # so this is not deterministic.
+    if prop_names:
+        num_cols = len(prop_names)
+        max_cell_width = int(table_width / num_cols) - 2
+    else:
+        max_cell_width = table_width
 
     header_line = []
     if include_classes:
         header_line.append("classname")
     header_line.extend(prop_names)
 
-    title = objects[0].classname
+    # Fold long property names
+    new_header_line = []
+    for header in header_line:
+        if len(header) > max_cell_width:
+            new_header_line.append(fold_string(header, max_cell_width))
+        else:
+            new_header_line.append(header)
 
-    for inst in objects:
+    title = insts[0].classname
+
+    for inst in insts:
         if not isinstance(inst, CIMInstance):
             raise ValueError('Only CIMInstance display allows table output')
-        # Look for not allowed property types
-        for name in prop_names:
-            if name in inst.properties:
-                p = inst.properties[name]
-                if p.embedded_object:
-                    raise ValueError('Cannot process embeddedObject property '
-                                     ' %s' % name)
 
-        line = [inst.classname] if include_classes else []
-        # get value for each property in this object
-        # TODO: account for possible non-existence of name
-        for name in prop_names:
-            # Account for possible instances without all properties
-            if name not in inst.properties:
-                val_str = '?no_name?'
-            else:
-                value = inst.get(name)
-                p = inst.properties[name]
-                if not value:
-                    val_str = ''
-                else:
-                    if p.is_array:
-                        val_str = _array_value(p.type, value)
-                    else:
-                        val_str = _scalar_value(p.type, value)
-            if max_cell_width:
-                if len(val_str) > max_cell_width:
-                    val_str = fold_string(val_str, max_cell_width)
-            line.append(val_str)
-        lines.append(line)
+    lines = _format_instances_as_rows(insts, max_cell_width=max_cell_width,
+                                      include_classes=include_classes)
 
-    click.echo(format_table(lines, header_line, title=title,
-                            table_format=context.output_format))
+    click.echo(format_table(lines, new_header_line, title=title,
+                            table_format=table_format))
 
 
-def _scalar_value(type_, value_, max_width=None):
+def _print_objects_as_table(context, objects):
     """
-    Private function to map provided value to string for output.
-    Used by :meth:`tomof`.
+    Call the method for each type of object to print that object type
+    information as a table.
 
-    Parameters:
-
-      value_ (:term:`CIM data type`): Value to be mapped to string for MOF
-        output.
-
-      max_wdith (:term:`integer`): If not None causes any result string
-      longer than the integer value of max_width to be folded.
-
-    Return:
-        The string value of value_ based on type_
+    Output format is retrieved from context.
     """
-
-    if type_ == 'string':
-        _str = mofstr(value_, indent=0)
-    elif type_ == 'datetime':
-        _str = '"%s"' % str(value_)
+    if USE_TERMINAL_WIDTH:
+        table_width = click.get_terminal_size()[0]
     else:
-        _str = str(value_)
-    if max_width:
-        if len(str) > max_width:
-            _str = fold_string(_str, max_width)
-    return _str
+        table_width = DEFAULT_TABLE_WIDTH
+
+    output_format = context.output_format
+    if isinstance(objects[0], CIMInstance):
+        _print_instances_as_table(objects, table_width, output_format)
+    elif isinstance(objects[0], CIMClass):
+        _print_classes_as_table(objects, table_width, output_format)
+    elif isinstance(objects[0], CIMQualifierDeclaration):
+        _print_qual_decls_as_table(objects, table_width, output_format)
+    elif isinstance(objects[0], (CIMClassName, CIMInstanceName,
+                                 six.string_types)):
+        _print_paths_as_table(objects, table_width, output_format)
+    else:
+        raise click.ClickException("Cannot print %s as table" %
+                                   type(objects[0]))
 
 
-# TODO We do not know how to handle the fold mechanism here
-def _array_value(type_, value_, fold=False, max_cell_width=None):
+def _indent_str(indent):
     """
-    Output array of values either on single line or one line per value.
+    Return a MOF indent pad unicode string from the indent integer variable
+    that defines number of spaces to indent. Used to format MOF output.
+    """
+    return u''.ljust(indent, u' ')
+
+
+def mofval(value, indent=0, maxline=DEFAULT_MAX_CELL_WIDTH, line_pos=0,
+           end_space=0):
+    """
+    Low level function that returns the MOF representation of a non-string
+    value (i.e. a value that cannot not be split into multiple parts, for
+    example a numeric or boolean value).
+
+    If the MOF representation of the value does not fit into the remaining
+    space of the current line, it is put into a new line, considering the
+    specified indentation.
+
+    NOTE: This method is derived from pywbem mofval but differs in that we
+    want to output even if we violate the maxline limit on the new line. This
+    method favors outputing data over exceptions.
 
     Parameters:
 
-      fold (bool): If True, fold the output string for each entry.
+      value (:term:`unicode string`): The non-string value. Must not be `None`.
 
+      indent (:term:`integer`): Number of spaces to indent any new lines that
+        are generated.
+
+      maxline (:term:`integer`): Maximum line length for the generated MOF.
+
+      line_pos (:term:`integer`): Length of content already on the current
+        line.
+
+      end_space (:term:`integer`): Length of space to be left free on the last
+        line.
+
+    Returns:
+
+      tuple of
+        * :term:`unicode string`: MOF string.
+        * new line_pos
     """
-    def enum_value(type_, value_, sep, max_cell_width):
-        """ Convert the array values and return resulting string"""
-        str_ = ""
-        for i, val_ in enumerate(value_):
+
+    assert isinstance(value, six.text_type)
+
+    # Check for output on current line
+    # if fits or this is first entry on the line
+    avl_len = maxline - line_pos - end_space
+    if len(value) <= avl_len or line_pos == 0:
+        line_pos += len(value)
+        return value, line_pos
+
+    mof_str = u'\n' + _indent_str(indent) + value
+    line_pos = indent + len(value)
+    return mof_str, line_pos
+
+
+def _scalar_value_tomof(value, type, indent=0, maxline=DEFAULT_MAX_CELL_WIDTH,
+                        line_pos=0, end_space=0, avoid_splits=False):
+    # pylint: disable=line-too-long,redefined-builtin
+    """
+    Return a MOF string representing a scalar CIM-typed value.
+
+    `None` is returned as 'NULL'.
+
+    NOTE: This code taken from pywbem 0.14.0
+
+    Parameters:
+
+      value (:term:`CIM data type`, :term:`number`, :class:`~pywbem.CIMInstance`, :class:`~pywbem.CIMClass`):
+        The scalar CIM-typed value. May be `None`.
+
+        Must not be an array/list/tuple. Must not be a :ref:`CIM object` other
+        than those listed.
+
+      type (string): CIM data type name.
+
+      indent (:term:`integer`): Number of spaces to indent any new lines that
+        are generated.
+
+      maxline (:term:`integer`): Maximum line length for the generated MOF.
+
+      line_pos (:term:`integer`): Length of content already on the current
+        line.
+
+      end_space (:term:`integer`): Length of space to be left free on the last
+        line.
+
+      avoid_splits (bool): Avoid splits at the price of starting a new line
+        instead of using the current line.
+
+    Returns:
+
+      tuple of
+        * :term:`unicode string`: MOF string.
+        * new line_pos
+    """  # noqa: E501
+
+    if value is None:
+        return mofval(u'NULL', indent, maxline, line_pos, end_space)
+
+    if type == 'string':  # pylint: disable=no-else-raise
+        if isinstance(value, six.string_types):
+            return mofstr(value, indent, maxline, line_pos, end_space,
+                          avoid_splits)
+
+        if isinstance(value, (CIMInstance, CIMClass)):
+            # embedded instance or class
+            return mofstr(value.tomof(), indent, maxline, line_pos, end_space,
+                          avoid_splits)
+        raise TypeError("Scalar value of CIM type {0} has invalid Python type "
+                        "type {1} for conversion to a MOF string".format
+                        (type, builtin_type(value)))
+
+        # TODO Integrate _format into pywbemcli
+        #  _format("Scalar value of CIM type {0} has invalid Python type "
+        #        "type {1} for conversion to a MOF string",
+        #        type, builtin_type(value)))
+
+    elif type == 'char16':
+        return mofstr(value, indent, maxline, line_pos, end_space, avoid_splits,
+                      quote_char=u"'")
+    elif type == 'boolean':
+        val = u'true' if value else u'false'
+        return mofval(val, indent, maxline, line_pos, end_space)
+    elif type == 'datetime':
+        val = six.text_type(value)
+        return mofstr(val, indent, maxline, line_pos, end_space, avoid_splits)
+    elif type == 'reference':
+        val = value.to_wbem_uri()
+        return mofstr(val, indent, maxline, line_pos, end_space, avoid_splits)
+    elif isinstance(value, (CIMFloat, CIMInt, int, _Longint)):
+        val = six.text_type(value)
+        return mofval(val, indent, maxline, line_pos, end_space)
+    else:
+        assert isinstance(value, float), \
+            "Scalar value of CIM type {0} has invalid Python type {1} " \
+            "for conversion to a MOF string".format(type, builtin_type(value))
+        val = repr(value)
+        return mofval(val, indent, maxline, line_pos, end_space)
+
+
+def _value_tomof(value, type, indent=0, maxline=DEFAULT_MAX_CELL_WIDTH,
+                 line_pos=0, end_space=0, avoid_splits=False):
+    # pylint: disable=redefined-builtin
+    """
+    Return a MOF string representing a CIM-typed value (scalar or array).
+
+    In case of an array, the array items are separated by comma, but the
+    surrounding curly braces are not added.
+
+    Parameters:
+
+      value (CIM-typed value or list of CIM-typed values): The value.
+
+      indent (:term:`integer`): Number of spaces to indent any new lines that
+        are generated.
+
+      maxline (:term:`integer`): Maximum line length for the generated MOF.
+
+      line_pos (:term:`integer`): Length of content already on the current
+        line.
+
+      end_space (:term:`integer`): Length of space to be left free on the last
+        line.
+
+      avoid_splits (bool): Avoid splits at the price of starting a new line
+        instead of using the current line.
+
+    Returns:
+
+      tuple of
+        * :term:`unicode string`: MOF string.
+        * new line_pos
+    """
+
+    if isinstance(value, list):
+
+        mof = []
+
+        for i, v in enumerate(value):
+
             if i > 0:
-                str_ += sep
-            str_ += _scalar_value(type_, val_, max_width=max_cell_width)
-        return str_
+                # Assume we would add comma and space as separator
+                line_pos += 2
 
-    sep = ', ' if not fold else ',\n'
-    str_ = enum_value(type_, value_, sep, max_cell_width)
+            val_str, line_pos = _scalar_value_tomof(
+                v, type, indent, maxline, line_pos, end_space + 2, avoid_splits)
 
-    return str_
+            if i > 0:
+                # Add the actual separator
+                mof.append(u',')
+                if val_str[0] != '\n':
+                    mof.append(u' ')
+                else:
+                    # Adjust by the space we did not need
+                    line_pos -= 1
+
+            mof.append(val_str)
+
+        mof_str = u''.join(mof)
+
+    else:
+        mof_str, line_pos = _scalar_value_tomof(
+            value, type, indent, maxline, line_pos, end_space, avoid_splits)
+
+    return mof_str, line_pos
 
 
-def format_table(rows, headers, table_format='simple', title=None,
+def format_table(rows, headers, title=None, table_format='simple',
                  sort_columns=None):
     """
     General print table function.  Prints a list of lists in a
     table format where each inner list is a row.
     This code is temporary while the tabulate package is updated
-    to being  capable of supporting multiline cells.
 
       Parameters:
           headers (list strings) where each string is a

--- a/pywbemcli/config.py
+++ b/pywbemcli/config.py
@@ -41,7 +41,8 @@ However, they should be used from the ``pywbemcli`` namespace.
 
 __all__ = ['DEFAULT_CONNECTION_TIMEOUT', 'DEFAULT_OUTPUT_FORMAT',
            'DEFAULT_NAMESPACE', 'PYWBEMCLI_PROMPT', 'PYWBEMCLI_HISTORY_FILE',
-           'DEFAULT_MAXPULLCNT', 'MAX_TIMEOUT', 'DEFAULT_URL_SCHEME']
+           'DEFAULT_MAXPULLCNT', 'MAX_TIMEOUT', 'DEFAULT_URL_SCHEME',
+           'USE_TERMINAL_WIDTH', 'DEFAULT_TABLE_WIDTH']
 
 #: Default value in seconds for a WBEMConnection to timeout if the value
 #: is not set by an input parameter.
@@ -87,3 +88,14 @@ DEFAULT_MAXPULLCNT = 1000
 #: allow a connection timeout value larger than this on the command line or
 #: internal option for timeout.
 MAX_TIMEOUT = 300
+
+#: If True, the table formatter uses the terminal width as the maximum width
+#: of a table. If False it uses the DEFAULT_TABLE_WIDTH config variable. This
+#: sets the maximum width of table output. The table formatter tries to
+#: build any table output within this character width.
+USE_TERMINAL_WIDTH = True
+
+#: Default maximum character width of tables if USE_TERMINAL_WIDTH is NOT set.
+#: If this variable is an integer, that is the maximum width. If None, tables
+#: are output with no limit on width.
+DEFAULT_TABLE_WIDTH = 150

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -476,6 +476,24 @@ GET_INST_ALL_TYPES = """instance of PyWBEM_AllTypes {
 
 """
 
+ENUM_INST_TABLE_RESP = """CIM_Foo
++--------------+---------------+
+| InstanceID   | IntegerProp   |
++==============+===============+
+| "CIM_Foo1"   | 1             |
++--------------+---------------+
+| "CIM_Foo2"   | 2             |
++--------------+---------------+
+| "CIM_Foo3"   |               |
++--------------+---------------+
+"""
+
+ENUM_INST_GET_TABLE_RESP = """CIM_Foo
+InstanceID      IntegerProp
+------------  -------------
+"CIM_Foo1"                1
+"""
+
 REF_INSTS = """instance of TST_Lineage {
    InstanceID = "MikeSofi";
    parent = "/root/cimv2:TST_Person.name=\\\"Mike\\\"";
@@ -558,6 +576,13 @@ TEST_CASES = [
     ['Verify instance subcommand enumerate deepinheritance CIM_Foo -d',
      ['enumerate', 'CIM_Foo', '-d'],
      {'stdout': ENUM_INST_RESP,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance subcommand -o grid enumerate deepinheritance CIM_Foo -d',
+     {'args': ['enumerate', 'CIM_Foo', '-d'],
+      'global': ['-o', 'grid']},
+     {'stdout': ENUM_INST_TABLE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
@@ -689,6 +714,14 @@ TEST_CASES = [
       'rc': 0,
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
+
+
+    ['Verify instance subcommand -o grid get CIM_Foo -d',
+     {'args': ['get', 'CIM_Foo.InstanceID="CIM_Foo1"'],
+      'global': ['-o', 'simple']},
+     {'stdout': ENUM_INST_GET_TABLE_RESP,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
 
     #
     #  get subcommand errors

--- a/tests/unit/test_qualdecl_subcmd.py
+++ b/tests/unit/test_qualdecl_subcmd.py
@@ -160,6 +160,16 @@ QD_TBL_OUT = """Qualifier Declarations
 +-------------+---------+---------+---------+-------------+-----------------+
 """
 
+QD_TBL_GET_OUT = """Qualifier Declarations
++----------+---------+---------+---------+-------------+----------------+
+| Name     | Type    | Value   | Array   | Scopes      | Flavors        |
++==========+=========+=========+=========+=============+================+
+| Abstract | boolean | False   | False   | CLASS       | EnableOverride |
+|          |         |         |         | ASSOCIATION | Restricted     |
+|          |         |         |         | INDICATION  |                |
++----------+---------+---------+---------+-------------+----------------+
+"""
+
 # The following variables are used to control tests executed during
 # development of tests
 OK = True      # set to OK for tests passed. Set OK = False to execute one test
@@ -241,6 +251,15 @@ TEST_CASES = [
      {'args': ['enumerate'],
       'global': ['-o', 'grid']},
      {'stdout': QD_TBL_OUT,
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+
+    ['Verify qualifier subcommand -o grid get Abstract table out',
+     {'args': ['get', 'abstract'],
+      'global': ['-o', 'grid']},
+     {'stdout': QD_TBL_GET_OUT,
       'rc': 0,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],


### PR DESCRIPTION
WIP
Fix issues with the table formatter for cim instances

Modifies the code that produces table output for lists of instances (each property value is a column, each instance is a row) and qual decls( each row is a qual decl, the columns are the qual decl attributes) to improve the output quality and to produce the output values similar to the mof representations.

Note: We have not solved the issue with table form for classes so it just returns the mof.  