### PR TITLE
Extend and clean up the documentation part 2

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -17,45 +17,85 @@ This documentation uses a few special terms to refer to Python types:
 
 .. glossary::
 
-   string
-      a :term:`unicode string` or a :term:`byte string`
+   CIM-XML
+     the name of the protocol used in the DMTF specification :term:`DSP0200`
+     the protocol pywbemcli uses to communicate with WBEM servers.
 
-   unicode string
-      a Unicode string type (:func:`unicode <py2:unicode>` in
-      Python 2, and :class:`py3:str` in Python 3)
+   INSTANCENAME
+      an argument of several of the command-group ``instance`` subcommands that
+      allows two possible inputs based on another subcommand option(``--interactive``).
 
-   byte string
-      a byte string type (:class:`py2:str` in Python 2, and
-      :class:`py3:bytes` in Python 3). Unless otherwise
-      indicated, byte strings in pywbem are always UTF-8 encoded.
+      When ``interactive`` is set the INSTANCENAME is  a string representation of
+      a CIMInstanceName formatted as defined by  :term:`WBEM-URI`
+
+      Otherwise the INSTANCENAME should be a classname in which case pywbemcli
+        will get the instance names from the WBEM server and present a
+        selection list for the user to select an instance
+        name :ref:`Displaying CIM instances or CIM instance names`
 
    connection id
-      a string (:term:`string`) that uniquely identifies each
-      :class:`pywbem.WBEMConnection` object created. The connection id is
-      immutable and is accessible from
+      a string that uniquely identifies each :class:`pywbem.WBEMConnection`
+      object created. The connection id is immutable and is accessible from
       :attr:`pywbem.WBEMConnection.conn_id`. It is included in of each log
       record created for pywbem log output and may be used to correlate pywbem
       log records for a single connection.
-
-   number
-      one of the number types :class:`py:int`, :class:`py2:long` (Python 2
-      only), or :class:`py:float`.
-
-   integer
-      one of the integer types :class:`py:int` or :class:`py2:long` (Python 2
-      only).
 
    DeprecationWarning
       a standard Python warning that indicates a deprecated functionality.
       See section :ref:`Deprecation and compatibility policy` and the standard
       Python module :mod:`py:warnings` for details.
 
-    MOF
-        MOF(Managed Object Format) is the language used byt the DMTF to
-        describe in textual form CIM objects including CIM classes,
-        CIM Instance, etc.  It is one of the output formats provided for
-        the display of CIM objects in pywbemcli. See DMTF `DSP0004` for more
-        information on the MOF format.
+   connections file
+      A file maintained by pywbemcli and managed by the pywbemcli
+      ``connections`` command group.  The file name is ``pywbemcli_connections.json``
+      and the file must be in the directory in which pywbemcli is executed.
+      Multiple connection files may exist in different directories.
+      The connection file contains a JSON definition of the parameters for
+      each connection with a name for the connection so that connections may
+      be predefined and pywbemcli commands executed against them using only
+      the connection name.
+
+   MOF
+      MOF(Managed Object Format) is the language used by the DMTF to
+      describe in textual form CIM objects including CIM classes,
+      CIM Instance, etc.  It is one of the output formats provided for
+      the display of CIM objects in pywbemcli. See DMTF term:`DSP0004` for more
+      information on the MOF format.
+
+   WBEM-URI
+      The wbem uri is a standardized text form for CIM instance names. It is
+      documented in DMTF DSP0207. Pywbemcli uses the untyped WBEM URI::
+
+            WBEM-URI = WBEM-URI-UntypedNamespacePath /
+                       WBEM-URI-UntypedClassPath /
+                       WBEM-URI-UntypedInstancePath
+
+            WBEM-URI-UntypedNamespacePath = namespacePath
+            WBEM-URI-UntypedClassPath     = namespacePath ":" className
+            WBEM-URI-UntypedInstancePath  = WBEM-URI-UntypedInstancePath
+                                            className "." key_value_pairs
+
+            namespacePath = [namespaceType ":"] namespaceHandle
+            namespaceType = ("http" ["s"]) / ("cimxml.wbem" ["s"])
+            namespaceHandle = ["//" authority] "/" [namespaceName]
+            namespaName     = IDENTIFIER *("/"IDENTIFIER))
+
+            // Untyped key value pairs
+            key_value_pairs  = key_value_pair *("," key_value_pair)
+            key_value_pair   = key_name "=" key_value
+            key_value        = stringValue / charValue / booleanValue /
+                               integerValue / realValue /
+                               "\"" datetimeValue "\"" /
+                               "\"" referenceValue "\""
+
+      In pywbemcli the WBEM-URI is used as the format for instance names on
+      commands such as ``instance get <instance-name>``
+
+      In these cases, the normal use is to specify only the classname and
+      keybindings so that examples of valid WBEM-URIs would be::
+
+        CIM_RegisteredProfile.InstanceID="acme:1"
+        CIM_RegisteredProfile.InstanceID=100
 
 .. _`Profile advertisement methodologies`:
 
@@ -174,17 +214,6 @@ Glossary
 
 .. glossary::
 
-   dynamic indication filter
-   dynamic filter
-      An indication filter in a WBEM server whose life cycle is managed by a
-      client.
-      See :term:`DSP1054` for an authoritative definition and for details.
-
-   static indication filter
-   static filter
-      An indication filter in a WBEM server that pre-exists and whose life
-      cycle cannot be managed by a client.
-      See :term:`DSP1054` for an authoritative definition and for details.
 
 .. _`References`:
 
@@ -214,21 +243,6 @@ References
    DSP1033
       `DMTF DSP1033, Profile Registration Profile, Version 1.1 <https://www.dmtf.org/standards/published_documents/DSP1033_1.1.pdf>`_
 
-   DSP1054
-      `DMTF DSP1054, Indications Profile, Version 1.2 <https://www.dmtf.org/standards/published_documents/DSP1054_1.2.pdf>`_
-
-   DSP1092
-      `DMTF DSP1092, WBEM Server Profile, Version 1.0 <https://www.dmtf.org/standards/published_documents/DSP1092_1.0.pdf>`_
-
-   X.509
-      `ITU-T X.509, Information technology - Open Systems Interconnection - The Directory: Public-key and attribute certificate frameworks <https://www.itu.int/rec/T-REC-X.509/en>`_
-
-   RFC2616
-      `IETF RFC2616, Hypertext Transfer Protocol -- HTTP/1.1, June 1999 <https://tools.ietf.org/html/rfc2616>`_
-
-   RFC2617
-      `IETF RFC2617, HTTP Authentication: Basic and Digest Access Authentication, June 1999 <https://tools.ietf.org/html/rfc2617>`_
-
    RFC3986
       `IETF RFC3986, Uniform Resource Identifier (URI): Generic Syntax, January 2005 <https://tools.ietf.org/html/rfc3986>`_
 
@@ -237,6 +251,9 @@ References
 
    WBEM Standards
       `DMTF WBEM Standards <https://www.dmtf.org/standards/wbem>`_
+
+   SMI-S
+      `SNIA Storage Management Initiative Specification`_
 
    Python Glossary
       * `Python 2.7 Glossary <https://docs.python.org/2.7/glossary.html>`_

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,61 +4,6 @@
 Change log
 ==========
 
-.. ifconfig:: version.endswith('dev0')
+This is the initial release of pywbemtools and therefore there is no change log.
 
