### PR TITLE
Clean up a number of pylint messages and change the word global to

### DIFF
--- a/pywbemtools/pywbemcli/__init__.py
+++ b/pywbemtools/pywbemcli/__init__.py
@@ -14,6 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Pywbemcli is a command line WBEM client that uses pywbem as its communication
+interface with WBEM Servers. It is written in pure Python and supports Python 2
+and Python 3.
+"""
+
 from __future__ import absolute_import
 
 import sys
@@ -35,7 +41,7 @@ from ._version import __version__  # noqa: F401
 
 _python_m = sys.version_info[0]  # pylint: disable=invalid-name
 _python_n = sys.version_info[1]  # pylint: disable=invalid-name
-if _python_m == 2 and _python_n < 6:
-    raise RuntimeError('On Python 2, pywbem requires Python 2.6 or higher')
-elif _python_m == 3 and _python_n < 4:
+if _python_m == 2 and _python_n < 7:
+    raise RuntimeError('On Python 2, pywbem requires Python 2.7 or higher')
+if _python_m == 3 and _python_n < 4:
     raise RuntimeError('On Python 3, pywbem requires Python 3.4 or higher')

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -719,7 +719,7 @@ def cmd_instance_enumerate(context, classname, options):
                 ClassName=classname,
                 namespace=options['namespace'],
                 FilterQuery=options['filterquery'],
-                FilterQueryLanguage=get_filterquerylanguage(options)),
+                FilterQueryLanguage=get_filterquerylanguage(options))
             if options['sort']:
                 results = sort_cimobjects(results)
         else:
@@ -762,7 +762,7 @@ def cmd_instance_references(context, instancename, options):
                 ResultClass=options['resultclass'],
                 Role=options['role'],
                 FilterQuery=options['filterquery'],
-                FilterQueryLanguage=get_filterquerylanguage(options)),
+                FilterQueryLanguage=get_filterquerylanguage(options))
             if options['sort']:
                 results = sort_cimobjects(results)
         else:
@@ -805,7 +805,7 @@ def cmd_instance_associators(context, instancename, options):
                 ResultClass=options['resultclass'],
                 ResultRole=options['resultrole'],
                 FilterQuery=options['filterquery'],
-                FilterQueryLanguage=get_filterquerylanguage(options)),
+                FilterQueryLanguage=get_filterquerylanguage(options))
             if options['sort']:
                 results.sort()
         else:

--- a/pywbemtools/pywbemcli/_cmd_qualifier.py
+++ b/pywbemtools/pywbemcli/_cmd_qualifier.py
@@ -44,7 +44,7 @@ def qualifier_group():
     general options (see 'pywbemcli --help') can also be specified before the
     command. These are NOT retained after the command is executed.
     """
-    pass
+    pass  # pylint: disable=unnecessary-pass
 
 
 @qualifier_group.command('get', options_metavar=CMD_OPTS_TXT)

--- a/pywbemtools/pywbemcli/_context_obj.py
+++ b/pywbemtools/pywbemcli/_context_obj.py
@@ -150,9 +150,8 @@ class ContextObj(object):  # pylint: disable=useless-object-inheritance
     def execute_cmd(self, cmd):
         """
         Call the cmd executor defined by cmd with the spinner. If the
-        WBEMServer object has not been created it is created and the
-        result stored in global storage so that this wbem server can be
-        used for interactive commands.
+        WBEMServer object has not been created it is created so that this wbem
+        server can be used for interactive commands.
 
         This method is called by every subcommand execution to setup and
         execute the command. Thus, each subcommand has the line similar to:
@@ -242,25 +241,26 @@ class ContextObj(object):  # pylint: disable=useless-object-inheritance
         """
         If the wbem server has not been connected yet, connect it. The
         wbemserver object is saved both in the context and as a GLOBAL
-        This global is used to determine that the server has been connected.
-        TODO: Rather than a global, we should be the wbemserver into the
+        This GLOBAL is used to determine that the server has been connected.
+        TODO: FUTURE Rather than a global, we should be the wbemserver into the
         parent probably.
 
         Both the WBEMConnection and WBEMServer objects are established
         at this point since the cost of doing the WBEMServer object is low.
-        The existence of the WBEMSerer object in the global is the flag that
+        The existence of the WBEMServer object in the GLOBALS is the flag that
         this server connection has been established already.
 
