### PR TITLE
Add function level test for instance xxx --interactive subcmd option

### DIFF
--- a/tests/unit/cli_test_extensions.py
+++ b/tests/unit/cli_test_extensions.py
@@ -20,14 +20,14 @@ class CLITestsBase(object):  # pylint: disable=too-few-public-methods
         Defines methods to execute tests on pywbemcli.
 
     """
-    def subcmd_test(self, desc, subcmd, inputs, exp_response, mock_file,
+    def subcmd_test(self, desc, subcmd, inputs, exp_response, mock_files,
                     condition, verbose=None):
         # pylint: disable=line-too-long, no-self-use
         """
         Test method to execute test on pywbemcli by calling the executable
         pywbemcli for the command defined by subcmd with arguments defined
         by args. This can execute pywbemcli either with a mock environment
-        by using the mock_file variable or without mock if the mock_file
+        by using the mock_files variable or without mock if the mock_files
         parameter is None. The method tests the results of the execution
         of pywbemcli using the exp_response parameter.
 
@@ -131,7 +131,7 @@ class CLITestsBase(object):  # pylint: disable=too-few-public-methods
                'rc' expected exit_code from pywbemcli.  If None, code 0
                is expected.
 
-          mock_file (:term:`string` or None):
+          mock_files (:term:`string` or list of string or None):
             If this is a string, this test will be executed using the
             --mock-server pywbemcl option with this file as the name of the
             objects to be compiled or executed. This should be just a file name
@@ -185,16 +185,16 @@ class CLITestsBase(object):  # pylint: disable=too-few-public-methods
         if global_args:
             cmd_line.extend(global_args)
 
-        if mock_file:
-            if isinstance(mock_file, (list, tuple)):
-                for item in mock_file:
+        if mock_files:
+            if isinstance(mock_files, (list, tuple)):
+                for item in mock_files:
                     cmd_line.extend(['--mock-server',
                                      os.path.join(TEST_DIR, item)])
-            elif isinstance(mock_file, six.string_types):
+            elif isinstance(mock_files, six.string_types):
                 cmd_line.extend(['--mock-server',
-                                 os.path.join(TEST_DIR, mock_file)])
+                                 os.path.join(TEST_DIR, mock_files)])
             else:
-                assert("CLI_TEST_EXTENSIONS mock_file %s invalid" % mock_file)
+                assert("CLI_TEST_EXTENSIONS mock_file %s invalid" % mock_files)
 
         if not stdin:
             cmd_line.append(subcmd)

--- a/tests/unit/mock_prompt_0.py
+++ b/tests/unit/mock_prompt_0.py
@@ -1,0 +1,41 @@
+# (C) Copyright 2017 IBM Corp.
+# (C) Copyright 2017 Inova Development Inc.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+    Python code to mock pywbemcli._common.pywbemcli_prompt. Returns the
+    value defined in RETURN_VALUE
+
+    This file was defined to mock the return from pywbemcli instance
+    get/delete/... with the simple_assoc_mock_model and return "0" to represent
+    the first entry in the displayed output.
+
+    Add this file to the set of mock options and the prompt for picking
+    the instance will be output but the prompt for a response from the
+    user will be bypassed and the value defined in RETURN_VALUE returned.
+"""
+from mock import Mock
+
+import pywbemcli._common
+RETURN_VALUE = "0"
+
+
+def mock_prompt(msg):
+    """Mock function to replace pywbemcli_prompt and return a value"""
+    print(msg)
+    return RETURN_VALUE
+
+
+# pylint: disable=protected-access
+pywbemcli._common.pywbemcli_prompt = Mock(side_effect=mock_prompt)

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -27,6 +27,8 @@ SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
 ASSOC_MOCK_FILE = 'simple_assoc_mock_model.mof'
 ALLTYPES_MOCK_FILE = 'all_types.mof'
 INVOKE_METHOD_MOCK_FILE = "simple_mock_invokemethod.py"
+MOCK_PROMPT1_FILE = "mock_prompt_0.py"
+
 
 INST_HELP = """Usage: pywbemcli instance [COMMAND-OPTIONS] COMMAND [ARGS]...
 
