### PR TITLE
Fix  issues in the top level menu for pywbemcli

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -16,113 +16,129 @@ The following defines the help output for the `pywbemcli  --help` subcommand
 
     Usage: pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS]...
 
-      Command line browser for WBEM Servers. This cli tool implements the
-      CIM/XML client APIs as defined in pywbem to make requests to a WBEM
-      server. This browser uses subcommands to:
+      WBEM Server command line browser. This cli tool implements the CIM/XML
+      client APIs as defined in pywbem to make requests to a WBEM server. This
+      browser uses subcommands to:
 
           * Explore the characteristics of WBEM Servers based on using the
             pywbem client APIs.  It can manage/inspect CIM_Classes and
-            CIM_instanceson the server.
+            CIM_instances on the server.
 
-          * In addition it can inspect namespaces and other server information
-            and inspect and manage WBEM indication subscriptions.
+          * In addition it can inspect namespaces, profiles, subscriptions,
+            and other server information and inspect and manage WBEM
+            indication subscriptions.
 
-      The options shown above that can also be specified on any of the
+      The global options shown above that can also be specified on any of the
       (sub-)commands as well as the command line.
 
     Options:
-      -s, --server TEXT               Hostname or IP address with scheme of the
-                                      WBEMServer in  format
-                                      [{scheme}://]{host}[:{port}]. Scheme must be
-                                      "https" or "http" (Default: "https"). Host
-                                      defines a  short or fully qualified DNS
-                                      hostname, a literal  IPV4 address (dotted)
-                                      or a literal IPV6 address Port (optional)
-                                      defines a  WBEM server protocol to be used
-                                      (Defaults 5988(HTTP) and  5989 (HTTPS).
+      -s, --server URI                Hostname or IP address with scheme of the
+                                      WBEMServer in format
+                                      [{scheme}://]{host}[:{port}] (optional, see
+                                      --name).
+                                      - Scheme: must be "https" or "http"
+                                      [Default: "https"].
+                                      - Host: defines short or
+                                      fully qualified DNS hostname, a literal IPV4
+                                      address (dotted) or a literal IPV6 address.
+                                      - Port: (optional) defines WBEM server port
+                                      to be used [Defaults:5988(HTTP) and 5989
+                                      (HTTPS)].
                                       (EnvVar: PYWBEMCLI_SERVER).
-      -N, --name TEXT                 Optional name for the connection.  If the
-                                      name option is not set, the name "default"
-                                      is used. If the name option exists and the
+      -N, --name NAME                 Name for the connection(optional, see
+                                      --server).  If this option exists and the
                                       server option does not exist pywbemcli
                                       attempts to retrieve the connection
-                                      information from persistent storage. If the
-                                      server option exists that is used as the
-                                      connection name
-      -d, --default_namespace TEXT    Default Namespace to use in the target
+                                      information from the connections file. If
+                                      the server option exists that is used as the
+                                      connection definition with the name
+                                      "default". This option and --server are
+                                      mutually exclusive.(EnvVar: PYWBEMCLI_NAME).
+      -d, --default_namespace NAMESPACE
+                                      Default Namespace to use in the target
                                       WBEMServer if no namespace is defined in the
-                                      subcommand(EnvVar:
-                                      PYWBEMCLI_DEFAULT_NAMESPACE). (Default:
-                                      root/cimv2).
-      -u, --user TEXT                 User name for the WBEM Server connection.
-                                      (EnvVar: PYWBEMCLI_USER).
-      -p, --password TEXT             Password for the WBEM Server. Will be
+                                      subcommand(EnvVar: PYWBEMCLI_NAME)
+                                      []Default: root/cimv2].
+      -u, --user USER                 User name for the WBEM Server connection.
+                                      (EnvVar: PYWBEMCLI_NAME)
+      -p, --password PASSWORD         Password for the WBEM Server. Will be
                                       requested as part  of initialization if user
                                       name exists and it is not  provided by this
-                                      option.(EnvVar: PYWBEMCLI_PASSWORD ).
-      -t, --timeout INTEGER RANGE     Operation timeout for the WBEM Server in
-                                      seconds. (EnvVar: PYWBEMCLI_TIMEOUT).
-                                      Default: 30
+                                      option.(EnvVar: PYWBEMCLI_PASSWORD).
+      -t, --timeout INTEGER           Operation timeout for the WBEM Server in
+                                      seconds.
+                                      (EnvVar:
+                                      PYWBEMCLI_PYWBEMCLI_TIMEOUT)
       -n, --noverify                  If set, client does not verify server
-                                      certificate.
+                                      certificate.(EnvVar: PYWBEMCLI_NOVERIFY).
       -c, --certfile TEXT             Server certfile. Ignored if noverify flag
                                       set. (EnvVar: PYWBEMCLI_CERTFILE).
-      -k, --keyfile TEXT              Client private key file. (EnvVar:
+      -k, --keyfile FILE PATH         Client private key file. (EnvVar:
                                       PYWBEMCLI_KEYFILE).
       --ca_certs TEXT                 File or directory containing certificates
-                                      that will be matched against a certificate
-                                      received from the WBEM server. Set the --no-
-                                      verify-cert option to bypass client
-                                      verification of the WBEM server certificate.
-                                      (EnvVar: PYWBEMCLI_CA_CERTS).Default:
-                                      Searches for matching certificates in the
-                                      following system directories: /etc/pki/ca-
-                                      trust/extracted/openssl/ca-bundle.trust.crt
-                                      /etc/ssl/certs
-                                      /etc/ssl/certificates
-      -o, --output-format [table|plain|simple|grid|rst|mof|xml|txt|repr|tree]
-                                      Output format (Default: simple). pywbemcli
-                                      may override the format choice depending on
-                                      the operation since not all formats apply to
-                                      all output data types. For CIM structured
-                                      objects (ex. CIMInstance), the default
-                                      output format is mof.
+                                      that will be matched against certificate
+                                      received from WBEM server. Set --no-verify-
+                                      cert option to bypass client verification of
+                                      the WBEM server certificate.  (EnvVar:
+                                      PYWBEMCLI_CA_CERTS).
+                                      [Default: Searches for
+                                      matching certificates in the following
+                                      system directories: /etc/pki/ca-
+                                      trust/extracted/openssl/ca-bundle.trust.crt]
+                                      /etc/ssl/certs]
+                                      /etc/ssl/certificates]
+      -o, --output-format <choice>    Output format. Multiple table and CIMObjects
+                                      formats. pywbemcli may override the format
+                                      choice depending on the operation since not
+                                      all formats apply to all output data types.
+                                      Choices further defined in documentation.
+                                      Choices: ['table', 'plain', 'simple',
+                                      'grid', 'rst', 'mof', 'xml', 'txt', 'repr',
+                                      'tree']
+                                      [Default: "simple"]
       --use-pull_ops [yes|no|either]  Determines whether the pull operations are
