### PR TITLE
Change the search algorithm for the class find command from regex

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -198,7 +198,7 @@ The following defines the help output for the `pywbemcli class --help` subcomman
       associators   Get the associated classes for CLASSNAME.
       delete        Delete a single CIM class.
       enumerate     Enumerate classes from the WBEM Server.
-      find          Find all classes that match CLASSNAME-REGEX.
+      find          Find all classes that match CLASSNAME-GLOB.
       get           Get and display a single CIM class.
       invokemethod  Invoke the class method named methodname.
       references    Get the reference classes for CLASSNAME.
@@ -373,25 +373,26 @@ The following defines the help output for the `pywbemcli class find --help` subc
 
 ::
 
-    Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME-REGEX
+    Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME-GLOB
 
-      Find all classes that match CLASSNAME-REGEX.
+      Find all classes that match CLASSNAME-GLOB.
 
       Find all classes in the namespace(s) of the target WBEMServer that match
-      the CLASSNAME-REGEX regular expression argument and return the classnames.
-      The CLASSNAME-REGEX argument is required.
+      the CLASSNAME-GLOB regular expression argument and return the classnames.
+      The CLASSNAME-GLOB argument is required.
 
-      The CLASSNAME-REGEX argument may be either a complete classname or a
+      The CLASSNAME-GLOB argument may be either a complete classname or a
       regular expression that can be matched to one or more classnames. To limit
       the filter to a single classname, terminate the classname with $.
 
-      The regular expression is anchored to the beginning of the classname and
-      is case insensitive. Thus, `pywbem_` returns all classes that begin with
-      `PyWBEM_`, `pywbem_`, etc. '.*system' returns classnames that include the
-      case insensitive string `system`.
+      The GLOB expression is anchored to the beginning of the CLASSNAME-GLOB, is
+      is case insensitive and uses the standard GLOB special characters (*(match
+      everything), ?(match single character)). Thus, `pywbem_*` returns all
+      classes that begin with `PyWBEM_`, `pywbem_`, etc. '.*system*' returns
+      classnames that include the case insensitive string `system`.
 
-      The namespace option limits the search to the defined namespace. Otherwise
-      all namespaces in the target server are searched.
+      The namespace option limits the search to the defined namespaces.
+      Otherwise all namespaces in the target server are searched.
 
       Output is in table format if table output specified. Otherwise it is in
       the form <namespace>:<classname>
@@ -1066,25 +1067,27 @@ The following defines the help output for the `pywbemcli instance count --help` 
 
 ::
 
-    Usage: pywbemcli instance count [COMMAND-OPTIONS] CLASSNAME-REGEX
+    Usage: pywbemcli instance count [COMMAND-OPTIONS] CLASSNAME-GLOB
 
       Get instance count for classes.
 
       Displays the count of instances for the classes defined by the `CLASSNAME-
-      REGEX` argument in one or more namespaces.
+      GLOB` argument in one or more namespaces.
 
-      The size of the response may be limited by CLASSNAME-REGEX argument which
+      The size of the response may be limited by CLASSNAME-GLOB argument which
       defines a regular expression based on the desired class names so that only
-      classes that match the regex are counted. The CLASSNAME-regex argument is
+      classes that match the regex are counted. The CLASSNAME-GLOB argument is
       optional.
 
-      The CLASSNAME-regex argument may be either a complete classname or a
+      The CLASSNAME-GLOB argument may be either a complete classname or a
       regular expression that can be matched to one or more classnames. To limit
       the filter to a single classname, terminate the classname with $.
 
-      The CLASSNAME-REGEX regular expression is anchored to the beginning of the
-      classname and is case insensitive. Thus `pywbem_` returns all classes that
-      begin with `PyWBEM_`, `pywbem_`, etc.
+      The GLOB expression is anchored to the beginning of the CLASSNAME-GLOB, is
+      is case insensitive and uses the standard GLOB special characters (*(match
+      everything), ?(match single character)). Thus, `pywbem_*` returns all
+      classes that begin with `PyWBEM_`, `pywbem_`, etc. '.*system*' returns
+      classnames that include the case insensitive string `system`.
 
       This operation can take a long time to execute since it enumerates all
       classes in the namespace.

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -410,7 +410,7 @@ def instance_query(context, query, **options):
 
 
 @instance_group.command('count', options_metavar=CMD_OPTS_TXT)
-@click.argument('classname', type=str, metavar='CLASSNAME-REGEX',
+@click.argument('classname', type=str, metavar='CLASSNAME-GLOB',
                 required=False)
 @click.option('-s', '--sort', is_flag=True, required=False,
               help='Sort by instance count. Otherwise sorted by classname')
@@ -421,20 +421,23 @@ def instance_count(context, classname, **options):
     Get instance count for classes.
 
     Displays the count of instances for the classes defined by the
-    `CLASSNAME-REGEX` argument in one or more namespaces.
+    `CLASSNAME-GLOB` argument in one or more namespaces.
 
-    The size of the response may be limited by CLASSNAME-REGEX argument which
+    The size of the response may be limited by CLASSNAME-GLOB argument which
     defines a regular expression based on the desired class names so that only
-    classes that match the regex are counted. The CLASSNAME-regex argument is
+    classes that match the regex are counted. The CLASSNAME-GLOB argument is
     optional.
 
-    The CLASSNAME-regex argument may be either a complete classname or a regular
+    The CLASSNAME-GLOB argument may be either a complete classname or a regular
     expression that can be matched to one or more classnames. To limit the
     filter to a single classname, terminate the classname with $.
 
-    The CLASSNAME-REGEX regular expression is anchored to the beginning of the
-    classname and is case insensitive. Thus `pywbem_` returns all classes that
-    begin with `PyWBEM_`, `pywbem_`, etc.
+    The GLOB expression is anchored to the beginning of the CLASSNAME-GLOB, is
+    is case insensitive and uses the standard GLOB special characters
+    (*(match everything), ?(match single character)).
+    Thus, `pywbem_*` returns all classes that begin with
+    `PyWBEM_`, `pywbem_`, etc. '.*system*' returns classnames that include
+    the case insensitive string `system`.
 
     This operation can take a long time to execute since it enumerates all
     classes in the namespace.

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -19,6 +19,7 @@ Common Functions applicable across multiple components of pywbemcli
 
 from __future__ import absolute_import, unicode_literals
 
+import fnmatch
 import re
 from textwrap import fill
 from operator import itemgetter
@@ -270,7 +271,7 @@ def is_classname(str_):
     return not re.match(r'[a-zA_Z0-9_].*\.', str_)
 
 
-def filter_namelist(regex, name_list, ignore_case=True):
+def filter_namelist(pattern, name_list, ignore_case=True):
     """
     Filter out names in name_list that do not match compiled_regex.
 
@@ -283,7 +284,7 @@ def filter_namelist(regex, name_list, ignore_case=True):
         - .*ABC matches any name that includes ABC
 
     Parameters:
-      regex (:term: `String`) Python regular expression to match.
+      pattern (:term: `String`) Python glob pattern to match.
 
       name_list: List of strings to be matched.
 
@@ -299,8 +300,8 @@ def filter_namelist(regex, name_list, ignore_case=True):
     flags = re.IGNORECASE if ignore_case else None
     # compile the regex since it used multiple times
     try:
-        compiled_regex = re.compile(regex, flags) if flags \
-            else re.compile(regex)
+        regex = fnmatch.translate(pattern)
+        compiled_regex = re.compile(regex, flags)
 
     except Exception as ex:
         raise click.ClickException('Regex compile error. '

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -204,25 +204,28 @@ Options:
   -h, --help              Show this message and exit.
 """
 
-INST_COUNT_HELP = """Usage: pywbemcli instance count [COMMAND-OPTIONS] CLASSNAME-REGEX
+INST_COUNT_HELP = """
+Usage: pywbemcli instance count [COMMAND-OPTIONS] CLASSNAME-GLOB
 
   Get instance count for classes.
 
   Displays the count of instances for the classes defined by the `CLASSNAME-