-.. # Reenable the following lines when working on a development version:
-
-This version of the documentation is development version |version| and
-contains the `master` branch up to this commit:
-
-.. git_changelog::
-   :revisions: 1
-
-
-pywbemcli v0.5.0.dev0
----------------------
-
-Released: Not yet
-
-This is the initial release of pywbemcli command line tool.
-
-Incompatible changes
-^^^^^^^^^^^^^^^^^^^^
-
-Enhancements
-^^^^^^^^^^^^
-
-* Add input argument to _common.format_table to define sort of the
-  rows of the table as a function of the formatting.
-
-Bug fixes
-^^^^^^^^^
-
-* Fix issues with the create_instance function. It now processes scalar
-  and array properties. Issue # 11
-* fix issue with the help_over file format.  It was output as .md file and
-  the resulting output could be viewed by only some tools (i.e. github
-  messed it up). Changed to display as a .rst file output. (see issue #27gi)
-
-* Fix issues around password so that we get the password from a prompt rather
-  than just from the command line. This also adds a form of persistence to
-  save info on connections by using the connection group.  It adds several
-  subcommands to the connection group to show, list, create, delete, etc.
-  connections so the user can maintain a list of WBEM servers that can be easily
-  referenced rather than having to type them in.(issue # 6))
-
-* Fix issues with `class find`. Failed when namespace specified with -n,
-  did not turn off spinner, double sorted output.
-
-* Fix issue where cmd line log option was not passed to named connections or
-  when connection select used.
-
-Build, test, quality
-^^^^^^^^^^^^^^^^^^^^
-
-* Test: Removed pinning of distro version on Travis to Ubuntu xenial (16.04) 
-  for Python 3.7, because that is now the default distro version, in order to
-  pick up a future increase of the default distro version automatically.
-
-Documentation
-^^^^^^^^^^^^^
+The change log will be enabled for future releases.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ The pywbemtools github page is: ``https://github.com/pywbem/pywbemtools <https:/
    pywbemclicmdlineinterface.rst
    pywbemclisubcommands.rst
    pywbemclicmdshelp.rst
-   pywbemclispecificfeatures.rst
+   pywbemclispecialfeatures.rst
    mock_support.rst
    appendix.rst
    changes.rst

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -24,48 +24,59 @@ Introduction
 Pywbemtools features
 --------------------
 
-The pywbemtools package is a pure Python package that contains tools and
-applications that interact with WBEM servers:
+Pywbemtools is a collection of command line tools that communicate with WBEM
+Servers. The tools are written in pure Python and support Python 2 and Python
+3.
 
-* pywbemcli: A command line interface WBEM client module in pywbemtools that
-  interacts with WBEM servers
+Pywbemtools provides a command line tool (pywbemcli) that uses the pywbem
+Python WBEM client infrastructure to issue operations to a WBEM server using
+the WBEM standards defined by the DMTF to perform system management tasks.
 
-These tools use ``pywbem`` as the client WBEM infrastructure to communication
-with the WBEM servers.
+WBEM standards are used for a wide variety of systems management tasks
+in the industry including DMTF management standards and the SNIA Storage
+Management Initiative Specification(SMI-S).
 
-Pywbemtools and pywbem WBEM Client are packages in the github pywbem repository.
+Pywbemtools and pywbem WBEM Client are packages in the github pywbem repository
+and are released to PyPi. Pywbemcli is a module in pywbemtools.
 
-.. _`
-Pywbemcli command line WBEM client`:
+
+.. _`Pywbemcli command line interface WBEM client`:
 
 Pywbemcli command line interface WBEM client
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Pywbemcli provides access to WBEM servers directly from the command line.
-It provides commands to:
+Pywbemcli provides access to WBEM servers from the command line on multiple OS
+platforms. It provides functionality to:
 
-1. Inspect and manage the CIM Objects CIMClasses, CIMInstances,
-and CIM QualifierDeclaractions defined by the server using the
-requests APIs of the pywbem package.
+* Explore the CIM data of WBEM Servers. It can manage/inspect the CIM model
+  components including CIM classes, CIM instances, and CIM qualifiers and execute
+  CIM methods and queries on the WBEM server. It implements subcommands to
+  execute the :term:`CIM-XML` operations defined in the DMTF specification CIM Operations
+  Over HTTP(:term:`DSP0200`).
 
-2. Inspect and manage higher level components of the WBEM server including:
+* Inspect/manage WBEM server functionality including:
 
-   * CIM Namespaces
-   * WBEM Server brand information
-   * WBEM management profiles
+  * CIM namespaces,
+  * WBEM registered management profiles,
+  * WBEM server brand information
 
-3. Display information on the interactions with the server including logs and
-   time statistics.
+* Capture detailed information on interactions with the WBEM server including
+  time statistics.
 
-4. Maintain a persistent repository of WBEM server defintions so that server
-   definitions can be accesed by name.
+* Maintain a file of WBEM server definitions so that pywbemcli can access
+  multiple servers by name.
+
+* Provide both a command line interface and an interactive mode where multiple
+  pywbemcli commands can be executed within the context of a WBEM server.
+
 
 .. _`Supported environments`:
 
 Supported environments
 ----------------------
 
-The pywbemcli package is supported in these environments:
+The pywbemcli module of the pywbemtools package is supported in these
+environments:
 
 * Operating systems: Linux, Windows, MacOS
 * Python versions: 2.7, 3.4, and greater
@@ -114,14 +125,6 @@ branch of the Git repository of the package:
 .. code-block:: text
 
     $ pip install git+https://github.com/pywbem/pywbemtools.git@master
-
-You can verify that the pywbemtools package and its dependent packages are
-installed correctly by importing the package into Python:
-
-.. code-block:: text
-
-    $ python -c "import pywbemcli; print('ok')"
-    ok
 
 Verification of the installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -195,7 +198,7 @@ presence of a ".devD" suffix in the version string. Development versions are
 pre-versions of the next assumed version that is not yet released. For example,
 version 0.5.1.dev2 is development pre-version #2 of the next version to be
 released after 0.5.0. Version 1.5.1 is an `assumed` next version, because the
-`actually released` next version might be 0.2.0 or even 1.0.0.
+`actually released` next version might be 0.7.0 or even 1.0.0.
 
 
 .. _`Compatibility`:
@@ -209,13 +212,13 @@ that the user can safely upgrade to that new version without encountering
 compatibility issues.
 
 This package uses the rules of `Semantic Versioning 2.0.0`_ for compatibility
-between package versions, and for :ref:`deprecations <Deprecations>`.
+between package versions, and for deprecations.
 
-The public interfaces of this package that are subject to the semantic versioning
-rules (and specificically to its compatibility rules) is the CLI syntax described in
-this documentation.
+The public command line interface of this package that is subject to the
+semantic versioning rules (and specificically to its compatibility rules) is
+the CLI syntax described in this documentation.
 
-The output formats are currently the subject of compatiblity assurances.
+The output formats are currently not the subject of compatiblity assurances.
 
 Violations of these compatibility rules are described in section
 :ref:`Change log`.
@@ -239,7 +242,7 @@ suppressed by default. They can be shown for example in any of these ways:
 
   ``PYTHONWARNINGS=default``
 
-It is recommended that users of this package run their test code with
+It is recommended that users of this package run their tests with
 :exc:`~py:exceptions.DeprecationWarning` warnings being shown, so they become
 aware of any use of deprecated functionality.
 

--- a/docs/mock_support.rst
+++ b/docs/mock_support.rst
@@ -3,67 +3,81 @@
 Mock WBEM server support
 ========================
 
+.. _`Mock support overview`:
+
+Mock support overview
+---------------------
+
 Support for mocking a WBEM server is integrated into pywbemcli using  the
-pywbemcli ``--mock-server`` global command line option.  This allows executing
-the pywbemcli against a mock WBEM server rather than a real WBEM
-server.
+pywbemcli  general command line option (``-m``or ``--mock-server``).  This
+allows executing pywbemcli against a mock WBEM server integrated into the
+pywbemcli process rather than a real WBEM server.
 
-The pywbem mock support uses :class:`pywbem\pywbem_mock.FakedWBEMConnection`
-to define a mock server and build a mock repository that contains data for
-responses to pywbemcli from the values of the ``--mock-server`` option.
+When the --mock-server option is used on the pywbemcli command line it
+replaces the --server option
 
-This command line option constructs an instance of
-:class:`~pywbem\pywbem_mock.FakedWBEMConnection` in place of
-:class:`~pywbem\pywbem.WBEMConnection` and allows building the mock repository
-of CIMQualifierDeclarations, CIM classes, and CIM instances in the mock
-repository from the files defined with the ``--mock-server``.
+The ``--mock-server`` option constructs an instance of the pywbem class
+:class:`~pywbem.pywbem_mock.FakedWBEMConnection` in place of the pywbem class
+:class:`~pywbem.pywbem.WBEMConnection` and allows building the mock repository
+of CIM qualifier declarations, CIM classes, and CIM instances in the mock
+repository from the file specified with the ``--mock-server`` option.
 
-Each instance of the ``--mock-server`` option defines a single file or file
-path:
+The ``--mock-server`` option defines a single file path that pywbemcli will
+pass to the repository building tools in pywbem when pywbemcli is started. This
+option may be used multiple times and each use of the option specifies the file
+path of one of the following types of files:
 
-* `MOF` file (file extension ``mof``) - If the option value is a `MOF` file,
-  pywbemcli compiles the MOF and inserts the CIM objects into the mock
-  repository. The file may contain MOF definitions for CIM qualifier
-  declarations, CIM classes  and CIM instances.
+* ``MOF`` file (file extension ``mof``) - If the option value is the file path of
+  a `MOF` file, pywbemcli compiles the MOF and inserts the CIM objects into the
+  mock repository. The file may contain MOF definitions for CIM qualifier
+  declarations, CIM classes  and CIM instances when pywbemcli is started.  The
+  CIM objects will be inserted into the default namespace defined for the
+  current connection.
 
-* Python file (file extension ``py``) - If the option value is a Python file,
-  that file is executed with the following global variables passed to the
-  file:
+* Python file (file extension ``py``) - If the option value is the file path of
+  a Python file, that file is executed with the following Python GLOBAL
+  variables passed to the file when pywbemcli is started:
 
-    * ``CONN`` - an instance object of
-                 :class:`~pywbem\pywbem_mock.FakedWBEMConnection`). The methods
+    * ``CONN`` - an instance of
+                 :class:`~pywbem.pywbem_mock.FakedWBEMConnection`). The methods
                  of this instance object can be used to add data to the
                  mock repository.
 
-    * ``SERVER`` - an instance object of :class:`~pywbem\WBEMServer`). The
+    * ``SERVER`` - an instance of :class:`~pywbem.WBEMServer`). The
                    methods of this instance object can be used to add data to
                    them mock repository. This instance can be useful to get
                    namespace information or build more complex objects
                    for the mock repository.
 
     * ``VERBOSE`` - a boolean flag that is based on the pywbemcli option
-                    ``--verbose``
+                    ``--verbose``.
 
   The file can contain any Python statements or functions and can insert them
-  into the :class:`~pywbem\pywbem_mock.FakedWBEMConnection` using the
+
+  into the :class:`~pywbem.pywbem_mock.FakedWBEMConnection` using the
   methods in that class
 
-  Generally, the Python file will contain pywbem CIMQualifierDeclaration,
-  CIMClass, and CIMInstance instance objects and a calls to
-  :meth:`~pywbem\pywbem_mock.FakedWBEMConnection.add_cim objects` to insert
-  objects into the repository.  It may also contain pywbem method callbacks
-  (define in pywbem as ``method_callback_interface``) to define server methods
-  that will process InvokeMethod calls from pywbemcli.
+  The  Python file may contain pywbem CIMQualifierDeclaration,
+  CIMClass, and CIMInstance instance objects and calls to
+  :meth:`~pywbem.pywbem_mock.FakedWBEMConnection.add_cim objects` to insert
+  objects into the repository.
 
-Pywbemcli logging (``--log``) can be enabled when the `--mock-server` option is
+  It may also implement pywbem CIM method callbacks (defined in pywbem as
+  ``method_callback_interface``) for handling InvokeMethod operations requested
+  from pywbemcli.
+
+Pywbemcli logging (`` -l`` or ``--log``) can be enabled when the `--mock-server` option is
 enabled. However, since the mock support does not use HTTP, the `http`  of the
 log option will generate no output.
 
-Defining files for the mock respository
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The following is a  simplistic MOF file that defines somee qualifier
-declarations, a CIMClass, and a CIMInstance of that class:
+.. _`Creating files for the mock respository`:
+
+Creating files for the mock respository
+---------------------------------------
+
+The following is a MOF file (tst_file.mof) that defines some qualifier
+declarations, a single CIMClass, and a single CIMInstance of that class:
 
 .. code-block:: text
 
@@ -99,23 +113,64 @@ declarations, a CIMClass, and a CIMInstance of that class:
         uint32 DeleteNothing();
     };
 
+    # define the instance of CIM_Foo in MOF
+    # NOTE that the alias $foo1 creates the instance name
     instance of CIM_Foo as $foo1 {
         InstanceID = "CIM_Foo1";
         IntegerProp = 1;
         };
 
-The pywbemcli command to test class enumerate with the pywbem mock MOF above in
-the file ``test_file.mof`` and in the mock repository is::
+The pywbemcli command to insert these CIM objects into the mock repository
+(where the file containing the above MOF is tst_file.mof)  and then to
+enumerate its CIM classes is::
 
-    pywbemcli --mock-server tst_file.mof
+    $ pywbemcli --mock-server tst_file.mof class enumerate
 
-The following is a simple Python file that will insert CIM objects  defined
-using the pywbem APIs into the mock repository in the default namespace. If the
-``--verbose`` general option is set on the pywbemcli command line, the global
-variable ``VERBOSE`` will be set True and the code below  will display the
-repository and test that the class is in the repository with GetClass:
+           [Description ( "Simple CIM Class" )]
+        class CIM_Foo {
+
+              [Key ( true ),
+               Description ( "This is key property." )]
+           string InstanceID;
+
+              [Description ( "This is Uint32 property." )]
+           uint32 IntegerProp;
+
+              [Description ( "Method with in and out parameters" )]
+           uint32 Fuzzy(
+                 [IN ( true ),
+                  OUT ( true ),
+                  Description ( "Define data to be returned in output parameter" )]
+              string TestInOutParameter,
+                 [IN ( true ),
+                  OUT ( true ),
+                  Description ( "Test of ref in/out parameter" )]
+              CIM_Foo REF TestRef,
+                 [IN ( false ),
+                  OUT ( true ),
+                  Description ( "Rtns method name if exists on input" )]
+              string OutputParam,
+                 [IN ( true ),
+                  Description ( "Defines return value if provided." )]
+              uint32 OutputRtnValue);
+
+              [Description ( "Method with no Parameters" )]
+           uint32 DeleteNothing();
+
+        };
+      $
+
+The following is a  Python code (in a file tst_file.py)) that will insert CIM
+objects defined using the pywbem APIs into the mock repository in the default
+namespace. If the ``--verbose`` general option is set on the pywbemcli command
+line, the global variable ``VERBOSE`` will be set True and the code below  will
+display the repository and test that the class is in the repository with
+GetClass:
 
 .. code-block:: python
+
+    # CONN and VERBOSE are GLOBAL available to this code when executed in
+    # during pywbemcli startup
 
     from pywbem import CIMQualifier, CIMClass, CIMProperty, CIMMethod
 
@@ -150,4 +205,6 @@ repository and test that the class is in the repository with GetClass:
 
 The pywbemcli command for a test using this mock data is::
 
-    pywbemcli --mock-server tst_file.mof.py class enumerate
+
+    $ pywbemcli --mock-server tst_file.mof.py class enumerate
+

--- a/docs/pywbemclicmdlineinterface.rst
+++ b/docs/pywbemclicmdlineinterface.rst
@@ -18,8 +18,41 @@
 Pywbemcli command line interface
 ================================
 
