### PR TITLE
Modify one --names_only option

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -268,7 +268,7 @@ The following defines the help output for the `pywbemcli class associators --hel
                                       -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                       empty string the server should return no
                                       properties.
-      -o, --names_only                Show only the returned object names.
+      -o, --names-only                Retrieve only the returned object names.
       -s, --sort                      Sort into alphabetical order by classname.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
@@ -356,7 +356,7 @@ The following defines the help output for the `pywbemcli class enumerate --help`
       -c, --includeclassorigin  Request that server include classorigin in the
                                 result.On some WBEM operations, server may ignore
                                 this option.
-      -o, --names_only          Show only the returned object names.
+      -o, --names-only          Retrieve only the returned object names.
       -s, --sort                Sort into alphabetical order by classname.
       -n, --namespace <name>    Namespace to use for this operation. If defined
                                 that namespace overrides the general options
@@ -546,7 +546,7 @@ The following defines the help output for the `pywbemcli class references --help
                                       -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                       empty string the server should return no
                                       properties.
-      -o, --names_only                Show only the returned object names.
+      -o, --names-only                Retrieve only the returned object names.
       -s, --sort                      Sort into alphabetical order by classname.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
@@ -1059,7 +1059,7 @@ The following defines the help output for the `pywbemcli instance associators --
                                       -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                       empty string the server should return no
                                       properties.
-      -o, --names_only                Show only the returned object names.
+      -o, --names-only                Retrieve only the returned object names.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
                                       options namespace
@@ -1269,7 +1269,7 @@ The following defines the help output for the `pywbemcli instance enumerate --he
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
                                       options namespace
-      -o, --names_only                Show only the returned object names.
+      -o, --names-only                Retrieve only the returned object names.
       -s, --sort                      Sort into alphabetical order by classname.
       -S, --summary                   Return only summary of objects (count).
       -f, --filterquery TEXT          A filter query to be passed to the server if
@@ -1564,7 +1564,7 @@ The following defines the help output for the `pywbemcli instance references --h
                                       -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                       empty string the server should return no
                                       properties.
-      -o, --names_only                Show only the returned object names.
+      -o, --names-only                Retrieve only the returned object names.
       -n, --namespace <name>          Namespace to use for this operation. If
                                       defined that namespace overrides the general
                                       options namespace

--- a/pywbemtools/pywbemcli/_common_options.py
+++ b/pywbemtools/pywbemcli/_common_options.py
@@ -39,8 +39,8 @@ propertylist_option = [                      # pylint: disable=invalid-name
                       'properties.')]
 
 names_only_option = [                      # pylint: disable=invalid-name
-    click.option('-o', '--names_only', is_flag=True, required=False,
-                 help='Show only the returned object names.')]
+    click.option('-o', '--names-only', is_flag=True, required=False,
+                 help='Retrieve only the returned object names.')]
 
 sort_option = [                            # pylint: disable=invalid-name
     click.option('-s', '--sort', is_flag=True, required=False,

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -126,7 +126,7 @@ Options:
   -c, --includeclassorigin  Request that server include classorigin in the
                             result.On some WBEM operations, server may ignore
                             this option.
-  -o, --names_only          Show only the returned object names.
+  -o, --names-only          Retrieve only the returned object names.
   -s, --sort                Sort into alphabetical order by classname.
   -n, --namespace <name>    Namespace to use for this operation. If defined
                             that namespace overrides the general options
@@ -262,7 +262,7 @@ Options:
                                   -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                   empty string the server should return no
                                   properties.
-  -o, --names_only                Show only the returned object names.
+  -o, --names-only                Retrieve only the returned object names.
   -s, --sort                      Sort into alphabetical order by classname.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
@@ -477,7 +477,6 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-
     ['Verify class subcommand enumerate CIM_Foo localonly',
      ['enumerate', 'CIM_Foo', '--localonly'],
      {'stdout':
@@ -525,8 +524,8 @@ TEST_CASES = [
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo --names_only',
-     ['enumerate', 'CIM_Foo', '--names_only'],
+    ['Verify class subcommand enumerate CIM_Foo --names-only',
+     ['enumerate', 'CIM_Foo', '--names-only'],
      {'stdout': ['CIM_Foo', 'CIM_Foo_sub', 'CIM_Foo_sub2'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -113,7 +113,7 @@ Options:
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace
-  -o, --names_only                Show only the returned object names.
+  -o, --names-only                Retrieve only the returned object names.
   -s, --sort                      Sort into alphabetical order by classname.
   -S, --summary                   Return only summary of objects (count).
   -f, --filterquery TEXT          A filter query to be passed to the server if
@@ -322,7 +322,7 @@ Options:
                                   -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                   empty string the server should return no
                                   properties.
-  -o, --names_only                Show only the returned object names.
+  -o, --names-only                Retrieve only the returned object names.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace
@@ -463,7 +463,7 @@ Options:
                                   -p pn1 -p pn22 or -p pn1,pn2). If defined as
                                   empty string the server should return no
                                   properties.
-  -o, --names_only                Show only the returned object names.
+  -o, --names-only                Retrieve only the returned object names.
   -n, --namespace <name>          Namespace to use for this operation. If
                                   defined that namespace overrides the general
                                   options namespace


### PR DESCRIPTION
Modify the --names_only option to --names-only which is the standard we
want to use for all options (no _ as part of the option names)