-  REGEX` argument in one or more namespaces.
+  GLOB` argument in one or more namespaces.
 
-  The size of the response may be limited by CLASSNAME-REGEX argument which
+  The size of the response may be limited by CLASSNAME-GLOB argument which
   defines a regular expression based on the desired class names so that only
-  classes that match the regex are counted. The CLASSNAME-regex argument is
+  classes that match the regex are counted. The CLASSNAME-GLOB argument is
   optional.
 
-  The CLASSNAME-regex argument may be either a complete classname or a
+  The CLASSNAME-GLOB argument may be either a complete classname or a
   regular expression that can be matched to one or more classnames. To limit
   the filter to a single classname, terminate the classname with $.
 
-  The CLASSNAME-REGEX regular expression is anchored to the beginning of the
-  classname and is case insensitive. Thus `pywbem_` returns all classes that
-  begin with `PyWBEM_`, `pywbem_`, etc.
+  The GLOB expression is anchored to the beginning of the CLASSNAME-GLOB, is
+  is case insensitive and uses the standard GLOB special characters (*(match
+  everything), ?(match single character)). Thus, `pywbem_*` returns all
+  classes that begin with `PyWBEM_`, `pywbem_`, etc. '.*system*' returns
+  classnames that include the case insensitive string `system`.
 
   This operation can take a long time to execute since it enumerates all
   classes in the namespace.
@@ -1324,7 +1327,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify instance subcommand count, Return table of instances',
-     ['count', 'CIM_'],
+     ['count', 'CIM_*'],
      {'stdout': ['Count of instances per class',
                  '+---------+---------+',
                  '| Class   |   count |',
@@ -1336,7 +1339,7 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance subcommand count, --sort. Return table of instances',
-     ['count', 'CIM_'],
+     ['count', 'CIM_*'],
      {'stdout': ['Count of instances per class',
                  '+---------+---------+',
                  '| Class   |   count |',


### PR DESCRIPTION
While testing I concluded that the search mechanism in the class find command required me to remember more than I wanted to to if I wanted just a simple search.  I had to remember that it was anchored and if I wanted to unanchor it at the .* at the beginning, etc.  The glob seems easier to remember.

Therefore this pr proposes changing the pattern matcher from regex based to glob based but with universal insensitivitly to case.

Change the search algorithm for the classname from list of classnames in the class find command  and instance count command from regex to glob based.   Since this is a simple search a pattern matcher similiar to glob for files seemed easier for the user than the regex that we were using. This means only two wild card characters, not the the full set of regex escapes.

This means that searches change. For example

CIM_   to CIM_*        To find all classes names that start with CIM_
.*Watch to *Watch*    To find classes with the word Watch in them

The search remains case insensitive.

Changes tests and adds couple of more tests for find and count