-This package provides a command line interface (CLI) in the ``pywbemcli`` tool
-that supports communication with a WBEM server through the pywbem client API.
+Pywbemcli provides a command line interface(CLI) interaction with WBEM servers.
+
+The command line  can contain the following components::
+
+* general-options - see :ref:`Command line general options`
+
+* command-group - A name of a group of subcommands
+
+* command - Alternative to command-group when there are no
+  subcommands.
+
+* subcommand - Command name within a command group
+
+* args - Arguments and options that are defined for a particular
+  command or subcommand.
+
+The syntax is:
+
+.. code-block:: text
+
+    pywbemcli <general-options> <command-group>|<command> <args>
+
+    where:
+        command-group = <command> <subcommand>
+
+A command-group is the name of an object, referencing an entity (ex. class
+refers to operation on CIM classes). The subcommands are generally actions on
+the objects defined by the command-group name. Thus ``class`` is a
+command-group name used to access CIM classes and ``get`` is a subcommand so::
+
+    $ pywbemcli --output-format mof class get CIM_ManagedElement --namespace interop
+
+Defines a command to get the class `CIM_ManagedElement` from the current
+target server in the namespace `interop` and display it in the
+``mof`` output-format.
 
 .. _`Modes of operation`:
 
@@ -29,7 +62,7 @@ Modes of operation
 Pywbemcli supports two modes of operation:
 
 * `Interactive mode`_: Invoking an interactive pywbemcli shell for typing
-  pywbemcli sub-commands.
+  pywbemcli commands.
 * `Command mode`_: Executing standalone non-interactive commands.
 
 .. _`Interactive mode`:
@@ -43,7 +76,7 @@ shell), and external commands (that are executed in the standard shell for the
 user).
 
 This pywbemcli shell is started when the ``pywbemcli`` command is invoked
-without specifying any (sub-)commands:
+without specifying any command-group or command:
 
 .. code-block:: text
 
@@ -51,7 +84,7 @@ without specifying any (sub-)commands:
     pywbemcli> _
 
 Alternatively, the pywbemcl shell can also be started by specifying the ``repl``
-COMMAND:
+command:
 
 .. code-block:: text
 
@@ -61,13 +94,15 @@ COMMAND:
 The pywbemcli shell uses the prompt ``pywbemcli> ``, The cursor is shown in
 the examples above as an underscore ``_``.
 
-General options may be specified on the ``pywbemcli`` command, and they serve
-as the definition of the connection to a WBEM server and as defaults for the
-pywbemcli commands that can be typed in the pywbemcli shell.
+General options are specified on the pywbemcli command; they serve
+as the parameters for the connection to a WBEM server and values for the
+pywbemcli commands and arguments that can be typed in the pywbemcli shell.
 
 The pywbemcli commands that can be typed in the pywbemcli shell are the
-command line arguments that would follow the ``pywbemcli`` command when used in
-`command mode`_:
+command or command-group that would follow the ``pywbemcli`` command and
+general options when used in `command mode`_. The following example
+starts a pywbemcli shell in interactive mode and executes serveral commands
+(ex. `class enumerate -o`).
 
 .. code-block:: text
 
@@ -78,15 +113,13 @@ command line arguments that would follow the ``pywbemcli`` command when used in
     . . . <MOF output of the class CIM_System from the WBEM server>
     pywbemcli shell uses the >> :q
 
-For example, the pywbemcli shell command ``class get CIM_System`` in the example
+The pywbemcli shell command ``class get CIM_System`` in the example
 above has the same effect as the standalone command:
 
 .. code-block:: text
 
     $ pywbemcli -s http://localhost -u username class get CIM_System
     . . . <MOF formated display of the CIM_System class>
-
-See also `Environment variables and avoiding password prompts`_.
 
 The internal commands ``:?``, ``:h``, or ``:help`` display general help
 information for external and internal commands:
@@ -108,26 +141,28 @@ In this help text, "REPL" stands for "Read-Execute-Print-Loop" which is a
 term that denotes the pywbemcli shell interactive mode.
 
 In addition to using one of the internal shell commands shown in the help text
-above, you can also exit the pywbemcli shell by typing `Ctrl-D`.
+above, you can also exit the pywbemcli shell by typing `Ctrl-D`. Note that the
+pywbemshell exit command may vary by operating system
 
-Typing ``--help`` in the pywbemcli shell displays general help information for
-the pywbemcli commands, which includes general options and a list of the
-supported commands:
+Typing ``--help`` or ``-h`` in the pywbemcli shell displays general help
+information for the pywbemcli commands, which includes general options and a
+list of the supported commands.
 
 .. code-block:: text
 
-    pywbemcli shell uses the >> --help
-    Usage: pywbemcli  [GENERAL-OPTIONS] COMMAND [ARGS]...
+    $ pywbemcli --help
 
-      Command line browser for WBEM servers. This cli tool implements the
-      CIM/XML client APIs as defined in pywbem to make requests to a WBEM
-      server.
+    Pywbemcli is a command line WBEM client that uses the DMTF CIM/XML
+    protocol to communicate with WBEM servers. Pywbemcli can:
 
-      The options shown above that can also be specified on any of the
-      (sub-)commands.
+    . . .
+
+    For more detailed information, see:
+
+      https://pywbemtools.readthedocs.io/en/latest/
 
     Options:
-      -s, --server TEXT               Hostname or IP address of the WBEMServer
+      -s, --server URI                Hostname or IP address of the WBEMServer
                                       (Default: PYWBEMCLI_SERVER environment
                                       variable).
       -d, --default_namespace TEXT    Default Namespace to use in the target
@@ -218,7 +253,8 @@ Examples:
     Enter password: <password>
     . . .
 
-In command mode, bash tab completion is also supported, but must be enabled.
+In command mode, tab completion is also supported for some shells, but must be
+enabled specifically for each shell.
 
 For example, with a bash shell, enter the following before using pywbemcli to
 enable completion:
@@ -241,20 +277,14 @@ completion:
     $ pywbemcli class <TAB><TAB>
     ... <shows the class sub-commands to select from>
 
-.. _`Command line parameters and options`:
+.. _`Command line general options`:
 
 Command line general options
 ----------------------------
 
-There are two groups of command line options (GENERAL-OPTIONS and COMMAND (also
-called command group) options(ARGS)) as shown below:
-
-.. code-block:: text
-
-    $ pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS]...
-
-The general options are entered before the COMMAND. For example the following
-enumerates the qualifier declarations and outputs the result as a table:
+The general options are entered before the command-group or command. For
+example the following enumerates the qualifier declarations and outputs the
+result as a table:
 
 .. code-block:: text
 
@@ -289,21 +319,21 @@ interactive mode and as a table:
     |             |         |         |         | REFERENCE | ToSubclass      |
     +-------------+---------+---------+---------+-----------+-----------------+
 
-    pywbemcli>
+   pywbemcli>
 
-**Note:** with this use of the general options as part of an interactive mode
+**Note:** - With this use of the general options as part of an interactive mode
 command, the options redefinitions are not retained between command executions.
 
-.. _`Pywbemcli command line parameters and options`:
+.. _`Pywbemcli command line general options`:
 
 Pywbemcli command line general options
 --------------------------------------
 
-Generally the pywbemcli command line options are as follows (See the help in
+The pywbemcli command line options are as follows (See the help in
 pywbemcli and section :ref:`pywbemcli Help Command Details` for more precise
 information on each command group arguments and options):
 
-* **--server** Host name or IP address of the WBEMServer to which
+* ``--server`` Host name or IP address of the WBEMServer to which
   pywbemcli will connect in the format::
 
     [{scheme}://]{host}[:{port}]
@@ -312,52 +342,64 @@ information on each command group arguments and options):
 
   * Scheme: must be "https" or "http" [Default: "https"].
   * Host: defines short/fully qualified DNS hostname, literal
-    IPV4 address (dotted), or literal IPV6 address.
+    IPV4 address (dotted), or literal IPV6 address. see :term:`RFC3986` and
+    :term:`RFC6874`
   * Port: (optional) defines WBEM server port to be used [Defaults: 5988(HTTP)
     and 5989(HTTPS)]. (EnvVar: PYWBEMCLI_SERVER).
 
   The server parameter is conditionally optional (see ``--name``). If the
-  ``-name`` option exists and there is a server in the conne
+  ``--name`` option exists and there is a server with the name defined by
+  ``--name`` defined in the :term:`connections file` the parameters of that
+  name are used for the connection.
 
   In the interactive mode this connection is not actually executed until a
   COMMAND is entered.
-* **--name** - The name of a WBEMServer that is defined in the connection
-  file or define a name for a connection that will be entered in the connection
+* ``--name`` - The name of a WBEMServer that is defined in the connection
+  file or to define a name for a connection that will be entered in the connection
   file if the ``--server`` parameter exists.  The server parameters for this
   connection will be set in pywbemcli.
-  In the interactive mode this connection is not actually executed until
+  In the interactive mode this connection is not actually used until
   a COMMAND is entered.
 
-  A new server could be defined in the connection file with a name is defined
-  as follows::
+  A new server (``myserver``)may be defined in the connection file with a
+  name is defined as follows::
 
-    pywbemcli -s http://localhost -N mylocalhost -u user -p password connection save
+    $ pywbemcli -s http://localhost -N myserver -u user -p password connection save
 
-* **--default_namespace** - Default namespace to use in the target
-   WBEMServer if no namespace is defined in a command. If not used, the
+  To use an existing server named ``myserver`` in the defined connections:
+
+    $ pywbemcli --name myserver  class get CIM_ManagedElement
+
+  See :ref:`Connection command group` for more information on managing
+  connections.
+
+* ``--default_namespace`` - Default namespace to use in the target
+   WBEM server if no namespace is defined in a command. If not defined the
    pywbemcli default is ``root/cimv2``.  This is the namespace used on all
    requests unless a specific namespace is defined by:
 
    * In the interactive mode prepending the command group name with the
      ``--namespace`` option.
-   * Using the -n command option to define a namespace.
+   * Using the ``--namespace`` or ``-n`` command option to define a namespace
+     on commands that specify this option.
    * Executing a command that looks in multiple namespaces (ex. ``class find``).
-
-* **--user** - Username for the WBEM server if a user name is required to
-   authenticate the client.
-* **--password TEXT** - Password for the WBEM server (Default:
-  PYWBEMCLI_PASSWORD environment variable).
-* **--noverify** - If set, client does not verify server certificate. Any
-  certificate returned by the server is ignored.
-* **--certfile - TEXT** Server certificate file. Not used if noverify set or
+* ``--user`` - Username for the WBEM server if a user name is required to
+  authenticate the client.
+* ``--password`` - Password for the WBEM server. This option is normally
+  required if the ``--pasword`` is used.  If the user does not enter a password
+  when ``--user`` is set, pywbemcli will prompt for the password.
+  See :ref:``Environment variables and avoiding password prompts``
+* ``--noverify`` - If set, client does not verify server certificate. Any
+  certificate returned by the server is accepted.
+* ``--certfile`` Server certificate file. Not used if ``--noverify`` set or
   the connection does not use SSL (i.e. http)
-* **--keyfile** - Client private key file
-* **--output-format** Output format choice (Default: mof).
+* ``--keyfile`` - Client private key file
+* ``--output-format`` Output format choice (Default: mof).
   Note that the actual output format may differ because some results only allow
-  selected formats. See ref:`Output formats`.
-* **--use-pull_ops** [``yes|no|either``] - Determines whether the pull operations are
+  selected formats. See :ref:`Output formats`.
+* ``--use-pull_ops`` [``yes``|``no``|``either``] - Determines whether the pull operations are
   used for EnumerateInstances, AssociatorInstances, ReferenceInstances, and
-  ExecQuery operations See ref:`Using pywbemcli and the DMTF pull operations`
+  ExecQuery operations See :ref:`Pywbemcli and the DMTF pull operations`
   for more information on pull operations:
 
   * ``yes`` means that pull requests will be used and if the server does not
@@ -366,16 +408,16 @@ information on each command group arguments and options):
   * ``either`` allows pywbem to try both pull and then traditional operations.
     The default is ``either``.
 
