### PR TITLE
Modify connection table formatting

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -794,7 +794,8 @@ The following defines the help output for the `pywbemcli connection list --help`
       List the entries in the connection file.
 
       This subcommand displays all entries in the connection file as a table
-      using the command line output_format to define the table format.
+      using the command line output_format to define the table format with
+      default of simple format.
 
       An "*" after the name indicates the currently selected connection.
 

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -1298,6 +1298,41 @@ def _value_tomof(value, type, indent=0, maxline=DEFAULT_MAX_CELL_WIDTH,
     return mof_str, line_pos
 
 
+def hide_empty_columns(headers, rows):
+    """
+    Removes columns from rows if the colmuns are considered empty.
+    The definiton of an empty row is"
+    1. All entries for the column in all rows are None or "" if type string.
+    2. All entries for the column in all rows are None if number.
+
+    Returns new rows and headers
+    """
+    def column_is_empty(rows, column):
+        """
+        Determine if entries for defined column in all rows are considered
+        empty.
+        Returns True if all are empty. Otherwise returns False
+        """
+        for row in rows:
+            if isinstance(row[column], six.integer_types) and \
+                    row[column] is not None:
+                return False
+            if row[column]:
+                return False
+        return True
+
+    # Remove empty rows
+    for row in rows:
+        assert len(row) == len(headers)
+    for column in range(len(headers) - 1, -1, -1):
+        if column_is_empty(rows, column):
+            del headers[column]
+            for row in rows:
+                del row[column]
+
+    return headers, rows
+
+
 def format_table(rows, headers, title=None, table_format='simple',
                  sort_columns=None):
     """

--- a/tests/unit/test_connection_subcmd.py
+++ b/tests/unit/test_connection_subcmd.py
@@ -212,7 +212,8 @@ Usage: pywbemcli connection list [COMMAND-OPTIONS]
   List the entries in the connection file.
 
   This subcommand displays all entries in the connection file as a table
-  using the command line output_format to define the table format.
+  using the command line output_format to define the table format with
+  default of simple format.
 
   An "*" after the name indicates the currently selected connection.
 
@@ -380,11 +381,7 @@ TEST_CASES = [
      {'global': ['-o', 'simple'],
       'args': ['list']},
      {'stdout': [
-         "WBEMServer Connections:",
-         "name    server uri    namespace    user    password    "
-         "timeout    noverify    certfile    keyfile    log",
-         "------  ------------  -----------  ------  ----------  ---------  "
-         "----------  ----------  ---------  -----"],
+         "WBEMServer Connections:", ""],
       'test': 'lines'},
      None, OK],
 
@@ -450,11 +447,14 @@ TEST_CASES = [
     ['Verify connection subcommand list  with 2 servers defined',
      {'global': ['--output-format', 'simple'],
       'args': ['list']},
-     {'stdout': ["test1   http://blah      root/cimv2                       "
-                 "           False",
-                 "test2   http://blahblah  root/cimv2   fred    argh        "
-                 "       18  True                               api=file,all"],
-      'test': 'in'},
+     {'stdout': ['WBEMServerConnections:',
+                 'name    server uri namespace user timeout noverify    log',
+                 '---------------------------------------------------------'
+                 '------------',
+                 "test1   http://blah      root/cimv2   False",
+                 "test2   http://blahblah  root/cimv2   fred  18  True "
+                 "api=file,all"],
+      'test': 'linesnows'},
      None, OK],
 
 
@@ -468,11 +468,14 @@ TEST_CASES = [
      ' next pywbemcli call',
      {'global': ['--output-format', 'simple'],
       'args': ['list']},
-     {'stdout': ["test1   http://blah      root/cimv2                       "
-                 "           False",
-                 "test2   http://blahblah  root/cimv2   fred    argh        "
-                 "       18  True                               api=file,all"],
-      'test': 'in'},
+     {'stdout': ['WBEMServerConnections:',
+                 'name    server uri namespace user timeout noverify    log',
+                 '---------------------------------------------------------'
+                 '------------',
+                 'test1   http://blah      root/cimv2  False',
+                 'test2   http://blahblah  root/cimv2   fred 18  True '
+                 'api=file,all'],
+      'test': 'linesnows'},
      None, OK],
 
     ['Verify connection subcommand delete ',
@@ -493,12 +496,8 @@ TEST_CASES = [
      {'global': ['-o', 'simple'],
       'args': ['list']},
      {'stdout': [
-         "WBEMServer Connections:",
-         "name    server uri    namespace    user    password    "
-         "timeout    noverify    certfile    keyfile    log",
-         "------  ------------  -----------  ------  ----------  ---------  "
-         "----------  ----------  ---------  -----"],
-      'test': 'lines',
+         "WBEMServer Connections:", ""],
+      'test': 'linesnows',
       'file': {'before': 'None', 'after': 'None'}},
 
      None, OK],


### PR DESCRIPTION
Modify the connection table so that it only shows rows that are not
empty. Since many of the possible rows of connections may be empty, this
makes the resulting display much more compact and readable.

Also remove the password display from this table.  The password is still
visible from the connection show command.

We created a general function but applied it only to this table for now.