### PR TITLE
Change global --version option. 

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -143,7 +143,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       documentation for more information.(EnvVar:
                                       PYWBEMCLI_MOCK_SERVER).
       --version                       Show the version of this command and the
-                                      package and exit
+                                      pywbem package and exit.
       -h, --help                      Show this message and exit.
 
     Commands:

--- a/tests/unit/test_connection_subcmd.py
+++ b/tests/unit/test_connection_subcmd.py
@@ -681,7 +681,7 @@ class TestSubcmdClass(CLITestsBase):
                 test_file(exp_response['file']['before'])
 
         self.subcmd_test(desc, self.subcmd, inputs, exp_response,
-                         mock, condition, verbose=True)
+                         mock, condition, verbose=False)
 
         if 'file' in exp_response:
             if 'after' in exp_response['file']:

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -159,7 +159,7 @@ Options:
                                   documentation for more information.(EnvVar:
                                   PYWBEMCLI_MOCK_SERVER).
   --version                       Show the version of this command and the
-                                  package and exit
+                                  pywbem package and exit.
   -h, --help                      Show this message and exit.
 
 Commands:
@@ -276,7 +276,8 @@ TEST_CASES = [
      {'global': ['-s', 'http://blah', '--version'],
       'subcmd': 'connection',
       'args': ['show']},
-     {'stdout': [r'^pywbemcli, version [0-9]+\.[0-9]+\.[0-9]+'],
+     {'stdout': [r'^pywbemcli, version [0-9]+\.[0-9]+\.[0-9]+',
+                 r'^pywbem, version [0-9]+\.[0-9]+\.[0-9]+'],
       'rc': 0,
       'test': 'regex'},
      None, OK],


### PR DESCRIPTION
Changed the --version option to display both the pywbemcli version and the pywbem version. This also extends the tests to cover this extension.

This pr contains ONLY the version change and one other minor code change in pywbemcli/pywbemcli.py. An earlier version also changed the help text but that was moved to another pr to simplify review of this PR.

See commit message for details