### PR TITLE
Changes to _common.py and _test_common.py as follows:

### DIFF
--- a/pywbemcli/_cmd_connection.py
+++ b/pywbemcli/_cmd_connection.py
@@ -28,7 +28,7 @@ from pywbem import Error, DEFAULT_CA_CERT_PATHS, LOGGER_SIMPLE_NAMES, \
     DEFAULT_LOG_DETAIL_LEVEL
 
 from .pywbemcli import cli
-from ._common import CMD_OPTS_TXT, pick_from_list, format_table, \
+from ._common import CMD_OPTS_TXT, pick_one_from_list, format_table, \
     verify_operation
 from ._common_options import add_options, verify_option
 from ._pywbem_server import PywbemServer
@@ -385,8 +385,8 @@ def cmd_connection_select(context, name):
         conn_names = list(six.viewkeys(pywbemcli_servers))
         conn_names = sorted(conn_names)
         if conn_names:
-            name = pick_from_list(context, conn_names,
-                                  "Select a connection or Ctrl_C to abort.")
+            name = pick_one_from_list(context, conn_names,
+                                      "Select a connection or Ctrl_C to abort.")
         else:
             raise click.ClickException(
                 'Connection repository empty' % name)
@@ -432,8 +432,8 @@ def cmd_connection_delete(context, name, options):
                 'No names defined in connection file' % name)
 
         context.spinner.stop()
-        name = pick_from_list(context, conn_names,
-                              "Select a connection or CTRL_C to abort.")
+        name = pick_one_from_list(context, conn_names,
+                                  "Select a connection or CTRL_C to abort.")
 
     # name defined. Test if in servers.
     if name in pywbemcli_servers:

--- a/pywbemcli/_cmd_instance.py
+++ b/pywbemcli/_cmd_instance.py
@@ -23,7 +23,7 @@ import click
 from pywbem import Error, CIMError, CIM_ERR_NOT_FOUND
 from .pywbemcli import cli
 from ._common import display_cim_objects, parse_wbemuri_str, \
-    pick_instance, objects_sort, resolve_propertylist, create_ciminstance, \
+    pick_instance, sort_cimobjects, resolve_propertylist, create_ciminstance, \
     filter_namelist, CMD_OPTS_TXT, format_table, verify_operation, \
     process_invokemethod
 from ._common_options import propertylist_option, names_only_option, \
@@ -646,7 +646,7 @@ def cmd_instance_enumerate(context, classname, options):
                 PropertyList=resolve_propertylist(options['propertylist']))
 
             if options['sort']:
-                results = objects_sort(results)
+                results = sort_cimobjects(results)
 
         display_cim_objects(context, results, context.output_format,
                             summary=options['summary'])
@@ -686,7 +686,7 @@ def cmd_instance_references(context, instancename, options):
             if options['sort']:
                 results.sort(key=lambda x: x.classname)
         if options['sort']:
-            results = objects_sort(results)
+            results = sort_cimobjects(results)
 
         display_cim_objects(context, results, context.output_format,
                             summary=options['summary'])

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -469,7 +469,7 @@ TEST_CASES = [
 
     ['class subcommand verify bad regex',
      ['find', '.**sub2', '-n', 'root/cimv2'],
-     {'stderr': "Error: Regex Compile Error: error: multiple repeat",
+     {'stderr': ["Error:", "Regex compile error", "multiple", "sub2"],
       'rc': 1,
       'test': 'regex'},  # regex because re message text changes with py version
      SIMPLE_MOCK_FILE, OK],

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -478,7 +478,7 @@ GET_INST_ALL_TYPES = """instance of PyWBEM_AllTypes {
 
 """
 
-ENUM_INST_TABLE_RESP = """CIM_Foo
+ENUM_INST_TABLE_RESP = """Instances: CIM_Foo
 +--------------+---------------+
 | InstanceID   | IntegerProp   |
 +==============+===============+
@@ -490,7 +490,19 @@ ENUM_INST_TABLE_RESP = """CIM_Foo
 +--------------+---------------+
 """
 
-ENUM_INST_GET_TABLE_RESP = """CIM_Foo
+ENUM_INSTNAME_TABLE_RESP = """InstanceNames: CIM_Foo
++--------+-------------+----------------------------------------+
+| host   | namespace   | keybindings                            |
++========+=============+========================================+
+|        | root/cimv2  | NocaseDict({'InstanceID': 'CIM_Foo1'}) |
++--------+-------------+----------------------------------------+
+|        | root/cimv2  | NocaseDict({'InstanceID': 'CIM_Foo2'}) |
++--------+-------------+----------------------------------------+
+|        | root/cimv2  | NocaseDict({'InstanceID': 'CIM_Foo3'}) |
++--------+-------------+----------------------------------------+
+"""
+
+ENUM_INST_GET_TABLE_RESP = """Instances: CIM_Foo
 InstanceID      IntegerProp
 ------------  -------------
 "CIM_Foo1"                1
@@ -584,10 +596,25 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
+    ['Verify instance subcommand enumerate deepinheritance CIM_Foo '
+     '--deepinheritance',
+     ['enumerate', 'CIM_Foo', '--deepinheritance'],
+     {'stdout': ENUM_INST_RESP,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
     ['Verify instance subcommand -o grid enumerate deepinheritance CIM_Foo -d',
      {'args': ['enumerate', 'CIM_Foo', '-d'],
       'global': ['-o', 'grid']},
      {'stdout': ENUM_INST_TABLE_RESP,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance subcommand -o grid enumerate deepinheritance '
+     'CIM_Foo -d -o',
+     {'args': ['enumerate', 'CIM_Foo', '-d', '-o'],
+      'global': ['-o', 'grid']},
+     {'stdout': ENUM_INSTNAME_TABLE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
@@ -720,7 +747,7 @@ TEST_CASES = [
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand -o grid get CIM_Foo -d',
+    ['Verify instance subcommand -o grid get CIM_Foo',
      {'args': ['get', 'CIM_Foo.InstanceID="CIM_Foo1"'],
       'global': ['-o', 'simple']},
      {'stdout': ENUM_INST_GET_TABLE_RESP,

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -104,9 +104,6 @@ def execute_pywbemcli(args, env=None, stdin=None, verbose=None):
     if stdin and six.PY3:
         stdin = stdin.encode('utf-8')
 
-    if stdin:
-        print('stdin %r' % stdin)
-
     # The click package on Windows writes NL at the Python level
     # as '\r\r\n' at the level of the shell under some cases. This is
     # documented in Click issue #1271 for Click 7.0 The Popen universal_newlines
@@ -118,7 +115,8 @@ def execute_pywbemcli(args, env=None, stdin=None, verbose=None):
     # proc = Popen(cmd_args, shell=True, stdout=PIPE, stderr=PIPE, stdin=PIPE,
     #             universal_newlines=True)
     # stout_str, stderr_str = proc.communicate(input=stdin)
-    # Temp alternative is the following line and the second change
+    # Temp alternative is the following line with universal_newlines=False
+    # and the second change to fix the EOLs ourself.
     proc = Popen(cmd_args, shell=False, stdin=PIPE, stdout=PIPE, stderr=PIPE,
                  universal_newlines=False)
 
@@ -126,7 +124,6 @@ def execute_pywbemcli(args, env=None, stdin=None, verbose=None):
     rc = proc.returncode
 
     if verbose:
-        print("executed_pywbemcli rc = %s" % rc)
         print('output type %s\nstdout:%r\nstderr:%r' % (type(stdout_str),
                                                         stdout_str,
                                                         stderr_str))
@@ -140,16 +137,12 @@ def execute_pywbemcli(args, env=None, stdin=None, verbose=None):
     # Second part of temp patch for CRCRNL. Does what popen does and
     # CRCRNL replacement.
     if sys.platform == 'win32':
-        # print('STDOUTBeforeReplace type %s\n%r' %
-        #      (type(stdout_str), stdout_str))
         stdout_str = stdout_str.replace('\r\r\n', '\n')  \
                                .replace('\r\n', '\n')  \
                                .replace('\r', '')
         stderr_str = stderr_str.replace('\r\r\n', '\n')  \
                                .replace('\r\n', '\n')  \
                                .replace('\r', '')
-        # print('STDOUTAfterReplace type %s\n%r' % (type(stdout_str),
-        #                                                 stdout_str))
 
     return rc, stdout_str, stderr_str
 


### PR DESCRIPTION
Added new function for future and added unit tests for several common functions. This moved overall coverage up about 3 - 4 percent.

1. Add new function (pick_multiple_from_list) for future use.

2. Add a number of new tests for _common.py into tests_common.py including:

    a. tests for property list

    b. Sort qualifier declarations function

    c.  Added unit tests for pick_one_from_list and pick_multiple_from_list using mock patch.  This is more complete than the functional tests since it tests error inputs, etc.  Note: The one thing we have not included in the tests is the Ctrl-C prompt response that aborts the command.

3. Minor cleanup of some pylints, etc.

4. Corrected issue with display CIMInstanceNames as table function and
added unit test for this function.