-                                      used forthe EnumerateInstances,
-                                      associatorinstances,referenceinstances, and
-                                      ExecQuery operations. yes means that pull
-                                      will be used and if the server does not
-                                      support pull, the operation will fail. No
-                                      choice forces pywbemcli to try only the
-                                      traditional non-pull operations. either
-                                      allows pywbem to try both pull and then
-                                      traditional operations. This choice is
-                                      acomplished by using the Iter... operations
-                                      as the underlying pywbem api call.  The
-                                      default is either.
-      --pull-max-cnt INTEGER          MaxObjectCount of objects to be returned if
-                                      pull operations are used. This must be  a
-                                      positive non-zero integer. Default is 1000.
+                                      used for EnumerateInstances,
+                                      associatorinstances, referenceinstances, and
+                                      ExecQuery operations.
+                                      - "yes": pull
+                                      operations used; if server does not support
+                                      pull, the operation will fail.
+                                      - "no":
+                                      forces pywbemcli to try only the traditional
+                                      non-pull operations.
+                                      - "either": pywbemcli
+                                      trys first pull and then  traditional
+                                      operations.
+                                      (EnvVar: PYWBEMCLI_USE_PULL)
+                                      [Default: either]
+      --pull-max-cnt INTEGER          MaxObjectCount of objects to be returned for
+                                      each request if pull operations are used.
+                                      Must be  a positive non-zero
+                                      integer.(EnvVar: PYWBEMCLI_PULL_MAX_CNT)
+                                      [Default: 1000]
       -T, --timestats                 Show time statistics of WBEM server
