### PR TITLE
Fix issue #231 unhandled exception on startup (alternate solution to pr # 233

### DIFF
--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -471,10 +471,16 @@ def cmd_connection_add(context, options):
     """
     name = options['name']
     server = options['server']
+    mock_server = options['mock_server']
     connections = ConnectionRepository()
     if name in connections:
         raise click.ClickException('Connection name "%s" already defined'
                                    % name)
+
+    if not mock_server and not server:
+        raise click.ClickException('Add failed; missing server definition. A '
+                                   'server using either "--server" or '
+                                   '"--mock-server" required.')
 
     try:
         new_server = PywbemServer(server, options['default_namespace'],

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -23,7 +23,6 @@ import fnmatch
 import re
 from textwrap import fill
 from operator import itemgetter
-from prompt_toolkit import prompt
 import six
 import click
 import tabulate
@@ -114,14 +113,6 @@ def warning_msg(msg):
     click.echo('WARNING: %s' % msg)
 
 
-def pywbemcli_prompt(msg):
-    """
-    This function isolates the prompt call so that it can be mocked for
-    pywbemcli tests.
-    """
-    return prompt(msg)
-
-
 def pick_one_from_list(context, options, title):
     """
     Interactive component that displays a set of options (strings) and asks
@@ -158,7 +149,7 @@ def pick_one_from_list(context, options, title):
             % index
         while True:
             try:
-                selection_txt = pywbemcli_prompt(msg)
+                selection_txt = click.prompt(msg)
                 selection = int(selection_txt)
                 if 0 <= selection <= index:
                     if context:
@@ -245,7 +236,7 @@ def pick_multiple_from_list(context, options, title):
     msg = 'Select entry by index or hit enter to end selection>'
     while True:
         try:
-            selection_txt = pywbemcli_prompt(msg)
+            selection_txt = click.prompt(msg)
             if not selection_txt:
                 if context:
                     context.spinner.start()
@@ -335,7 +326,6 @@ def verify_operation(txt, msg=None):
       Returns:
         (:class:`py:bool`) where true corresponds to 'y' prompt response
     """
-
     if click.confirm(txt):
         return True
     if msg:

--- a/pywbemtools/pywbemcli/_pywbem_server.py
+++ b/pywbemtools/pywbemcli/_pywbem_server.py
@@ -114,12 +114,11 @@ class PywbemServer(object):
             and operation information to create a connection to the server
             and execute cim_operations on the server.
         """
-        if not server_url and not mock_server:
-            raise ValueError('Missing server definition "--server" or '
-                             '"--mock-server" required')
+
         if server_url and mock_server:
             raise ValueError('Simultaneous "--server" and '
-                             '"--mock-server" not allowed')
+                             '"--mock-server" not allowed. Server: %s, '
+                             'mock_server %s' % (server_url, mock_server))
         self._server_url = server_url
         self._mock_server = mock_server
 
@@ -379,15 +378,11 @@ class PywbemServer(object):
                 raise click.Abort()
         else:
             if not self.server_url:
-                raise click.ClickException('Server URL is empty. Cannot '
+                raise click.ClickException('No server found. Cannot '
                                            'connect.')
             self._server_url = _validate_server_url(self._server_url)
             if self.keyfile is not None and self.certfile is None:
                 ValueError('keyfile option requires certfile option')
-
-            # If supplied by connect request, save the password
-            # if password:
-            #   self._password = password
 
             creds = (self.user, self.password) if self.user or \
                 self.password else None

--- a/tests/unit/mock_confirm_n.py
+++ b/tests/unit/mock_confirm_n.py
@@ -1,3 +1,8 @@
+# !PROCESS!AT!STARTUP!
+# The previous statement is used by pywbemcli to force this script to be
+# run at pywbemcli startup and not included in the list of --mock-server
+# files that are used to build the repository.  This is a development
+# test aid.
 # (C) Copyright 2017 IBM Corp.
 # (C) Copyright 2017 Inova Development Inc.
 # All Rights Reserved
@@ -27,7 +32,7 @@ RETURN_VALUE = False
 
 def mock_confirm(msg):
     """Mock function to replace pywbemcli_prompt and return a value"""
-    print(msg)
+    print('MOCK_CLICK_CONFIRM(n): %s' % msg)
     return RETURN_VALUE
 
 

--- a/tests/unit/mock_confirm_y.py
+++ b/tests/unit/mock_confirm_y.py
@@ -1,5 +1,10 @@
-# (C) Copyright 2017 IBM Corp.
-# (C) Copyright 2017 Inova Development Inc.
+# !PROCESS!AT!STARTUP!
+# The previous statement is used by pywbemcli to force this script to be
+# run at pywbemcli startup and not included in the list of --mock-server
+# files that are used to build the repository.  This is a development
+# test aid.
+# (C) Copyright 2019 IBM Corp.
+# (C) Copyright 2019 Inova Development Inc.
 # All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +32,7 @@ RETURN_VALUE = True
 
 def mock_confirm(msg):
     """Mock function to replace pywbemcli_prompt and return a value"""
-    print(msg)
+    print('MOCK_CLICK_CONFIRM(y): %s' % msg)
     return RETURN_VALUE
 
 

--- a/tests/unit/mock_prompt_0.py
+++ b/tests/unit/mock_prompt_0.py
@@ -1,5 +1,10 @@
-# (C) Copyright 2017 IBM Corp.
-# (C) Copyright 2017 Inova Development Inc.
+# !PROCESS!AT!STARTUP!
+# The previous statement is used by pywbemcli to force this script to be
+# run at pywbemcli startup and not included in the list of --mock-server
+# files that are used to build the repository.  This is a development
+# test aid.
+# (C) Copyright 2019 IBM Corp.
+# (C) Copyright 2019 Inova Development Inc.
 # All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,5 +42,4 @@ def mock_prompt(msg):
     return RETURN_VALUE
 
 
-# pylint: disable=protected-access
-pywbemtools.pywbemcli._common.pywbemcli_prompt = Mock(side_effect=mock_prompt)
+pywbemtools.pywbemcli.click.prompt = Mock(side_effect=mock_prompt)

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -42,7 +42,6 @@ from pywbemtools.pywbemcli._common import parse_wbemuri_str, \
     pick_one_from_list, pick_multiple_from_list, hide_empty_columns, \
     verify_operation, split_str_w_esc
 # pylint: disable=unused-import
-from pywbemtools.pywbemcli._common import pywbemcli_prompt  # noqa: F401
 from pywbemtools.pywbemcli._context_obj import ContextObj
 
 
@@ -348,7 +347,7 @@ def test_pick_one_from_list(testcase, options, choices, exp_rtn):
     values from the mock.
     """
     # setup mock for this test
-    mock_function = 'pywbemtools.pywbemcli._common.pywbemcli_prompt'
+    mock_function = 'pywbemtools.pywbemcli.click.prompt'
     with patch(mock_function, side_effect=choices) as mock_prompt:
         # The code to be tested
         title = "Test pick_one_from_list"
@@ -405,7 +404,7 @@ TESTCASES_PICK_MULTIPLE_FROM_LIST = [
 def test_pick_multiple_from_list(testcase, options, choices, exp_rtn):
     """Test for pick_one_from_list function"""
     # setup mock for this test
-    mock_function = 'pywbemtools.pywbemcli._common.pywbemcli_prompt'
+    mock_function = 'pywbemtools.pywbemcli.click.prompt'
     with patch(mock_function, side_effect=choices) as mock_prompt:
         # The code to be tested
         title = "test_pick_multiple_from_list"
@@ -634,7 +633,7 @@ TESTCASES_VERIFY_OPERATION = [
 @simplified_test_function
 def test_verify_operation(testcase, txt, abort_msg, result):
     """
-    This method mocks the click.click_confirm function to generate a response
+    This method mocks the click.confirm function to generate a response
     to the verify operation function
     """
     @patch('pywbemtools.pywbemcli.click.confirm', return_value=result)

--- a/tests/unit/test_connection_subcmd.py
+++ b/tests/unit/test_connection_subcmd.py
@@ -368,13 +368,13 @@ TEST_CASES = [
       'test': 'lines'},
      None, OK],
 
-    ['Verify --moc-server and --server together fail.',
+    ['Verify --mock-server and --server together fail.',
      ['add', '--mock-server', 'test1.mof', '--server', 'http://blah',
       '--name', 'fred'],
-     {'stderr': 'Error: Add failed. Simultaneous "--server" and '
+     {'stderr': 'Add failed. Simultaneous "--server" and '
       '"--mock-server" not allowed',
       'rc': 1,
-      'test': 'lines'},
+      'test': 'regex'},
      None, OK],
 
     #
@@ -396,16 +396,17 @@ TEST_CASES = [
          "  Timeout: None", "  Noverify: False", "  Certfile: None",
          "  Keyfile: None", "  use-pull-ops: None", "  mock: ",
          "  log: None"],
-      'test': 'in'},
+      'test': 'in',
+      'file': {'before': 'exists', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection subcommand add with complex options and verify',
+    ['Verify connection subcommand add with complex options',
      ['add', '--name', 'test2', '-s', 'http://blahblah', '-u', 'fred', '-p',
-      'argh', '-t', '18', '-N', '-l', 'api=file,all', '--verify'],
-     {'stdout': "Execute add connection",
-      'test': ['test2', 'Execute add connection'],
+      'argh', '-t', '18', '-N', '-l', 'api=file,all'],
+     {'stdout': "",
+      'test': 'regex',
       'file': {'before': 'exists', 'after': 'exists'}},
-     MOCK_CONFIRMY_FILE, OK],
+     None, OK],
 
     ['Verify connection subcommand show  ',
      ['show', 'test1'],
@@ -608,9 +609,8 @@ TEST_CASES = [
 
     ['Verify connection subcommand add no server option fails, no --server',
      ['add', '--name', 'blah'],
-     {'stderr': ['Error:',
-                 'Add failed',
-                 'Missing server definition',
+     {'stderr': ['Add failed',
+                 'missing server definition',
                  '"--server" or "--mock-server" required'],
       'rc': 1,
       'test': 'regex'},
@@ -685,7 +685,7 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify connection subcommand select mocktest with prompt ',
+    ['Verify connection subcommand select mocktest with prompt',
      ['select'],
      {'stdout': "",
       'test': 'in',
@@ -725,7 +725,8 @@ TEST_CASES = [
     ['Verify save server with cmd line params to empty connections file. Use '
      '--verify',
      {'args': ['save', '--verify'],
-      'global': ['--name', 'svrtest2',
+      'global': ['--server', 'http://blah',
+                 '--name', 'svrtest2',
                  '--timeout', '45',
                  '--use-pull-ops', 'no',
                  '--default-namespace', 'root/blah',
@@ -773,7 +774,7 @@ TEST_CASES = [
      ['show', 'svrtest2'],
      {'stdout': [
          "Name: svrtest2",
-         "  WBEMServer uri: None",
+         "  WBEMServer uri: http://blah",
          "  Default-namespace: root/blah", "  User: john", "  Password: pw",
          "  Timeout: 45", "  Noverify: True", "  Certfile: mycertfile.pem",
          "  Keyfile: mykeyfile.pem", "  use-pull-ops: False",
@@ -787,14 +788,22 @@ TEST_CASES = [
      ['delete', 'mocktest2'],
      {'stdout': "",
       'test': 'regex',
-      'file': {'before': 'exists', 'after': 'exists'}},
+      'file': {'before': 'exists', 'after': 'None'}},
      None, OK],
 
-    ['Verify connection subcommand delete works',
+    ['Verify connection subcommand delete Fails, No file',
      ['delete', 'svrtest2'],
      {'stdout': "",
       'test': 'regex',
       'file': {'before': 'exists', 'after': 'none'}},
+     None, OK],
+
+    ['Verify connection subcommand delete Fails, No file',
+     ['delete', 'svrtest2'],
+     {'stderr': "svrtest2 not a defined connection name",
+      'rc': 1,
+      'test': 'regex',
+      'file': {'before': 'none', 'after': 'none'}},
      None, OK],
 ]
 
@@ -842,7 +851,7 @@ class TestSubcmdClass(CLITestsBase):
                 test_file(exp_response['file']['before'])
 
         self.subcmd_test(desc, self.subcmd, inputs, exp_response,
-                         mock, condition)
+                         mock, condition, verbose=False)
 
         if 'file' in exp_response:
             if 'after' in exp_response['file']:

--- a/tests/unit/test_global_options.py
+++ b/tests/unit/test_global_options.py
@@ -331,7 +331,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --mock option, file does not exist',
-     {'global': ['-m', 'invalidfilename.mof'],
+     {'global': ['--mock-server', 'invalidfilename.mof'],
       'subcmd': 'connection',
       'args': ['show']},
      {'stderr': [r'Error: --mock-server: File:',
@@ -343,7 +343,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --mock option, file with bad extension',
-     {'global': ['-m', 'invalidfilename.mofx'],
+     {'global': ['--mock-server', 'invalidfilename.mofx'],
       'subcmd': 'connection',
       'args': ['show']},
      {'stderr': [r'Error: --mock-server: File: ',
@@ -397,12 +397,25 @@ TEST_CASES = [
       'test': 'in'},
      None, OK],
 
-    ['Verify --mock_server and --server options together fail',
-     {'global': ['--mock-server', 'fred', '--server', 'http://localhost'],
+    ['Verify simultaneous --mock_server and --server options fail',
+     {'global': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
+                 '--server', 'http://localhost'],
       'subcmd': 'connection',
       'args': ['show']},
-     {'stderr': ['Conflicting server definition. Do not use --server '
+     {'stderr': ['Conflicting server definitions. Do not use --server '
                  'and --mock-server simultaneously',
+                 'Aborted!'],
+      'rc': 1,
+      'test': 'regex'},
+     None, OK],
+
+    ['Verify --mock_server invalid name',
+     {'global': ['--mock-server', 'fred'],
+      'subcmd': 'connection',
+      'args': ['show']},
+     {'stderr': ['--mock-server: File:',
+                 'fred',
+                 'extension: "" not valid.',
                  'Aborted!'],
       'rc': 1,
       'test': 'regex'},
@@ -549,6 +562,19 @@ TEST_CASES = [
      {'subcmd': 'connection',
       'args': ['delete', 'globaltest1']},
      {'stderr': "Error: globaltest1 not a defined connection name",
+      'rc': 1,
+      'test': 'regex'},
+     None, OK],
+
+
+    ['Verify connection without server definition and subcommand that '
+     ' requires connection fails.',
+     {'subcmd': 'class',
+      'args': ['enumerate']},
+     {'stderr': 'No server defined for subcommand that requires server. '
+                'Define a server with "--server", "--mock-server", or '
+                '"--name" general options; or in interactive mode, use '
+                '"connection select" to enable a connection',
       'rc': 1,
       'test': 'regex'},
      None, OK],

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -1338,7 +1338,7 @@ Instances: PyWBEM_AllTypes
                  '};',
                  'Execute ModifyInstance'],
       'rc': 0,
-      'test': 'linesnows'},
+      'test': 'regex'},
      [ALLTYPES_MOCK_FILE, MOCK_CONFIRM_Y_FILE], OK],
 
     ['Verify instance subcommand modify, single good change with verify no',
@@ -1865,7 +1865,6 @@ Instances: PyWBEM_AllTypes
      {'stdout': ASSOC_INSTS,
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
-
 
     ['Verify instance subcommand associators with query, traditional ops',
      {'args': ['associators', 'TST_Person.name="Mike"', '--filterquery',


### PR DESCRIPTION
Alternate to another PR that fixes issue # 231.

Fixes the issue of unhandled exception when no --server or --mock-server
by adding test for this condition.  At the same time we moved the code
that creates the WBEMConnection or FakedWBEMConnection to as late as
possible so that only a subcommand that requires the connection activates
the creation.

However fixing the unhandled exception issue  creates a second
problem in that we are using --mock-server
to implement mocks within pywbemcli for tests (mock prompts and mock
confirms) where console input is required. Moving the WBEMConnection
creation causes this pywbemcli test code to not be executed on startup
so that the mocks for the tests are not created.  Thus, we added
a flag in the first line of the files to be included in --mock-server
that tells pywbemcli to eval that file on startup and not put it into
the --mock-server file list (i.e. it is our test, not the users mock).
Note that we consider this an undocumented test feature.

Also removed an artifical call hiearchy in _common (pywbmecliprompt) and
moved from using prompt_toolkit. prompt to click.prompt.

Added tests for the new conditions.