### PR TITLE
Fix a number of pylints in pywbemcli

### DIFF
--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -51,7 +51,7 @@ def connection_group():
     general options (see 'pywbemcli --help') can also be specified before the
     command. These are NOT retained after the command is executed.
     """
-    pass
+    pass  # pylint: disable=unnecessary-pass
 
 
 @connection_group.command('export', options_metavar=CMD_OPTS_TXT)
@@ -129,7 +129,7 @@ def connection_select(context, name):
     context.execute_cmd(lambda: cmd_connection_select(context, name))
 
 
-# TODO Maybe most of these options can be generalized for here and cli
+# TODO: Future Maybe most of these options can be generalized for here and cli
 
 # pylint: disable=bad-continuation
 @connection_group.command('add', options_metavar=CMD_OPTS_TXT)
@@ -314,10 +314,10 @@ def show_connection_information(context, svr, separate_line=True):
                   svr.keyfile, sep,
                   svr.use_pull_ops, sep,
                   svr.pull_max_cnt, sep,
-                  ", ".join(svr._mock_server), sep,
+                  ", ".join(svr.mock_server), sep,
                   svr.log))
 
-    if svr._mock_server and context.verbose:
+    if svr.mock_server and context.verbose:
         click.echo(context.conn.display_repository())
 
 ################################################################
@@ -447,7 +447,6 @@ def cmd_connection_delete(context, name, options):
 
     # name defined. Test if in servers.
     if name in pywbemcli_servers:
-        # TODO test for same as current connection. Error if it is
         if pywbemcli_servers[name] == context.pywbem_server:
             click.echo('Deleting current connection %s' % name)
         context.spinner.stop()

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -84,7 +84,7 @@ def instance_group():
     general options (see 'pywbemcli --help') can also be specified before the
     command. These are NOT retained after the command is executed.
     """
-    pass
+    pass  # pylint: disable=unnecessary-pass
 
 
 @instance_group.command('get', options_metavar=CMD_OPTS_TXT)
@@ -543,14 +543,13 @@ def cmd_instance_create(context, classname, options):
             classname, namespace=options['namespace'], LocalOnly=False)
     except CIMError as ce:
         if ce.status_code == CIM_ERR_NOT_FOUND:
-            ns = options['namespace'] if options['namespace'] else \
-                context.conn.default_namespace
+            ns = options['namespace'] or context.conn.default_namespace
             raise click.ClickException('CIMClass: "%s" does not exist in '
                                        'namespace "%s" in WEB '
                                        'server: %s.'
                                        % (classname, ns, context.conn))
-        else:
-            raise click.ClickException('Exception %s' % ce)
+
+        raise click.ClickException('Exception %s' % ce)
     except Error as er:
         raise click.ClickException('Exception %s' % er)
 
@@ -565,7 +564,6 @@ def cmd_instance_create(context, classname, options):
         if not verify_operation("Execute CreateInstance operation"):
             return
     try:
-        # TODO: Future Possibly create log of instance created.
         name = context.conn.CreateInstance(new_inst,
                                            namespace=options['namespace'])
 
@@ -603,8 +601,8 @@ def cmd_instance_modify(context, instancename, options):
                                        'server: %s'
                                        % (instancepath.classname,
                                           context.conn.uri))
-        else:
-            raise click.ClickException('Exception %s' % ce)
+
+        raise click.ClickException('Exception %s' % ce)
     except Error as er:
         raise click.ClickException('Exception %s' % er)
 
@@ -622,7 +620,6 @@ def cmd_instance_modify(context, instancename, options):
             return
 
     try:
-        # TODO: Future Possibly create log of instance modified.
         context.conn.ModifyInstance(modified_inst,
                                     PropertyList=property_list)
     except Error as er:

--- a/pywbemtools/pywbemcli/_connection_repository.py
+++ b/pywbemtools/pywbemcli/_connection_repository.py
@@ -34,6 +34,7 @@ DEFAULT_CONNECTIONS_PATH = os.path.join(os.getcwd(), DEFAULT_CONNECTIONS_FILE)
 
 
 class ConnectionRepository(object):
+    # pylint: disable=useless-object-inheritance
     """
     Manage the set of connections defined.  The data for the predefined
     connection exists on disk between pywbemcli sessions and within an
@@ -100,7 +101,7 @@ class ConnectionRepository(object):
 
     def __delitem__(self, key):
         del self._pywbemcli_servers[key]
-        self.save()
+        self._write_file()
 
     def __len__(self):
         return len(ConnectionRepository._pywbemcli_servers)

--- a/pywbemtools/pywbemcli/_context_obj.py
+++ b/pywbemtools/pywbemcli/_context_obj.py
@@ -37,7 +37,7 @@ PYWBEM_SERVER_OBJ = None
 PYWBEM_SERVERS = {}
 
 
-class ContextObj(object):
+class ContextObj(object):  # pylint: disable=useless-object-inheritance
     """
         Manage the pywbemcli context that is carried within the Click
         context object in the obj parameter. This is the object that
