### PR TITLE
Modify the short form values of some general options.

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -62,7 +62,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       and 5989(HTTPS)].
                                       (EnvVar:
                                       PYWBEMCLI_SERVER).
-      -N, --name NAME                 Name for the connection.  If this option
+      -n, --name NAME                 Name for the connection.  If this option
                                       exists and the server option does not exist
                                       pywbemcli retrieves the connection
                                       information from the connections file
@@ -84,13 +84,13 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       requested as part  of initialization if user
                                       name exists and it is not  provided by this
                                       option.(EnvVar: PYWBEMCLI_PASSWORD).
-      -t, --timeout INTEGER           Timeout completion of WBEM server operation
-                                      in seconds.
+      -t, --timeout INTEGER           Client timeout completion of WBEM server
+                                      operation in seconds.
                                       (EnvVar:
                                       PYWBEMCLI_PYWBEMCLI_TIMEOUT)
-      -n, --noverify                  If set, client does not verify WBEM server
+      -N, --noverify                  If set, client does not verify WBEM server
                                       certificate.(EnvVar: PYWBEMCLI_NOVERIFY).
-      -c, --certfile TEXT             Server certfile. Ignored if noverify flag
+      -c, --certfile TEXT             Server certfile. Ignored if --noverify flag
                                       set. (EnvVar: PYWBEMCLI_CERTFILE).
       -k, --keyfile FILE PATH         Client private key file. (EnvVar:
                                       PYWBEMCLI_KEYFILE).
@@ -117,7 +117,8 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       Object: [mof|xml|txt|tree]
                                       [Default:
                                       "simple"]
-      --use-pull-ops [yes|no|either]  Determines whether pull operations are used
+      -U, --use-pull-ops [yes|no|either]
+                                      Determines whether pull operations are used
                                       for EnumerateInstances, AssociatorInstances,
                                       ReferenceInstances, and ExecQuery
                                       operations.
@@ -682,7 +683,7 @@ The following defines the help output for the `pywbemcli connection add --help` 
                                       defines WBEM server port to be used
                                       [Defaults: 5988(HTTP) and 5989(HTTPS)].
                                       [required]
-      -N, --name NAME                 Required name for the connection(optional,
+      -n, --name NAME                 Required name for the connection(optional,
                                       see --server).  This is the name for this
                                       defined WBEM server in the connection file
                                       [required]
@@ -696,7 +697,7 @@ The following defines the help output for the `pywbemcli connection add --help` 
                                       option.
       -t, --timeout INTEGER RANGE     Operation timeout for the WBEM Server in
                                       seconds. Default: 30
-      -n, --noverify                  If set, client does not verify server
+      -N, --noverify                  If set, client does not verify server
                                       certificate.
       -c, --certfile TEXT             Server certfile. Ignored if noverify flag
                                       set.

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -141,7 +141,7 @@ def connection_select(context, name):
                    'literal IPV4 address (dotted), or literal IPV6 address\n'
                    '* Port: (optional) defines WBEM server port to be used '
                    '[Defaults: 5988(HTTP) and 5989(HTTPS)].\n')