-        TODO: We should probably move this logic to the first place a
+        TODO: FUTURE - We should probably move this logic to the first place a
         connection is actually established so that if we have not-password
         commands in the environment they do not force the password request.
         Logical would be the first time the conn or wbem_server property is
         used in pywbem_server.
 
         """
-        # TODO investigate putting this into parent context instead of global
+        # TODO: FUTURE investigate putting this into parent context instead of
+        #       global
 
-        # if no server defined, do not try to connect. This allows
+        # If no server defined, do not try to connect. This allows
         # commands like help, connection new, select to execute without
         # a target server defined.
         if self._pywbem_server and self._pywbem_server.wbem_server is None:

--- a/pywbemtools/pywbemcli/_version.py
+++ b/pywbemtools/pywbemcli/_version.py
@@ -46,5 +46,5 @@ _PYTHON_M = sys.version_info[0]
 _PYTHON_N = sys.version_info[1]
 if _PYTHON_M == 2 and _PYTHON_N < 7:
     raise RuntimeError('On Python 2, pywbemtools requires Python 2.7')
-elif _PYTHON_M == 3 and _PYTHON_N < 4:
+if _PYTHON_M == 3 and _PYTHON_N < 4:
     raise RuntimeError('On Python 3, pywbemtools requires Python 3.4 or higher')

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -228,10 +228,10 @@ def cli(ctx, server, name, default_namespace, user, password, timeout, noverify,
 
         https://pywbemtools.readthedocs.io/en/latest/
     """
-    # In interactive mode, global options specified in cmd line are used as
+    # In interactive mode, general options specified in cmd line are used as
     # defaults for interactive commands.
     # This requires being able to determine for each option whether it has been
-    # specified and is why global options don't define defaults in the
+    # specified and is why general options don't define defaults in the
     # decorators that define them.
 
     if ctx.obj is None:

--- a/tests/live_unit/test_pegasus.py
+++ b/tests/live_unit/test_pegasus.py
@@ -92,9 +92,10 @@ class TestsContainer(ClientTest):
         if six.PY3:
             # pylint: disable=no-member
             return self.assertRegex(test_str, regex)
-        else:
-            return self.assertRegexpMatches(test_str,
-                                            regex)  # pylint: disable=no-member
+
+        # pylint: disable=no-member, deprecated-method
+        return self.assertRegexpMatches(test_str,
+                                        regex)  # pylint: disable=no-member
 
 
 class ClassTests(TestsContainer):
@@ -107,7 +108,7 @@ class ClassTests(TestsContainer):
         return exitcode, std_out_str, std_err_str
 
     def test_get_simple(self):
-        """ """
+        """Test a get of CIM_ManagedElement"""
         exitcode, out, err = self.class_cmd('get CIM_ManagedElement')
 
         self.assertEqual(exitcode, 0)
@@ -115,10 +116,11 @@ class ClassTests(TestsContainer):
         self.assert_found('CIM_ManagedElement', out)
 
     def test__get_localonly(self):
-        """ """
+        """Test class get --localonly"""
         exitcode, out, err = self.class_cmd('get CIM_ManagedElement -l')
 
         self.assertEqual(exitcode, 0)
