### PR TITLE
Ks/refactor cim object sort

### DIFF
--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -390,8 +390,6 @@ def cmd_class_enumerate(context, classname, options):
                 ClassName=classname,
                 namespace=options['namespace'],
                 DeepInheritance=options['deepinheritance'])
-            if options['sort']:
-                results.sort()
         else:
             results = context.conn.EnumerateClasses(
                 ClassName=classname,
@@ -400,11 +398,9 @@ def cmd_class_enumerate(context, classname, options):
                 DeepInheritance=options['deepinheritance'],
                 IncludeQualifiers=options['includequalifiers'],
                 IncludeClassOrigin=options['includeclassorigin'])
-            if options['sort']:
-                results.sort(key=lambda x: x.classname)
 
         display_cim_objects(context, results, context.output_format,
-                            summary=options['summary'])
+                            summary=options['summary'], sort=options['sort'])
 
     except Error as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
@@ -423,8 +419,6 @@ def cmd_class_references(context, classname, options):
                 classname,
                 ResultClass=options['resultclass'],
                 Role=options['role'])
-            if options['sort']:
-                results.sort()
         else:
             results = context.conn.References(
                 classname,
@@ -433,11 +427,9 @@ def cmd_class_references(context, classname, options):
                 IncludeQualifiers=options['includequalifiers'],
                 IncludeClassOrigin=options['includeclassorigin'],
                 PropertyList=resolve_propertylist(options['propertylist']))
-            if options['sort']:
-                results.sort(key=lambda x: x[1].classname)
 
         display_cim_objects(context, results, context.output_format,
-                            summary=options['summary'])
+                            summary=options['summary'], sort=options['sort'])
 
     except Error as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
@@ -458,8 +450,6 @@ def cmd_class_associators(context, classname, options):
                 Role=options['role'],
                 ResultClass=options['resultclass'],
                 ResultRole=options['resultrole'])
-            if options['sort']:
-                results.sort()
         else:
             results = context.conn.Associators(
                 classname,
@@ -470,11 +460,9 @@ def cmd_class_associators(context, classname, options):
                 IncludeQualifiers=options['includequalifiers'],
                 IncludeClassOrigin=options['includeclassorigin'],
                 PropertyList=resolve_propertylist(options['propertylist']))
-            if options['sort']:
-                results.sort(key=lambda x: x[1].classname)
 
         display_cim_objects(context, results, context.output_format,
-                            summary=options['summary'])
+                            summary=options['summary'], sort=options['sort'])
 
     except Error as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -23,7 +23,7 @@ import click
 from pywbem import Error, CIMError, CIM_ERR_NOT_FOUND
 from .pywbemcli import cli
 from ._common import display_cim_objects, parse_wbemuri_str, \
-    pick_instance, sort_cimobjects, resolve_propertylist, create_ciminstance, \
+    pick_instance, resolve_propertylist, create_ciminstance, \
     filter_namelist, CMD_OPTS_TXT, format_table, verify_operation, \
     process_invokemethod
 from ._common_options import propertylist_option, names_only_option, \
@@ -720,8 +720,6 @@ def cmd_instance_enumerate(context, classname, options):
                 namespace=options['namespace'],
                 FilterQuery=options['filterquery'],
                 FilterQueryLanguage=get_filterquerylanguage(options))
-            if options['sort']:
-                results = sort_cimobjects(results)
         else:
             results = context.conn.PyWbemcliEnumerateInstances(
                 ClassName=classname,
@@ -733,11 +731,9 @@ def cmd_instance_enumerate(context, classname, options):
                 FilterQuery=options['filterquery'],
                 FilterQueryLanguage=get_filterquerylanguage(options),
                 PropertyList=resolve_propertylist(options['propertylist']))
-            if options['sort']:
-                results = sort_cimobjects(results)
 
         display_cim_objects(context, results, context.output_format,
-                            summary=options['summary'])
+                            summary=options['summary'], sort=options['sort'])
 
     except (Error, ValueError) as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