-                                      operations after  each command execution.
+                                      operations after each command execution.
       -l, --log COMP=DEST:DETAIL,...  Enable logging of CIM Operations and set a
                                       component to a log level, destination, and
                                       detail level.
-                                      COMP: [api|http|all], Default:
+                                      - COMP: [api|http|all],
+                                      Default: all
+                                      - DEST: [file|stderr], Default:
+                                      file
+                                      - DETAIL:[all|paths|summary], Default:
                                       all
-                                      DEST: [file|stderr], Default: file
-                                      DETAIL:[all|paths|summary], Default: all
       -v, --verbose                   Display extra information about the
                                       processing.
-      -m, --mock-server FILENAME      If this option is defined, a mock WBEM
-                                      server is constructed as the target WBEM
-                                      server and the option value defines a MOF or
-                                      Python file to be used to populate the mock
-                                      repository. This option may be used multiple
-                                      times where each use defines a single file
-                                      or file_path.See the pywbemcli documentation
-                                      for more information.
-      --version                       Show the version of this command and exit.
+      -m, --mock-server FILENAME      Define, a mock WBEM server is as the target
+                                      WBEM server. The option value defines a MOF
+                                      or Python file path used to populate the
+                                      mock repository. This option may be used
+                                      multiple times where each use defines a
+                                      single file_path.See the pywbemtools
+                                      documentation for more information.(EnvVar:
+                                      PYWBEMCLI_MOCK_SERVER).
+      --version                       Show the version of this command and the
+                                      package and exit
       -h, --help                      Show this message and exit.
 
     Commands:

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -33,18 +33,22 @@ The following defines the help output for the `pywbemcli  --help` subcommand
 
     Options:
       -s, --server URI                Hostname or IP address with scheme of the