+        self.assertEqual(err, "")
         self.assert_found('CIM_ManagedElement', out)
 
         exitcode, out, err = self.class_cmd(

--- a/tests/unit/cli_test_extensions.py
+++ b/tests/unit/cli_test_extensions.py
@@ -15,7 +15,8 @@ from .utils import execute_pywbemcli, assert_rc, assert_patterns, assert_lines
 TEST_DIR = os.path.dirname(__file__)
 
 
-class CLITestsBase(object):  # pylint: disable=too-few-public-methods
+class CLITestsBase(object):
+    # pylint: disable=too-few-public-methods, useless-object-inheritance
     """
         Defines methods to execute tests on pywbemcli.
 

--- a/tests/unit/mock_prompt_0.py
+++ b/tests/unit/mock_prompt_0.py
@@ -27,7 +27,7 @@
 """
 from mock import Mock
 
-import pywbemtools.pywbemcli._common
+import pywbemtools
 RETURN_VALUE = "0"
 
 

--- a/tests/unit/pytest_extensions.py
+++ b/tests/unit/pytest_extensions.py
@@ -15,7 +15,7 @@ if six.PY3:
     # pylint: disable=no-name-in-module
     from inspect import Signature, Parameter
 else:
-    from funcsigs import Signature, Parameter
+    from funcsigs import Signature, Parameter  # pylint: disable=import-error
 
 __all__ = ['simplified_test_function']
 

--- a/tests/unit/simple_mock_invokemethod.py
+++ b/tests/unit/simple_mock_invokemethod.py
@@ -1,32 +1,36 @@
 """
-mocker test script that installs a callback to be executed. This is based on
-the CIM_Foo class in the simple_mock_model.mof test file
+mock_pywbem test script that installs a method callback to be executed. This is
+based on the CIM_Foo class in the simple_mock_model.mof test file
 
 """
+# test that GLOBALS exist
+assert "CONN" in globals()
+assert 'SERVER' in globals()
+assert 'VERBOSE'in globals()
 
 
 def fuzzy_callback(conn, object_name, methodname, **params):
     # pylint: disable=attribute-defined-outside-init, unused-argument
     # pylint: disable=invalid-name
     """
-    InvokeMethod callback.  This is a simple callback that just tests
-    methodname and then returns returnvalue and params from the
-    TestInvokeMethod object attributes.
+    InvokeMethod callback defined in accord with pywbem
+    method_callback_interface which defines the input parameters and return
+    values for a mock of a CIMMethod execution in a WBEM server.  This is a
+    simple callback that just tests methodname and then returns returnvalue and
+    params from the TestInvokeMethod object attributes.
     """
-
-    if 'TestOutParameter' in params:
-        return_params = params['TestOutParameter']
-    else:
-        return_params = []
+    return_params = params.get('TestOutParameter', [])
     if 'TestRef' in params:
-        return_params.append[params['TestRef']]
-    return_value = 0
-    if 'OutputRtnValue' in params:
-        return_value = params['OutputRtnValue']
+        return_params.append(params['TestRef'])
+
+    return_value = params.get('OutputRtnValue', 0)
 
     return (return_value, return_params)
 
 
-global CONN
+# Add the the callback to the mock repository
+global CONN  # pylint: disable=global-at-module-level
 # This method expected to use the global namespace
+# pylint: disable=undefined-variable
+
 CONN.add_method_callback('CIM_Foo', 'Fuzzy', fuzzy_callback)  # noqa: F821

--- a/tests/unit/simple_python_mock_script.py
+++ b/tests/unit/simple_python_mock_script.py
@@ -1,22 +1,29 @@
 """
     Test script to be loaded with pywbemcli --mock-server global option to test
     capability to execute python code as part of startup.
-    This script loads a single class into the repository and displays
-    the resulting repository.
-    This script includes an assert to confirm that the class is loaded into
-    the repository.
+    This script loads a single class into the repository.
+    This script includes  asserts to confirm that the class is loaded into
+    the repositoryand to verify that the GLOBALS are passed to this code from
+    pywbemcli.
 """
 from pywbem import CIMQualifier, CIMClass, CIMProperty, CIMMethod
+
+# test that GLOBALS exist
+assert "CONN" in globals()
+assert 'SERVER' in globals()
+assert 'VERBOSE'in globals()
 
 
 def build_classes():
     """
-    Builds and returns a single class: CIM_Foo that to be used as a
-    test class for the mock class tests.
+    Function that builds and returns a single class: CIM_Foo that will to be
+     used as a test class for the mock class tests.
     """
+    # build the key properties
     qkey = {'Key': CIMQualifier('Key', True)}
     dkey = {'Description': CIMQualifier('Description', 'blah blah')}
 
+    # build the CIMClass with properties and methods.
     c = CIMClass(
         'CIM_FooDirLoad', qualifiers=dkey,
         properties={'InstanceID':
@@ -29,9 +36,9 @@ def build_classes():
                  'Fuzzy': CIMMethod('Fuzzy', 'string', qualifiers=dkey,
                                     class_origin='CIM_Foo',
                                     propagated=False)})
-    global CONN
-    CONN.add_cimobjects(c)
+    # add the objects to the mock repository
+    CONN.add_cimobjects(c)  # noqa: F821
 
 
 build_classes()
-assert(CONN.GetClass('CIM_FooDirLoad'))
+assert(CONN.GetClass('CIM_FooDirLoad'))  # noqa: F821

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -630,8 +630,8 @@ class TestParseWbemUri(object):  # TODO: move this to pytest
             assert isinstance(obj.host, type(exp_host))
 
 
-# TODO pytestify this test and the others in this file
-class FilterNamelistTest(object):  # pytlint: disable=useless-object-inheritance
+# TODO: Future pytestify this test and the others in this file
+class FilterNamelistTest(object):  # pylint: disable=useless-object-inheritance
     """Test the common filter_namelist function."""
 
     name_list = ['CIM_abc', 'CIM_def', 'CIM_123', 'TST_abc']

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -60,7 +60,7 @@ Commands:
 """
 
 # pylint: disable=line-too-long
-INST_ENUM_HELP = """
+INST_ENUMERATE_HELP = """
 Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME
 
   Enumerate instances or names of CLASSNAME.
@@ -116,6 +116,17 @@ Options:
   -o, --names_only                Show only the returned object names.
   -s, --sort                      Sort into alphabetical order by classname.
   -S, --summary                   Return only summary of objects (count).
+  -f, --filterquery TEXT          A filter query to be passed to the server if
+                                  the pull operations are used. If this option
+                                  is defined and the --filterquerylanguage is
+                                  None, pywbemcli assumes DMTF:FQL. If this
+                                  option is defined and the traditional
+                                  operations are used, the filter is not sent
+                                  to the server. See the documentation for
+                                  more information. (Default: None)
+  --filterquerylanguage TEXT      A filterquery language to be used with a
+                                  filter query defined by --filterquery.
+                                  (Default: None)
   -h, --help                      Show this message and exit.
 """
 
@@ -123,6 +134,8 @@ INST_GET_HELP = """
 Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME
 
   Get a single CIMInstance.
+
+
 
   Gets the instance defined by `INSTANCENAME` where `INSTANCENAME` must
   resolve to the instance name of the desired instance. This may be supplied
@@ -320,6 +333,17 @@ Options:
                                   class from which the instance to process is
                                   selected.
   -S, --summary                   Return only summary of objects (count).
+  -f, --filterquery TEXT          A filter query to be passed to the server if
+                                  the pull operations are used. If this option
+                                  is defined and the --filterquerylanguage is
+                                  None, pywbemcli assumes DMTF:FQL. If this
+                                  option is defined and the traditional
+                                  operations are used, the filter is not sent
+                                  to the server. See the documentation for
+                                  more information. (Default: None)
+  --filterquerylanguage TEXT      A filterquery language to be used with a
+                                  filter query defined by --filterquery.
+                                  (Default: None)
   -h, --help                      Show this message and exit.
 """
 
@@ -450,6 +474,17 @@ Options:
                                   class from which the instance to process is
                                   selected.
   -S, --summary                   Return only summary of objects (count).
+  -f, --filterquery TEXT          A filter query to be passed to the server if
+                                  the pull operations are used. If this option
+                                  is defined and the --filterquerylanguage is
+                                  None, pywbemcli assumes DMTF:FQL. If this
+                                  option is defined and the traditional
+                                  operations are used, the filter is not sent
+                                  to the server. See the documentation for
+                                  more information. (Default: None)
+  --filterquerylanguage TEXT      A filterquery language to be used with a
+                                  filter query defined by --filterquery.
+                                  (Default: None)
   -h, --help                      Show this message and exit.
 """
 
@@ -639,7 +674,7 @@ TEST_CASES = [
     #
     ['Verify instance subcommand enumerate  --help response',
      ['enumerate', '--help'],
-     {'stdout': INST_ENUM_HELP,
+     {'stdout': INST_ENUMERATE_HELP,
       'test': 'linesnows'},
      None, OK],
 
@@ -726,9 +761,9 @@ TEST_CASES = [
     ['Verify instance subcommand enumerate with query , traditional ops',
      {'args': ['enumerate', 'CIM_Foo', '--filterquery', 'InstanceID = 3'],
       'global': ['--use-pull-ops', 'no']},
-     {'stdout': ENUM_INST_RESP,
+     {'stdout': "ValueError: EnumerateInstances does not support FilterQuery",
       'test': 'linesnows'},
-     SIMPLE_MOCK_FILE, OK],
+     SIMPLE_MOCK_FILE, FAIL],
 
     #
     # instance enumerate error returns
@@ -755,7 +790,7 @@ TEST_CASES = [
       ['Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME', ],
       'rc': 2,
       'test': 'in'},
-     SIMPLE_MOCK_FILE, RUN],
+     SIMPLE_MOCK_FILE, OK],
 
 
     #
@@ -1569,4 +1604,4 @@ class TestSubcmd(CLITestsBase):
         Execute pybemcli with the defined input and test output.
         """
         self.subcmd_test(desc, self.subcmd, inputs, exp_response,
-                         mock, condition)
+                         mock, condition, verbose=True)