@@ -197,7 +197,7 @@ class ContextObj(object):
         include_svr = False
         for name, stats in snapshot:  # pylint: disable=unused-variable
             # TODO: clean up pywbem stats so this is in pywbem, not here
-            if stats._server_time_stored:  # pylint: protected-access
+            if stats._server_time_stored:  # pylint: disable=protected-access
                 include_svr = True
 
         # build list of column names

--- a/pywbemtools/pywbemcli/_pywbem_server.py
+++ b/pywbemtools/pywbemcli/_pywbem_server.py
@@ -151,7 +151,7 @@ class PywbemServer(object):
                (self.server_url, self.name, self.default_namespace,
                 self.user, self.password, self.timeout, self.noverify,
                 self.certfile, self.keyfile, self.ca_certs, self.use_pull_ops,
-                self.pull_max_cnt, self.stats_enabled, self._mock_server,
+                self.pull_max_cnt, self.stats_enabled, self.mock_server,
                 self._log)
 
     @property
@@ -272,6 +272,13 @@ class PywbemServer(object):
         """
         return self._wbem_server
 
+    @property
+    def mock_server(self):
+        """
+        :term: `list of strings`: list of file paths for mock server setup.
+        """
+        return self._mock_server
+
     def _validate_timeout(self):
         """
         Validate that timeout parameter is in proper range.
@@ -325,7 +332,7 @@ class PywbemServer(object):
                  "ca_certs": self.ca_certs,
                  "use_pull_ops": self.use_pull_ops,
                  "pull_max_cnt": self.pull_max_cnt,
-                 "mock_server": self._mock_server,
+                 "mock_server": self.mock_server,
                  "log": self.log}
         return dict_
 
@@ -363,8 +370,9 @@ class PywbemServer(object):
                                       self._wbem_server,
                                       self._mock_server,
                                       verbose)
-            except IOError as io:
-                click.echo('IOError exception %s' % io, err=True)
+            except Exception as ex:
+                click.echo('Repository build exception %s.: %s' % (
+                    ex.__class__.__name__, ex), err=True)
                 raise click.Abort()
         else:
             if not self.server_url:

--- a/pywbemtools/pywbemcli/_pywbemcli_operations.py
+++ b/pywbemtools/pywbemcli/_pywbemcli_operations.py
@@ -29,7 +29,8 @@ import os
 import sys
 import traceback
 
-from pywbem import WBEMConnection, CIMError, CIM_ERR_FAILED
+from pywbem import WBEMConnection, CIMError, CIM_ERR_FAILED, \
+    Error
 import pywbem_mock
 
 from .config import DEFAULT_MAXPULLCNT