@@ -770,8 +766,6 @@ def cmd_instance_references(context, instancename, options):
                 Role=options['role'],
                 FilterQuery=options['filterquery'],
                 FilterQueryLanguage=get_filterquerylanguage(options))
-            if options['sort']:
-                results = sort_cimobjects(results)
         else:
             results = context.conn.PyWbemcliReferenceInstances(
                 instancepath,
@@ -782,13 +776,9 @@ def cmd_instance_references(context, instancename, options):
                 FilterQuery=options['filterquery'],
                 FilterQueryLanguage=get_filterquerylanguage(options),
                 PropertyList=resolve_propertylist(options['propertylist']))
-            if options['sort']:
-                results.sort(key=lambda x: x.classname)
-        if options['sort']:
-            results = sort_cimobjects(results)
 
         display_cim_objects(context, results, context.output_format,
-                            summary=options['summary'])
+                            summary=options['summary'], sort=options['sort'])
 
     except (Error, ValueError) as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
@@ -820,8 +810,6 @@ def cmd_instance_associators(context, instancename, options):
                 ResultRole=options['resultrole'],
                 FilterQuery=options['filterquery'],
                 FilterQueryLanguage=get_filterquerylanguage(options))
-            if options['sort']:
-                results.sort()
         else:
             results = context.conn.PyWbemcliAssociatorInstances(
                 instancepath,
@@ -834,11 +822,9 @@ def cmd_instance_associators(context, instancename, options):
                 FilterQuery=options['filterquery'],
                 FilterQueryLanguage=get_filterquerylanguage(options),
                 PropertyList=resolve_propertylist(options['propertylist']))
-            if options['sort']:
-                results.sort(key=lambda x: x.classname)
 
         display_cim_objects(context, results, context.output_format,
-                            summary=options['summary'])
+                            summary=options['summary'], sort=options['sort'])
 
     except (Error, ValueError) as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
@@ -928,11 +914,8 @@ def cmd_instance_query(context, query, options):
                                                        query,
                                                        options['namespace'])
 
-        if options['sort']:
-            results.sort(key=lambda x: x.classname)
-
         display_cim_objects(context, results, context.output_format,
-                            summary=options['summary'])
+                            summary=options['summary'], sort=options['sort'])
 
     except Error as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))

--- a/pywbemtools/pywbemcli/_cmd_qualifier.py
+++ b/pywbemtools/pywbemcli/_cmd_qualifier.py
@@ -24,7 +24,7 @@ import click
 from pywbem import Error
 from .pywbemcli import cli
 from ._common import display_cim_objects, CMD_OPTS_TXT, \
-    output_format_is_table
+    output_format_is_table, sort_cimobjects
 from ._common_options import namespace_option, add_options, \
     summary_objects_option
 
@@ -108,10 +108,8 @@ def cmd_qualifier_enumerate(context, options):
     Execute the command for enumerate qualifiers and desplay the result.
     """
     try:
-        qual_decls = context.conn.EnumerateQualifiers(
-            namespace=options['namespace'])
-
-        qual_decls.sort(key=lambda x: x.name)
+        qual_decls = sort_cimobjects(context.conn.EnumerateQualifiers(
+            namespace=options['namespace']))
 
         display_cim_objects(context, qual_decls, context.output_format,
                             summary=options['summary'])

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -422,8 +422,8 @@ class TST_MemberOfFamilyCollection {
 """
 
 
-OK = True  # mark tests OK when they execute correctly
-RUN = True  # Mark OK = False and current test case being created RUN
+OK = True     # mark tests OK when they execute correctly
+RUN = True    # Mark OK = False and current test case being created RUN
 FAIL = False  # Any test currently FAILING or not tested yet
 
 # pylint: enable=line-too-long


### PR DESCRIPTION
No external changes.  Refactored the sort functiion and made its application a parameter of the display_cim_object function.

All display sorts of response CIMObjects now go through this singe function.