--- a/tests/unit/test_pywbem_server.py
+++ b/tests/unit/test_pywbem_server.py
@@ -26,6 +26,8 @@ import unittest
 
 from pywbemtools.pywbemcli._pywbem_server import PywbemServer
 
+# TODO: Future - Move these tests to pytest
+
 
 class PywbemServerTests(unittest.TestCase):
     """ Test the PywbemServer class """
@@ -47,6 +49,7 @@ class PywbemServerTests(unittest.TestCase):
         print(svr)
 
     def test_all_parms(self):
+        """Test all the PywbemServer input parameters"""
         server = 'http://localhost'
         ns = 'root/cimv2'
         user = 'Fred'
@@ -70,6 +73,7 @@ class PywbemServerTests(unittest.TestCase):
         self.assertEqual(svr.keyfile, keyfile)
 
     def test_all_connect(self):
+        """Test all input parameters"""
         server = 'http://localhost'
         ns = 'root/cimv2'
         user = 'Fred'

--- a/tests/unit/utils/wbemserver_mock.py
+++ b/tests/unit/utils/wbemserver_mock.py
@@ -108,6 +108,7 @@ DEFAULT_WBEM_SERVER_MOCK_DICT = {
 
 
 class WbemServerMock(object):
+    # pylint: disable=useless-object-inheritance, too-many-instance-attributes
     """
     Class that mocks the classes and methods used by the pywbem
     WBEMServer class so that the WBEMServer class will produce valid data
@@ -154,10 +155,10 @@ class WbemServerMock(object):
         # Retrieved from globals setup by pywbemcli for
         #  WBEMConnection object
         #  WBEMServer object
-        global CONN
-        self.conn = CONN
-        global SERVER
-        self.wbem_server = SERVER
+        global CONN  # pylint: disable=global-variable-not-assigned
+        self.conn = CONN  # pylint: disable=undefined-variable
+        global SERVER  # pylint: disable=global-variable-not-assigned
+        self.wbem_server = SERVER  # pylint: disable=undefined-variable
         self.build_mock()
 
     def __str__(self):
@@ -204,9 +205,9 @@ class WbemServerMock(object):
             self.dmtf_schema_ver, self.schema_dir,
             class_names=self.server_mock_data['class_names'], verbose=False)
 
-        for fn in self.pg_schema_files:
-            pg_file = os.path.join(self.pg_schema_dir, fn)
-            self.conn.compile_mof_file(pg_file, namespace=default_namespace,
+        for filename in self.pg_schema_files:
+            filepath = os.path.join(self.pg_schema_dir, filename)
+            self.conn.compile_mof_file(filepath, namespace=default_namespace,
                                        search_paths=[self.pg_schema_dir],
                                        verbose=False)
 
@@ -220,6 +221,7 @@ class WbemServerMock(object):
                             property_values=None,
                             include_missing_properties=True,
                             include_path=True):
+        # pylint: disable=too-many-arguments
         """
         Build instance from classname using class_name property to get class
         from a repository.
@@ -272,10 +274,10 @@ class WbemServerMock(object):
         Build instances of CIM_Namespace defined by test_namespaces list. These
         instances are built into the interop namespace
         """
-        for ns in namespaces:
+        for namespace in namespaces:
             nsdict = {"SystemName": self.system_name,
                       "ObjectManagerName": self.object_manager_name,
-                      'Name': ns,
+                      'Name': namespace,
                       'CreationClassName': 'PG_Namespace',
                       'ObjectManagerCreationClassName': 'CIM_ObjectManager',
                       'SystemCreationClassName': 'CIM_ComputerSystem'}
@@ -313,11 +315,11 @@ class WbemServerMock(object):
         for value in range(0, 22):
             org_vm_dict[org_vm.tovalues(value)] = value
 
-        for p in profiles:
-            instance_id = '%s+%s+%s' % (p[0], p[1], p[2])
-            reg_prof_dict = {'RegisteredOrganization': org_vm_dict[p[0]],
-                             'RegisteredName': p[1],
-                             'RegisteredVersion': p[2],
+        for profile in profiles:
+            instance_id = '%s+%s+%s' % (profile[0], profile[1], profile[2])
+            reg_prof_dict = {'RegisteredOrganization': org_vm_dict[profile[0]],
+                             'RegisteredName': profile[1],
+                             'RegisteredVersion': profile[2],
                              'InstanceID': instance_id}
             rpinst = self.inst_from_classname("CIM_RegisteredProfile",
                                               namespace=self.interop_ns,


### PR DESCRIPTION
Clean up a number of pylint messages and change the word global togeneral when refering to the general options.

Pr # 218 based on this PR.  

**NOTE:** This PR left a test display (verbose=True in test_instance_subcmds.py by accident. We only saw it with the next PR so fixed there sinice I am uncomfortable with rebasing to changes in a pr that was already rebased into another pr.

Change definiton in __init__ of minimum version of python from 2.6 to
2.7

Most of the pylints were hidden with the # pylint: definition but a few
were changed by changing code to what the pylint recommended.

We also caught a couple of real issues that flake8 was overlooking. 