@@ -303,7 +304,8 @@ class BuildRepositoryMixin(object):
         """
         for file_path in file_path_list:
             if not os.path.exists(file_path):
-                raise IOError("No such file: %s", file_path)
+                raise IOError("No such file: %s" % file_path)
+
             ext = os.path.splitext(file_path)[1]
             if ext == '.mof':
                 conn.compile_mof_file(file_path)
@@ -316,7 +318,7 @@ class BuildRepositoryMixin(object):
                                         'VERBOSE': verbose}
                         # pylint: disable=exec-used
                         exec(fp.read(), globalparams, None)
-                except IOError:
+                except (IOError, Error):
                     raise
 
         # Other errors, display complete traceback

--- a/tests/unit/mof_with_error.mof
+++ b/tests/unit/mof_with_error.mof
@@ -1,0 +1,3 @@
+class CIM_Foo {
+        badtypedef InstanceID;
+}

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -740,32 +740,32 @@ TEST_CASES = [
     ['Verify class subcommand associators simple request,',
      ['associators', 'TST_Person', ],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Person',
-      'class TST_Person {',
-      '',
-      '      [Key ( true ),',
-      '       Description ( "This is key prop" )]',
-      '   string name;',
-      '',
-      '   string extraProperty = "defaultvalue";',
-      '',
-      '};',
-      ''],
+                 'class TST_Person {',
+                 '',
+                 '      [Key ( true ),',
+                 '       Description ( "This is key prop" )]',
+                 '   string name;',
+                 '',
+                 '   string extraProperty = "defaultvalue";',
+                 '',
+                 '};',
+                 ''],
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
     ['Verify class subcommand associators simple request, one parameter',
      ['associators', 'TST_Person', '-a', 'TST_MemberOfFamilyCollection'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Person',
-      'class TST_Person {',
-      '',
-      '      [Key ( true ),',
-      '       Description ( "This is key prop" )]',
-      '   string name;',
-      '',
-      '   string extraProperty = "defaultvalue";',
-      '',
-      '};',
-      ''],
+                 'class TST_Person {',
+                 '',
+                 '      [Key ( true ),',
+                 '       Description ( "This is key prop" )]',
+                 '   string name;',
+                 '',
+                 '   string extraProperty = "defaultvalue";',
+                 '',
+                 '};',
+                 ''],
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
@@ -776,16 +776,16 @@ TEST_CASES = [
       '--resultrole', 'family',
       '--resultclass', 'TST_Person'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Person',
-      'class TST_Person {',
-      '',
-      '      [Key ( true ),',
-      '       Description ( "This is key prop" )]',
-      '   string name;',
-      '',
-      '   string extraProperty = "defaultvalue";',
-      '',
-      '};',
-      ''],
+                 'class TST_Person {',
+                 '',
+                 '      [Key ( true ),',
+                 '       Description ( "This is key prop" )]',
+                 '   string name;',
+                 '',
+                 '   string extraProperty = "defaultvalue";',
+                 '',
+                 '};',
+                 ''],
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
@@ -796,16 +796,16 @@ TEST_CASES = [
       '-R', 'family',
       '-C', 'TST_Person'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Person',
-      'class TST_Person {',
-      '',
-      '      [Key ( true ),',
-      '       Description ( "This is key prop" )]',
-      '   string name;',
-      '',
-      '   string extraProperty = "defaultvalue";',
-      '',
-      '};',
-      ''],
+                 'class TST_Person {',
+                 '',
+                 '      [Key ( true ),',
+                 '       Description ( "This is key prop" )]',
+                 '   string name;',
+                 '',
+                 '   string extraProperty = "defaultvalue";',
+                 '',
+                 '};',
+                 ''],
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
@@ -858,7 +858,7 @@ TEST_CASES = [
     ['Verify class subcommand associators no CLASSNAM, . ',
      ['associators'],
      {'stderr': ['Error: Missing argument "CLASSNAME".', ],
-       'rc': 2,
+      'rc': 2,
       'test': 'in'},
      None, OK],
 
@@ -906,7 +906,7 @@ TEST_CASES = [
     ['Verify class subcommand references no CLASSNAME',
      ['references'],
      {'stderr': ['Error: Missing argument "CLASSNAME".', ],
-       'rc': 2,
+      'rc': 2,
       'test': 'in'},
      None, OK],
 
@@ -1020,7 +1020,8 @@ class TestSubcmdClass(CLITestsBase):
                          mock, condition)
 
 
-class TestClassGeneral(object):  # pylint: disable=too-few-public-methods
+class TestClassGeneral(object):
+    # pylint: disable=too-few-public-methods, useless-object-inheritance
     """
     Test class using pytest for the subcommands of the class subcommand
     """
@@ -1044,7 +1045,8 @@ class TestClassGeneral(object):  # pylint: disable=too-few-public-methods
             "stderr={!r}".format(stderr)
 
 
-class TestClassEnumerate(object):  # pylint: disable=too-few-public-methods
+class TestClassEnumerate(object):
+    # pylint: disable=too-few-public-methods, useless-object-inheritance
     """
     Test the options of the pywbemcli class enumerate' subcommand
     """

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -28,6 +28,7 @@ TEST_DIR = os.path.dirname(__file__)
 
 SIMPLE_MOCK_FILE_PATH = os.path.join(TEST_DIR, 'simple_mock_model.mof')
 PYTHON_MOCK_FILE_PATH = os.path.join(TEST_DIR, 'simple_python_mock_script.py')
+BAD_MOF_FILE_PATH = os.path.join(TEST_DIR, 'mof_with_error.mof')
 
 GLOBAL_HELP = """
 Usage: pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS]...
@@ -350,6 +351,17 @@ TEST_CASES = [
       'test': 'regex'},
      None, OK],
 
+
+    ['Verify --mock option, file with mof containing syntax error',
+     {'global': ['-m', BAD_MOF_FILE_PATH],
+      'subcmd': 'class',
+      'args': ['enumerate']},
+     {'stderr': ['badtypedef InstanceID;',
+                 'Repository build exception MOFParseError.: MOFParseError:',
+                 'Aborted!'],
+      'rc': 1,
+      'test': 'regex'},
+     None, OK],
 
     ['Verify --name options with new name but not in repo failse',
      {'global': ['-N', 'fred'],


### PR DESCRIPTION
Clean up a number of pylint warnings in pywbemcli.  Most of them were just adding the disable but there were actually a couple of errors.

As part of these changes I also modified the build_repository exceptions to better output exceptions
from the mof parser.