@@ -715,13 +717,30 @@ TEST_CASES = [
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-
     ['Verify instance subcommand -o grid get CIM_Foo -d',
      {'args': ['get', 'CIM_Foo.InstanceID="CIM_Foo1"'],
       'global': ['-o', 'simple']},
      {'stdout': ENUM_INST_GET_TABLE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance subcommand get with interactive option',
+     ['get', 'TST_Person', '-i'],
+     {'stdout':
+      ['//FakedUrl/root/cimv2:TST_Person.name="Mike"',
+       'instance of TST_Person {'],
+      'rc': 0,
+      'test': 'in'},
+     [ASSOC_MOCK_FILE, MOCK_PROMPT1_FILE], OK],
+
+    ['Verify instance subcommand get with interactive option',
+     ['get', 'TST_Person', '--interactive'],
+     {'stdout':
+      ['//FakedUrl/root/cimv2:TST_Person.name="Mike"',
+       'instance of TST_Person {'],
+      'rc': 0,
+      'test': 'in'},
+     [ASSOC_MOCK_FILE, MOCK_PROMPT1_FILE], OK],
 
     #
     #  get subcommand errors
@@ -733,15 +752,6 @@ TEST_CASES = [
       'rc': 2,
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
-
-    ['Verify instance subcommand get error. bad classname',
-     ['get', 'CIM_Foo.InstanceID="CIM_blah"'],
-     {'stderr':
-      ["Error: CIMError: 6"],
-      'rc': 1,
-      'test': 'in'},
-     SIMPLE_MOCK_FILE, OK],
-
     #
     #  instance create subcommand
     #
@@ -993,6 +1003,25 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
+    ['Verify instance subcommand delete with interactive option',
+     ['delete', 'TST_Person', '-i'],
+     {'stdout':
+      ['//FakedUrl/root/cimv2:TST_Person.name="Mike"'],
+      'rc': 0,
+      'test': 'in'},
+     [ASSOC_MOCK_FILE, MOCK_PROMPT1_FILE], OK],
+
+    ['Verify instance subcommand delete with interactive option',
+     ['delete', 'TST_Person', '--interactive'],
+     {'stdout':
+      ['//FakedUrl/root/cimv2:TST_Person.name="Mike"'],
+      'rc': 0,
+      'test': 'in'},
+     [ASSOC_MOCK_FILE, MOCK_PROMPT1_FILE], OK],
+
+    #
+    # Delete subcommand error tests
+    #
     ['Verify instance subcommand delete, missing instance name',
      ['delete'],
      {'stderr':
@@ -1109,7 +1138,6 @@ TEST_CASES = [
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    # TODO add more invalid references tests
     ['Verify instance subcommand references, no instance name',
      ['references'],
      {'stderr': ['Usage: pywbemcli instance references [COMMAND-OPTIONS] '
@@ -1124,6 +1152,29 @@ TEST_CASES = [
       'rc': 0,
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
+
+    ['Verify instance subcommand references with interactive option -i',
+     ['references', 'TST_Person', '-i'],
+     {'stdout':
+      ['//FakedUrl/root/cimv2:TST_Person.name="Mike"',
+       'instance of TST_Lineage {',
+       'instance of TST_MemberOfFamilyCollection {'],
+      'rc': 0,
+      'test': 'in'},
+     [ASSOC_MOCK_FILE, MOCK_PROMPT1_FILE], OK],
+
+    ['Verify instance subcommand references with interactive option '
+     '--interactive',
+     ['references', 'TST_Person', '--interactive'],
+     {'stdout':
+      ['//FakedUrl/root/cimv2:TST_Person.name="Mike"',
+       'instance of TST_Lineage {',
+       'instance of TST_MemberOfFamilyCollection {'],
+      'rc': 0,
+      'test': 'in'},
+     [ASSOC_MOCK_FILE, MOCK_PROMPT1_FILE], OK],
+
+    # TODO add more invalid references tests
 
     #
     #  instance associators subcommand
@@ -1168,6 +1219,19 @@ TEST_CASES = [
       'rc': 0,
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
+
+    ['Verify instance subcommand associators with interactive option -i',
+     ['associators', 'TST_Person', '-i'],
+     {'stdout':
+      ['//FakedUrl/root/cimv2:TST_Person.name="Mike"',
+       'instance of TST_Person {',
+       'instance of TST_FamilyCollection {'],
+      'rc': 0,
+      'test': 'in'},
+     [ASSOC_MOCK_FILE, MOCK_PROMPT1_FILE], OK],
+
+    # TODO add associators error tests
+
     #
     #  instance count subcommand
     #
@@ -1197,6 +1261,7 @@ TEST_CASES = [
       'rc': 0,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
+
     # TODO add subclass instances to the count test.
 
     #


### PR DESCRIPTION
Adds a functional level test for the --interacive mode for pywbem instance get/delete/references/associators commands. Also refactors the _common picl_from_list function.

See commit for details.

This does not depend on any other PRs