-* **--pull-max-cnt**  MaxObjectCount of objects to be returned if
+* ``--pull-max-cnt``  MaxObjectCount of objects to be returned if
   pull operations are used. This must be  a positive non-zero integer. Default
-  is 1000. See ref:`Using pywbemcli and the DMTF pull operations` for more
+  is 1000. See :ref:`Pywbemcli and the DMTF pull operations` for more
   information on pull operations.
 
-* **--log** - See ref:`Pywbemcli defined logging`.
-* **--verbose**  Display extra information about theprocessing.
-* **--version** Show the version of this command the version of pywbem imported
-      then and exit.
-* **--help** Show the help which describes the command line options and exit.
+* ``--log`` - See:ref:`Pywbemcli defined logging`.
+* ``--verbose``  Display extra information about the processing.
+* ``--version`` Show the version of this command and of the pywbem package
+      imported then exit.
+* ``--help`` Show the help which describes the command line options and exit.
 
 
 .. _`Environment variables and avoiding password prompts`:
@@ -436,7 +478,7 @@ without a password prompt:
       . . . <The display output from get class>
 
 If the operations performed by a particular pywbemcli command do not
-require a password or no user is supplied, no password is prompted for:
+require a password or no user is supplied, no password is prompted for example:
 
 .. code-block:: text
 
@@ -478,8 +520,9 @@ any subsequent pywbemcli commands:
 CLI commands
 ------------
 
-For a description of the commands supported by pywbemcli, consult its
-help system or section ref:`pywbemcli Help Command Details`. For example:
+For a description of the commands supported by pywbemcli, see section
+:ref:`Pywbemcli command groups, comands and subcommands` and
+section:ref:`pywbemcli Help Command Details`. For example:
 
 .. code-block:: text
 
@@ -515,8 +558,8 @@ For example:
 
 .. _`Pywbemcli and the DMTF pull operations`:
 
-Using pywbemcli and the DMTF pull operations
---------------------------------------------
+Pywbemcli and the DMTF pull operations
+--------------------------------------
 
 For DMTF CIM/XML operations that can return many objects the DMTF CIM/XML protocol
 allows two variations on the enumerate operations (enumerate and an operation
@@ -545,13 +588,15 @@ operations through two general options:
   to return for each open/pull operation. max_pull_cnt of 1000 objects is the
   default size which from experience is a logical choice.
 
-The one issue with using the the either choice is that there are limitations
-with the original operations that do not exist with the pull operations:
+  The one issue with using the the ``either`` choice is that there are limitations
+  with the original operations that do not exist with the pull operations:
 
-* The original operations did not support the query (--) option which passes a
-  filter query to the WBEM server so that it filters the responses before
-  they are returned. This can greatly reduce the size of the responses if
-  effectively used.
+  * The original operations did not support the filtering of responses  with a
+    query language query (--FilterQueryLanguage and --FilterQuery) option which
+    passes a filter query to the WBEM server so that it filters the responses
+    before they are returned. This can greatly reduce the size of the responses
+    if effectively used but is used only when the pull operations are available
+    on the server and used with pywbemcli.
 
 
 .. _`Output formats`:
@@ -565,14 +610,14 @@ can be selected with the ``-o`` or ``--output-format`` option.
 Generally the formats fall into three groups however, not all formats are
 applicable sto all subcommands:
 
-* **Table output formats** - There are a variety of table formats ref:`Table formats`.
+* **Table output formats** - There are a variety of table formats:ref:`Table formats`.
 * **CIM model formats** - These formats provide display of returned CIM objects in
   formats that are specific to the CIM Model (ex. MOF, XML, etc.).
-  see ref:`CIM object formats`.
+  see:ref:`CIM object formats`.
 * **ASCII tree format** - This format option provides a tree display of outputs that
   are logical to display as a tree.  Thus, the command `pywbemcli class tree . . .`
   which shows the hiearchy of the cim classes defined by a WBEM server uses the
-  tree output format. See ref:`ASCII tree format`.
+  tree output format. See:ref:`ASCII tree format`.
 
 
 .. _`Table formats`:
@@ -582,13 +627,22 @@ Table formats
 
 There different variations of the table format primarily define different
 formatting of the borders for tables. The following are examples of the
-table formats.
+table formats with a single command ``class find CIM_Foo``:
 
 * ``-o table``: Tables with a single-line border. This is the default:
 
   .. code-block:: text
 
-    TODO: Fix this table after other PRs accepted
+    Find class CIM_Foo
+    +-------------+-----------------+
+    | Namespace   | Classname       |
+    |-------------+-----------------|
+    | root/cimv2  | CIM_Foo         |
+    | root/cimv2  | CIM_Foo_sub     |
+    | root/cimv2  | CIM_Foo_sub2    |
+    | root/cimv2  | CIM_Foo_sub_sub |
+    +-------------+-----------------+
+
 
 * ``-o simple``: Tables with a line between header row and data rows, but
   otherwise without borders:
@@ -715,7 +769,7 @@ CIM objects:
 NOTE: The above is output as a single line and has been manually formatted for
 this documentation.
 
-.. _`Ascii tree format`:
+.. _`ASCII tree format`:
 
 ASCII tree format
 ^^^^^^^^^^^^^^^^^
@@ -750,10 +804,10 @@ standard Python logging facility.
 Logging is configured and enabled using the ``--log`` general option on the
 commmand line or the `PYWBEMCLI_LOG` environment variable.
 
-Pywbemccli provides logging of operations between the pywbemcli client and
-a WBEM server, allowing logging of the operation calls that send
+Pywbemcli can log  operation calls that send
 requests to a WBEM server and their responses or the HTTP messages between
-the pywbemcli client and the WBEM server.
+the pywbemcli client and the WBEM server including both the pywbem APIs
+and their responses and the HTTP requests and responses.
 
 The default is no logging if the ``--log`` option is not specified with a
 configuration string.
@@ -764,12 +818,14 @@ The general format of the ``--log`` option is a string with up to 3 fields
 .. code-block:: text
 
     LOG_CONFIG_STRING := CONFIG[,CONFIG]
-    CONFIG := COMPONENT"="[DESTINATION[":"DETAIL]
-    COMPONENT := ('all' / 'api' / 'http')
-    DESTINATION := ('stderr' / 'file')
-    DETAIL := ('all'/ 'path'/ 'summary')
+    CONFIG            := COMPONENT"="[DESTINATION[":"DETAIL]
+    COMPONENT         := ('all' / 'api' / 'http')
+    DESTINATION       := ('stderr' / 'file')
+    DETAIL            := ('all'/ 'path'/ 'summary')
 
-For example:
+For example the following log configuration string logs only the pywbem api
+calls and responses summary information to a file and the http requests and
+responses to stderr:
 
 .. code-block:: text
 
@@ -802,20 +858,24 @@ information generated. The possible keywords are:
     `api` responses. This reduces the data included in the responses.
     Exceptions are fully logged.
 
-  * `summary` - Logs the requests but only the count of objects receied
+  * `summary` - Logs the requests but only the count of objects received
     in the response.  Exceptions are fully logged.
 
-The log output is routed to the field defined by DESTINATION and includes the
+The log output is routed to the output defined by DESTINATION and includes the
 information determined by the COMPONENT and DETAIL fields.
 
 For example, logging only of the summary  api information would look something
-like gisthe following::
+like gisthe following:
+
+.. code-block:: text
 
     $ pywbemcli -s http://localhost -u blah -p pw -l api=file:summary class enumerate -o
 
 produces log output for the class enumerate operation in the log file
 pywbemcli.log as follows showing the input parameters to the pywbem method
 EnumerateClassName and the number of objects in the response:
+
+.. code-block:: text
 
     2019-07-09 18:27:22,103-pywbem.api.1-27716-Request:1-27716 EnumerateClassNames(ClassName=None, DeepInheritance=False, namespace=None)
     2019-07-09 18:27:22,142-pywbem.api.1-27716-Return:1-27716 EnumerateClassNames(list of str; count=103)
@@ -832,7 +892,7 @@ Pywbemcli connections file
 
 Pywbemcli provides the capability to persistent the definition of parameters
 for connecting to WBEM servers identified by name using the ``connection``
-COMMAND (see ref:`pywbemcli connection --help`). Once defined, these named
+COMMAND (see:ref:`pywbemcli connection --help`). Once defined, these named
 connections are saved in a a JSON formatted file named
 ``pywbemcliservers.json`` in the current directory from which pywbemcli was
 executed.
@@ -840,7 +900,7 @@ executed.
 To create a new persistent connection, the pywbemcli should be executed with
 the server option, the name option and any other general parameters desired for
 the connection in the interactive mode.  Then executing the ``connection save``
-COMMAND will save the new connection in the connection file. For example:
+COMMAND will save the new connection in the connections file. For example:
 
 .. code-block:: text
 

--- a/docs/pywbemclispecialfeatures.rst
+++ b/docs/pywbemclispecialfeatures.rst
@@ -78,6 +78,63 @@ Note that there is a special request `server test-pull` that will test if
 a server implements the pull operations and for which of the possible operations
 pull is implemented.
 
+The following table defines which pywbemcli commands are used for the corresponding pywbem
+request operations
+
+=================================  ==============================================
+WBEM CIM-XML Operation             pywbemtools command-group command
+=================================  ==============================================
+EnumerateInstances                 instance enumerate INSTANCENAME
+EnumerateInstanceNames             instance enumerate INSTANCENAME --name_only
+GetInstance                        instance get INSTANCENAME
+ModifyInstance                     instance modify
+CreateInstance                     instance create
+DeleteInstance                     instance delete INSTANCENAME
+Associators                        instance associators INSTANCENAME
+Associators                        class associators CLASSNAME
+AssociatorNames                    instance associators INSTANCENAME --name_only
+AssociatorNames                    class associators CLASSNAME --name_only
+References                         instance references INSTANCENAME
+References                         class references CLASSNAME
+ReferenceNames                     instance references INSTANCENAME --name_only
+ReferenceNames                     class references CLASSNAME --name_only
+InvokeMethod                       instance invokemethod INSTANCENAME --name_only
+ReferenceNames                     class invokemethod CLASSNAME --name_only
+ExecQuery                          instance query
+IterEnumerateInstances             instance enumerate INSTANCENAME
+IterEnumerateInstancePaths         instance enumerate INSTANCENAME --name_only
+IterAssociatorInstances            instance associators INSTANCENAME
+IterAssociatorInstancePaths        instance associators INSTANCENAME --name_only
+IterReferenceInstances             instance references INSTANCENAME
+IterReferenceInstancePaths         instance references INSTANCENAME --name_only
+IterQueryInstances                 instance query
+When --use-pull-ops either or yes  TODO
+OpenEnumerateInstances             instance enumerate INSTANCENAME
+OpenEnumerateInstancePaths         instance enumerate INSTANCENAME --name_only
+OpenAssociatorInstances            instance associators INSTANCENAME
+OpenAssociatorInstancePaths        instance associators INSTANCENAME --name_only
+OpenReferenceInstances             instance references INSTANCENAME
+OpenReferenceInstancePaths         instance references INSTANCENAME --name_only
+OpenQueryInstances                 instance references INSTANCENAME --name_only
+PullInstancesWithPath              part of pull sequence
+PullInstancePaths                  part of pull sequence
+PullInstances                      part of pull sequence
+CloseEnumeration                   Not implemented
+EnumerateClasses                   class enumerate CLASSNAME
+EnumerateClassNames                class enumerate --name-only
+GetClass                           class get CLASSNAME
+ModifyClass                        Not implemented
+CreateClass                        Not implemented
+DeleteClass                        class delete CLASSNAME
+EnumerateQualifiers                qualifier enumerate
+GetQualifier                       qualifier get QUALIFIERNAME
+SetQualifier                       Not implemented
+DeleteQualifier                    Not Implemented
+=================================  ==============================================
+
+1. Iter operations are all used as the common code path by pywbemcli. It is
+these operations that determine whether the original operations (ex. EnumerateInstances)
+
 
 .. _`Displaying CIM instances or CIM instance names`:
 

--- a/docs/pywbemclispecialfeatures.rst
+++ b/docs/pywbemclispecialfeatures.rst
@@ -1,4 +1,4 @@
-.. Copyright  2017 IBM Corp. and Inova Development Inc.
+g.. Copyright  2017 IBM Corp. and Inova Development Inc.
 ..
 .. Licensed under the Apache License, Version 2.0 (the "License");
 .. you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
 ..
 
 
-.. _`Pywbemcli Specific Features`:
+.. _`Pywbemcli special command line features`:
 
-Pywbemcli Specific Features
-===========================
+Pywbemcli special command line features
+=======================================
 
 Pywbemcli includes several features in the syntax that are worth presenting
 in detail to help the user understand the background purpose and syntatic
@@ -27,7 +27,9 @@ implementation of the features. This includes:
   same command group.
 
 * The ability to receive either CIM instances or CIM instance names with only
-  a change of an option on the commands that request CIM instances.
+  a change of an option on the commands that request CIM instances. The option
+  ``-o`` or ``--name-only`` defines whether only the instance name or the complete
+  object will be displayed.
 
 * The ability to interactively select the data for certain objects as opposed
   to having to enter the full name.
@@ -60,7 +62,7 @@ parameter `max_object_cnt` sets the `MaxObjectCount` variable on the operation
 request if the pull operations are to be set which tells the wbem server to
 limit the size of the response.  As an example::
 
-    pywbemcli -s http/localhost use-pull-ops=yes max_object_cnt=10
+    pywbemcli --server http/localhost use-pull-ops=yes max_object_cnt=10
 
 would force the use of the pull operations and return an error if the target
 server did not implement them and would set the MaxObjCount parameter on the
@@ -83,15 +85,16 @@ Displaying CIM instances or CIM instance names
 ----------------------------------------------
 
 The pywbem API includes different WBEM operations (ex. EnumerateInstances and
-EnumerateInstanceNames). To simplify the overall CLI syntax pywbemcli combines
-these into a single subcommand (i.e. enumerate, references, associators)
-and includes an option (``-o,`` or ``--names-only``) that determines whether the
-instance names or instances are retrieved from the WBEM Server.
+EnumerateInstanceNames) to request CIM objects or just their names. To
+simplify the overall CLI syntax pywbemcli combines these into a single
+subcommand (i.e. enumerate, references, associators) and includes an option
+(``-o,`` or ``--names-only``) that determines whether the instance names or
+instances are retrieved from the WBEM Server.
 
 Thus, for example an `instance enumerate` with and without the ``-o`` option::
 
 
-    $ pywbemcli -m tests/unit/simple_mock_model.mof instance enumerate CIM_Foo
+    $ pywbemcli --mock-server tests/unit/simple_mock_model.mof instance enumerate CIM_Foo
     instance of CIM_Foo {
        InstanceID = "CIM_Foo1";
        IntegerProp = 1;
@@ -106,7 +109,7 @@ Thus, for example an `instance enumerate` with and without the ``-o`` option::
        InstanceID = "CIM_Foo3";
     };
 
-    $ pywbemcli -m tests/unit/simple_mock_model.mof instance enumerate CIM_Foo -o
+    $ pywbemcli --mock-server tests/unit/simple_mock_model.mof instance enumerate CIM_Foo -o
 
     root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"
 
@@ -120,14 +123,14 @@ Interactively selecting INSTANCENAME
 ------------------------------------
 
 Arguments like the INSTANCENAME on some of the instance group subcommands (
-get, references, associators, etc) can be very difficult to correctly enter since it can
-involve multiple keybindings, use of quotation marks, etc.  To simplify this
-pywbemcli includes a option ``--interactive`` on these commands that allows
-the user to specify only the class name, retrieves all the instance names
-from the server and presents the user with a select list from which an instance
-name can be chosen. The following is an example::
+get, references, associators, etc) can be very difficult to correctly enter
+since it can involve multiple keybindings, use of quotation marks, etc.  To
+simplify this pywbemcli includes a option (``-i`` or ``--interactive``) on
+these commands that allows the user to specify only the class name, retrieves
+all the instance names from the server and presents the user with a select list
+from which an instance name can be chosen. The following is an example::
 
-    $ pywbemcli -m tests/unit/simple_mock_model.mof instance get CIM_Foo -i
+    $ pywbemcli --mock-server tests/unit/simple_mock_model.mof instance get CIM_Foo --interactive
     Pick Instance name to process
     0: root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"
     1: root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"

--- a/docs/pywbemclisubcommands.rst
+++ b/docs/pywbemclisubcommands.rst
@@ -36,6 +36,10 @@ target server and display it in the defined output-format.
 The pywbemcli command groups are described below and the help output from
 pywbemcli documented in :ref:`pywbemcli Help Command Details`
 
+**NOTE:** Many of the examples below use the pywbem_mock module and the
+corresponding pywbemcli general option ``--mock-server`` with mock files
+in the pywbemtools tests/unit subdirectory because it is easy.
+
 .. _`Class command group`:
 
 Class command group
@@ -46,7 +50,7 @@ The **class** group defines subcommands that act on CIM classes. see
 
 * **associators** to get the class level associators for a class defined
   as an input argument in the default namespace or the namespace defined with this
-  subcommand display in the defined format. This subcommand can display the
+  subcommand displayed in the defined format. It can display the
   class in several formats including MOF, XML, and REPR. It requires the class
   name as input.  This returns the class level associators but not the instance
   associators. The :ref:`Instance subcommand group` includes the corresponding
@@ -59,9 +63,10 @@ The **class** group defines subcommands that act on CIM classes. see
   See :ref:`pywbemcli class associators --help` for details.
 * **delete** to delete the class defined by the CLASSNAME argument. Note that
   many WBEM servers may not allow this operation or may severely limit the
-  conditions under which a class can be deleted from the server. For example::
+  conditions under which a class can be deleted from the server. For example
+  to delete the class ``CIM_Blah``::
 
-    $ pywbemcli class delete CIM_blah     << attempt to delete CIM_Blah
+    $ pywbemcli class delete CIM_blah
     $
 
   Pywbemcli will not delete a class that has subclasses.
@@ -69,7 +74,7 @@ The **class** group defines subcommands that act on CIM classes. see
 * **enumerate** to enumerate classes or their classnames in the default
   namespace or the namespace defined with this subcommand.  If the
   ``--DeepInheritance``/``-d`  option is set it shows all the classes in the
-  hiearchy, not just the next level f the hiearchy::
+  hierarchy, not just the next level f the hierarchy::
 
     $ pywbemcli --mock-server mockassoc class enumerate --name-only
     TST_Person
@@ -79,8 +84,8 @@ The **class** group defines subcommands that act on CIM classes. see
     $
 
   See :ref:`pywbemcli class enumerate --help` for details.
-* **find** to find classes in the target WBEM server across namespaces.  The
-  input argument is a regular expression which is used to search namespaces
+* **find** to find classes in the target WBEM server across multiple namespaces.
+  The input argument is a regular expression which is used to search namespaces
   for matching class names.  This subcommand uses a regex for the classname to
   attempt to list the names and namespaces of all of the classes in the WBEM
   Server (or the namespaces defined with the ``--namespaces``/``-n` option)::