-@click.option('-N', '--name', type=str, metavar='NAME', required=True,
+@click.option('-n', '--name', type=str, metavar='NAME', required=True,
               help='Required name for the connection(optional, see --server).  '
                    'This is the name for this defined WBEM server in the'
                    ' connection file')
@@ -160,7 +160,7 @@ def connection_select(context, name):
 @click.option('-t', '--timeout', type=click.IntRange(0, MAX_TIMEOUT),
               help="Operation timeout for the WBEM Server in seconds. "
                    "Default: " + "%s" % DEFAULT_CONNECTION_TIMEOUT)
-@click.option('-n', '--noverify', is_flag=True,
+@click.option('-N', '--noverify', is_flag=True,
               help='If set, client does not verify server certificate.')
 @click.option('-c', '--certfile', type=str,
               help="Server certfile. Ignored if noverify flag set. ")

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -67,7 +67,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    'used '
                    '[Defaults: 5988(HTTP) and 5989(HTTPS)].\n' +
                    '(EnvVar: {ev}).'.format(ev=PywbemServer.server_envvar))
-@click.option('-N', '--name', type=str,
+@click.option('-n', '--name', type=str,
               metavar='NAME',
               envvar=PywbemServer.name_envvar,
               help='Name for the connection.  If this '
@@ -102,15 +102,16 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('-t', '--timeout', type=click.IntRange(0, MAX_TIMEOUT),
               metavar='INTEGER',
               envvar=PywbemServer.timeout_envvar,
-              help="Timeout completion of WBEM server operation in seconds.\n"
+              help='Client timeout completion of WBEM server operation in '
+                   'seconds.\n' +
                    '(EnvVar: PYWBEMCLI_{})'.format(PywbemServer.timeout_envvar))
-@click.option('-n', '--noverify', is_flag=True,
+@click.option('-N', '--noverify', is_flag=True,
               envvar=PywbemServer.noverify_envvar,
               help='If set, client does not verify WBEM server certificate.' +
                    '(EnvVar: {ev}).'.format(ev=PywbemServer.noverify_envvar))
 @click.option('-c', '--certfile', type=str,
               envvar=PywbemServer.certfile_envvar,
-              help="Server certfile. Ignored if noverify flag set. " +
+              help="Server certfile. Ignored if --noverify flag set. " +
                    '(EnvVar: {ev}).'.format(ev=PywbemServer.certfile_envvar))
 @click.option('-k', '--keyfile', type=str,
               metavar='FILE PATH',
@@ -140,7 +141,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    .format(tb='|'.join(TABLE_FORMATS),
                            ob='|'.join(CIM_OBJECT_OUTPUT_FORMATS)) +
                    '[Default: "{}"]'.format(DEFAULT_OUTPUT_FORMAT))
-@click.option('--use-pull-ops',
+@click.option('-U', '--use-pull-ops',
               envvar=PywbemServer.use_pull_ops_envvar,
               type=click.Choice(['yes', 'no', 'either']),
               help='Determines whether pull operations are used for '

--- a/tests/unit/test_connection_subcmd.py
+++ b/tests/unit/test_connection_subcmd.py
@@ -157,7 +157,7 @@ Options:
                                   defines WBEM server port to be used
                                   [Defaults: 5988(HTTP) and 5989(HTTPS)].
                                   [required]
-  -N, --name NAME                 Required name for the connection(optional,
+  -n, --name NAME                 Required name for the connection(optional,
                                   see --server).  This is the name for this
                                   defined WBEM server in the connection file
                                   [required]
@@ -171,7 +171,7 @@ Options:
                                   option.
   -t, --timeout INTEGER RANGE     Operation timeout for the WBEM Server in
                                   seconds. Default: 30
-  -n, --noverify                  If set, client does not verify server
+  -N, --noverify                  If set, client does not verify server
                                   certificate.
   -c, --certfile TEXT             Server certfile. Ignored if noverify flag
                                   set.
@@ -397,7 +397,7 @@ TEST_CASES = [
     # and what was in the repository.
     #
     ['Verify connection subcommand add with simple arguments only.',
-     ['add', '-N', 'test1', '-s', 'http://blah'],
+     ['add', '--name', 'test1', '-s', 'http://blah'],
      {'stdout': "",
       'test': 'lines',
       'file': {'before': 'none', 'after': 'exists'}},
@@ -415,8 +415,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify connection subcommand add with complex options.',
-     ['add', '-N', 'test2', '-s', 'http://blahblah', '-u', 'fred', '-p',
-      'argh', '-t', '18', '-n', '-l', 'api=file,all'],
+     ['add', '--name', 'test2', '-s', 'http://blahblah', '-u', 'fred', '-p',
+      'argh', '-t', '18', '-N', '-l', 'api=file,all'],
      {'stdout': "",
       'test': 'lines',
       'file': {'before': 'exists', 'after': 'exists'}},
@@ -546,10 +546,10 @@ TEST_CASES = [
      None, OK],
 
     # uses regex because windows generates set and linux export in statements
-    # No file verification required. Does not usefile
+    # No file verification required. Does not use file
     ['Verify connection subcommand export',
      {'args': ['export'],
-      'global': ['-s', 'http://blah', '-u', 'fred', '-p', 'arghh', '-n',
+      'global': ['-s', 'http://blah', '-u', 'fred', '-p', 'arghh', '-N',
                  '-c', 'certfile.txt', '-k', 'keyfile.txt', '-t', '12']},
      {'stdout': ['PYWBEMCLI_SERVER=http://blah$',
                  'PYWBEMCLI_DEFAULT_NAMESPACE=root/cimv2$',
@@ -585,7 +585,7 @@ TEST_CASES = [
 
 
     ['Verify connection subcommand add with bad arg fails',
-     ['add', '-N', 'addallargs', '-s', 'http://blah',
+     ['add', '--name', 'addallargs', '-s', 'http://blah',
       '--timeout', 'fred', ],
      {'stderr': ['Usage: pywbemcli connection add [COMMAND-OPTIONS]',
                  'Error: Invalid value for "-t" / "--timeout": '
@@ -596,7 +596,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify connection subcommand add no server option fails',
-     ['add', '-N', 'blah'],
+     ['add', '--name', 'blah'],
      {'stderr': ['Usage: pywbemcli connection add [COMMAND-OPTIONS]',
                  'Try "pywbemcli connection add -h" for help.',
                  '',
@@ -631,7 +631,7 @@ TEST_CASES = [
      {'stderr': ['Usage: pywbemcli connection add [COMMAND-OPTIONS]',
                  'Try "pywbemcli connection add -h" for help.',
                  '',
-                 'Error: Missing option "-N" / "--name".'],
+                 'Error: Missing option "-n" / "--name".'],
       'rc': 2,
       'test': 'lines',
       'file': {'before': 'none', 'after': 'none'}},

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -79,7 +79,7 @@ Options:
                                   and 5989(HTTPS)].
                                   (EnvVar:
                                   PYWBEMCLI_SERVER).
-  -N, --name NAME                 Name for the connection.  If this option
+  -n, --name NAME                 Name for the connection.  If this option
                                   exists and the server option does not exist
                                   pywbemcli retrieves the connection
                                   information from the connections file
@@ -101,13 +101,13 @@ Options:
                                   requested as part  of initialization if user
                                   name exists and it is not  provided by this
                                   option.(EnvVar: PYWBEMCLI_PASSWORD).
-  -t, --timeout INTEGER           Timeout completion of WBEM server operation
-                                  in seconds.
+  -t, --timeout INTEGER           Client timeout completion of WBEM server
+                                  operation in seconds.
                                   (EnvVar:
                                   PYWBEMCLI_PYWBEMCLI_TIMEOUT)
-  -n, --noverify                  If set, client does not verify WBEM server
+  -N, --noverify                  If set, client does not verify WBEM server
                                   certificate.(EnvVar: PYWBEMCLI_NOVERIFY).
-  -c, --certfile TEXT             Server certfile. Ignored if noverify flag
+  -c, --certfile TEXT             Server certfile. Ignored if --noverify flag
                                   set. (EnvVar: PYWBEMCLI_CERTFILE).
   -k, --keyfile FILE PATH         Client private key file. (EnvVar:
                                   PYWBEMCLI_KEYFILE).
@@ -134,7 +134,8 @@ Options:
                                   Object: [mof|xml|txt|tree]
                                   [Default:
                                   "simple"]
-  --use-pull-ops [yes|no|either]  Determines whether pull operations are used
+  -U, --use-pull-ops [yes|no|either]
+                                  Determines whether pull operations are used
                                   for EnumerateInstances, AssociatorInstances,
                                   ReferenceInstances, and ExecQuery
                                   operations.
@@ -251,7 +252,7 @@ TEST_CASES = [
       'test': 'in'},
      None, OK],
 
-    ['Verify valid pull_ops parameter.',
+    ['Verify valid --use-pull_ops parameter.',
      {'global': ['-s', 'http://blah', '--use-pull-ops', 'either'],
       'subcmd': 'connection',
       'args': ['show']},
@@ -260,11 +261,11 @@ TEST_CASES = [
       'test': 'in'},
      None, OK],
 
-    ['Verify invalid pull-ops parameter.',
+    ['Verify invalid --use-pull-ops parameter.',
      {'global': ['-s', 'http://blah', '--use-pull-ops', 'blah'],
       'subcmd': 'connection',
       'args': ['show']},
-     {'stderr': ['Error: Invalid value for "--use-pull-ops": invalid choice: '
+     {'stderr': ['Invalid value for "-U" / "--use-pull-ops": invalid choice: '
                  'blah. (choose from yes, no, either)'],
       'rc': 2,
       'test': 'in'},
@@ -367,7 +368,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --name options with new name but not in repo failse',
-     {'global': ['-N', 'fred'],
+     {'global': ['-n', 'fred'],
       'subcmd': 'connection',
       'args': ['show']},
      {'stderr': 'Error: Named connection "fred" does not exist',


### PR DESCRIPTION
Change the short for --name from -N to -n

Modify the short form values of some general options.

Change the short for --noverify from -n to -N

This is because in working with pywbemcli I find that I use the --name
much more often than the --noverify because I put definitions into the
connections file and then reuse the definition.

I had considered changing --name to an argument but found that there are
issues in click with general arguments and command groups that I did not
want to sort out now.

Add short from for --use-pull-ops as -U. -u already used for --user

Modified the test for --timeout to clarify that it is client timeout

Make same modifications to connection add options.