### PR TITLE
Fix class find subcommand

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -42,7 +42,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
 
       For more detailed information, see:
 
-      https:\https://pywbemtools.readthedocs.io/en/latest/
+          https://pywbemtools.readthedocs.io/en/latest/
 
     Options:
       -s, --server URI                Hostname or IP address with scheme of the
@@ -129,7 +129,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       pull operations.
                                       * "either": pywbemcli trys
                                       first pull and then  traditional operations.
-                                      (EnvVar: PYWBEMCLI_USE_PULL) [Default:
+                                      (EnvVar: PYWBEMCLI_USE_PULL_OPS) [Default:
                                       either]
       --pull-max-cnt INTEGER          Maximium object count of objects to be
                                       returned for each request if pull operations
@@ -398,8 +398,10 @@ The following defines the help output for the `pywbemcli class find --help` subc
 
     Options:
       -s, --sort              Sort into alphabetical order by classname.
-      -n, --namespace <name>  Namespace to use for this operation. If defined that
-                              namespace overrides the general options namespace
+      -n, --namespace <name>  Namespace(s) to use for this operation. If defined
+                              only those namespaces are searched rather than all
+                              available namespaces. ex: -n root/interop -n
+                              root/cimv2
       -h, --help              Show this message and exit.
 
 

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -63,7 +63,7 @@ def class_group():
     general options (see 'pywbemcli --help') can also be specified before the
     command. These are NOT retained after the command is executed.
     """
-    pass
+    pass  # pylint: disable=unnecessary-pass
 
 
 @class_group.command('get', options_metavar=CMD_OPTS_TXT)
@@ -274,7 +274,11 @@ def class_associators(context, classname, **options):
 @class_group.command('find', options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME-REGEX', required=True)
 @add_options(sort_option)
-@add_options(namespace_option)
+@click.option('-n', '--namespace', type=str, multiple=True,
+              required=False, metavar='<name>',
+              help='Namespace(s) to use for this operation. If defined only '
+              'those namespaces are searched rather than all available '
+              'namespaces. ex: -n root/interop -n root/cimv2')
 @click.pass_obj
 def class_find(context, classname, **options):
     """
@@ -479,7 +483,7 @@ def cmd_class_find(context, classname, options):
     a list of classes/namespaces
     """
     if options['namespace']:
-        ns_names = [options['namespace']]
+        ns_names = options['namespace']
     else:
         try:
             ns_names = context.wbem_server.namespaces

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -30,7 +30,8 @@ SIMPLE_MOCK_FILE_EXT = 'simple_mock_model_ext.mof'
 INVOKE_METHOD_MOCK_FILE = 'simple_mock_invokemethod.py'
 SIMPLE_ASSOC_MOCK_FILE = 'simple_assoc_mock_model.mof'
 
-CLS_HELP = """Usage: pywbemcli class [COMMAND-OPTIONS] COMMAND [ARGS]...
+CLS_HELP = """
+Usage: pywbemcli class [COMMAND-OPTIONS] COMMAND [ARGS]...
 
   Command group to manage CIM classes.
 
@@ -52,7 +53,8 @@ Commands:
   tree          Display CIM class inheritance hierarchy tree.
 """
 
-CLS_ENUM_HELP = """Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME
+CLS_ENUM_HELP = """
+Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME
 
   Enumerate classes from the WBEM Server.
 
@@ -89,8 +91,8 @@ Options:
   -h, --help                Show this message and exit.
 """
 
-# pylint: disable=line-too-long
-CLASS_FIND_HELP = """Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME-REGEX
+CLASS_FIND_HELP = """
+Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME-REGEX
 
   Find all classes that match CLASSNAME-REGEX.
 
@@ -115,12 +117,14 @@ CLASS_FIND_HELP = """Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME-REG
 
 Options:
   -s, --sort              Sort into alphabetical order by classname.
-  -n, --namespace <name>  Namespace to use for this operation. If defined that
-                          namespace overrides the general options namespace
+  -n, --namespace <name>  Namespace(s) to use for this operation. If defined
+                          only those namespaces are searched rather than all
+                          available namespaces. ex: -n root/interop -n
+                          root/cimv2
   -h, --help              Show this message and exit.
-"""  # pylint: enable=line-too-long
-
-CLASS_TREE_HELP = """Usage: pywbemcli class tree [COMMAND-OPTIONS] CLASSNAME
+"""
+CLASS_TREE_HELP = """
+Usage: pywbemcli class tree [COMMAND-OPTIONS] CLASSNAME
 
   Display CIM class inheritance hierarchy tree.
 
@@ -149,7 +153,8 @@ Options:
   -h, --help              Show this message and exit.
 """
 
-CLASS_DELETE_HELP = """Usage: pywbemcli class delete [COMMAND-OPTIONS] CLASSNAME
+CLASS_DELETE_HELP = """
+Usage: pywbemcli class delete [COMMAND-OPTIONS] CLASSNAME
 
   Delete a single CIM class.
 


### PR DESCRIPTION
The help was incorrect for this subcommand because it used the standard
namespace option but the behavior is different. The standard options is
about selecting another namespace than the default.  This is about
limiting the search to a namespace.

At the same time it seemed logical to extend it to allow using multiple
namespaces rather than a single namespace so we made that change also.