@@ -106,8 +111,8 @@ The **class** group defines subcommands that act on CIM classes. see
 
   See :ref:`pywbemcli class find --help` for details.
 * **get** to get a single class in the default namespace or the namespace
-  defined with this subcommand and display in the defined format. This
-  subcommand can display the class in several formats including MOF, XML, and
+  defined with this subcommand displayed in the defined format. It
+  can display the class in several formats including MOF, XML, and
   REPR. It requires the class name as input::
 
       $ pywbemcli> --name mock1 class get CIM_Foo
@@ -151,14 +156,14 @@ The **class** group defines subcommands that act on CIM classes. see
   name.   See :ref:`pywbemcli class invokemethod --help` for details.
 * **references** to get the class level reference classes or classnames for a
   class defined as an input argument in the default namespace or the namespace
-  defined with this subcommand display in the defined format. This subcommand
+  defined with this subcommand displayed in the defined format. This subcommand
   can display the class in several formats including MOF, XML, and REPR.. This
   returns the class level references but not the instance references. The
   :ref:`Instance subcommand group` includes a corresponding instance references
   operation::
 
-
     $pywbemcli --mock-server mockassoc class references TST_Person --name-only
+
     //FakedUrl/root/cimv2:TST_Lineage
     //FakedUrl/root/cimv2:TST_MemberOfFamilyCollection
 
@@ -192,7 +197,7 @@ The **instance** group defines subcommands that act on CIM instances including:
 
 * **associators** to get the associator instances for the instance name defined
   as input argument in the default namespace or the namespace defined with this
-  subcommand display in the defined format. The inThis subcommand can display the
+  subcommand displayed in the defined format. The inThis subcommand can display the
   class in several formats including MOF, XML, and REPR.::
 
     $ pywbemcli --name mockassoc instance references TST_Person --name-only --interactive
@@ -282,7 +287,7 @@ The **instance** group defines subcommands that act on CIM instances including:
 
   See :ref:`pywbemcli instance enumerate --help` for details.
 * **get** to get a single CIM instance from the default namespace or the
-    namespace defined with the subcommand and display it in the defined format.
+    namespace defined with the subcommand displayed in the defined format.
     The instance to be deleted is the ``INSTANCENAME`` argument. The form is
     determined by the ``--interactive`` options and must be either:
 
@@ -308,7 +313,7 @@ The **instance** group defines subcommands that act on CIM instances including:
   See :ref:`pywbemcli instance delete --help` for details.
 * **references** to get the reference instances or paths for a
   instance defined as an input argument in the default namespace or the
-  namespace defined with this subcommand display in the defined format. This
+  namespace defined with this subcommand displayed in the defined format. This
   subcommand can display the class in several formats including MOF, XML, and
   REPR.::
 
@@ -537,7 +542,7 @@ viewing servers defined in the the file. This allows multiple connections to be
 defined and then used by name rather than through the detailed information
 about the connection.
 
-Connections in the :term:`connection` file can be created by:
+Connections in the :term:`connections file` can be created by:
 
 * Using the add subcommand. This allows defining the parameters of a connection
   as a subcommand

--- a/docs/pywbemclisubcommands.rst
+++ b/docs/pywbemclisubcommands.rst
@@ -13,130 +13,315 @@
 .. limitations under the License.
 ..
 