-                                      WBEMServer in format
-                                      [{scheme}://]{host}[:{port}] (optional, see
-                                      --name).
-                                      - Scheme: must be "https" or "http"
-                                      [Default: "https"].
-                                      - Host: defines short or
-                                      fully qualified DNS hostname, a literal IPV4
-                                      address (dotted) or a literal IPV6 address.
-                                      - Port: (optional) defines WBEM server port
-                                      to be used [Defaults:5988(HTTP) and 5989
-                                      (HTTPS)].
-                                      (EnvVar: PYWBEMCLI_SERVER).
+                                      WBEMServer in format:
+                                      [{scheme}://]{host}[:{port}]
+                                      The server
+                                      parameter is conditionally optional (see
+                                      --name)
+                                      * Scheme: must be "https" or "http"
+                                      [Default: "https"]
+                                      * Host: defines
+                                      short/fully qualified DNS hostname, literal
+                                      IPV4 address (dotted), or literal IPV6
+                                      address
+                                      * Port: (optional) defines WBEM
+                                      server port to be used [Defaults: 5988(HTTP)
+                                      and 5989(HTTPS)].
+                                      (EnvVar:
+                                      PYWBEMCLI_SERVER).
       -N, --name NAME                 Name for the connection(optional, see
                                       --server).  If this option exists and the
                                       server option does not exist pywbemcli
@@ -92,21 +96,21 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       choice depending on the operation since not
                                       all formats apply to all output data types.
                                       Choices further defined in documentation.
-                                      Choices: ['table', 'plain', 'simple',
-                                      'grid', 'rst', 'mof', 'xml', 'txt', 'repr',
-                                      'tree']
+                                      Choices: Table:
+                                      [table|plain|simple|grid|rst], Object:
+                                      [mof|xml|txt|tree]
                                       [Default: "simple"]
       --use-pull_ops [yes|no|either]  Determines whether the pull operations are
                                       used for EnumerateInstances,
                                       associatorinstances, referenceinstances, and
                                       ExecQuery operations.
-                                      - "yes": pull
+                                      * "yes": pull
                                       operations used; if server does not support
                                       pull, the operation will fail.
-                                      - "no":
+                                      * "no":
                                       forces pywbemcli to try only the traditional
                                       non-pull operations.
-                                      - "either": pywbemcli
+                                      * "either": pywbemcli
                                       trys first pull and then  traditional
                                       operations.
                                       (EnvVar: PYWBEMCLI_USE_PULL)
@@ -121,15 +125,15 @@ The following defines the help output for the `pywbemcli  --help` subcommand
       -l, --log COMP=DEST:DETAIL,...  Enable logging of CIM Operations and set a
                                       component to a log level, destination, and
                                       detail level.
-                                      - COMP: [api|http|all],
+                                      * COMP: [api|http|all],
                                       Default: all
-                                      - DEST: [file|stderr], Default:
+                                      * DEST: [file|stderr], Default:
                                       file
-                                      - DETAIL:[all|paths|summary], Default:
+                                      * DETAIL:[all|paths|summary], Default:
                                       all
       -v, --verbose                   Display extra information about the
                                       processing.
-      -m, --mock-server FILENAME      Define, a mock WBEM server is as the target
+      -m, --mock-server FILENAME      Defines, a mock WBEM server is as the target
                                       WBEM server. The option value defines a MOF
                                       or Python file path used to populate the
                                       mock repository. This option may be used

--- a/pywbemcli/_common.py
+++ b/pywbemcli/_common.py
@@ -742,10 +742,9 @@ def display_cim_objects_summary(context, objects):
     count.
     """
     context.spinner.stop()
-    if context.output_format:
-        output_format = context.output_format
-    else:
-        output_format = 'mof'
+
+    # default when displaying cim objects is mof
+    output_format = context.output_format or 'mof'
 
     if objects:
         cim_type = get_cimtype(objects)
@@ -762,7 +761,6 @@ def display_cim_objects_summary(context, objects):
 
 
 def display_cim_objects(context, objects, output_format=None, summary=False):
-    # pylint: disable=line-too-long
     """
     Display CIM objects in form determined by input parameters.
 
@@ -802,13 +800,13 @@ def display_cim_objects(context, objects, output_format=None, summary=False):
       summary(:class:`py:bool`):
         Boolean that defines whether the data in objects should be displayed
         or just a summary of the objects (ex. count of number of objects).
-    """    # noqa: E501
-    # pylint: enable=line-too-long
+    """
     context.spinner.stop()
 
     if summary:
         display_cim_objects_summary(context, objects)
         return
+
     # default when displaying cim objects is mof
     output_format = context.output_format or 'mof'
 

--- a/pywbemcli/_context_obj.py
+++ b/pywbemcli/_context_obj.py
@@ -45,13 +45,13 @@ class ContextObj(object):
         the information that is common to the multiple click subcommands
     """
     # pylint: disable=unused-argument
-    def __init__(self, pywbem_server, output_format, use_pull,
+    def __init__(self, pywbem_server, output_format, use_pull_ops,
                  pull_max_cnt, timestats, log, verbose):
 
         self._pywbem_server = pywbem_server
         self._output_format = output_format
+        self._use_pull_ops = use_pull_ops
         self._pull_max_cnt = pull_max_cnt
-        self._use_pull = use_pull
         self._verbose = verbose
         self._timestats = timestats
         self._spinner = click_spinner.Spinner()
@@ -59,9 +59,10 @@ class ContextObj(object):
 
     def __repr__(self):
         return 'ContextObj(at 0x%08x, pywbem_server=%s, outputformat=%s, ' \
-               'pull_max_cnt=%s, use_pull=%s, timestats=%s, verbose=%s' % \
+               'use_pull_ops=%s, pull_max_cnt=%s, timestats=%s, verbose=%s' % \
                (id(self), self.pywbem_server, self.output_format,
-                self.pull_max_cnt, self.use_pull, self.timestats, self.verbose)
+                self.use_pull_ops, self.pull_max_cnt, self.timestats,
+                self.verbose)
 
     @property
     def output_format(self):
@@ -80,13 +81,13 @@ class ContextObj(object):
         return self._timestats
 
     @property
-    def use_pull(self):
+    def use_pull_ops(self):
         """
         :term:`string`: Choice of whether pull, traditional or either type
         of operation is to be used for the instance enumerates, references,
         or associator commands.
         """
-        return self._use_pull
+        return self._use_pull_ops
 
     @property
     def pull_max_cnt(self):

--- a/pywbemcli/_pywbem_server.py
+++ b/pywbemcli/_pywbem_server.py
@@ -86,6 +86,7 @@ class PywbemServer(object):  # pylint: disable=too-many-instance-attributes
     # where server connection information are be saved and used as alternate
     # input sources for pywbemcli arguments and options.
     server_envvar = 'PYWBEMCLI_SERVER'
+    name_envvar = 'PYWBEMCLI_NAME'
     user_envvar = 'PYWBEMCLI_USER'
     password_envvar = 'PYWBEMCLI_PASSWORD'
     defaultnamespace_envvar = 'PYWBEMCLI_DEFAULT_NAMESPACE'

--- a/pywbemcli/pywbemcli.py
+++ b/pywbemcli/pywbemcli.py
@@ -245,9 +245,11 @@ def cli(ctx, server, name, default_namespace, user, password, timeout, noverify,
                 raise click.ClickException(
                     'Invalid choice for use_pull_ops %s' % use_pull_ops)
         else:
-            use_pull_ops = 'either'
+            use_pull_ops = DEFAULT_PULL_CHOICE
+
         if pull_max_cnt is None:
             pull_max_cnt = DEFAULT_MAXPULLCNT
+
         if timeout is None:
             timeout = DEFAULT_CONNECTION_TIMEOUT
 
@@ -303,9 +305,9 @@ def cli(ctx, server, name, default_namespace, user, password, timeout, noverify,
         if output_format is None:
             output_format = ctx.obj.output_format
         if use_pull_ops is None:
-            output_format = ctx.obj.use_pull_ops
+            use_pull_ops = ctx.obj.use_pull_ops
         if pull_max_cnt is None:
-            output_format = ctx.obj.use_pull_ops
+            pull_max_cnt = ctx.obj.use_pull_ops
         if pywbem_server is None:
             timestats = ctx.obj.pull_max_cnt
         if log is None:

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -1,3 +1,18 @@
+# (C) Copyright 2017 IBM Corp.
+# (C) Copyright 2017 Inova Development Inc.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """
 Test global options that can be tested without a subcommand
 """
@@ -41,8 +56,7 @@ class TestGlobalOptions(object):
         assert re.match(r'^pywbemcli, version [0-9]+\.[0-9]+\.[0-9]+', stdout)
         assert stderr == ""
 
-    # TODO remap this to use the same test_funct decorator as pywbem when
-    # that code is committed.
+    # TODO remap this to use the same test_funct decorator as pywbem.
     @pytest.mark.parametrize(
         "desc, tst_files, exp_result_start, exp_result_end, exp_rc, exp_stderr",
         [


### PR DESCRIPTION
Fixed a number of issues in the option defintions, help, etc. for the global options including:

1. Inconsistent definition of the envvars that apply to options

2. A couple of options that we implemented default in the menu when the
basic strategy is to not do that but set the defaults in the top level
function.

3. Modify the name of the use_pull input parameter and property in
ContextObj class to match name used elsewhere (use_pull to use_pull_ops)

4. Add env var definition for the global name option.

5. Clean up the help text of a number of the global options to achieve
consistent use of the env vars and the defaults  in the help .

6. Rewrite some text to clarify and to more clearly define choices in
options.