### PR TITLE
Remove includequalifiers option on associators/references

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -225,7 +225,7 @@ The following defines the help output for the `pywbemcli class associators --hel
       argument filtered by the --assocclass, --resultclass, --role and
       --resultrole options and modified by the other options.
 
-      Results are formatted as defined by the output format global option.
+      Results are formatted as defined by the output format general option.
 
     Options:
       -a, --assocclass <class name>   Filter by the association class name
@@ -252,20 +252,22 @@ The following defines the help output for the `pywbemcli class associators --hel
                                       Optional.
       --no-qualifiers                 If set, request server to not include
                                       qualifiers in the returned class(s). The
-                                      default behavior is to request include
-                                      qualifiers in the returned class(s).
-      -c, --includeclassorigin        Include classorigin in the result.
+                                      default behavior is to request qualifiers in
+                                      returned class(s).
+      -c, --includeclassorigin        Request that server include classorigin in
+                                      the result.On some WBEM operations, server
+                                      may ignore this option.
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
                                       option not specified a Null property list is
                                       created and the server returns all
                                       properties. Multiple properties may be
                                       defined with either a comma separated list
-                                      defining the option multiple times. (ex: -p
-                                      pn1 -p pn22 or -p pn1,pn2). If defined as
+                                      or by using the option multiple times. (ex:
+                                      -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                       empty string the server should return no
                                       properties.
-      -o, --names_only                Show only local properties of the class.
+      -o, --names_only                Show only the returned object names.
       -s, --sort                      Sort into alphabetical order by classname.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
@@ -332,7 +334,7 @@ The following defines the help output for the `pywbemcli class enumerate --help`
       at the top of the class hierarchy or from  the position in the class
       hierarchy defined by `CLASSNAME` argument if provided.
 
-      The output format is defined by the output-format global option.
+      The output format is defined by the output-format general option.
 
       The includeclassqualifiers, includeclassorigin options define optional
       information to be included in the output.
@@ -340,7 +342,7 @@ The following defines the help output for the `pywbemcli class enumerate --help`
       The deepinheritance option defines whether the complete hiearchy is
       retrieved or just the next level in the hiearchy.
 
-      Results are formatted as defined by the output format global option.
+      Results are formatted as defined by the output format general option.
 
     Options:
       -d, --deepinheritance     Return complete subclass hierarchy for this class
@@ -349,10 +351,11 @@ The following defines the help output for the `pywbemcli class enumerate --help`
       -l, --localonly           Show only local properties of the class.
       --no-qualifiers           If set, request server to not include qualifiers
                                 in the returned class(s). The default behavior is
-                                to request include qualifiers in the returned
-                                class(s).
-      -c, --includeclassorigin  Include classorigin in the result.
-      -o, --names_only          Show only local properties of the class.
+                                to request qualifiers in returned class(s).
+      -c, --includeclassorigin  Request that server include classorigin in the
+                                result.On some WBEM operations, server may ignore
+                                this option.
+      -o, --names_only          Show only the returned object names.
       -s, --sort                Sort into alphabetical order by classname.
       -n, --namespace <name>    Namespace to use for this operation. If defined
                                 that namespace overrides the general options
@@ -430,25 +433,27 @@ The following defines the help output for the `pywbemcli class get --help` subco
       exception.
 
       The --includeclassorigin, --includeclassqualifiers, and --propertylist
-      options determine what parts of the class definition are tetrieved.
+      options determine what parts of the class definition are retrieved.
 
-      Results are formatted as defined by the output format global option.
+      Results are formatted as defined by the output format general option.
 
     Options:
       -l, --localonly                 Show only local properties of the class.
       --no-qualifiers                 If set, request server to not include
                                       qualifiers in the returned class(s). The
-                                      default behavior is to request include
-                                      qualifiers in the returned class(s).
-      -c, --includeclassorigin        Include classorigin in the result.
+                                      default behavior is to request qualifiers in
+                                      returned class(s).
+      -c, --includeclassorigin        Request that server include classorigin in
+                                      the result.On some WBEM operations, server
+                                      may ignore this option.
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
                                       option not specified a Null property list is
                                       created and the server returns all
                                       properties. Multiple properties may be
                                       defined with either a comma separated list
-                                      defining the option multiple times. (ex: -p
-                                      pn1 -p pn22 or -p pn1,pn2). If defined as
+                                      or by using the option multiple times. (ex:
+                                      -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                       empty string the server should return no
                                       properties.
       -n, --namespace <name>          Namespace to use for this operation. If
@@ -512,7 +517,7 @@ The following defines the help output for the `pywbemcli class references --help
       filtered by the role and result class options and modified by the other
       options.
 
-      Results are displayed as defined by the output format global option.
+      Results are displayed as defined by the output format general option.
 
     Options:
       -R, --resultclass <class name>  Filter by the result classname provided.
@@ -520,25 +525,27 @@ The following defines the help output for the `pywbemcli class references --help
                                       this class or its subclasses. Optional.
       -r, --role <role name>          Filter by the role name provided. Each
                                       returned class (or classname) should refer
-                                      to the target instance through a property
-                                      with a name that matches the value of this
+                                      to the target class through a property with
+                                      a name that matches the value of this
                                       parameter. Optional.
       --no-qualifiers                 If set, request server to not include
                                       qualifiers in the returned class(s). The
-                                      default behavior is to request include
-                                      qualifiers in the returned class(s).
-      -c, --includeclassorigin        Include classorigin in the result.
+                                      default behavior is to request qualifiers in
+                                      returned class(s).
+      -c, --includeclassorigin        Request that server include classorigin in
+                                      the result.On some WBEM operations, server
+                                      may ignore this option.
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
                                       option not specified a Null property list is
                                       created and the server returns all
                                       properties. Multiple properties may be
                                       defined with either a comma separated list
-                                      defining the option multiple times. (ex: -p
-                                      pn1 -p pn22 or -p pn1,pn2). If defined as
+                                      or by using the option multiple times. (ex:
+                                      -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                       empty string the server should return no
                                       properties.
-      -o, --names_only                Show only local properties of the class.
+      -o, --names_only                Show only the returned object names.
       -s, --sort                      Sort into alphabetical order by classname.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
@@ -576,7 +583,7 @@ The following defines the help output for the `pywbemcli class tree --help` subc
       class hiearchy of superclasses leading to CLASSNAME is displayed.
 
       This is a separate subcommand because it is tied specifically to
-      displaying in a tree format.so that the --output-format global option is
+      displaying in a tree format.so that the --output-format general option is
       ignored.
 
     Options:
@@ -1003,7 +1010,7 @@ The following defines the help output for the `pywbemcli instance associators --
       interactive option. Pywbemcli presents a list of instances in the class
       from which one can be chosen as the target.
 
-      Results are formatted as defined by the output format global option.
+      Results are formatted as defined by the --output_format general option.
 
     Options:
       -a, --assocclass <class name>   Filter by the association class name
@@ -1029,19 +1036,28 @@ The following defines the help output for the `pywbemcli instance associators --
                                       role (property name in the association that
                                       matches this parameter). Optional.
       -q, --includequalifiers         If set, requests server to include
-                                      qualifiers in the returned instance(s).
-      -c, --includeclassorigin        Include classorigin in the result.
+                                      qualifiers in the returned instances. This
+                                      subcommand may use either pull or
+                                      traditional operations depending on the
+                                      server and the "--use--pull-ops" general
+                                      option. If pull operations are used,
+                                      qualifiers will not be included, even if
+                                      this option is specified. If traditional
+                                      operations are used, inclusion of qualifiers
+                                      depends on the server.
+      -c, --includeclassorigin        Include class origin attribute in returned
+                                      instance(s).
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
                                       option not specified a Null property list is
                                       created and the server returns all
                                       properties. Multiple properties may be
                                       defined with either a comma separated list
-                                      defining the option multiple times. (ex: -p
-                                      pn1 -p pn22 or -p pn1,pn2). If defined as
+                                      or by using the option multiple times. (ex:
+                                      -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                       empty string the server should return no
                                       properties.
-      -o, --names_only                Show only local properties of the class.
+      -o, --names_only                Show only the returned object names.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
                                       options namespace
@@ -1199,31 +1215,48 @@ The following defines the help output for the `pywbemcli instance enumerate --he
       Displays the returned instances in mof, xml, or table formats or the
       instance names as a string or XML formats (--names-only option).
 
-      Results are formatted as defined by the output format global option.
+      Results are formatted as defined by the --output_format general option.
 
     Options:
-      -l, --localonly                 Show only local properties of the class.
+      -l, --localonly                 Show only local properties of the instances.
+                                      This subcommand may use either pull or
+                                      traditional operations depending on the
+                                      server and the "--use--pull-ops" general
+                                      option. If pull operations are used, this
+                                      parameters will not be included, even if
+                                      specified. If traditional operations are
+                                      used, some servers do not process the
+                                      parameter.
       -d, --deepinheritance           If set, requests server to return properties
                                       in subclasses of the target instances class.
                                       If option not specified only properties from
                                       target class are returned
       -q, --includequalifiers         If set, requests server to include
-                                      qualifiers in the returned instance(s).
-      -c, --includeclassorigin        Include ClassOrigin in the result.
+                                      qualifiers in the returned instances. This
+                                      subcommand may use either pull or
+                                      traditional operations depending on the
+                                      server and the "--use--pull-ops" general
+                                      option. If pull operations are used,
+                                      qualifiers will not be included, even if
+                                      this option is specified. If traditional
+                                      operations are used, inclusion of qualifiers
+                                      depends on the server.
+      -c, --includeclassorigin        Include class origin attribute in returned
+                                      instance(s).
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
                                       option not specified a Null property list is
                                       created and the server returns all
                                       properties. Multiple properties may be
                                       defined with either a comma separated list
-                                      defining the option multiple times. (ex: -p
-                                      pn1 -p pn22 or -p pn1,pn2). If defined as
+                                      or by using the option multiple times. (ex:
+                                      -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                       empty string the server should return no
                                       properties.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
                                       options namespace
-      -o, --names_only                Show only local properties of the class.
+      -o, --names_only                Show only the returned object names.
       -s, --sort                      Sort into alphabetical order by classname.
       -S, --summary                   Return only summary of objects (count).
       -h, --help                      Show this message and exit.
@@ -1259,13 +1292,15 @@ The following defines the help output for the `pywbemcli instance get --help` su
       Otherwise the INSTANCENAME must be a CIM instance name in the format
       defined by DMTF `DSP0207`.
 
-      Results are formatted as defined by the output format global option.
+      Results are formatted as defined by the --output_format general option.
 
     Options:
-      -l, --localonly                 Show only local properties of the returned
-                                      instance.
+      -l, --localonly                 Request that server show only local
+                                      properties of the returned instance. Some
+                                      servers may not process this parameter.
       -q, --includequalifiers         If set, requests server to include
-                                      qualifiers in the returned instance(s).
+                                      qualifiers in the returned instances. Not
+                                      all servers return qualifiers on instances
       -c, --includeclassorigin        Include class origin attribute in returned
                                       instance(s).
       -p, --propertylist <property name>
@@ -1274,8 +1309,8 @@ The following defines the help output for the `pywbemcli instance get --help` su
                                       created and the server returns all
                                       properties. Multiple properties may be
                                       defined with either a comma separated list
-                                      defining the option multiple times. (ex: -p
-                                      pn1 -p pn22 or -p pn1,pn2). If defined as
+                                      or by using the option multiple times. (ex:
+                                      -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                       empty string the server should return no
                                       properties.
       -n, --namespace <name>          Namespace to use for this operation. If
@@ -1429,7 +1464,7 @@ The following defines the help output for the `pywbemcli instance query --help` 
 
       The results of the query are displayed as mof or xml.
 
-      Results are formatted as defined by the output format global option.
+      Results are formatted as defined by the --output_format general option.
 
     Options:
       -l, --querylanguage QUERY LANGUAGE
@@ -1471,7 +1506,7 @@ The following defines the help output for the `pywbemcli instance references --h
       of instances names in the class from which you can be chosen as the
       target.
 
-      Results are formatted as defined by the output format global option.
+      Results are formatted as defined by the --output_format general option.
 
     Options:
       -R, --resultclass <class name>  Filter by the result class name provided.
@@ -1484,19 +1519,28 @@ The following defines the help output for the `pywbemcli instance references --h
                                       property with aname that matches the value
                                       of this parameter. Optional.
       -q, --includequalifiers         If set, requests server to include
-                                      qualifiers in the returned instance(s).
-      -c, --includeclassorigin        Include classorigin in the result.
+                                      qualifiers in the returned instances. This
+                                      subcommand may use either pull or
+                                      traditional operations depending on the
+                                      server and the "--use--pull-ops" general
+                                      option. If pull operations are used,
+                                      qualifiers will not be included, even if
+                                      this option is specified. If traditional
+                                      operations are used, inclusion of qualifiers
+                                      depends on the server.
+      -c, --includeclassorigin        Include class origin attribute in returned
+                                      instance(s).
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
                                       option not specified a Null property list is
                                       created and the server returns all
                                       properties. Multiple properties may be
                                       defined with either a comma separated list
-                                      defining the option multiple times. (ex: -p
-                                      pn1 -p pn22 or -p pn1,pn2). If defined as
+                                      or by using the option multiple times. (ex:
+                                      -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                       empty string the server should return no
                                       properties.
-      -o, --names_only                Show only local properties of the class.
+      -o, --names_only                Show only the returned object names.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
                                       options namespace

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 """
 Click Command definition for the class command group which includes
-cmds for get, enumerate, list of classes.
+cmds for get, enumerate, associators, references, find, etc. of the objects
+CIMClass on a WBEM server
 """
 from __future__ import absolute_import
 
@@ -39,19 +40,17 @@ from ._displaytree import display_class_tree
 #
 
 includeclassqualifiers_option = [              # pylint: disable=invalid-name
-    click.option('--no-qualifiers', is_flag=True,
+    click.option('--no-qualifiers', 'includequalifiers', is_flag=True,
                  required=False, default=True,
                  help='If set, request server to not include qualifiers in '
                       'the returned class(s). The default behavior is to '
-                      'request include qualifiers in the returned class(s).')]
+                      'request qualifiers in returned class(s).')]
 
 deepinheritance_option = [              # pylint: disable=invalid-name
     click.option('-d', '--deepinheritance', is_flag=True, required=False,
                  help='If set, request server to return complete subclass '
                       'hiearchy for this class. The default is False which '
                       'requests only one level of subclasses.')]
-
-# TODO add a case sensitive option for those things that use regex
 
 
 @cli.group('class', options_metavar=CMD_OPTS_TXT)
@@ -87,9 +86,9 @@ def class_get(context, classname, **options):
     exception.
 
     The --includeclassorigin, --includeclassqualifiers, and --propertylist
-    options determine what parts of the class definition are tetrieved.
+    options determine what parts of the class definition are retrieved.
 
-    Results are formatted as defined by the output format global option.
+    Results are formatted as defined by the output format general option.
 
     """
     context.execute_cmd(lambda: cmd_class_get(context, classname, options))
@@ -174,7 +173,7 @@ def class_enumerate(context, classname, **options):
     either at the top of the class hierarchy or from  the position in the
     class hierarchy defined by `CLASSNAME` argument if provided.
 
-    The output format is defined by the output-format global option.
+    The output format is defined by the output-format general option.
 
     The includeclassqualifiers, includeclassorigin options define optional
     information to be included in the output.
@@ -182,7 +181,7 @@ def class_enumerate(context, classname, **options):
     The deepinheritance option defines whether the complete hiearchy is
     retrieved or just the next level in the hiearchy.
 
-    Results are formatted as defined by the output format global option.
+    Results are formatted as defined by the output format general option.
     """
     context.execute_cmd(lambda: cmd_class_enumerate(context, classname,
                                                     options))
@@ -198,7 +197,7 @@ def class_enumerate(context, classname, **options):
 @click.option('-r', '--role', type=str, required=False,
               metavar='<role name>',
               help='Filter by the role name provided. Each returned class '
-                   '(or classname) should refer to the target instance through '
+                   '(or classname) should refer to the target class through '
                    'a property with a name that matches the value of this '
                    'parameter. Optional.')
 @add_options(includeclassqualifiers_option)
@@ -217,7 +216,7 @@ def class_references(context, classname, **options):
     filtered by the role and result class options and modified by the
     other options.
 
-    Results are displayed as defined by the output format global option.
+    Results are displayed as defined by the output format general option.
     """
     context.execute_cmd(lambda: cmd_class_references(context, classname,
                                                      options))
@@ -265,7 +264,7 @@ def class_associators(context, classname, **options):
     argument filtered by the --assocclass, --resultclass, --role and
     --resultrole options and modified by the other options.
 
-    Results are formatted as defined by the output format global option.
+    Results are formatted as defined by the output format general option.
     """
     context.execute_cmd(lambda: cmd_class_associators(context, classname,
                                                       options))
@@ -335,7 +334,7 @@ def class_tree(context, classname, **options):
     the class hiearchy of superclasses leading to CLASSNAME is displayed.
 
     This is a separate subcommand because it is tied specifically to displaying
-    in a tree format.so that the --output-format global option is ignored.
+    in a tree format.so that the --output-format general option is ignored.
     """
     context.execute_cmd(lambda: cmd_class_tree(context, classname, options))
 
@@ -360,7 +359,7 @@ def cmd_class_get(context, classname, options):
             classname,
             namespace=options['namespace'],
             LocalOnly=options['localonly'],
-            IncludeQualifiers=options['no_qualifiers'],
+            IncludeQualifiers=options['includequalifiers'],
             IncludeClassOrigin=options['includeclassorigin'],
             PropertyList=resolve_propertylist(options['propertylist']))
 
@@ -399,7 +398,7 @@ def cmd_class_enumerate(context, classname, options):
                 namespace=options['namespace'],
                 LocalOnly=options['localonly'],
                 DeepInheritance=options['deepinheritance'],
-                IncludeQualifiers=options['no_qualifiers'],
+                IncludeQualifiers=options['includequalifiers'],
                 IncludeClassOrigin=options['includeclassorigin'])
             if options['sort']:
                 results.sort(key=lambda x: x.classname)
@@ -431,7 +430,7 @@ def cmd_class_references(context, classname, options):
                 classname,
                 ResultClass=options['resultclass'],
                 Role=options['role'],
-                IncludeQualifiers=options['no_qualifiers'],
+                IncludeQualifiers=options['includequalifiers'],
                 IncludeClassOrigin=options['includeclassorigin'],
                 PropertyList=resolve_propertylist(options['propertylist']))
             if options['sort']:
@@ -468,7 +467,7 @@ def cmd_class_associators(context, classname, options):
                 Role=options['role'],
                 ResultClass=options['resultclass'],
                 ResultRole=options['resultrole'],
-                IncludeQualifiers=options['no_qualifiers'],
+                IncludeQualifiers=options['includequalifiers'],
                 IncludeClassOrigin=options['includeclassorigin'],
                 PropertyList=resolve_propertylist(options['propertylist']))
             if options['sort']:

--- a/pywbemtools/pywbemcli/_common_options.py
+++ b/pywbemtools/pywbemcli/_common_options.py
@@ -32,15 +32,15 @@ propertylist_option = [                      # pylint: disable=invalid-name
                  help='Define a propertylist for the request. If option '
                       'not specified a Null property list is created and the '
                       'server returns all properties. Multiple properties may '
-                      'be defined with either a comma separated list defining '
-                      'the option multiple times. '
+                      'be defined with either a comma separated list or by '
+                      'using the option multiple times. '
                       '(ex: -p pn1 -p pn22 or -p pn1,pn2). '
                       'If defined as empty string the server should return no '
                       'properties.')]
 
 names_only_option = [                      # pylint: disable=invalid-name
     click.option('-o', '--names_only', is_flag=True, required=False,
-                 help='Show only local properties of the class.')]
+                 help='Show only the returned object names.')]
 
 sort_option = [                            # pylint: disable=invalid-name
     click.option('-s', '--sort', is_flag=True, required=False,
@@ -49,7 +49,9 @@ sort_option = [                            # pylint: disable=invalid-name
 includeclassorigin_option = [            # pylint: disable=invalid-name
     click.option('-c', '--includeclassorigin', is_flag=True,
                  required=False,
-                 help='Include classorigin in the result.')]
+                 help='Request that server include classorigin in the result.'
+                      'On some WBEM operations, server may ignore this '
+                      'option.')]
 
 namespace_option = [                     # pylint: disable=invalid-name
     click.option('-n', '--namespace', type=str,

--- a/pywbemtools/pywbemcli/_context_obj.py
+++ b/pywbemtools/pywbemcli/_context_obj.py
@@ -227,6 +227,7 @@ class ContextObj(object):  # pylint: disable=useless-object-inheritance
             else:
                 row = [stats.count, stats.exception_count, time,
                        req_len, reply_len, stats.name]
+            rows.append(row)
 
         # only add table description if verbose on.
         if self.verbose:
@@ -235,7 +236,6 @@ class ContextObj(object):  # pylint: disable=useless-object-inheritance
         else:
             title = None
 
-        rows.append(row)
         click.echo(format_table(rows, hdr, title=title))
 
     def connect_wbem_server(self):

--- a/tests/unit/cli_test_extensions.py
+++ b/tests/unit/cli_test_extensions.py
@@ -106,7 +106,7 @@ class CLITestsBase(object):  # pylint: disable=too-few-public-methods
                  Compares for exact match between the expected response and the
                  returned data line by line. The number of lines and the data
                  in each line must match.  If the expected response is a single
-                 string is is split into lines separated at each new line
+                 string it is split into lines separated at each new line
                  before the match
 
                  'linesnows' - Expected response may be either list of strings

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -53,6 +53,49 @@ Commands:
   tree          Display CIM class inheritance hierarchy tree.
 """
 
+CLS_GET_HELP = """
+Usage: pywbemcli class get [COMMAND-OPTIONS] CLASSNAME
+
+  Get and display a single CIM class.
+
+  Get a single CIM class defined by the CLASSNAME argument from the WBEM
+  server and display it. Normally it is retrieved from the default namespace
+  in the server.
+
+  If the class is not found in the WBEM Server, the server returns an
+  exception.
+
+  The --includeclassorigin, --includeclassqualifiers, and --propertylist
+  options determine what parts of the class definition are retrieved.
+
+  Results are formatted as defined by the output format general option.
+
+Options:
+  -l, --localonly                 Show only local properties of the class.
+  --no-qualifiers                 If set, request server to not include
+                                  qualifiers in the returned class(s). The
+                                  default behavior is to request qualifiers in
+                                  returned class(s).
+  -c, --includeclassorigin        Request that server include classorigin in
+                                  the result.On some WBEM operations, server
+                                  may ignore this option.
+  -p, --propertylist <property name>
+                                  Define a propertylist for the request. If
+                                  option not specified a Null property list is
+                                  created and the server returns all
+                                  properties. Multiple properties may be
+                                  defined with either a comma separated list
+                                  or by using the option multiple times. (ex:
+                                  -p pn1 -p pn22 or -p pn1,pn2). If defined as
+                                  empty string the server should return no
+                                  properties.
+  -n, --namespace <name>          Namespace to use for this operation. If
+                                  defined that namespace overrides the general
+                                  options namespace
+  -h, --help                      Show this message and exit.
+"""
+
+
 CLS_ENUM_HELP = """
 Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME
 
@@ -62,7 +105,7 @@ Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME
   at the top of the class hierarchy or from  the position in the class
   hierarchy defined by `CLASSNAME` argument if provided.
 
-  The output format is defined by the output-format global option.
+  The output format is defined by the output-format general option.
 
   The includeclassqualifiers, includeclassorigin options define optional
   information to be included in the output.
@@ -70,7 +113,7 @@ Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME
   The deepinheritance option defines whether the complete hiearchy is
   retrieved or just the next level in the hiearchy.
 
-  Results are formatted as defined by the output format global option.
+  Results are formatted as defined by the output format general option.
 
 Options:
   -d, --deepinheritance     Return complete subclass hierarchy for this class
@@ -79,10 +122,11 @@ Options:
   -l, --localonly           Show only local properties of the class.
   --no-qualifiers           If set, request server to not include qualifiers
                             in the returned class(s). The default behavior is
-                            to request include qualifiers in the returned
-                            class(s).
-  -c, --includeclassorigin  Include classorigin in the result.
-  -o, --names_only          Show only local properties of the class.
+                            to request qualifiers in returned class(s).
+  -c, --includeclassorigin  Request that server include classorigin in the
+                            result.On some WBEM operations, server may ignore
+                            this option.
+  -o, --names_only          Show only the returned object names.
   -s, --sort                Sort into alphabetical order by classname.
   -n, --namespace <name>    Namespace to use for this operation. If defined
                             that namespace overrides the general options
@@ -142,7 +186,7 @@ Usage: pywbemcli class tree [COMMAND-OPTIONS] CLASSNAME
   class hiearchy of superclasses leading to CLASSNAME is displayed.
 
   This is a separate subcommand because it is tied specifically to
-  displaying in a tree format.so that the --output-format global option is
+  displaying in a tree format.so that the --output-format general option is
   ignored.
 
 Options:
@@ -181,31 +225,140 @@ Options:
   -h, --help              Show this message and exit.
 """
 
+CLS_REFERENCES_HELP = """
+Usage: pywbemcli class references [COMMAND-OPTIONS] CLASSNAME
+
+  Get the reference classes for CLASSNAME.
+
+  Get the reference classes (or class names) for the CLASSNAME argument
+  filtered by the role and result class options and modified by the other
+  options.
+
+  Results are displayed as defined by the output format general option.
+
+Options:
+  -R, --resultclass <class name>  Filter by the result classname provided.
+                                  Each returned class (or classname) should be
+                                  this class or its subclasses. Optional.
+  -r, --role <role name>          Filter by the role name provided. Each
+                                  returned class (or classname) should refer
+                                  to the target class through a property with
+                                  a name that matches the value of this
+                                  parameter. Optional.
+  --no-qualifiers                 If set, request server to not include
+                                  qualifiers in the returned class(s). The
+                                  default behavior is to request qualifiers in
+                                  returned class(s).
+  -c, --includeclassorigin        Request that server include classorigin in
+                                  the result.On some WBEM operations, server
+                                  may ignore this option.
+  -p, --propertylist <property name>
+                                  Define a propertylist for the request. If
+                                  option not specified a Null property list is
+                                  created and the server returns all
+                                  properties. Multiple properties may be
+                                  defined with either a comma separated list
+                                  or by using the option multiple times. (ex:
+                                  -p pn1 -p pn22 or -p pn1,pn2). If defined as
+                                  empty string the server should return no
+                                  properties.
+  -o, --names_only                Show only the returned object names.
+  -s, --sort                      Sort into alphabetical order by classname.
+  -n, --namespace <name>          Namespace to use for this operation. If
+                                  defined that namespace overrides the general
+                                  options namespace
+  -S, --summary                   Return only summary of objects (count).
+  -h, --help                      Show this message and exit.
+"""
+
+CIMFOO_SUB_SUB = """
+   [Description ( "Subclass of CIM_Foo_sub" )]
+class CIM_Foo_sub_sub : CIM_Foo_sub {
+
+   string cimfoo_sub_sub;
+
+   string cimfoo_sub;
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   string InstanceID;
+
+      [Description ( "This is Uint32 property." )]
+   uint32 IntegerProp;
+
+      [Description ( "Sample method with input and output parameters" )]
+   uint32 Method1(
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Response param 2" )]
+      string OutputParam2);
+
+      [Description ( "Method with in and out parameters" )]
+   uint32 Fuzzy(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_Foo REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue);
+
+      [Description ( "Method with no Parameters" )]
+   uint32 DeleteNothing();
+
+};
+
+"""
+
+CIMFOO_SUB_SUB_NO_QUALS = """
+class CIM_Foo_sub_sub : CIM_Foo_sub {
+
+   string cimfoo_sub_sub;
+
+   string cimfoo_sub;
+
+   string InstanceID;
+
+   uint32 IntegerProp;
+
+   uint32 Method1(
+      string OutputParam2);
+
+   uint32 Fuzzy(
+      string TestInOutParameter,
+      CIM_Foo REF TestRef,
+      string OutputParam,
+      uint32 OutputRtnValue);
+
+   uint32 DeleteNothing();
+
+};
+"""
 REFERENCES_CLASS_RTN = [
     '//FakedUrl/root/cimv2:TST_Lineage',
-    '   [Association ( true ),',
-    '    Description (',
-    '       " Lineage defines the relationship between parents and '
-    'children." )]',
     'class TST_Lineage {',
     '',
-    '      [key ( true )]',
     '   string InstanceID;',
     '',
     '   TST_Person REF parent;',
     '',
     '   TST_Person REF child;',
-    ''
-    '};'
+    '',
+    '};',
+    '',
     '//FakedUrl/root/cimv2:TST_MemberOfFamilyCollection',
-    '   [Association ( true ),',
-    '    Description ( " Family gathers person to family." )]',
     'class TST_MemberOfFamilyCollection {',
     '',
-    '      [key ( true )]',
     '   TST_Person REF family;',
     '',
-    '      [key ( true )]',
     '   TST_Person REF member;',
     '',
     '};',
@@ -213,19 +366,60 @@ REFERENCES_CLASS_RTN = [
 
 REFERENCES_CLASS_RTN2 = [
     '//FakedUrl/root/cimv2:TST_MemberOfFamilyCollection',
-    '   [Association ( true ),',
-    '    Description ( " Family gathers person to family." )]',
     'class TST_MemberOfFamilyCollection {',
     '',
-    '      [key ( true )]',
     '   TST_Person REF family;',
     '',
-    '      [key ( true )]',
     '   TST_Person REF member;',
     '',
     '};',
     '',
     '']
+
+REFERENCES_CLASS_RTN_QUALS1 = """
+//FakedUrl/root/cimv2:TST_Lineage
+   [Association ( true ),
+    Description (
+       " Lineage defines the relationship between parents and children." )]
+class TST_Lineage {
+
+      [key ( true )]
+   string InstanceID;
+
+   TST_Person REF parent;
+
+   TST_Person REF child;
+
+};
+
+//FakedUrl/root/cimv2:TST_MemberOfFamilyCollection
+   [Association ( true ),
+    Description ( " Family gathers person to family." )]
+class TST_MemberOfFamilyCollection {
+
+      [key ( true )]
+   TST_Person REF family;
+
+      [key ( true )]
+   TST_Person REF member;
+
+};
+"""
+
+REFERENCES_CLASS_RTN_QUALS2 = """
+//FakedUrl/root/cimv2:TST_MemberOfFamilyCollection
+   [Association ( true ),
+    Description ( " Family gathers person to family." )]
+class TST_MemberOfFamilyCollection {
+
+      [key ( true )]
+   TST_Person REF family;
+
+      [key ( true )]
+   TST_Person REF member;
+
+};
+"""
 
 
 OK = True  # mark tests OK when they execute correctly
@@ -277,11 +471,24 @@ TEST_CASES = [
       'test': 'startswith'},
      SIMPLE_MOCK_FILE, OK],
 
+    ['Verify class subcommand enumerate CIM_Foo_sub',
+     ['enumerate', 'CIM_Foo_sub'],
+     {'stdout': CIMFOO_SUB_SUB,
+      'test': 'linesnows'},
+     SIMPLE_MOCK_FILE, OK],
+
+
     ['Verify class subcommand enumerate CIM_Foo localonly',
      ['enumerate', 'CIM_Foo', '--localonly'],
      {'stdout':
       '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify class subcommand enumerate CIM_Foo -no-qualifiers',
+     ['enumerate', 'CIM_Foo_sub', '--no-qualifiers'],
+     {'stdout': CIMFOO_SUB_SUB_NO_QUALS,
+      'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify class subcommand enumerate CIM_Foo -d',
@@ -351,10 +558,10 @@ TEST_CASES = [
     #
     # Test class get
     #
-    ['Verify class subcommand get  --help response',
+    ['Verify class subcommand get --help response',
      ['get', '--help'],
-     {'stdout': 'Usage: pywbemcli class get [COMMAND-OPTIONS] CLASSNAME',
-      'test': 'startswith'},
+     {'stdout': CLS_GET_HELP,
+      'test': 'linesnows'},
      None, OK],
 
     # subcommand get localonly option
@@ -365,7 +572,7 @@ TEST_CASES = [
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand get localonly. Tests whole response',
+    ['Verify class subcommand get localonly. Tests whole response with -l',
      ['get', 'CIM_Foo_sub2', '-l'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
                  '',
@@ -375,7 +582,7 @@ TEST_CASES = [
       'test': 'patterns'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand get localonly. Tests whole response',
+    ['Verify class subcommand get localonly. Tests whole response --localonly',
      ['get', 'CIM_Foo_sub2', '--localonly'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
                  '',
@@ -732,7 +939,6 @@ TEST_CASES = [
                  'provided.',
                  '-R, --resultrole <role name>    Filter by the result role '
                  'name provided.',
-                 '--no-qualifiers',
                  '-c, --includeclassorigin', ],
       'test': 'in'},
      None, OK],
@@ -867,23 +1073,15 @@ TEST_CASES = [
     #
     ['Verify class subcommand references --help, . ',
      ['references', '--help'],
-     {'stdout': ['Usage: pywbemcli class references [COMMAND-OPTIONS] '
-                 'CLASSNAME',
-                 'Get the reference classes for CLASSNAME.',
-                 '-R, --resultclass <class name>  Filter by the result '
-                 'classname provided.',
-                 '-r, --role <role name>          Filter by the role name '
-                 'provided.',
-                 '--no-qualifiers',
-                 '-c, --includeclassorigin', ],
-      'test': 'in'},
+     {'stdout': CLS_REFERENCES_HELP,
+      'test': 'linesnows'},
      None, OK],
 
     ['Verify class subcommand references simple request, -s',
      ['references', 'TST_Person', '-s'],
-     {'stdout': REFERENCES_CLASS_RTN,
+     {'stdout': REFERENCES_CLASS_RTN_QUALS1,
       'test': 'linesnows'},
-     SIMPLE_ASSOC_MOCK_FILE, RUN],
+     SIMPLE_ASSOC_MOCK_FILE, OK],
 
     ['Verify class subcommand references simple request -o -s',
      ['references', 'TST_Person', '-o', '-s'],
@@ -896,7 +1094,7 @@ TEST_CASES = [
      ['references', 'TST_Person',
       '--role', 'member',
       '--resultclass', 'TST_MemberOfFamilyCollection'],
-     {'stdout': REFERENCES_CLASS_RTN2,
+     {'stdout': REFERENCES_CLASS_RTN_QUALS2,
       'test': 'linesnows'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
@@ -1017,7 +1215,7 @@ class TestSubcmdClass(CLITestsBase):
             pywbemcli command.
         """
         self.subcmd_test(desc, self.subcmd, inputs, exp_response,
-                         mock, condition)
+                         mock, condition, verbose=False)
 
 
 class TestClassGeneral(object):

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -72,31 +72,48 @@ Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME
   Displays the returned instances in mof, xml, or table formats or the
   instance names as a string or XML formats (--names-only option).
 
-  Results are formatted as defined by the output format global option.
+  Results are formatted as defined by the --output_format general option.
 
 Options:
-  -l, --localonly                 Show only local properties of the class.
+  -l, --localonly                 Show only local properties of the instances.
+                                  This subcommand may use either pull or
+                                  traditional operations depending on the
+                                  server and the "--use--pull-ops" general
+                                  option. If pull operations are used, this
+                                  parameters will not be included, even if
+                                  specified. If traditional operations are
+                                  used, some servers do not process the
+                                  parameter.
   -d, --deepinheritance           If set, requests server to return properties
                                   in subclasses of the target instances class.
                                   If option not specified only properties from
                                   target class are returned
   -q, --includequalifiers         If set, requests server to include
-                                  qualifiers in the returned instance(s).
-  -c, --includeclassorigin        Include ClassOrigin in the result.
+                                  qualifiers in the returned instances. This
+                                  subcommand may use either pull or
+                                  traditional operations depending on the
+                                  server and the "--use--pull-ops" general
+                                  option. If pull operations are used,
+                                  qualifiers will not be included, even if
+                                  this option is specified. If traditional
+                                  operations are used, inclusion of qualifiers
+                                  depends on the server.
+  -c, --includeclassorigin        Include class origin attribute in returned
+                                  instance(s).
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
                                   option not specified a Null property list is
                                   created and the server returns all
                                   properties. Multiple properties may be
                                   defined with either a comma separated list
-                                  defining the option multiple times. (ex: -p
-                                  pn1 -p pn22 or -p pn1,pn2). If defined as
+                                  or by using the option multiple times. (ex:
+                                  -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                   empty string the server should return no
                                   properties.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace
-  -o, --names_only                Show only local properties of the class.
+  -o, --names_only                Show only the returned object names.
   -s, --sort                      Sort into alphabetical order by classname.
   -S, --summary                   Return only summary of objects (count).
   -h, --help                      Show this message and exit.
@@ -121,13 +138,15 @@ Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME
   Otherwise the INSTANCENAME must be a CIM instance name in the format
   defined by DMTF `DSP0207`.
 
-  Results are formatted as defined by the output format global option.
+  Results are formatted as defined by the --output_format general option.
 
 Options:
-  -l, --localonly                 Show only local properties of the returned
-                                  instance.
+  -l, --localonly                 Request that server show only local
+                                  properties of the returned instance. Some
+                                  servers may not process this parameter.
   -q, --includequalifiers         If set, requests server to include
-                                  qualifiers in the returned instance(s).
+                                  qualifiers in the returned instances. Not
+                                  all servers return qualifiers on instances
   -c, --includeclassorigin        Include class origin attribute in returned
                                   instance(s).
   -p, --propertylist <property name>
@@ -136,8 +155,8 @@ Options:
                                   created and the server returns all
                                   properties. Multiple properties may be
                                   defined with either a comma separated list
-                                  defining the option multiple times. (ex: -p
-                                  pn1 -p pn22 or -p pn1,pn2). If defined as
+                                  or by using the option multiple times. (ex:
+                                  -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                   empty string the server should return no
                                   properties.
   -n, --namespace <name>          Namespace to use for this operation. If
@@ -148,7 +167,8 @@ Options:
                                   presented with a list of instances of the
                                   class from which the instance to process is
                                   selected.
-  -h, --help                      Show this message and exit."""
+  -h, --help                      Show this message and exit.
+"""
 
 INST_CREATE_HELP = """
 Usage: pywbemcli instance create [COMMAND-OPTIONS] CLASSNAME
@@ -255,7 +275,7 @@ Usage: pywbemcli instance references [COMMAND-OPTIONS] INSTANCENAME
   of instances names in the class from which you can be chosen as the
   target.
 
-  Results are formatted as defined by the output format global option.
+  Results are formatted as defined by the --output_format general option.
 
 Options:
   -R, --resultclass <class name>  Filter by the result class name provided.
@@ -268,19 +288,28 @@ Options:
                                   property with aname that matches the value
                                   of this parameter. Optional.
   -q, --includequalifiers         If set, requests server to include
-                                  qualifiers in the returned instance(s).
-  -c, --includeclassorigin        Include classorigin in the result.
+                                  qualifiers in the returned instances. This
+                                  subcommand may use either pull or
+                                  traditional operations depending on the
+                                  server and the "--use--pull-ops" general
+                                  option. If pull operations are used,
+                                  qualifiers will not be included, even if
+                                  this option is specified. If traditional
+                                  operations are used, inclusion of qualifiers
+                                  depends on the server.
+  -c, --includeclassorigin        Include class origin attribute in returned
+                                  instance(s).
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
                                   option not specified a Null property list is
                                   created and the server returns all
                                   properties. Multiple properties may be
                                   defined with either a comma separated list
-                                  defining the option multiple times. (ex: -p
-                                  pn1 -p pn22 or -p pn1,pn2). If defined as
+                                  or by using the option multiple times. (ex:
+                                  -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                   empty string the server should return no
                                   properties.
-  -o, --names_only                Show only local properties of the class.
+  -o, --names_only                Show only the returned object names.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace
@@ -291,7 +320,8 @@ Options:
                                   class from which the instance to process is
                                   selected.
   -S, --summary                   Return only summary of objects (count).
-  -h, --help                      Show this message and exit."""
+  -h, --help                      Show this message and exit.
+"""
 
 INST_MODIFY_HELP = """
 Usage: pywbemcli instance modify [COMMAND-OPTIONS] INSTANCENAME
@@ -343,7 +373,8 @@ Options:
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace
-  -h, --help                      Show this message and exit."""
+  -h, --help                      Show this message and exit.
+"""
 
 INST_ASSOCIATORS_HELP = """
 Usage: pywbemcli instance associators [COMMAND-OPTIONS] INSTANCENAME
@@ -361,7 +392,7 @@ Usage: pywbemcli instance associators [COMMAND-OPTIONS] INSTANCENAME
   interactive option. Pywbemcli presents a list of instances in the class
   from which one can be chosen as the target.
 
-  Results are formatted as defined by the output format global option.
+  Results are formatted as defined by the --output_format general option.
 
 Options:
   -a, --assocclass <class name>   Filter by the association class name
@@ -387,19 +418,28 @@ Options:
                                   role (property name in the association that
                                   matches this parameter). Optional.
   -q, --includequalifiers         If set, requests server to include
-                                  qualifiers in the returned instance(s).
-  -c, --includeclassorigin        Include classorigin in the result.
+                                  qualifiers in the returned instances. This
+                                  subcommand may use either pull or
+                                  traditional operations depending on the
+                                  server and the "--use--pull-ops" general
+                                  option. If pull operations are used,
+                                  qualifiers will not be included, even if
+                                  this option is specified. If traditional
+                                  operations are used, inclusion of qualifiers
+                                  depends on the server.
+  -c, --includeclassorigin        Include class origin attribute in returned
+                                  instance(s).
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
                                   option not specified a Null property list is
                                   created and the server returns all
                                   properties. Multiple properties may be
                                   defined with either a comma separated list
-                                  defining the option multiple times. (ex: -p
-                                  pn1 -p pn22 or -p pn1,pn2). If defined as
+                                  or by using the option multiple times. (ex:
+                                  -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                   empty string the server should return no
                                   properties.
-  -o, --names_only                Show only local properties of the class.
+  -o, --names_only                Show only the returned object names.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace
@@ -410,7 +450,8 @@ Options:
                                   class from which the instance to process is
                                   selected.
   -S, --summary                   Return only summary of objects (count).
-  -h, --help                      Show this message and exit."""
+  -h, --help                      Show this message and exit.
+"""
 
 INST_INVOKE_METHOD_HELP = """
 Usage: pywbemcli instance invokemethod [COMMAND-OPTIONS] INSTANCENAME
@@ -453,7 +494,8 @@ Options:
   -n, --namespace <name>      Namespace to use for this operation. If defined
                               that namespace overrides the general options
                               namespace
-  -h, --help                  Show this message and exit."""
+  -h, --help                  Show this message and exit.
+"""
 
 ENUM_INST_RESP = """instance of CIM_Foo {
    InstanceID = "CIM_Foo1";
@@ -631,6 +673,21 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
+    ['Verify instance subcommand enumerate CIM_Foo --includequalifiers',
+     ['enumerate', 'CIM_Foo', '--includequalifiers'],
+     {'stdout': ENUM_INST_RESP,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance subcommand enumerate CIM_Foo includequalifiers and '
+     ' --use-pull-ops no',
+     {'args': ['enumerate', 'CIM_Foo', '--includequalifiers'],
+      'global': ['--use-pull-ops', 'no']},
+     {'stdout': ENUM_INST_RESP,
+      'test': 'linesnows'},
+     SIMPLE_MOCK_FILE, OK],
+
+
     ['Verify instance subcommand enumerate deepinheritance CIM_Foo -d',
      ['enumerate', 'CIM_Foo', '-d'],
      {'stdout': ENUM_INST_RESP,
@@ -737,6 +794,31 @@ TEST_CASES = [
     ['Verify instance subcommand get with instancename --localonly returns '
      ' data',
      ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--localonly'],
+     {'stdout': ['instance of CIM_Foo {',
+                 '   InstanceID = "CIM_Foo1";',
+                 '   IntegerProp = 1;',
+                 '};',
+                 ''],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance subcommand get with instancename --includequalifiers '
+     'returns data',
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--includequalifiers'],
+     {'stdout': ['instance of CIM_Foo {',
+                 '   InstanceID = "CIM_Foo1";',
+                 '   IntegerProp = 1;',
+                 '};',
+                 ''],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance subcommand get with instancename --includequalifiers and '
+     'general --use-pull-ops returns data',
+     {'args': ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--includequalifiers'],
+      'global': ['--use-pull-ops', 'no']},
      {'stdout': ['instance of CIM_Foo {',
                  '   InstanceID = "CIM_Foo1";',
                  '   IntegerProp = 1;',
@@ -1236,6 +1318,21 @@ TEST_CASES = [
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
+    ['Verify instance subcommand references --includequalifiers',
+     ['references', 'TST_Person.name="Mike"', '--includequalifiers'],
+     {'stdout': REF_INSTS,
+      'test': 'linesnows'},
+     ASSOC_MOCK_FILE, RUN],
+
+    ['Verify instance subcommand references includequalifiers and '
+     ' --use-pull-ops no',
+     {'args': ['references', 'TST_Person.name="Mike"', '--includequalifiers'],
+      'global': ['--use-pull-ops', 'no']},
+     {'stdout': REF_INSTS,
+      'test': 'linesnows'},
+     ASSOC_MOCK_FILE, RUN],
+
+
     ['Verify instance subcommand references -o, returns paths with resultclass '
      'not a real ref returns no paths',
      ['references', 'TST_Person.name="Mike"', '-o',
@@ -1299,7 +1396,6 @@ TEST_CASES = [
       'rc': 0,
       'test': 'linesnows'},
      None, OK],
-    # TODO  add valid associators tests
 
     ['Verify instance subcommand associators, returns instances',
      ['associators', 'TST_Person.name="Mike"'],
@@ -1307,6 +1403,21 @@ TEST_CASES = [
       'rc': 0,
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
+
+    ['Verify instance subcommand associators, --includequalifiers',
+     ['associators', 'TST_Person.name="Mike"', '--includequalifiers'],
+     {'stdout': ASSOC_INSTS,
+      'rc': 0,
+      'test': 'lines'},
+     ASSOC_MOCK_FILE, RUN],
+
+    ['Verify instance subcommand associators, --includequalifiers wo pull',
+     {'global': ['--use-pull-ops', 'no'],
+      'args': ['associators', 'TST_Person.name="Mike"', '--includequalifiers']},
+     {'stdout': ASSOC_INSTS,
+      'rc': 0,
+      'test': 'lines'},
+     ASSOC_MOCK_FILE, RUN],
 
     ['Verify instance subcommand associators -o, returns data',
      ['associators', 'TST_Person.name="Mike"', '-o'],
@@ -1318,7 +1429,9 @@ TEST_CASES = [
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    # TODO add invalid associators tests
+
+    # Invalid associators tests
+
     ['Verify instance subcommand associators, no instance name',
      ['associators'],
      {'stderr': ['Usage: pywbemcli instance associators [COMMAND-OPTIONS] '
@@ -1351,7 +1464,7 @@ TEST_CASES = [
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, RUN],
 
-    # TODO add associators error tests
+    # TODO add more associators error tests
 
     #
     #  instance count subcommand


### PR DESCRIPTION
This pr has two commits, the original and the one with corrections after discussion.

This started as proposal to remove the includequalifiers from pywbemtools instance enum, assoc, ref after we found issue with includequalifier. Later we found it was actually in pywbem but had already submitted a pr submission.   After discussion we agreed to leave them in but to modify the definitions to reflect the issues.

Now this PR:
1. extended the tests to insure that pywbemtools and is incpywbem are working together to the includequalifiers options on both class and instance operations.

2. Modifies the text of the help for the instance includequalifiers to clarify that they may or may not work.

3. Extends the tests for the class command group in several areas.

There were the following additional changes:

1. I originally used the word global for what we now call the general options.  The word global was still used in the class command group in the help text so I changed it.

2. A test failed when I started this and found that it was due to line of code moved in context_obj.py  statistics format.  Cleared that up.

3. Also modified the includeclassorigin click option to use a common option. It was hand coded in each use.