-.. _`pywbemcli subcommand options`:
-
-pywbemcli subcommand options
-============================
-
-There are a number of ``pywbemcli``  groups and subcommands defined.  Each subcommand
-may have arguments  and options (defined with - or -- as part of the
-name). While many arguments and options are specific to each subcommand, there
-are several that are more general and apply to multiple subcommands including
-the following:
-
-* --interactive - On subcommands where this option is available it changes
-  the behavior of the subcommand. Instead of just outputting a result and
-  exiting the subcommand, ``pywbemcli`` presents a list for the user to use
-  to select one of the options.  This is used, for example, with the
-  ``instances get`` to get a list of instances to display rather than having
-  to type in the complete instance name.
-
-* --namespace - On subcommands this overrides the current default namespace
-  defined by the general option --namespace only for this subcommand. The
-  current default namespace is retained.
-
-* --name_only - On subcommands where this option exist, it changes the
-  request to the server and the display from acquiring the full object to
-  just acquiring the object names.  Thus, for example::
-
-  $ pywbemcli class enumerate       # displays the mof of all classes
-
-  $ pywbemcli class enumerate -o     # displays only the names of the classes
 
 .. _`Pywbemcli command groups, comands and subcommands`:
 
-Pywbemcli command groups, commands and subcommands
-==================================================
+Pywbemcli command groups, comands and subcommands
+=================================================
 
-The general command structure of pywbemcli is::
+The command syntax of pywbemcli is::
 
-    pywbemcli <general-options> <cmd-group>|<command> <subcommand> <ARGS>
+    $ pywbemcli <general-options> <cmd-group>|<command> <args>
 
-Each command group is a noun, referencing an entity (ex. class
-refers to operation on CIM classes). The subcommands are generally actions on
-those entities defined by the group name. Thus ``class`` is a group and
-``get`` is a subcommand so:
+    where:
+        cmd_group = <command> <subcommand>
 
-    $ pywbemcli class get CIM_ManagedElement
+Each command group is a noun, referencing an entity (ex. class).
 
-Defines a command to get the class `CIM_ManagedElement` from the current
+    $ pywbemcli -s http://localhost class get CIM_ManagedElement
+
+defines a command to get the class `CIM_ManagedElement` from the current
 target server and display it in the defined output-format.
 
-
-The pywbemcli command groups are as follows: Note that this is the current
-list of command groups and subcommands and this will grow in the future.
+The pywbemcli command groups are described below and the help output from
+pywbemcli documented in :ref:`pywbemcli Help Command Details`
 
 .. _`Class command group`:
 
 Class command group
-----------------------
+-------------------
 
-The **class** group defines subcommands that act on CIM classes including:
+The **class** group defines subcommands that act on CIM classes. see
+:ref:`pywbemcli class --help`. This group includes the following commands:
 
-* **get** to get a single class and display in the defined format.
-  See ref:`pywbemcli class get --help` for details.
-* **enumerate** to enumerate classes or their classnames in a
-  namespace or the namespace defined with this subcommand.
-  See ref:`pywbemcli class enumerate --help` for details.
 * **associators** to get the class level associators for a class defined
-  as an input argument.  This returns the class level associators
-  but not the instance  associators. The ``instance`` command group
-  includes an associators operation..
-  See ref:`pywbemcli class associators --help` for details.
+  as an input argument in the default namespace or the namespace defined with this
+  subcommand display in the defined format. This subcommand can display the
+  class in several formats including MOF, XML, and REPR. It requires the class
+  name as input.  This returns the class level associators but not the instance
+  associators. The :ref:`Instance subcommand group` includes the corresponding
+  associators operation for instances::
 
-* **references** to get the class level reference classes or classnames for a
-  class defined as an input argument. This returns the class level references
-  but not the instance references. The ``instance`` command group
-  includes an references operation..
-  See ref:`pywbemcli class associators --help` for details.
-* **delete** Delete the class defined by the CLASSNAME argument. Note that
+      $ pywbemcli --name mockassoc class associators TST_Person --names_only
+        //FakedUrl/root/cimv2:TST_Person
+      $
+
+  See :ref:`pywbemcli class associators --help` for details.
+* **delete** to delete the class defined by the CLASSNAME argument. Note that
   many WBEM servers may not allow this operation or may severely limit the
-  conditions under which a class can be deleted from the server.
-  See ref:`pywbemcli class delete --help` for details.
-* **find** to find classes in the target wbem server.  In this case the
-  input argument is a regular expression which is used to search all namespaces for
-  matching class names.
-  See ref:`pywbemcli class find --help` for details.
-* **tree** to display the class hierarchy as a tree.
-  See ref:`pywbemcli class hiearchy --help` for details.
+  conditions under which a class can be deleted from the server. For example::
+
+    $ pywbemcli class delete CIM_blah     << attempt to delete CIM_Blah
+    $
+
+  Pywbemcli will not delete a class that has subclasses.
+  See :ref:`pywbemcli class delete --help` for details.
+* **enumerate** to enumerate classes or their classnames in the default
+  namespace or the namespace defined with this subcommand.  If the
+  ``--DeepInheritance``/``-d`  option is set it shows all the classes in the
+  hiearchy, not just the next level f the hiearchy::
+
+    $ pywbemcli --mock-server mockassoc class enumerate --name-only
+    TST_Person
+    TST_Lineage
+    TST_MemberOfFamilyCollection
+    TST_FamilyCollection
+    $
+
+  See :ref:`pywbemcli class enumerate --help` for details.
+* **find** to find classes in the target WBEM server across namespaces.  The
+  input argument is a regular expression which is used to search namespaces
+  for matching class names.  This subcommand uses a regex for the classname to
+  attempt to list the names and namespaces of all of the classes in the WBEM
+  Server (or the namespaces defined with the ``--namespaces``/``-n` option)::
+
+      $ pywbemcli> class find .*_WBEMS
+      root/PG_InterOp:CIM_WBEMServer
+      root/PG_InterOp:CIM_WBEMServerCapabilities
+      root/PG_InterOp:CIM_WBEMServerNamespace
+      root/PG_InterOp:CIM_WBEMService
+      test/EmbeddedInstance/Dynamic:CIM_WBEMService
+      test/EmbeddedInstance/Static:CIM_WBEMService
+      test/TestProvider:CIM_WBEMServer
+      test/TestProvider:CIM_WBEMServerCapabilities
+      test/TestProvider:CIM_WBEMServerNamespace
+      test/TestProvider:CIM_WBEMService
+      root/SampleProvider:CIM_WBEMService
+      root/cimv2:CIM_WBEMServer
+      root/cimv2:CIM_WBEMServerCapabilities
+      root/cimv2:CIM_WBEMServerNamespace
+      root/cimv2:CIM_WBEMService
+      root/PG_Internal:PG_WBEMSLPTemplate
+      $
+
+  See :ref:`pywbemcli class find --help` for details.
+* **get** to get a single class in the default namespace or the namespace
+  defined with this subcommand and display in the defined format. This
+  subcommand can display the class in several formats including MOF, XML, and
+  REPR. It requires the class name as input::
+
+      $ pywbemcli> --name mock1 class get CIM_Foo
+           [Description ( "Simple CIM Class" )]
+        class CIM_Foo {
+
+              [Key ( true ),
+               Description ( "This is key property." )]
+           string InstanceID;
+
+              [Description ( "This is Uint32 property." )]
+           uint32 IntegerProp;
+
+              [Description ( "Method with in and out parameters" )]
+           uint32 Fuzzy(
+                 [IN ( true ),
+                  OUT ( true ),
+                  Description ( "Define data to be returned in output parameter" )]
+              string TestInOutParameter,
+                 [IN ( true ),
+                  OUT ( true ),
+                  Description ( "Test of ref in/out parameter" )]
+              CIM_Foo REF TestRef,
+                 [IN ( false ),
+                  OUT ( true ),
+                  Description ( "Rtns method name if exists on input" )]
+              string OutputParam,
+                 [IN ( true ),
+                  Description ( "Defines return value if provided." )]
+              uint32 OutputRtnValue);
+
+              [Description ( "Method with no Parameters" )]
+           uint32 DeleteNothing();
+
+        };
+      $
+
+  See :ref:`pywbemcli class get --help` for details.
 * **invokemethod** to invoke a method defined for the class argument. This
   subcommand executed the invokemethod with the classname, not an instance
-  name.   See ref:`pywbemcli class invokemethod --help` for details.
+  name.   See :ref:`pywbemcli class invokemethod --help` for details.
+* **references** to get the class level reference classes or classnames for a
+  class defined as an input argument in the default namespace or the namespace
+  defined with this subcommand display in the defined format. This subcommand
+  can display the class in several formats including MOF, XML, and REPR.. This
+  returns the class level references but not the instance references. The
+  :ref:`Instance subcommand group` includes a corresponding instance references
+  operation::
+
+
+    $pywbemcli --mock-server mockassoc class references TST_Person --name-only
+    //FakedUrl/root/cimv2:TST_Lineage
+    //FakedUrl/root/cimv2:TST_MemberOfFamilyCollection
+
+  See :ref:`pywbemcli class associators --help` for details.
+* **tree** to display the class hierarchy as a tree.  This subcommand
+  outputs an ascii tree defining the hiearchy of the class name input parameter
+  as a tree::
+
+      $ pywbemcli class tree CIM_Foo
+
+        CIM_Foo
+         +-- CIM_Foo_sub
+         |   +-- CIM_Foo_sub_sub
+         +-- CIM_Foo_sub2
+
+  It can show either the subclasses or the superclasses of the defined class
+  (``--superclasses`` option).
+
+  This subcommand ignores the ``--output-format``\``-o' general option and
+  always outputs the ASCII tree format.
+
+  See :ref:`pywbemcli class tree --help` for details.
+
 
 .. _`Instance subcommand group`:
 
 Instance command group
--------------------------
+----------------------
 
-The **instance** group defines subcommands that act on CIMInstances including:
+The **instance** group defines subcommands that act on CIM instances including:
 
