### PR TITLE
Ks/fix filterquery exceptionmsg

### DIFF
--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -795,7 +795,7 @@ def cmd_instance_references(context, instancename, options):
     except ValueError as ve:
         raise click.ClickException('instance references failed because '
                                    'FilterQuery not allowed with traditional '
-                                   'EnumerateInstance. use_pull_ops: '
+                                   'References. use_pull_ops: '
                                    '%s. Exception: %s: %s' %
                                    (context.use_pull_ops,
                                     ve.__class__.__name__, ve))
@@ -845,7 +845,7 @@ def cmd_instance_associators(context, instancename, options):
     except ValueError as ve:
         raise click.ClickException('instance associators failed because '
                                    'FilterQuery not allowed with traditional '
-                                   'EnumerateInstance. use_pull_ops: '
+                                   'Associators. use_pull_ops: '
                                    '%s. Exception: %s: %s' %
                                    (context.use_pull_ops,
                                     ve.__class__.__name__, ve))

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -741,6 +741,13 @@ def cmd_instance_enumerate(context, classname, options):
 
     except (Error, ValueError) as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+    except ValueError as ve:
+        raise click.ClickException('instance enumerate failed because '
+                                   'FilterQuery not allowed with traditional '
+                                   'EnumerateInstance. use_pull_ops: '
+                                   '%s. Exception: %s: %s' %
+                                   (context.use_pull_ops,
+                                    ve.__class__.__name__, ve))
 
 
 def cmd_instance_references(context, instancename, options):
@@ -785,6 +792,13 @@ def cmd_instance_references(context, instancename, options):
 
     except (Error, ValueError) as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+    except ValueError as ve:
+        raise click.ClickException('instance references failed because '
+                                   'FilterQuery not allowed with traditional '
+                                   'EnumerateInstance. use_pull_ops: '
+                                   '%s. Exception: %s: %s' %
+                                   (context.use_pull_ops,
+                                    ve.__class__.__name__, ve))
 
 
 def cmd_instance_associators(context, instancename, options):
@@ -828,6 +842,13 @@ def cmd_instance_associators(context, instancename, options):
 
     except (Error, ValueError) as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+    except ValueError as ve:
+        raise click.ClickException('instance associators failed because '
+                                   'FilterQuery not allowed with traditional '
+                                   'EnumerateInstance. use_pull_ops: '
+                                   '%s. Exception: %s: %s' %
+                                   (context.use_pull_ops,
+                                    ve.__class__.__name__, ve))
 
 
 def cmd_instance_count(context, classname, options):


### PR DESCRIPTION
Change the short for --name from -N to -n

Modify the short form values of some general options.

Change the short for --noverify from -n to -N

This is because in working with pywbemcli I find that I use the --name
much more often than the --noverify because I put definitions into the
connections file and then reuse the definition.

I had considered changing --name to an argument but found that there are
issues in click with general arguments and command groups that I did not
want to sort out now.

Add short from for --use-pull-ops as -U. -u already used for --user

Modified the test for --timeout to clarify that it is client timeout

Make same modifications to connection add options.