-* **get** to get a single instance and display in the defined format.
-  See ref:`pywbemcli instance get --help` for details.
-* **enumerate** to enumerate instances or their paths in a
-  namespace or the namespace defined with this subcommand.
-  See ref:`pywbemcli instance enumerate --help` for details.
-* **associators** to get the associator instances for an instance defined
-  as an input argument.
-  See ref:`pywbemcli instance associators --help` for details.
-* **references** to get the reference instances or paths for a
-  instance defined as an input argument.
-  See ref:`pywbemcli instance references --help` for details.
-* **find** to find classes in the target wbem server.  In this case the
-  input argument is a regex which is used to search all namespaces for
-  matching class names.
-  See ref:`pywbemcli instance find --help` for details.
-* **query** to execute an execquery with query string defined as an argument.
-  See ref:`pywbemcli instance query --help` for details.
+* **associators** to get the associator instances for the instance name defined
+  as input argument in the default namespace or the namespace defined with this
+  subcommand display in the defined format. The inThis subcommand can display the
+  class in several formats including MOF, XML, and REPR.::
+
+    $ pywbemcli --name mockassoc instance references TST_Person --name-only --interactive
+    Pick Instance name to process: 0
+    0: root/cimv2:TST_Person.name="Mike"
+    1: root/cimv2:TST_Person.name="Saara"
+    2: root/cimv2:TST_Person.name="Sofi"
+    3: root/cimv2:TST_Person.name="Gabi"
+    4: root/cimv2:TST_PersonSub.name="Mikesub"
+    5: root/cimv2:TST_PersonSub.name="Saarasub"
+    6: root/cimv2:TST_PersonSub.name="Sofisub"
+    7: root/cimv2:TST_PersonSub.name="Gabisub"
+    Input integer between 0 and 7 or Ctrl-C to exit selection: 0   << user responds 0
+
+    //FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeSofi"
+    //FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeGabi"
+    //FakedUrl/root/cimv2:TST_MemberOfFamilyCollection.family="root/cimv2:TST_FamilyCollection.name=\"Family2\"",member="root/cimv2:TST_Person.name=\"Mike\""
+    $
+
+  See :ref:`pywbemcli instance associators --help` for details.
+* **count** count the number of instances in a namespace. For example::
+
+        $ pywbemcli --name mockassoc instance count
+        Count of instances per class
+        +------------------------------+---------+
+        | Class                        |   count |
+        |------------------------------+---------|
+        | TST_FamilyCollection         |       2 |
+        | TST_Lineage                  |       3 |
+        | TST_MemberOfFamilyCollection |       3 |
+        | TST_Person                   |       4 |
+        +------------------------------+---------+
+
+  See :ref:`pywbemcli instance count --help` for details.
+* **create** create a CIM instance in a namespace in the WBEM server.
+  The options of the pywbemcli ``instance create`` subcommand allow the
+  user to create an instance from properties where the properties are
+  defined as name/value pairs.  Since the WBEM server (and pywbem) requires
+  that each property be typed, pywbemtools uses the CIMClass from the WBEM
+  server to define the required type
+
+  For singular properties this is simply:
+
+    -p <property-name>=<property-value"
+
+    where quotes are only required if the value includes whitespace
+
+  For array properties the values are defined separated by commas::
+
+    -p <property-name>=<value>(,<value>)
+
+  An example would be::
+
+    $pywbemcli instance create TST_Blah InstancId="blah1", intprop=3, intarr=3,6,9
+
+  See :ref:`pywbemcli instance delete --help` for details.
+* **delete** delete an instance in a namespace.  The instance to be deleted is
+    the :term:`INSTANCENAME` argument. The form is determined by the
+    ``--interactive`` options and must be either:
+
+    * a string representation of a CIMInstanceName as defined by a :term:`WBEM-URI`
+    * A classname in which case pywbemcli will get the instance names from the
+      WBEM server and present a selection list for the user to select an
+      instance name :ref:`Displaying CIM instances or CIM instance names`
+
+  The following example deletes the instance defined by the explicit instance
+  name (Note the extra backslash required to escape the double quote on the
+  terminal)::
+
+    $ pywbemcli --name mockassoc instance delete root/cimv2:TST_Person.name=\"Saara\"
+    $
+
+  See :ref:`pywbemcli instance delete --help` for details.
+* **enumerate** to enumerate instances or their paths in the default in the
+  defined format. This subcommand can display the class in several formats
+  including MOF, XML, and REPR. namespace or the namespace defined with this
+  subcommand::
+
+    $ pywbemcli --name mockassocinstance enumerate TST_FamilyCollection
+    instance of TST_FamilyCollection {
+       name = "family1";
+    };
+
+    instance of TST_FamilyCollection {
+       name = "Family2";
+    };
+
+  See :ref:`pywbemcli instance enumerate --help` for details.
+* **get** to get a single CIM instance from the default namespace or the
+    namespace defined with the subcommand and display it in the defined format.
+    The instance to be deleted is the ``INSTANCENAME`` argument. The form is
+    determined by the ``--interactive`` options and must be either:
+
+    * a string representation of a CIMInstanceName as defined by a WBEM-URI
+    * A classname in which case pywbemcli will get the instance names from the
+      WBEM server and present a selection list for the user to select an
+      instance name :ref:`Displaying CIM instances or CIM instance names`::
+
+        $ pywbemcli --name mockassocinstance instance get root/cimv2:TST_Person.name=\"Saara\"
+        instance of TST_Person {
+           name = "Saara";
+        };
+
+  See :ref:`pywbemcli instance get --help` for details.
 * **invokemethod** to invoke a method defined for the class argument.
-  See ref:`pywbemcli instance invokemethod --help` for details.
-* **count** count the number of instances in a namespace.
-  See ref:`pywbemcli instance count --help` for details.
-* **delete** delete an instance in a namespace.
-  See ref:`pywbemcli instance delete --help` for details.
-* **create** create an instance in a namespace.
-  See ref:`pywbemcli instance delete --help` for details.
-* **modify** modify an instance in a namespace.
-  See ref:`pywbemcli instance delete --help` for details.
+  See :ref:`pywbemcli instance invokemethod --help` for details.
+* **modify** modify an instance in a namespace. The user provides the definition
+  of an instance in the same form as the ``add`` subcommand but the instance
+  must already exist in the WBEM server and the instance created from the
+  command line must include all of the key properties so that it can be
+  identified in the server.
+
+  See :ref:`pywbemcli instance delete --help` for details.
+* **references** to get the reference instances or paths for a
+  instance defined as an input argument in the default namespace or the
+  namespace defined with this subcommand display in the defined format. This
+  subcommand can display the class in several formats including MOF, XML, and
+  REPR.::
+
+        $ pywbemcli --name mockassocinstance instance references root/cimv2:TST_Person.name=\"Saara\"
+        instance of TST_Lineage {
+           InstanceID = "SaaraSofi";
+           parent = "/root/cimv2:TST_Person.name=\"Saara\"";
+           child = "/root/cimv2:TST_Person.name=\"Sofi\"";
+        };
+
+  See :ref:`pywbemcli instance references --help` for details.
+* **query** to execute an execquery with query string defined as an argument.
+  See :ref:`pywbemcli instance query --help` for details.
 
 .. _`qualifier command group`:
 
@@ -146,13 +331,41 @@ Qualifier command group
 The **qualifier** command group defines subcommands that act on
 CIMQualifierDeclarations including:
 
-* **get** to get a single qualifier declaration and display in the defined format.
-  See ref:`pywbemcli qualifier get --help` for details.
+* **get** to get a single qualifier declaration from the default_namespace or
+  the namespace defined with this command in the WBEM server and
+  display in the defined output format. The output formats can be either one
+  of the MOF formats or one of the table formats::
 
-* **enumerate** to enumerate qualifierDeclarations within the
-  current namespace or the namespace defined with this subcommand.
-  See ref:`pywbemcli qualifier enumerate --help` for details.
+    $ pywbemcli --name mockassocinstance qualifier get Key
+    Qualifier Key : boolean = false,
+        Scope(property, reference),
+        Flavor(DisableOverride, ToSubclass);
 
+  See :ref:`pywbemcli qualifier get --help` for details.
+
+* **enumerate** to enumerate all  qualifier declarations within the
+  default namespace or the namespace defined with this subcommand. The output
+  formats can be either one of the MOF formats or one of the table formats::
+
+    $ pywbemcli --name mockassocinstance --output-format table qualifier enumerate
+    Qualifier Declarations
+    +-------------+---------+---------+---------+-------------+-----------------+
+    | Name        | Type    | Value   | Array   | Scopes      | Flavors         |
+    |-------------+---------+---------+---------+-------------+-----------------|
+    | Association | boolean | False   | False   | ASSOCIATION | DisableOverride |
+    |             |         |         |         |             | ToSubclass      |
+    | Description | string  |         | False   | ANY         | EnableOverride  |
+    |             |         |         |         |             | ToSubclass      |
+    |             |         |         |         |             | Translatable    |
+    | In          | boolean | True    | False   | PARAMETER   | DisableOverride |
+    |             |         |         |         |             | ToSubclass      |
+    | Key         | boolean | False   | False   | PROPERTY    | DisableOverride |
+    |             |         |         |         | REFERENCE   | ToSubclass      |
+    | Out         | boolean | False   | False   | PARAMETER   | DisableOverride |
+    |             |         |         |         |             | ToSubclass      |
+    +-------------+---------+---------+---------+-------------+-----------------+
+
+  See :ref:`pywbemcli qualifier enumerate --help` for details.
 
 .. _`Server command group`:
 
@@ -160,40 +373,171 @@ Server command group
 --------------------
 
 The **server** command group defines subcommands that interact with a WBEM server
-to access information about the WBEM server itself. These commands use the
-pywbem ``WBEMServer`` class. The commands are:
+to access information about the WBEM server itself. These subcommands use the
+pywbem ``WBEMServer`` class. These subcommands are generally not namespace
+specific but access information about the server, namespaces, etc.
+The commands are:
 
-* **brand** to get general information on the server.
-  See ref:`pywbemcli server brand --help` for details.
+* **brand** to get general information on the server.  Brand information is an
+  attempt by pywbem and pywbemtools to determine the product that represents
+  the WBEM server infrastructure.  Since that was not clearly defined in the DMTF
+  specifications, this   command may return strange results but it returns
+  legitimate results for most servers::
+
+    $ pywbemcli --name op server brand
+    Server Brand:
+    +---------------------+
+    | WBEM Server Brand   |
+    |---------------------|
+    | OpenPegasus         |
+    +---------------------+
+
+  See :ref:`pywbemcli server brand --help` for details.
 * **connection** to display information on the connection defined for this
-  server. See ref:`pywbemcli server connection --help` for details.
-* **info** to get general information on the server.
-  See ref:`pywbemcli server info --help` for details.
-* **interop** to get a the name of the interop namespace target WBEM server.
-  See ref:`pywbemcli server interop --help` for details.
-* **namespaces** to get a list of the namespaces defined in the target server.
-  See ref:`pywbemcli server namespaces --help` for details.
-* **profiles** to get overall information on the profiles defined in the
-  target wbem server.   See ref:`pywbemcli server profiles --help` for details.
+  server.  This is same information as was defined when the connection was
+  saved with ``connection save``:
+
+    $pywbemcli --name op server connection
+
+    url: http://localhost
+    creds: ('kschopmeyer', 'test8play')
+    .x509: None
+    default_namespace: root/cimv2
+    timeout: 30 sec.
+    ca_certs: None
+
+  See :ref:`pywbemcli server connection --help` for details.
+* **info** to get general information on the server.  This subcommand returns
+  information on the brand, namespaces, and other reasonable information on the
+  WBEM Server::
+
+    $ pywbemcli --name op server info
+    Server General Information
+    +-------------+-----------+---------------------+-------------------------------+
+    | Brand       | Version   | Interop Namespace   | Namespaces                    |
+    |-------------+-----------+---------------------+-------------------------------|
+    | OpenPegasus | 2.15.0    | root/PG_InterOp     | root/PG_InterOp               |
+    |             |           |                     | root/benchmark                |
+    |             |           |                     | root/SampleProvider           |
+    |             |           |                     | test/CimsubTestNS2            |
+    |             |           |                     | test/CimsubTestNS3            |
+    |             |           |                     | test/CimsubTestNS0            |
+    |             |           |                     | test/CimsubTestNS1            |
+    |             |           |                     | root/PG_Internal              |
+    |             |           |                     | test/WsmTest                  |
+    |             |           |                     | test/TestIndSrcNS1            |
+    |             |           |                     | test/TestINdSrcNS2            |
+    |             |           |                     | test/EmbeddedInstance/Static  |
+    |             |           |                     | test/TestProvider             |
+    |             |           |                     | test/EmbeddedInstance/Dynamic |
+    |             |           |                     | root/cimv2                    |
+    |             |           |                     | root                          |
+    |             |           |                     | test/cimv2                    |
+    |             |           |                     | test/static                   |
+    +-------------+-----------+---------------------+-------------------------------+
+
+  See :ref:`pywbemcli server info --help` for details.
+* **interop** to get a the name of the interop namespace target WBEM server::
+
+    $ pywbemcli --name op server interop
+    Server Interop Namespace:
+    +------------------+
+    | Namespace Name   |
+    |------------------|
+    | root/PG_InterOp  |
+    +------------------+
+
+  See :ref:`pywbemcli server interop --help` for details.
+* **namespaces** to get a list of the namespaces defined in the target server::
+
+    $ pywbemcli --name op-o plain  --name op server namespaces
+    Server Namespaces:
+    Namespace Name
+    root/PG_InterOp
+    root/benchmark
+    root/SampleProvider
+    test/CimsubTestNS2
+    test/CimsubTestNS3
+    test/CimsubTestNS0
+    test/CimsubTestNS1
+    root/PG_Internal
+    test/WsmTest
+    test/TestIndSrcNS1
+    test/TestINdSrcNS2
+    test/EmbeddedInstance/Static
+    test/TestProvider
+    test/EmbeddedInstance/Dynamic
+    root/cimv2
+    root
+    test/cimv2
+    test/static
+    $
+
+  See :ref:`pywbemcli server namespaces --help` for details.
+* **profiles** to get overall information on the WBEM profiles defined in the
+  target wbem server. WBEM profiles are the mechanism WBEM uses to provide
+  the user the means to connection defined management functionality with
+  the implementation of that functionality in a WBEM server (see :term:`DSP1001`
+  and :term:`DSP1033`). The following example shows the CIM profiles in
+  an example WBEM server::
+
+     $ pywbemcli --output-format simple  --name op server profiles
+    Advertised management profiles:
+    Organization    Registered Name           Version
+    --------------  ------------------------  ---------
+    DMTF            CPU                       1.0.0
+    DMTF            Computer System           1.0.0
+    DMTF            Ethernet Port             1.0.0
+    DMTF            Fan                       1.0.0
+    DMTF            Indications               1.1.0
+    DMTF            Profile Registration      1.0.0
+    Other           Some Other Subprofile     0.1.0
+    Other           Some Subprofile           0.1.0
+    Other           SomeSystemProfile         0.1.0
+    SNIA            Array                     1.1.0
+    SNIA            Block Server Performance  1.1.0
+    SNIA            Disk Drive Lite           1.1.0
+    SNIA            Indication                1.1.0
+    SNIA            Indication                1.2.0
+    SNIA            Profile Registration      1.0.0
+    SNIA            SMI-S                     1.2.0
+    SNIA            Server                    1.1.0
+    SNIA            Server                    1.2.0
+    SNIA            Software                  1.1.0
+    SNIA            Software                  1.2.0
+
+
+  See :ref:`pywbemcli server profiles --help` for details.
 * **centralinsts** to get the instance names of the central/scoping instances of
-  one or more profiles in the target WBEM server.
-  See ref:`pywbemcli server centralinsts --help` for details.
+  one or more profiles in the target WBEM server::
+
+    $ pywbemcli> server centralinsts --org DMTF --profile "Computer System"
+    Advertised Central Instances:
+    +---------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+    | Profile                         | Central Instances                                                                                                                                                                                                                       |
+    |---------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+    | DMTF:Computer System:1.0.0      | //leonard/test/TestProvider:Test_StorageSystem.Name="StorageSystemInstance1",CreationClassName="Test_StorageSystem"://leonard/test/TestProvider:Test_StorageSystem.Name="StorageSystemInstance2",CreationClassName="Test_StorageSystem" |
+    +---------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+  See :ref:`pywbemcli server centralinsts --help` for details.
 * **test_pull** test for the existence of the pull operations in the target
-  WBEM server.
-  See ref:`pywbemcli server test_pull --help` for details.
+  WBEM server. NOTE: This subcommand not implemented.
+
+  See :ref:`pywbemcli server test_pull --help` for details.
 
 .. _`Connection command group`:
 
-Connection subcommand group
+Connection command group
 ---------------------------
 
 The **connection** command group defines subcommands that provide for a
 persistent file of connection definitons and allow selecting entries in this
-file as well as adding entries to the file, deleting from the file an viewing
-the file. This allows multiple connections to be defined and then used by name
-rather than through the detailed information about the connection.
+file as well as adding entries to the file, deleting entries from the file and
+viewing servers defined in the the file. This allows multiple connections to be
+defined and then used by name rather than through the detailed information
+about the connection.
 
-Connections in the connection file can be created by:
+Connections in the :term:`connection` file can be created by:
 
 * Using the add subcommand. This allows defining the parameters of a connection
   as a subcommand
@@ -207,7 +551,8 @@ used to create a connection and is largely the same information as is in the
 options for pywbemcli. The data includes:
 
 * **name** name of the connection (required).
-* **server_url** the url for the defined connection (required).
+* **server_url** the url for the defined connection (required unless
+  ``--mock-server``/``-m`` defined).
 * **default_namespace** the default namespace defined for the connection
   (required).
 * **user** the user name for the connection (optional).
@@ -224,46 +569,130 @@ options for pywbemcli. The data includes:
 * **log** optional log configuration.
 * **verbose** optional boolean that enables the verbose mode.
 * **output-format** optional output format.
+* **mock_server** optional definition of the files that define a mock server
+  environment using the pywbem mock module.
 
-The connections file is named ``pywbemcliservers.json`` in the directory
+The :term:`connections file` is named ``pywbemcliservers.json`` in the directory
 in which pywbemcli is executed. The data is stored in JSON format within this
-file.
+file.  Multiple connection files may be maintained in separate directories.
 
 The subcommands include:
 
-* **delete** delete a specific connection by name or by selection.
-  See ref:`pywbemcli connection delete --help` for details.
+* **add** creates a new connection using subcommand arguments and set the new
+  connection as the current connection. This subcommand does not save the
+  new connection to the :term:`connections file` (see ``connection save``)
+  The following
+  example shows creating a new connection from within the interactive mode of
+  pywbemcli. The parameters for the connection are defined through the input
+  options for the subcommand. These use the same option names as
+  the corresponding general options to define the WBEM server::
+
+    pywbemcli> connection add --name me --server http://localhost --user me --password mypw -no-verify
+    pywbemcli> connection list
+    WBEMServer Connections:
+    +-----------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------+
+    | name      | server uri       | namespace   | user        | password   |   timeout | noverify   | certfile   | keyfile   | log   |
+    |-----------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------|
+    | me*       | http://localhost | root/cimv2  | me          | mypw       |           | True       |            |           |       |
+    | mock1     |                  | root/cimv2  |             |            |        30 | False      |            |           |       |
+    | mockassoc |                  | root/cimv2  |             |            |        30 | False      |            |           |       |
+    | op        | http://localhost | root/cimv2  | kschopmeyer | test8play  |        30 | True       |            |           |       |
+    +-----------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------+
+    pywbemcli>
+
+  NOTE: The ``*`` on the name indicates the current connection, the one that
+  will be used for any commands. This can be changed using ``connection select``
+
+  See :ref:`pywbemcli connection add --help` for details.
+* **delete** delete a specific connection by name or by selection. The following
+  example deletes the connection defined in the add subcommand above::
+
+    $ pywbemcli connection delete me
+
+  To delete by selection:
+
+    $ pywbemcli connection delete
+    Select a connection or Ctrl_C to abort.
+    0: mock1
+    1: mockassoc
+    2: op
+    Input integer between 0 and 2 or Ctrl-C to exit selection: 1  << users enters
+
+    $
+
+
+  See :ref:`pywbemcli connection delete --help` for details.
 * **export** export the current connection information to environment variables.
-  See ref:`pywbemcli connection export --help` for details.
-* **list** list the connections in the connection file as a table.
-  See ref:`pywbemcli connection list --help` for details.
-* **add** create a new connection using the parameters.
-  See ref:`pywbemcli connection add --help` for details.
-* **save** create a new connection by saving the current connection information
-  to the connection file.  If the current connection does not have a name
+  See :ref:`pywbemcli connection export --help` for details.
+* **list** list the connections in the :term:`connections file` as a table. This produces
+  a table output showing the connections defined in the connections file.
+
+  See :ref:`pywbemcli connection list --help` for details.
+* **save** Save the current connection information
+  to the :term:`connections file`.  If the current connection does not have a name
   a console request asks for a name for the connection.
-  See ref:`pywbemcli connection save --help` for details.
+  See :ref:`pywbemcli connection save --help` for details.
 * **select** select a connection from the connection table.  A connection
   may be selected either by using the name argument or if no argument is
-  provided by selecting from a list presented on the console.
-  See ref:`pywbemcli connection select --help` for details.
-* **show** show information in the current connection.
-  See ref:`pywbemcli connection show --help` for details.
+  provided by selecting from a list presented on the console. The following
+  example shows changing connection from within the interactive mode of pywemcli::
+
+    pywbemcli> connection select
+    Select a connection or Ctrl_C to abort.
+    0: mock1
+    1: mockassoc
+    2: op
+    Input integer between 0 and 2 or Ctrl-C to exit selection: 1
+    pywbemcli> connection list
+    WBEMServer Connections:
+    +------------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------+
+    | name       | server uri       | namespace   | user        | password   |   timeout | noverify   | certfile   | keyfile   | log   |
+    |------------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------|
+    | mock1      |                  | root/cimv2  |             |            |        30 | False      |            |           |       |
+    | mockassoc* |                  | root/cimv2  |             |            |        30 | False      |            |           |       |
+    | op         | http://localhost | root/cimv2  | kschopmeyer | test8play  |        30 | True       |            |           |       |
+    +------------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------+
+    $ pywbemcli> connection show
+
+    Name: mockassoc
+      WBEMServer uri: None
+      Default_namespace: root/cimv2
+      User: None
+      Password: None
+      Timeout: 30
+      Noverify: False
+      Certfile: None
+      Keyfile: None
+      use-pull-ops: either
+      pull-max-cnt: 1000
+      mock: tests/unit/simple_assoc_mock_model.mof
+      log: None
+
+  See :ref:`pywbemcli connection select --help` for details.
+* **show** show information in the current connection.  See the the ``select``
+  above for an example of this subcommand
+  See :ref:`pywbemcli connection show --help` for details.
 * **test** execute a single predefined operation on the current connection
   to determine if it is a WBEM server. It executes a single EnumerateClasses
-  with WBEM operation in the default namespace.
-  See ref:`pywbemcli connection test --help` for details.
+  WBEM operation in the default namespace.
 
-TODO: Add examples of creating and deleting connections.
+  See :ref:`pywbemcli connection test --help` for details.
 
-
+  $ pywbemcli connection add --name me -s http://localhost --user me --password mypw --no-verify connection save
 
 .. _`Repl command`:
 
 Repl command
 ------------
 
-This command sets pywbemcli into the repl mode.
+This command sets pywbemcli into the :ref:`interactive mode`.  Pywbemcli can be started in
+the :ref:`interactive mode` either by entering::
+
+   $ pywbemcli repl
+
+or by executing the script without any command or command group::
+
+   $ pywbemcli
 
 
 .. _`Help command`:
@@ -272,7 +701,8 @@ Help command
 ------------
 
 The help command provides information on special commands and controls that
-can be executed in the repl mode. This is different than the --help option
-that provides information on command groups and commands.
+
+can be executed in the :ref:`interactive mode`. This is different than the ``--help`` option
+that provides information on command groups, and subcommands.
 
 


### PR DESCRIPTION
Clean up the rest of Andy's comments and finish examples.\ from issue # 191.  Note that this is based on having already committed a number of the changes earlier. This tries to pick up the remainder of the comments and issues.

I marked this for review.  

STATUS: Wed 17 July.  I changed or commented on Andy's comments ( I think I caught almost all of them and documented the current status with the comment). I did not get to read through completely last night.

In addition, I added a number of examples.

1. I think there are issues with links in this version.

2. There are some discussion items marked DISCUSSION in the issue itself.

DISCUSSION:

1. I have a section called pywbemcli special features. The goal was to point out some of the things like the --interactive option, pull operations, etc. but I am not sure that the name of the section makes sense.

2. In section 3 I added an overall syntax description of the syntax of the commands but have not looked at it after writing.  Also since it occurs in the general section that talks about modes, etc. I am not sure it really fits there.


