### PR TITLE
Fixes #232: Update documentation

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -8,24 +8,30 @@ This section contains information that is referenced from other sections,
 and that does not really need to be read in sequence.
 
 
-.. _'Special type names`:
+.. _'Special terms`:
 
-Special type names
-------------------
+Special terms
+-------------
 
 This documentation uses a few special terms to refer to Python types:
 
 .. glossary::
 
    CIM-XML
-     the name of the protocol used in the DMTF specification :term:`DSP0200`
-     the protocol pywbemcli uses to communicate with WBEM servers.
+     The name of the protocol used in the DMTF specification :term:`DSP0200`
+     that pywbem/pywbemcli use to communicate with WBEM servers.
+
+   CIM model output formats
+      Several of the output formats defined and available in the ``-o``\``--output-format``
+      general option are specific for the presentation of CIM objects(CIMClass,
+      CIMInstance, CIMParameter, CIMMethod, CIMClassName and CIMInstanceName)
+      This includes the format choices ``MOF``, ``XML``, ``REPR``.
 
    INSTANCENAME
       an argument of several of the command-group ``instance`` subcommands that
       allows two possible inputs based on another subcommand option(``--interactive``).
 
-      When ``interactive`` is set the INSTANCENAME is  a string representation of
+      When ``interactive`` is set the INSTANCENAME is a string representation of
       a CIMInstanceName formatted as defined by  :term:`WBEM-URI`
 
       Otherwise the INSTANCENAME should be a classname in which case pywbemcli
@@ -45,6 +51,14 @@ This documentation uses a few special terms to refer to Python types:
       See section :ref:`Deprecation and compatibility policy` and the standard
       Python module :mod:`py:warnings` for details.
 
+   CIM namespace
+      A CIM namespace (defined in :term:`DSP0004`) provides a scope of
+      uniqueness  for cim objects; specifically, the names of class objects and
+      of qualifier type objects shall be unique in a namespace. The compound
+      key of non- embedded instance objects shall also be unique across all
+      non-embedded instances of the class (not including subclasses) within the
+      namespace.
+
    connections file
       A file maintained by pywbemcli and managed by the pywbemcli
       ``connections`` command group.  The file name is ``pywbemcli_connections.json``
@@ -62,9 +76,21 @@ This documentation uses a few special terms to refer to Python types:
       the display of CIM objects in pywbemcli. See DMTF term:`DSP0004` for more
       information on the MOF format.
 
+   WBEM management profile
+      The DMTF and SNIA define specific profiles of manageability that are
+      published as specifications in the DMTF and within the SMI-S specification
+      in SNIA. A management profile defines the managability characteristics
+      of a specic set of services in terms of the CIM model and WBEM operations.
+      These profiles are documented by name and version and are incorporated into
+      compliant WBEM servers so that they can be discovered by WBEM clients to
+      determine the management capabilities of the WBEM server.
+      See :ref:`Profile advertisement methodologies`
+
    WBEM-URI
-      The wbem uri is a standardized text form for CIM instance names. It is
-      documented in DMTF DSP0207. Pywbemcli uses the untyped WBEM URI::
+      The wbem-uri is a standardized text form for CIM instance names. It is
+      documented in DMTF :term:`DSP0207`. Pywbemcli uses the untyped WBEM URI
+      as the format for instance names in cli input parameters
+      (i.e. :term:`INSTANCENAME`)::
 
             WBEM-URI = WBEM-URI-UntypedNamespacePath /
                        WBEM-URI-UntypedClassPath /
@@ -97,6 +123,19 @@ This documentation uses a few special terms to refer to Python types:
         CIM_RegisteredProfile.InstanceID="acme:1"
         CIM_RegisteredProfile.InstanceID=100
 
+   REPL
+      Stands for "Read-Execute-Print-Loop" which is a term that denotes the
+      pywbemcli shell interactive mode where multiple command-groups and
+      subcommands may be executed within the context of a connection defined
+      by a set of general options.
+
+   GLOB
+      A pathname pattern pattern expansion used in Unix environments. It is
+      used by pywbemcli to expand classnames in the ``class find`` subcommand.
+      No tilde expansion is done, but ``*``, ``?``, and character ranges
+      expressed with ``[]`` will be correctly matched.
+
+
 .. _`Profile advertisement methodologies`:
 
 Profile advertisement methodologies
@@ -112,7 +151,7 @@ class of choice. The reason is that this approach enables clients to work
 seamlessly with different server implementations, even when they have
 implemented a different set of management profiles.
 
-DMTF defines three profile advertisement methodologies in :term:`DSP1033`:
+The DMTF defines three profile advertisement methodologies in :term:`DSP1033`:
 
 * GetCentralInstances methodology (new in :term:`DSP1033` 1.1)
 * Central class methodology
@@ -177,8 +216,8 @@ a single invocation of an easy-to use method
 Profile implementations in a WBEM server are not entirely free when making a
 choice of which methodology to implement:
 
-* Autonomous profiles in a WBEM server must implement the central class
-  methodology, and may in addition implement the new GetCentralInstances
+* Autonomous profiles in a WBEM server must implement the central-class
+  methodology, and may in addition implement the GetCentralInstances
   methodology.
 
   Note that the scoping class methodology falls together with the
@@ -186,7 +225,7 @@ choice of which methodology to implement:
   class is also their central class.
 
 * Component profiles in a WBEM server may implement the central class
-  methodology and the new GetCentralInstances methodology, and must support the
+  methodology and the GetCentralInstances methodology, and must support the
   scoping class methodology.
 
   Note that implementing the scoping class methodology in a WBEM server
@@ -206,7 +245,7 @@ Older DMTF component profiles and older SNIA subprofiles do not always specify
 scoping class and scoping path. In such cases, the scoping class and scoping
 path can often be determined from the class diagram in the specification for
 the profile.
-Many times, CIM_System or CIM_ComputerSystem is the scoping class.
+Many times, ``CIM_System`` or ``CIM_ComputerSystem`` is the scoping class.
 .. _'Glossary`:
 
 Glossary
@@ -253,7 +292,7 @@ References
       `DMTF WBEM Standards <https://www.dmtf.org/standards/wbem>`_
 
    SMI-S
-      `SNIA Storage Management Initiative Specification`_
+      `SNIA Storage Management Initiative Specification <https://www.snia.org/forums/smi/tech_programs/smis_home>`_
 
    Python Glossary
       * `Python 2.7 Glossary <https://docs.python.org/2.7/glossary.html>`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -325,7 +325,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'pywbemcli', _short_description, [author], 1)
+    (master_doc, 'pywbemtools', _short_description, [author], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -338,8 +338,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'pywbemcli', _short_description,
-     author, 'pywbemcli', _short_description,
+    (master_doc, 'pywbemtools', _short_description,
+     author, 'pywbemtools', _short_description,
      'Miscellaneous'),
 ]
 
@@ -467,4 +467,16 @@ intersphinx_cache_limit = 5
 extlinks = {
   'nbview': ('http://nbviewer.jupyter.org/github/pywbem/pywbemcli/blob/master/docs/notebooks/%s', ''),
   'nbdown': ('https://github.com/pywbem/pywbemcli/raw/master/docs/notebooks/%s', '')
+}
+
+
+# http://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
+# Add the "intersphinx" extension
+extensions = [
+    'sphinx.ext.intersphinx',
+]
+# Addintersphinx mappings
+intersphinx_mapping = {
+    'pywbem': ('https://pywbem.readthedocs.io/en/stable', None),
+    'pywbem_mock': ('https://pywbem.readthedocs.io/en/stable', None),
 }

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,0 +1,261 @@
+
+.. _`Pywbemtools Development`:
+
+Pywbemtools development
+=======================
+
+This section only needs to be read by developers of the pywbemtools package.
+People that want to make a fix or develop some extension, and people that
+want to test the project are also considered developers for the purpose of
+this section.
+
+Generally development users will install pywbemtools by cloning the pywbemtools
+GitHub package and using the Make utility to handle the installation installation
+of pywbemtools and its prerequisites. This provides the user with all of the
+source of pywbemtools and in addition, the test environment and the documentation
+files.
+
+
+.. _`Repository`:
+
+Repository
+----------
+
+The repository for pywbemtools is on GitHub:
+
+https://github.com/pywbem/pywbemtools
+
+
+.. _`Setting up the development environment`:
+
+Setting up the development environment
+--------------------------------------
+
+It is recommended to use Linux as the development environment for pywbemtools.
+OS-X should work as well, but Windows requires a number of manual setup steps.
+
+1. Clone the Git repo of this project and switch to its working directory:
+
+   .. code-block:: bash
+
+        $ git clone git@github.com:pywbem/pywbemtools.git
+        $ cd pywbemtools
+
+2. It is recommended that you set up a `virtual Python environment`_.
+   Have the virtual Python environment active for all remaining steps.
+
+3. Install pywbemtools and its prerequisites for installing and running it
+   as described in :ref:`Installation`.
+   This will install Python packages into the active Python environment,
+   and OS-level packages.
+
+4. On Windows, perform the setup steps described in
+   :ref:`Manual setup on Windows`. On Linux and OS-X, the corresponding
+   setup is performed automatically as part of the next step.
+
+5. Install the prerequsites for pywbemtools development.
+   This will install Python packages into the active Python environment,
+   and OS-level packages:
+
+   .. code-block:: bash
+
+        $ make develop
+
+6. This project uses Make to do things in the currently active Python
+   environment. The command:
+
+   .. code-block:: bash
+
+        $ make
+
+   displays a list of valid Make targets and a short description of what each
+   target does.
+
+.. _virtual Python environment: https://docs.python-guide.org/en/latest/dev/virtualenvs/
+
+
+.. _`Manual setup on Windows`:
+
+Manual setup on Windows
+^^^^^^^^^^^^^^^^^^^^^^^
+
+For development of pywbemtools, you may use native windows or one of the Unix-like
+environments on Windows (such as CygWin, MinGW, Babun, or Gow).
+The pywbemtools tests that run on the Appveyor CI test with both CygWin
+and native windows.
+
+Note that Unix-like environments on Windows bring their own Python, so double
+check that the active Python environment is the one you want to install to.
+
+.. _`Prerequisites for development installation`:
+
+Prerequisites for development installation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. _pywbem installation documentation: https://pywbem.readthedocs.io/en/stable/intro.html#installation/
+
+See :ref:`Installation prerequisites for install with pip`
+
+
+.. _`Building the documentation`:
+
+Building the documentation
+--------------------------
+
+The ReadTheDocs (RTD) site is used to publish the documentation for the
+pywbemtools package at https://pywbem.readthedocs.io/
+
+This page is automatically updated whenever the Git repo for this package
+changes the branch from which this documentation is built.
+
+In order to build the documentation locally from the Git work directory,
+execute:
+
+::
+
+    $ make builddoc
+
+The top-level document to open with a web browser will be
+``build_doc/html/docs/index.html``.
+
+
+.. _`Testing`:
+
+.. # Keep the tests/README file in sync with this 'Testing' section.
+
+Testing
+-------
+
+All of the following `make` commands run the tests in the currently active
+Python environment. Depending on how the `pywbem` package is installed in that
+Python environment, either the `pywbem` and `pywbem_mock` directories in the
+main repository directory are used, or the installed `pywbem` package.
+The test case files and any utility functions they use are always used from
+the `tests` directory in the main repository directory.
+
+The `tests` directory has the following subdirectory structure:
+
+::
+
+    tests
+     +-- unit                Unit tests
+     |    +-- utils               Utility functions used by unit tests
+     +-- manual              Manual tests
+     +-- schema              The CIM schema MOF files used by some tests
+
+There are multiple types of tests in pywbem:
+
+1. Unit tests and function tests
+
+   Today, the unit tests and function tests are contained in the single
+   directory `unit`.
+
+   The distinction between unit tests and function tests as used in pywbemtools is
+   that function tests exercise the entire pywbemcli client component or entire
+   pywbem scripts using the pywbem mock module and mock CIM model definitions
+   to emulate a WBEM server, while unit tests exercise single modules without
+   using access to a WBEM server.
+
+   Generally, the function tests are organized by the command-group so that
+   the function tests for the class command-group are in the file
+   test_class_subcmd.py
+
+
+   Tests are run by executing:
+
+   ::
+
+       $ make test
+
+   Test execution can be modified by a number of environment variables, as
+   documented in the make help (execute `make help`).
+
+3. Manual tests
+
+   There are several Python scripts and shell scripts that can be run manually.
+   The results need to be validated manually.
+
+   These scripts are in the directory:
+
+   ::
+
+       tests/manual/
+
+   and are executed by simply invoking them from within the main directory
+   of the repository, e.g.:
+
+   ::
+
+       tests/manual/test_pegasus.py
+
+   Some of the scripts support a `--help` option that informs about their
+   usage.
+
+   Some tests depend on the existence of a DMTF Schema defining the classes and
+   qualifier declarations in a particular release
+
+4. Running Tox
+
+To run the unit and function tests in all supported Python environments, the
+Tox tool can be used. It creates the necessary virtual Python environments and
+executes `make test` (i.e. the unit and function tests) in each of them.
+
+For running Tox, it does not matter which Python environment is currently
+active, as long as the Python `tox` package is installed in it:
+
+::
+
+    $ tox                              # Run tests on all supported Python versions
+    $ tox -e py27                      # Run tests on Python 2.7
+
+
+.. _`Contributing`:
+
+Contributing
+------------
+
+Third party contributions to this project are welcome!
+
+In order to contribute, create a `Git pull request`_, considering this:
+
+.. _Git pull request: https://help.github.com/articles/using-pull-requests/
+
+* Test is required.
+* Each commit should only contain one "logical" change.
+* A "logical" change should be put into one commit, and not split over multiple
+  commits.
+* Large new features should be split into stages.
+* The commit message should not only summarize what you have done, but explain
+  why the change is useful.
+* The commit message must follow the format explained below.
+
+What comprises a "logical" change is subject to sound judgement. Sometimes, it
+makes sense to produce a set of commits for a feature (even if not large).
+For example, a first commit may introduce a (presumably) compatible API change
+without exploitation of that feature. With only this commit applied, it should
+be demonstrable that everything is still working as before. The next commit may
+be the exploitation of the feature in other components.
+
+For further discussion of good and bad practices regarding commits, see:
+
+* `OpenStack Git Commit Good Practice`_
+* `How to Get Your Change Into the Linux Kernel`_
+
+.. _OpenStack Git Commit Good Practice: https://wiki.openstack.org/wiki/GitCommitMessages
+.. _How to Get Your Change Into the Linux Kernel: https://www.kernel.org/doc/Documentation/SubmittingPatches
+
+
+.. _`Core Development Team`:
+
+Core Development Team
+---------------------
+
+Anyone can contribute to pywbem via pull requests as described in the previous
+section.
+
+The pywbem project has a core development team that holds regular web conferences
+and that is using Slack for offline communication, on the Slack workspace:
+https://pywbem.slack.com.
+
+The web conference and the Slack workspace are by invitation, and if you want
+to participate in the core team, please
+`open an issue <https://github.com/pywbem/pywbem/issues>`_ to let us know.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ Pywbemtools - A set of tools using pywbem
 This package contains tools that provide a command line interface to interact
 with WBEM servers
 
-The pywbemtools github page is: ``https://github.com/pywbem/pywbemtools <https://github.com/pywbem/pywbemtools>``.
+The pywbemtools github page is: `https://github.com/pywbem/pywbemtools <https://github.com/pywbem/pywbemtools>`_.
 
 .. toctree::
    :maxdepth: 2
@@ -13,10 +13,12 @@ The pywbemtools github page is: ``https://github.com/pywbem/pywbemtools <https:/
 
    introduction.rst
    pywbemclicmdlineinterface.rst
+   pywbemcligeneraloptions.rst
    pywbemclisubcommands.rst
    pywbemclicmdshelp.rst
    pywbemclispecialfeatures.rst
    mock_support.rst
+   development.rst
    appendix.rst
    changes.rst
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -36,8 +36,10 @@ WBEM standards are used for a wide variety of systems management tasks
 in the industry including DMTF management standards and the SNIA Storage
 Management Initiative Specification(SMI-S).
 
-Pywbemtools and pywbem WBEM Client are packages in the github pywbem repository
-and are released to PyPi. Pywbemcli is a module in pywbemtools.
+Pywbemtools and pywbem are packages in the GitHub pywbem project
+and are released to PyPI.
+
+Pywbemcli is a module in the pywbemtools package.
 
 
 .. _`Pywbemcli command line interface WBEM client`:
@@ -49,19 +51,19 @@ Pywbemcli provides access to WBEM servers from the command line on multiple OS
 platforms. It provides functionality to:
 
 * Explore the CIM data of WBEM Servers. It can manage/inspect the CIM model
-  components including CIM classes, CIM instances, and CIM qualifiers and execute
-  CIM methods and queries on the WBEM server. It implements subcommands to
-  execute the :term:`CIM-XML` operations defined in the DMTF specification CIM Operations
-  Over HTTP(:term:`DSP0200`).
+  components including CIM classes, CIM instances, and CIM qualifiers and
+  execute CIM methods and queries on the WBEM server. It implements subcommands
+  to execute the :term:`CIM-XML` operations defined in the DMTF specification
+  CIM Operations Over HTTP (:term:`DSP0200`).
 
 * Inspect/manage WBEM server functionality including:
 
-  * CIM namespaces,
-  * WBEM registered management profiles,
-  * WBEM server brand information
+  * CIM namespaces as (see :term:`CIM namespace`) ,
+  * WBEM registered profiles (see :term:`WBEM management profile`),
+  * WBEM server brand and version information.
 
 * Capture detailed information on interactions with the WBEM server including
-  time statistics.
+  time statistics and details of data flow.
 
 * Maintain a file of WBEM server definitions so that pywbemcli can access
   multiple servers by name.
@@ -75,12 +77,18 @@ platforms. It provides functionality to:
 Supported environments
 ----------------------
 
+.. _pywbem documentation: https://pywbem.readthedocs.io/en/stable/intro.html#wbem-servers
+
 The pywbemcli module of the pywbemtools package is supported in these
 environments:
 
-* Operating systems: Linux, Windows, MacOS
+* Operating systems: Linux, Windows, macOS
 * Python versions: 2.7, 3.4, and greater
-* pywbem 0.13.0 or greater
+* pywbem 0.14.4 or greater
+* WBEM servers: Any WBEM server that conforms to the DMTF specifications listed
+  in :ref:`Standards conformance`. WBEM servers supporting older versions of
+  these standards are also supported, but may have limitations.
+  See the `pywbem documentation` for more details.
 
 .. _`Installation`:
 
@@ -88,24 +96,83 @@ Installation
 ------------
 
 .. _virtual Python environment: http://docs.python-guide.org/en/latest/dev/virtualenvs/
-.. _Pypi: http://pypi.python.org/
+.. _PyPI: http://pypi.python.org/
 
-The easiest way to install the pywbemcli package is using Pip. Pip ensures
+
+This section describes the complete installation of pywbemtools with all steps
+including prerequisite operating system packages and manual post-processing
+steps, for users of pywbemcli. As a user of pywbemcli, you can import the pywbemtools
+Python package into your environment so that pywbemcli can be executed from the
+command line.
+
+The easiest way to install the pywbemtools package is using pip. Pip ensures
 that any dependent Python packages also get installed.
 
 Pip will install the packages into your currently active Python environment
-(your system Python or your predefined virtual Python environment).
+(your system Python or your predefined `virtual Python environment`_).
 
 It is beneficial to set up a `virtual Python environment`_ for your project,
 because that leaves your system Python installation unchanged, it does not
 require ``sudo`` rights, and last but not least it gives you better control
 about the installed packages and their versions.
 
-Installation of latest released version
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If you want to contribute to the pywbem project, you need to set up a
+development and test environment for pywbem. That has a larger set of OS-level
+prerequisites and its setup is described in the :ref:`Pywbemtools development` chapter.
 
-The following command installs the latest released version of the pywbemctools
-package from `Pypi`_ into the currently active Python environment:
+
+.. _`Pywbemtools installation with pip`:
+
+Pywbemtools installation with pip
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+.. _`Installation prerequisites`:
+
+Installation prerequisites
+""""""""""""""""""""""""""
+
+.. _pywbem installation documentation: https://pywbem.readthedocs.io/en/stable/intro.html#installation
+
+
+The Python environment into which you want to install must be the active
+Python environment, and must have at least the following packages
+installed:
+
+- Python, either python 2.7 or Python 3.4-3.7. Pywbemtools does not support
+  Python 2.6
+
+- Python installation support packages(all platforms):
+
+  - setuptools - http://pypi.python.org/pypi/setuptools
+  - wheel
+  - pip - generally installed with Python 3.x but may be a separate install
+    with Python 2.7 and with Cygwin Python releases.
+
+Other installation support packages:
+
+- Native windows:
+    - Chocolatey package manager. The pywbemtools package installation uses
+      Chocolatey to install software required for the pywbemtools installation
+      that is are normally available with unix style OSs (ex. make). See
+      https://chocolatey.org/ for the installation instructions for Chocolatey.
+- Windows Cygwin
+    - wget - wget can be installed as part of the cygwin installation or
+      added cygwin package update.
+    - python-devel - Probably named python2-devel / python3-devel
+
+Pywbemtools does install the``pywbem`` package which has a number of
+prerequisites for installation as documented in the `pywbem installation
+documentation`_. These requirements should be covered by the list above.
+
+
+.. _`Installation with pip`:
+
+Installation with pip
+"""""""""""""""""""""
+
+The following command installs the latest released version of the pywbemtools
+package from `PyPI`_ into the currently active Python environment:
 
 .. code-block:: text
 
@@ -115,27 +182,54 @@ This will download and install the latest released version of pywbemtools and
 its dependent packages into your current Python environment (e.g. into your
 system Python or into a virtual Python environment).
 
-Installation of latest development version
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
 As an alternative, if you want to install the latest development level of the
-pywbemctools package for some reason, install directly from the ``master``
+pywbemtools package for some reason, install directly from the ``master``
 branch of the Git repository of the package:
 
 .. code-block:: text
 
     $ pip install git+https://github.com/pywbem/pywbemtools.git@master
 
+
+.. _`Verification of the installation`:
+
 Verification of the installation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+""""""""""""""""""""""""""""""""
 
 You can verify that the pywbemcli package and its dependent packages are
-installed correctly by invoking:
+installed correctly by invoking pywbemcli. Invoking with the --version
+option displays the installed version of both pywbem and pywbemtools as
+shown in the following example:
 
 .. code-block:: bash
 
     $ pywbemcli --version
-    0.5.0
+      pywbemcli, version 0.5.0
+      pywbem, version 0.14.4
+
+
+Installation for development
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+See the :ref:`Pywbemtools Development` chapter.
+
+
+.. _`Standards conformance`:
+
+Standards conformance
+---------------------
+
+.. _pywbem standards conformance documentation: https://pywbem.readthedocs.io/en/stable/intro.html#standards-conformance
+
+Pywbemtools attempts to comply to the maximum possible with the relevant standards.
+
+Pywbemtools/pywbemcli is based on  and uses pywbem and pywbem. Therefore
+pywbemtools conformance to the relevant standards is defined in the `pywbem
+standards conformance documentation`.
+
+Therefore, the level of conformance and limitations for pywbemcli is the same
+as pywbem except for any specific notations in this document.
+
 
 .. _`Deprecation policy`:
 
@@ -215,10 +309,10 @@ This package uses the rules of `Semantic Versioning 2.0.0`_ for compatibility
 between package versions, and for deprecations.
 
 The public command line interface of this package that is subject to the
-semantic versioning rules (and specificically to its compatibility rules) is
+semantic versioning rules (and specifically to its compatibility rules) is
 the CLI syntax described in this documentation.
 
-The output formats are currently not the subject of compatiblity assurances.
+The output formats are currently not the subject of compatibility assurances.
 
 Violations of these compatibility rules are described in section
 :ref:`Change log`.

--- a/docs/mock_support.rst
+++ b/docs/mock_support.rst
@@ -13,71 +13,70 @@ pywbemcli  general command line option (``-m``or ``--mock-server``).  This
 allows executing pywbemcli against a mock WBEM server integrated into the
 pywbemcli process rather than a real WBEM server.
 
-When the --mock-server option is used on the pywbemcli command line it
-replaces the --server option
+When the ``--mock-server`` option is used on the pywbemcli command line it
+replaces the ``--server`` option.
 
 The ``--mock-server`` option constructs an instance of the pywbem class
-:class:`~pywbem.pywbem_mock.FakedWBEMConnection` in place of the pywbem class
-:class:`~pywbem.pywbem.WBEMConnection` and allows building the mock repository
+:class:`pywbem_mock.FakedWBEMConnection` in place of the pywbem class
+:class:`pywbem.WBEMConnection` and allows building the mock repository
 of CIM qualifier declarations, CIM classes, and CIM instances in the mock
 repository from the file specified with the ``--mock-server`` option.
 
-The ``--mock-server`` option defines a single file path that pywbemcli will
-pass to the repository building tools in pywbem when pywbemcli is started. This
-option may be used multiple times and each use of the option specifies the file
-path of one of the following types of files:
+Each instantion of the ``--mock-server`` option defines a single file path that
+pywbemcli will pass to the pywbem repository building tools when pywbemcli
+instantiates the connection. This option may be used multiple times and each
+use of the option specifies the file path of one of the following types of
+files:
 
-* ``MOF`` file (file extension ``mof``) - If the option value is the file path of
-  a `MOF` file, pywbemcli compiles the MOF and inserts the CIM objects into the
-  mock repository. The file may contain MOF definitions for CIM qualifier
-  declarations, CIM classes  and CIM instances when pywbemcli is started.  The
-  CIM objects will be inserted into the default namespace defined for the
-  current connection.
+* ``MOF`` file (file extension ``.mof``) - If the option value is the file path of
+  a ``MOF`` file, pywbemcli compiles the :term:`MOF` and inserts the CIM
+  objects into the mock repository. The file may contain :term:`MOF`
+  definitions for CIM qualifier declarations, CIM classes  and CIM instances
+  when pywbemcli is started.  The CIM objects will be inserted into the default
+  :term:`CIM namespace` defined for the current connection.
 
 * Python file (file extension ``py``) - If the option value is the file path of
   a Python file, that file is executed with the following Python GLOBAL
   variables passed to the file when pywbemcli is started:
 
-    * ``CONN`` - an instance of
-                 :class:`~pywbem.pywbem_mock.FakedWBEMConnection`). The methods
-                 of this instance object can be used to add data to the
-                 mock repository.
+    * ``CONN`` - an instance of :class:`pywbem_mock.FakedWBEMConnection` which
+      defines a fake(mock) WBEMConnection. The methods of this instance
+      object can be used to add data to a mock repository.
 
-    * ``SERVER`` - an instance of :class:`~pywbem.WBEMServer`). The
-                   methods of this instance object can be used to add data to
-                   them mock repository. This instance can be useful to get
-                   namespace information or build more complex objects
-                   for the mock repository.
+    * ``SERVER`` - an instance of :class:`pywbem.WBEMServer`. The
+      methods of this instance object can be used to add data to
+      them mock repository. This instance can be useful to get
+      namespace information or build more complex objects
+      for the mock repository.
 
     * ``VERBOSE`` - a boolean flag that is based on the pywbemcli option
-                    ``--verbose``.
+      ``--verbose``.
 
   The file can contain any Python statements or functions and can insert them
+  into the :class:`pywbem_mock.FakedWBEMConnection` using the
+  methods in that class.
 
-  into the :class:`~pywbem.pywbem_mock.FakedWBEMConnection` using the
-  methods in that class
+  The  Python file may contain :class:`pywbem.CIMQualifierDeclaration`,
+  :class:`pywbem.CIMClass`, and :class:`pywbem.CIMInstance` instance objects
+  and calls to :meth:`pywbem_mock.FakedWBEMConnection.add_cim_objects` to
+  insert objects into the repository.
 
-  The  Python file may contain pywbem CIMQualifierDeclaration,
-  CIMClass, and CIMInstance instance objects and calls to
-  :meth:`~pywbem.pywbem_mock.FakedWBEMConnection.add_cim objects` to insert
-  objects into the repository.
+  It may also implement pywbem CIM method callbacks, (:meth:`pywbem_mock.method_callback_interface`)
+  for handling InvokeMethod operations requested from pywbemcli.
 
-  It may also implement pywbem CIM method callbacks (defined in pywbem as
-  ``method_callback_interface``) for handling InvokeMethod operations requested
-  from pywbemcli.
-
-Pywbemcli logging (`` -l`` or ``--log``) can be enabled when the `--mock-server` option is
-enabled. However, since the mock support does not use HTTP, the `http`  of the
-log option will generate no output.
+Pywbemcli logging (`` -l`` or ``--log``) can be enabled when the
+`--mock-server` option is enabled. However, since the mock support does not use
+HTTP, the `http`  of the log option will generate no output.
 
 
-.. _`Creating files for the mock respository`:
+.. _`Creating files for the mock repository`:
 
-Creating files for the mock respository
+Creating files for the mock repository
 ---------------------------------------
 
-The following is a MOF file (tst_file.mof) that defines some qualifier
-declarations, a single CIMClass, and a single CIMInstance of that class:
+The following is an example  MOF file (``tst_file.mof``) that defines some
+qualifier declarations, a single CIMClass, and a single CIMInstance of that
+class:
 
 .. code-block:: text
 
@@ -121,7 +120,7 @@ declarations, a single CIMClass, and a single CIMInstance of that class:
         };
 
 The pywbemcli command to insert these CIM objects into the mock repository
-(where the file containing the above MOF is tst_file.mof)  and then to
+(where the file containing the above MOF is ``tst_file.mof``)  and then to
 enumerate its CIM classes is::
 
     $ pywbemcli --mock-server tst_file.mof class enumerate
@@ -160,7 +159,7 @@ enumerate its CIM classes is::
         };
       $
 
-The following is a  Python code (in a file tst_file.py)) that will insert CIM
+The following is Python code (in a file tst_file.py)) that will insert CIM
 objects defined using the pywbem APIs into the mock repository in the default
 namespace. If the ``--verbose`` general option is set on the pywbemcli command
 line, the global variable ``VERBOSE`` will be set True and the code below  will

--- a/docs/pywbemclicmdlineinterface.rst
+++ b/docs/pywbemclicmdlineinterface.rst
@@ -18,21 +18,25 @@
 Pywbemcli command line interface
 ================================
 
+This section defines the command line interface specifically for the
+pywbemcli module within the pywbemtools package. This tool is a single
+python script executed with the name ``pywbemcli``.
+
 Pywbemcli provides a command line interface(CLI) interaction with WBEM servers.
 
-The command line  can contain the following components::
+The command line can contain the following components:
 
-* general-options - see :ref:`Command line general options`
-
-* command-group - A name of a group of subcommands
-
-* command - Alternative to command-group when there are no
+* **general-options** - see :ref:`Command line general options`
+* **command-group** - A name of a group of subcommands
+* **command** - Alternative to command-group when there are no
   subcommands.
-
-* subcommand - Command name within a command group
-
-* args - Arguments and options that are defined for a particular
-  command or subcommand.
+* **subcommand** - Command name within a command group
+* **args** - Arguments and options that are defined for a particular
+  command or subcommand. Options are proceeded by the characters '-' for the
+  short form or '--' for the long form. (ex. ``-n`` or ``--namespace``).
+  Arguments do not have a prefix and are the first string following the
+  command/subcommand name. (ex. ``pywbemcli class get CIM_Foo``. CIM_Foo is
+  an argument.)
 
 The syntax is:
 
@@ -43,16 +47,16 @@ The syntax is:
     where:
         command-group = <command> <subcommand>
 
-A command-group is the name of an object, referencing an entity (ex. class
+A command-group is the name of an object, referencing an entity (ex. ``class``
 refers to operation on CIM classes). The subcommands are generally actions on
 the objects defined by the command-group name. Thus ``class`` is a
 command-group name used to access CIM classes and ``get`` is a subcommand so::
 
     $ pywbemcli --output-format mof class get CIM_ManagedElement --namespace interop
 
-Defines a command to get the class `CIM_ManagedElement` from the current
-target server in the namespace `interop` and display it in the
-``mof`` output-format.
+Defines a command sequence to get the class ``CIM_ManagedElement`` from the current
+target server in the namespace ``interop`` and display it in the
+``MOF`` output-format.
 
 .. _`Modes of operation`:
 
@@ -68,12 +72,12 @@ Pywbemcli supports two modes of operation:
 .. _`Interactive mode`:
 
 Interactive mode
-----------------
+^^^^^^^^^^^^^^^^
 
-In interactive mode, an interactive shell environment is brought up that allows
-typing pywbemcli commands, internal commands (for operating the pywbemcli
-shell), and external commands (that are executed in the standard shell for the
-user).
+In interactive mode also known as :term:`REPL` mode, an interactive shell
+environment is within pywbemcli that allows typing pywbemcli commands, internal
+commands (for operating the pywbemcli shell), and external commands (that are
+executed in the standard shell for the user).
 
 This pywbemcli shell is started when the ``pywbemcli`` command is invoked
 without specifying any command-group or command:
@@ -94,7 +98,7 @@ command:
 The pywbemcli shell uses the prompt ``pywbemcli> ``, The cursor is shown in
 the examples above as an underscore ``_``.
 
-General options are specified on the pywbemcli command; they serve
+General options are specified immediately after ``pywbemcli``; they serve
 as the parameters for the connection to a WBEM server and values for the
 pywbemcli commands and arguments that can be typed in the pywbemcli shell.
 
@@ -102,16 +106,19 @@ The pywbemcli commands that can be typed in the pywbemcli shell are the
 command or command-group that would follow the ``pywbemcli`` command and
 general options when used in `command mode`_. The following example
 starts a pywbemcli shell in interactive mode and executes serveral commands
-(ex. `class enumerate -o`).
+(ex. ``class enumerate -o``).
 
 .. code-block:: text
 
     $ pywbemcli -s http://localhost -d root/cimv2 -u username
-    pywbemcli shell uses the >> class enumerate -o
+
+    pywbemcli> class enumerate -o
     . . . <Enumeration of the names of classes in the defined namespace>
-    pywbemcli shell uses the >> class get CIM_System
+
+    pywbemcli> class get CIM_System
     . . . <MOF output of the class CIM_System from the WBEM server>
-    pywbemcli shell uses the >> :q
+
+    pywbemcli> :q
 
 The pywbemcli shell command ``class get CIM_System`` in the example
 above has the same effect as the standalone command:
@@ -135,14 +142,11 @@ information for external and internal commands:
       Internal Commands:
         prefix internal commands with ":"
         :?, :h, :help     displays general help information
-        :exit, :q, :quit  exits the repl
-
-In this help text, "REPL" stands for "Read-Execute-Print-Loop" which is a
-term that denotes the pywbemcli shell interactive mode.
+        :exit, :q, :quit  exits the REPL
 
 In addition to using one of the internal shell commands shown in the help text
-above, you can also exit the pywbemcli shell by typing `Ctrl-D`. Note that the
-pywbemshell exit command may vary by operating system
+above, you can also exit the pywbemcli shell by typing `Ctrl-D`. Note: the
+pywbemshell exit command may vary by operating system.
 
 Typing ``--help`` or ``-h`` in the pywbemcli shell displays general help
 information for the pywbemcli commands, which includes general options and a
@@ -188,8 +192,9 @@ The usage line in this help text shows the standalone command use. Within the
 pywbemcli shell (interactive mode), the ``pywbemcli`` word is omitted and the
 subcommand and options is typed in.
 
-Typing ``COMMAND --help``  or ``COMMAND -h`` in the pywbemcli shell displays
-help information for the specified pywbemcli command, for example:
+Typing ``command-group --help``,  or ``command-group -h``, or ``command-group
+subcommand --help`` in the pywbemcli shell displays help information for the
+specified pywbemcli command-group, for example:
 
 .. code-block:: text
 
@@ -233,28 +238,29 @@ using <up-arrow, down-arrow>.
 .. _`Command mode`:
 
 Command mode
-------------
+^^^^^^^^^^^^
 
-In command mode, the pywbemcli command performs its task and terminates,
+In command mode, the pywbemcli command performs its task and terminates
 like any other standalone non-interactive command.
 
 This mode is used when the pywbemcli command is invoked with a command or
-command group name:
+command-group name:
 
 .. code-block:: text
 
-    $ pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS...] [COMMAND-OPTIONS]
+    $ pywbemcli [GENERAL-OPTIONS] COMMAND|COMMANDGROUP COMMAND] [ARGS...]
 
-Examples:
+The following example defines a WBEM server and then executes ``class enumerate``:
 
 .. code-block:: text
 
-    $ pywbemcli -s http://localhost -d root/cimv2 -u username class get
+    $ pywbemcli --server http://localhost --default-namespace root/cimv2 --user username class enumerate
     Enter password: <password>
     . . .
+    <Returns MOF for classes found with the enumerate>
 
-In command mode, tab completion is also supported for some shells, but must be
-enabled specifically for each shell.
+In command mode, tab completion is also supported for some command shells, but
+must be enabled specifically for each shell.
 
 For example, with a bash shell, enter the following before using pywbemcli to
 enable completion:
@@ -282,13 +288,20 @@ completion:
 Command line general options
 ----------------------------
 
-The general options are entered before the command-group or command. For
-example the following enumerates the qualifier declarations and outputs the
-result as a table:
+The general options are entered before the command-group or command. They
+define:
+
+* Characteristics of the WBEM server against which the commands are to be
+  executed (i.e url, default-namespace, security paraemters, etc.)
+* Display and execution options that apply to multiple commands (i.e. output
+  formats, statistics keeping, etc.).
+
+For example the following enumerates the qualifier declarations and outputs the
+result as a ``simple`` table:
 
 .. code-block:: text
 
-    pywbemcli --output simple qualifier enumerate
+    pywbemcli --output-format simple qualifier enumerate
 
     or
 
@@ -305,7 +318,7 @@ interactive mode and as a table:
 
    $ pywbemcli
 
-   pywbemcli> -o table qualifier enumerate
+   pywbemcli> --output-format table qualifier enumerate
 
     Qualifier Declarations
     +-------------+---------+---------+---------+-----------+-----------------+
@@ -322,634 +335,5 @@ interactive mode and as a table:
    pywbemcli>
 
 **Note:** - With this use of the general options as part of an interactive mode
-command, the options redefinitions are not retained between command executions.
+command, the options redefinitions may not be retained between command executions.
 
-.. _`Pywbemcli command line general options`:
-
-Pywbemcli command line general options
---------------------------------------
-
-The pywbemcli command line options are as follows (See the help in
-pywbemcli and section :ref:`pywbemcli Help Command Details` for more precise
-information on each command group arguments and options):
-
-* ``--server`` Host name or IP address of the WBEMServer to which
-  pywbemcli will connect in the format::
-
-    [{scheme}://]{host}[:{port}]
-
-  Where:
-
-  * Scheme: must be "https" or "http" [Default: "https"].
-  * Host: defines short/fully qualified DNS hostname, literal
-    IPV4 address (dotted), or literal IPV6 address. see :term:`RFC3986` and
-    :term:`RFC6874`
-  * Port: (optional) defines WBEM server port to be used [Defaults: 5988(HTTP)
-    and 5989(HTTPS)]. (EnvVar: PYWBEMCLI_SERVER).
-
-  The server parameter is conditionally optional (see ``--name``). If the
-  ``--name`` option exists and there is a server with the name defined by
-  ``--name`` defined in the :term:`connections file` the parameters of that
-  name are used for the connection.
-
-  In the interactive mode this connection is not actually executed until a
-  COMMAND is entered.
-* ``--name`` - The name of a WBEMServer that is defined in the connection
-  file or to define a name for a connection that will be entered in the connection
-  file if the ``--server`` parameter exists.  The server parameters for this
-  connection will be set in pywbemcli.
-  In the interactive mode this connection is not actually used until
-  a COMMAND is entered.
-
-  A new server (``myserver``)may be defined in the connection file with a
-  name is defined as follows::
-
-    $ pywbemcli -s http://localhost -N myserver -u user -p password connection save
-
-  To use an existing server named ``myserver`` in the defined connections:
-
-    $ pywbemcli --name myserver  class get CIM_ManagedElement
-
-  See :ref:`Connection command group` for more information on managing
-  connections.
-
-* ``--default_namespace`` - Default namespace to use in the target
-   WBEM server if no namespace is defined in a command. If not defined the
-   pywbemcli default is ``root/cimv2``.  This is the namespace used on all
-   requests unless a specific namespace is defined by:
-
-   * In the interactive mode prepending the command group name with the
-     ``--namespace`` option.
-   * Using the ``--namespace`` or ``-n`` command option to define a namespace
-     on commands that specify this option.
-   * Executing a command that looks in multiple namespaces (ex. ``class find``).
-* ``--user`` - Username for the WBEM server if a user name is required to
-  authenticate the client.
-* ``--password`` - Password for the WBEM server. This option is normally
-  required if the ``--pasword`` is used.  If the user does not enter a password
-  when ``--user`` is set, pywbemcli will prompt for the password.
-  See :ref:``Environment variables and avoiding password prompts``
-* ``--noverify`` - If set, client does not verify server certificate. Any
-  certificate returned by the server is accepted.
-* ``--certfile`` Server certificate file. Not used if ``--noverify`` set or
-  the connection does not use SSL (i.e. http)
-* ``--keyfile`` - Client private key file
-* ``--output-format`` Output format choice (Default: mof).
-  Note that the actual output format may differ because some results only allow
-  selected formats. See :ref:`Output formats`.
-* ``--use-pull_ops`` [``yes``|``no``|``either``] - Determines whether the pull operations are
-  used for EnumerateInstances, AssociatorInstances, ReferenceInstances, and
-  ExecQuery operations See :ref:`Pywbemcli and the DMTF pull operations`
-  for more information on pull operations:
-
-  * ``yes`` means that pull requests will be used and if the server does not
-     support pull, the operation will fail.
-  * ``no`` forces pywbemcli to try only the traditional non-pull operations.
-  * ``either`` allows pywbem to try both pull and then traditional operations.
-    The default is ``either``.
-
-* ``--pull-max-cnt``  MaxObjectCount of objects to be returned if
-  pull operations are used. This must be  a positive non-zero integer. Default
-  is 1000. See :ref:`Pywbemcli and the DMTF pull operations` for more
-  information on pull operations.
-
-* ``--log`` - See:ref:`Pywbemcli defined logging`.
-* ``--verbose``  Display extra information about the processing.
-* ``--version`` Show the version of this command and of the pywbem package
-      imported then exit.
-* ``--help`` Show the help which describes the command line options and exit.
-
-
-.. _`Environment variables and avoiding password prompts`:
-
-Environment variables and avoiding password prompts
----------------------------------------------------
-
-Pywbemcli has environment variable options corresponding to the
-command line general options as follows:
-
-==============================  ============================
-Export Name                     Corresponding general option
-==============================  ============================
-PYWBEMCLI_SERVER                ``--server``
-PYWBEMCLI_NAME                  ``--name``
-PYWBEMCLI_USER                  ``--user``
-PYWBEMCLI_PASSWORD              ``--password``
-PYWBEMCLI_DEFAULT_NAMESPACE     ``--namespace``
-PYWBEMCLI_TIMEOUT               ``--timeout``
-PYWBEMCLI_KEYFILE               ``--keyfile``
-PYWBEMCLI_CERTFILE              ``--cerrtfile``
-PYWBEWCLI_CACERTS               ``--cacerts``
-PYWBEMCLI_USE_PULL              ``--use_pull_ops``
-PYWBEMCLI_PULL_MAX_CNT          ``--max_object_cnt``
-PYWBEMCLI_STATS_ENABLED         ``--stats_enabled``
-PYWBEMCLI_MOCK_SERVER           ``--mock_server``
-PYWBEMCLI_LOG                   ``--log``
-==============================  ============================
-
-If these environment variables are set, the corresponding general options on the
-command line are not required and the value of the environment variable is
-used.
-
-Thus, in the following example, the second line accesses the server
-``http://localhost``:
-
-.. code-block:: text
-
-      $ export PYWBEMCLI_SERVER=http://localhost
-      $ pywbemcli class get CIM_ManagedElement
-
-If the WBEM operations performed by a particular pywbemcli command require a
-password, the password is prompted for if the ``--user`` option is set (in both
-modes of operation) and the ``--pasword`` option is not set:
-
-.. code-block:: text
-
-      $ pywbemcli -s http://localhost -d root/cimv2 -u user class get
-      Enter password: <password>
-      . . . <The display output from get class>
-
-If both the ``--user`` and ``--password`` options are set, the command is executed
-without a password prompt:
-
-.. code-block:: text
-
-      $ pywbemcli -s http://localhost -d root/cimv2 -u user -p blah class get
-      . . . <The display output from get class>
-
-If the operations performed by a particular pywbemcli command do not
-require a password or no user is supplied, no password is prompted for example:
-
-.. code-block:: text
-
-      $ pywbemcli --help
-      . . . <help output>
-
-For script integration, it is important to have a way to avoid the interactive
-password prompt. This can be done by storing the password string in an
-environment variable or specifying it on the command line.
-
-The ``pywbemcli`` command supports a ``connection export`` (sub-)command that
-outputs the (bash/windows) shell commands to set all needed environment variables:
-
-.. code-block:: text
-
-      $ pywbemcli -s http://localhost -d root/cimv2 -u fred connection export
-      export PYWBEMCLI_SERVER=http://localhost
-      export PYWBEMCLI_NAMESPACE=root/cimv2
-      ...
-
-This ability can be used to set those environment variables and thus to persist
-the connection name in the shell environment, from where it will be used in
-any subsequent pywbemcli commands:
-
-.. code-block:: text
-
-      $ eval $(pywbemcli -s http://localhost -u username -d root/cimv2)
-
-      $ env |grep PYWBEMCLI
-      export PYWBEMCLI_SERVER=http://localhost
-      export PYWBEMCLI_NAMESPACE=root/cimv2
-
-      $ pywbemcli server namespaces
-      . . . <list of namespaces for the defined server>
-
-
-.. _`CLI commands`:
-
-CLI commands
-------------
-
-For a description of the commands supported by pywbemcli, see section
-:ref:`Pywbemcli command groups, comands and subcommands` and
-section:ref:`pywbemcli Help Command Details`. For example:
-
-.. code-block:: text
-
-    $ pywbemcli --help
-    . . . <general help, listing the general options and possible commands>
-
-    $ pywbemcli class --help
-    . . . <help for cpc command, listing its subcommands, arguments and
-          command-specific options>
-
-Note that the help text for any pywbemcl command group (such as ``class``) will
-not show the general options again.
-
-The general options (listed by ``pywbemcli --help``) can still be specified
-together with (sub-)commands even though they are not listed in their help
-text, but they must be specified before the (sub-)command, and any
-command-specific options (listed by ``pywbemcli COMMAND --help``) must be
-specified after the (sub-)command, like shown here:
-
-.. code-block:: text
-
-      $ pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS...] [COMMAND-OPTIONS]
-
-For example:
-
-.. code-block:: text
-
-    $ pywbemcli -s http:/<wbemserver> --outformat xml class enumerate
-
-    ... Displays the xml formatted output of the classes returned by
-        the enumerate class subcommand
-
-
-.. _`Pywbemcli and the DMTF pull operations`:
-
-Pywbemcli and the DMTF pull operations
---------------------------------------
-
-For DMTF CIM/XML operations that can return many objects the DMTF CIM/XML protocol
-allows two variations on the enumerate operations (enumerate and an operation
-sequence of OpenEnumerateInstances/PullInstances).
-
-While the pull operation may not be supported by all WBEM servers  they can be
-significantly more efficient when they are available.  Pywbem implements the
-client side of these operation and pywbemcli provides for the use of these
-operations through two general options:
-
-* ``--use-pull-operations`` - This option allows the user to select from the
-    the following alternatives:
-
-    * `either` - pywbemcli first tries the pull operation and if that fails
-      retries the operation with the corresponding non-pull operation. The
-      result of this first operation determines whether pull or the traditional
-      operation are used for any further requests during the current
-      pywbem interactive session. `either` is the default.
-
-    * ``yes`` - Forces the use of the pull operations and if those operations fail
-      generates an error.
-
-    * ``no`` - Forces the use of the non-pull operation.
-
-* ``--pull-max-cnt`` - Sets the maximum count of objects the server is allowed
-  to return for each open/pull operation. max_pull_cnt of 1000 objects is the
-  default size which from experience is a logical choice.
-
-  The one issue with using the the ``either`` choice is that there are limitations
-  with the original operations that do not exist with the pull operations:
-
-  * The original operations did not support the filtering of responses  with a
-    query language query (--FilterQueryLanguage and --FilterQuery) option which
-    passes a filter query to the WBEM server so that it filters the responses
-    before they are returned. This can greatly reduce the size of the responses
-    if effectively used but is used only when the pull operations are available
-    on the server and used with pywbemcli.
-
-
-.. _`Output formats`:
-
-Output formats
---------------
-
-Pywbemcli supports various output formats for the results. The output format
-can be selected with the ``-o`` or ``--output-format`` option.
-
-Generally the formats fall into three groups however, not all formats are
-applicable sto all subcommands:
-
-* **Table output formats** - There are a variety of table formats:ref:`Table formats`.
-* **CIM model formats** - These formats provide display of returned CIM objects in
-  formats that are specific to the CIM Model (ex. MOF, XML, etc.).
-  see:ref:`CIM object formats`.
-* **ASCII tree format** - This format option provides a tree display of outputs that
-  are logical to display as a tree.  Thus, the command `pywbemcli class tree . . .`
-  which shows the hiearchy of the cim classes defined by a WBEM server uses the
-  tree output format. See:ref:`ASCII tree format`.
-
-
-.. _`Table formats`:
-
-Table formats
-^^^^^^^^^^^^^
-
-There different variations of the table format primarily define different
-formatting of the borders for tables. The following are examples of the
-table formats with a single command ``class find CIM_Foo``:
-
-* ``-o table``: Tables with a single-line border. This is the default:
-
-  .. code-block:: text
-
-    Find class CIM_Foo
-    +-------------+-----------------+
-    | Namespace   | Classname       |
-    |-------------+-----------------|
-    | root/cimv2  | CIM_Foo         |
-    | root/cimv2  | CIM_Foo_sub     |
-    | root/cimv2  | CIM_Foo_sub2    |
-    | root/cimv2  | CIM_Foo_sub_sub |
-    +-------------+-----------------+
-
-
-* ``-o simple``: Tables with a line between header row and data rows, but
-  otherwise without borders:
-
-  .. code-block:: text
-
-    Instances: CIM_Foo
-    InstanceID    IntegerProp
-    ------------  -------------
-    "CIM_Foo1"    1
-    "CIM_Foo2"    2
-    "CIM_Foo3"
-
-* ``-o plain``: Tables without borders:
-
-  .. code-block:: text
-
-    Instances: CIM_Foo
-    InstanceID    IntegerProp
-    "CIM_Foo1"    1
-    "CIM_Foo2"    2
-    "CIM_Foo3"
-
-* ``-o grid``: Tables without borders:
-
-  .. code-block:: text
-
-    Instances: CIM_Foo
-    +--------------+---------------+
-    | InstanceID   |   IntegerProp |
-    +==============+===============+
-    | "CIM_Foo1"   |             1 |
-    +--------------+---------------+
-
-
-* ``-o rst``: Simple tables in `reStructuredText`_ markup:
-
-  .. code-block:: text
-
-    Instances: CIM_Foo
-    ============  =============
-    InstanceID    IntegerProp
-    ============  =============
-    "CIM_Foo1"    1
-    "CIM_Foo2"    2
-    "CIM_Foo3"
-    ============  =============
-
-
-.. _`reStructuredText`: http://docutils.sourceforge.net/docs/user/rst/quickref.html#tables
-.. _`Mediawiki`: http://www.mediawiki.org/wiki/Help:Tables
-.. _`HTML`: https://www.w3.org/TR/html401/struct/tables.html
-.. _`LaTeX`: https://en.wikibooks.org/wiki/LaTeX/Tables
-.. _`JSON`: http://json.org/example.html
-
-
-.. _`CIM object formats`:
-
-CIM object formats
-^^^^^^^^^^^^^^^^^^
-
-* ``-o mof``: Format for CIM classes, CIM instances, and CIM Parameters:
-
-MOF is the format used to define the models released by the DMTF and SNIA. It
-textually defines the components and structure and data of these elements:
-
-  .. code-block:: text
-
-    instance of CIM_Foo {
-       InstanceID = "CIM_Foo1";
-       IntegerProp = 1;
-    };
-
-* ``-o xml``: Alternate format for CIM classes and instances defined by DMTF.
-
-This is the format used in the DMTF CIM/XML protocol:
-
-  .. code-block:: text
-
-    <VALUE.OBJECTWITHLOCALPATH>
-        <LOCALINSTANCEPATH>
-            <LOCALNAMESPACEPATH>
-                <NAMESPACE NAME="root"/>
-                <NAMESPACE NAME="cimv2"/>
-            </LOCALNAMESPACEPATH>
-            <INSTANCENAME CLASSNAME="CIM_Foo">
-                <KEYBINDING NAME="InstanceID">
-                    <KEYVALUE VALUETYPE="string">CIM_Foo1</KEYVALUE>
-                </KEYBINDING>
-            </INSTANCENAME>
-        </LOCALINSTANCEPATH>
-        <INSTANCE CLASSNAME="CIM_Foo">
-            <PROPERTY NAME="InstanceID" PROPAGATED="false" TYPE="string">
-                <VALUE>CIM_Foo1</VALUE>
-            </PROPERTY>
-            <PROPERTY NAME="IntegerProp" PROPAGATED="false" TYPE="uint32">
-                <VALUE>1</VALUE>
-            </PROPERTY>
-        </INSTANCE>
-    </VALUE.OBJECTWITHLOCALPATH>
-
-* ``-o repr``: Python repr format of the objects.
-
-This is the structure and data of the pywbem Python objects representing these
-CIM objects and can be useful in understanding the pywbem interpetation of the
-CIM objects:
-
-  .. code-block:: text
-
-    CIMInstance(classname='CIM_Foo', path=CIMInstanceName(classname='CIM_Foo',
-        keybindings=NocaseDict({'InstanceID': 'CIM_Foo1'}), namespace='root/cimv2',
-        host=None),
-        properties=NocaseDict({
-          'InstanceID': CIMProperty(name='InstanceID',
-            value='CIM_Foo1', type='string', reference_class=None, embedded_object=None,
-            is_array=False, array_size=None, class_origin=None, propagated=False,
-            qualifiers=NocaseDict({})),
-          'IntegerProp': CIMProperty(name='IntegerProp', value=1, type='uint32',
-              reference_class=None, embedded_object=None, is_array=False,
-              array_size=None, class_origin=None, propagated=False,
-              qualifiers=NocaseDict({}))}), property_list=None,
-              qualifiers=NocaseDict({}))
-
-NOTE: The above is output as a single line and has been manually formatted for
-this documentation.
-
-.. _`ASCII tree format`:
-
-ASCII tree format
-^^^^^^^^^^^^^^^^^
-This output format it an ASCII based output that shows the tree structure of
-the results of certain subcommands.  It is used specifically to show the
-class class hiearchy tree as follows:
-
-.. code-block:: text
-
-  $pywbemcli -m tests/unit/simple_mock_model.mof class tree
-
-  root
-  +-- CIM_Foo
-      +-- CIM_Foo_sub
-      |   +-- CIM_Foo_sub_sub
-      +-- CIM_Foo_sub2
-
-This shows a very simple mock repository with 4 classes where CIM_Foo is the
-top level in the hiearchy, CIM_Foo_sub and CIM_Foo_sub2 are its subclasses, and
-CIM_Foo_sub_sub is the subclass of CIM_Foo_sub
-
-
-.. _`Pywbemcli defined logging`:
-
-Pywbemcli defined logging
--------------------------
-
-Pywbemccli provides for logging to either a file or the standard error stream
-of information passing between the pywbemcli client and a WBEM server using the
-standard Python logging facility.
-
-Logging is configured and enabled using the ``--log`` general option on the
-commmand line or the `PYWBEMCLI_LOG` environment variable.
-
-Pywbemcli can log  operation calls that send
-requests to a WBEM server and their responses or the HTTP messages between
-the pywbemcli client and the WBEM server including both the pywbem APIs
-and their responses and the HTTP requests and responses.
-
-The default is no logging if the ``--log`` option is not specified with a
-configuration string.
-
-The general format of the ``--log`` option is a string with up to 3 fields
-(COMPONENT, DESTINATION, DETAIL):
-
-.. code-block:: text
-
-    LOG_CONFIG_STRING := CONFIG[,CONFIG]
-    CONFIG            := COMPONENT"="[DESTINATION[":"DETAIL]
-    COMPONENT         := ('all' / 'api' / 'http')
-    DESTINATION       := ('stderr' / 'file')
-    DETAIL            := ('all'/ 'path'/ 'summary')
-
-For example the following log configuration string logs only the pywbem api
-calls and responses summary information to a file and the http requests and
-responses to stderr:
-
-.. code-block:: text
-
-      $ pywbemcli --log api=file:summary,http=stderr
-
-The COMPONENT field defines the component for which logging is enabled:
-
-  * `api` - Logs the calls to the pywbem methods that make requests to a
-    WBEM server. This logs both the requests and response including any
-    exceptions generated by error responses from the WBEM server.
-  * `http` - Logs the headers and data for HTTP requests and responses to the
-     WBEM server.
-  * `all` - (Default) Logs both the `api` and `http` components.
-
-The DESTINATION field specified the log destination:
-
-  * `stderr` - Log to stderr
-  * 'file' - (default) Log to the predefined pywbemcli file. The pywbemcli
-    log file is `pywbemcli.log` in the current directory.
-
-The DETAIL component of the log configuration string defines the level of
-logging information for the api and http components.  Because enormous quantities
-of information can be generated this option exists to limit the amount of
-information generated. The possible keywords are:
-
-  * `all` - (Default) Logs the full request including all input parameters and
-    the complete response including all data. Exceptions are fully logged.
-
-  * `paths` - Logs the full request but only the path component of the
-    `api` responses. This reduces the data included in the responses.
-    Exceptions are fully logged.
-
-  * `summary` - Logs the requests but only the count of objects received
-    in the response.  Exceptions are fully logged.
-
-The log output is routed to the output defined by DESTINATION and includes the
-information determined by the COMPONENT and DETAIL fields.
-
-For example, logging only of the summary  api information would look something
-like gisthe following:
-
-.. code-block:: text
-
-    $ pywbemcli -s http://localhost -u blah -p pw -l api=file:summary class enumerate -o
-
-produces log output for the class enumerate operation in the log file
-pywbemcli.log as follows showing the input parameters to the pywbem method
-EnumerateClassName and the number of objects in the response:
-
-.. code-block:: text
-
-    2019-07-09 18:27:22,103-pywbem.api.1-27716-Request:1-27716 EnumerateClassNames(ClassName=None, DeepInheritance=False, namespace=None)
-    2019-07-09 18:27:22,142-pywbem.api.1-27716-Return:1-27716 EnumerateClassNames(list of str; count=103)
-
-The format is::
-
-    <Date time>-<Component>.<ref:`connection id`>-<Direction>:<connection id> <PywbemOperation>(<data>)
-
-
-.. _`Pywbemcli connections file`:
-
-Pywbemcli connections file
---------------------------
-
-Pywbemcli provides the capability to persistent the definition of parameters
-for connecting to WBEM servers identified by name using the ``connection``
-COMMAND (see:ref:`pywbemcli connection --help`). Once defined, these named
-connections are saved in a a JSON formatted file named
-``pywbemcliservers.json`` in the current directory from which pywbemcli was
-executed.
-
-To create a new persistent connection, the pywbemcli should be executed with
-the server option, the name option and any other general parameters desired for
-the connection in the interactive mode.  Then executing the ``connection save``
-COMMAND will save the new connection in the connections file. For example:
-
-.. code-block:: text
-
-    $ pywbemcli -s "//localhost -u me -p blah -N testconn
-    pywbemcli> connection list
-    Name: testconn
-      WBEMServer uri: http://localhost
-      Default_namespace: root/cimv2
-      User: me
-      Password: blah
-      Timeout: 30
-      Noverify: False
-      Certfile: None
-      Keyfile: None
-      use-pull-ops: either
-      pull-max-cnt: 1000
-      mock:
-      log: None
-
-    pywbemcli> connection save
-    pywbemcli> connection list
-
-    name       server uri        namespace    user         password      timeout  noverify    certfile    keyfile    log
-    ---------  ----------------  -----------  -----------  ----------  ---------  ----------  ----------  ---------  -----
-    testconn*  http://localhost  root/blah    me           blah               30  False
-
-Note: The * indicates that this is the current connection.
-
-Other connections can be added from either the command mode or interactive mode.
-
-    pywbemcli> connection add Ronald http://blah2 -u you -p xxx
-    pywbemcli> connection list
-    WBEMServer Connections:
-    name      server uri        namespace    user         password      timeout  noverify    certfile    keyfile    log
-    --------  ----------------  -----------  -----------  ----------  ---------  ----------  ----------  ---------  -----
-    Ronald    http://blah2      root/cimv2   you          xxx                    False
-    testconn  http://localhost  root/blah    kschopmeyer  test8play          30  False
-
-Connections can be deleted with the ``connection delete`` command either with
-the command argument containing the connection name or with no name provided so
-pywbemcli presents a list of connections::
-
-    $ pywbemcli connection delete Ronald
-
-or::
-
-    $ pywbemcli connection delete
-    Select a connection or CTRL_C to abort.
-    0: Ronald
-    1: testconn
-    Input integer between 0 and 1 or Ctrl-C to exit selection: 0
-    $

--- a/docs/pywbemcligeneraloptions.rst
+++ b/docs/pywbemcligeneraloptions.rst
@@ -1,0 +1,660 @@
+.. _`Pywbemcli command line general options`:
+
+Pywbemcli command line general options
+======================================
+
+The pywbemcli command line options are as follows (See the help in
+pywbemcli and section :ref:`pywbemcli Help Command Details` for more precise
+information on each command-group arguments and options):
+
+* **--server/-s** - Host name or IP address of the WBEMServer to which
+  pywbemcli will connect in the format::
+
+    [{scheme}://]{host}[:{port}]
+
+  Where:
+
+  * Scheme: must be "https" or "http" [Default: "https"].
+  * Host: defines short/fully qualified DNS hostname, literal
+    IPV4 address (dotted), or literal IPV6 address. see :term:`RFC3986` and
+    :term:`RFC6874`
+  * Port: (optional) defines WBEM server port to be used [Defaults: 5988(HTTP)
+    and 5989(HTTPS)]. (EnvVar: PYWBEMCLI_SERVER).
+
+  The server parameter is conditionally optional (see ``--name`` options). If the
+  ``--name`` option exists and there is a server with the name defined by
+  ``--name`` defined in the :term:`connections file` the parameters of that
+  name are used for the connection.
+
+  In the interactive mode this connection is not actually executed until a
+  command or subcommand requiring access to the WBEM server is entered.
+* **--name/-n** - The name of a WBEMServer that is defined in the :term:``connection
+  file`` or, if the ``--server`` parameter exists, to define a name for a
+  connection that will be entered in the connection file.  The server
+  parameters for this connection will be set in pywbemcli.
+  In the interactive mode a connection is not actually used until
+  a command requiring access to the WBEM server is entered.
+
+  A new server (``myserver``)may be defined and saved in the connection file with a
+  name is defined as follows::
+
+    $ pywbemcli -s http://localhost --name myserver --user user --password password connection save
+
+  To use an existing server named ``myserver`` in the defined connections:
+
+    $ pywbemcli --name myserver class get CIM_ManagedElement
+
+  See :ref:`Connection command-group` for more information on managing
+  connections.
+
+* **--default_namespace/-d** - Default :term:`CIM namespace` to use in the target
+   WBEM server if no namespace is defined in a command. If not defined the
+   pywbemcli default is ``root/cimv2``.  This is the namespace used on all
+   server operation requests unless a specific namespace is defined by:
+
+   * In the interactive mode prepending the command-group name with the
+     ``--namespace`` option.
+   * Using the ``--namespace`` or ``-n`` command option to define a namespace
+     on subcommands that specify this option.
+   * Executing a command that looks in multiple namespaces (ex. ``class find``).
+* **--user/-u** - Username for the WBEM server if a user name is required to
+  authenticate the client.
+* **--password/-p** - Password for the WBEM server. This option is normally
+  required if the ``--user`` option is defined.  If the user does not enter a
+  password when ``--user`` - is set, pywbemcli will prompt for the password.
+  See :ref:``Avoiding password prompts``
+* **--noverify/-n** - If set, client does not verify server certificate. Any
+  certificate returned by the server is accepted.
+* **--certfile** - Server certificate file. Not used if ``--noverify`` set or
+  the connection does not use SSL (i.e. ``--server http://blah``)
+* **--keyfile** - Client private key file for the server to use to authenticate
+  the client if that is required by the WBEM server.
+* **--output-format/-o** - Output format choice (Default: mof).
+  Note that the actual output format may differ from this value because some
+  subcommands only allow selected formats. See :ref:`Output formats`.
+* **--use-pull_ops** [``yes``|``no``|``either``] - Determines whether the pull
+  operations are used for ``EnumerateInstances``, ``AssociatorInstances``,
+  ``ReferenceInstances``, and ``ExecQuery`` operations See :ref:`Pywbemcli and
+  the DMTF pull operations` for more information on pull operations:
+
+  * ``yes`` -  pull requests will be used and if the server does not
+     support pull, the operation will fail.
+  * ``no`` - forces pywbemcli to try only the traditional non-pull operations.
+  * ``either`` - (default )allows pywbem to try both pull and then traditional
+      operations.
+
+* **--pull-max-cnt** -  MaxObjectCount of objects to be returned for each pull
+  operation if pull operations are used. This must be  a positive non-zero
+  integer. Default is 1000. See :ref:`Pywbemcli and the DMTF pull operations`
+  for more information on pull operations.
+
+* **--mock-server** - Defines one or more files that define a mock server that
+  can be used to execute pywbemcli commands without access to a real server.
+  See chapter :ref:`Mock WBEM server support` for information on defining
+  mock servers.
+* **--log/-l** - See:ref:`Pywbemcli defined logging`. see
+  :ref:`Pywbemcli defined logging`
+* **--verbose/-v** -  Display extra information about the processing.
+* **--version** - Show the version of this command and of the pywbem package
+      imported then exit.
+* **--help/-h** - Show the help which describes the command line options and
+      exit.
+
+
+.. _`Environment variables for general options`:`:
+
+Environment variables for general options
+-----------------------------------------
+
+Pywbemcli has environment variable options corresponding to the
+command line general options as follows:
+
+==============================  ============================
+Export Name                     Corresponding general option
+==============================  ============================
+PYWBEMCLI_SERVER                ``--server``
+PYWBEMCLI_NAME                  ``--name``
+PYWBEMCLI_USER                  ``--user``
+PYWBEMCLI_PASSWORD              ``--password``
+PYWBEMCLI_OUTPUT_FORMAT         ``--output-format``
+PYWBEMCLI_DEFAULT_NAMESPACE     ``--namespace``
+PYWBEMCLI_TIMEOUT               ``--timeout``
+PYWBEMCLI_KEYFILE               ``--keyfile``
+PYWBEMCLI_CERTFILE              ``--certfile``
+PYWBEWCLI_CACERTS               ``--ca_certs``
+PYWBEMCLI_USE_PULL              ``--use_pull_ops``
+PYWBEMCLI_PULL_MAX_CNT          ``--pull-max-cnt``
+PYWBEMCLI_STATS_ENABLED         ``--timestats``
+PYWBEMCLI_MOCK_SERVER           ``--mock-server``
+PYWBEMCLI_LOG                   ``--log``
+==============================  ============================
+
+If these environment variables are set, the corresponding general options on the
+command line are not required and the value of the environment variable is
+used. Environment variable options are not provided for command/subcommand
+options or arguments.
+
+In the following example, the second line accesses the server
+``http://localhost`` defined by the export command:
+
+.. code-block:: text
+
+      $ export PYWBEMCLI_SERVER=http://localhost
+      $ pywbemcli class get CIM_ManagedElement
+
+
+.. _`Avoiding password prompts`:
+
+Avoiding password prompts
+-------------------------
+
+If the WBEM operations performed by a particular pywbemcli command require a
+password, the password is prompted for if the ``--user`` option is set (in both
+modes of operation) and the ``--pasword`` option is not set:
+
+.. code-block:: text
+
+      $ pywbemcli -s http://localhost -d root/cimv2 -u user class get
+      Enter password: <password>
+      . . . <The display output from get class>
+
+If both the ``--user`` and ``--password`` options are set, the command is executed
+without a password prompt:
+
+.. code-block:: text
+
+      $ pywbemcli -s http://localhost -d root/cimv2 -u user -p blah class get
+      . . . <The display output from get class>
+
+If the operations performed by a particular pywbemcli command do not
+require a password or no user is supplied, no password is prompted for example:
+
+.. code-block:: text
+
+      $ pywbemcli --help
+      . . . <help output>
+
+For script integration, it is important to have a way to avoid the interactive
+password prompt. This can be done by storing the password string in an
+environment variable or specifying it on the command line.
+
+The ``pywbemcli`` command supports a ``connection export`` (sub-)command that
+outputs the (bash/windows) shell commands to set all needed environment variables:
+
+.. code-block:: text
+
+      $ pywbemcli -s http://localhost -d root/cimv2 -u fred connection export
+      export PYWBEMCLI_SERVER=http://localhost
+      export PYWBEMCLI_NAMESPACE=root/cimv2
+      ...
+
+This ability can be used to set those environment variables and thus to persist
+the connection name in the shell environment, from where it will be used in
+any subsequent pywbemcli commands:
+
+.. code-block:: text
+
+      $ eval $(pywbemcli -s http://localhost -u username -d root/cimv2)
+
+      $ env |grep PYWBEMCLI
+      export PYWBEMCLI_SERVER=http://localhost
+      export PYWBEMCLI_NAMESPACE=root/cimv2
+
+      $ pywbemcli server namespaces
+      . . . <list of namespaces for the defined server>
+
+
+.. _`CLI commands`:
+
+CLI commands
+------------
+
+For a description of the commands and command-groups supported by pywbemcli,
+see section :ref:`Pywbemcli command groups, commands, and subcommands` and
+section:ref:`pywbemcli Help Command Details`. For example:
+
+.. code-block:: text
+
+    $ pywbemcli --help
+    . . . <general help, listing the general options and possible commands>
+
+    $ pywbemcli class --help
+    . . . <help for cpc command, listing its subcommands, arguments and
+          command-specific options>
+
+Note that the help text for any pywbemcli command-group (such as ``class``) will
+not show the general options again.
+
+The general options (listed by ``pywbemcli --help``) can still be specified
+together with (sub-)commands even though they are not listed in their help
+text, but they must be specified before the (sub-)command, and any
+command-specific options (listed by ``pywbemcli COMMAND --help``) must be
+specified after the (sub-)command, as shown here:
+
+.. code-block:: text
+
+      $ pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS...] [COMMAND-OPTIONS]
+
+For example:
+
+.. code-block:: text
+
+    $ pywbemcli -s http:/<wbemserver> --outformat xml class enumerate
+
+    ... Displays the xml formatted output of the classes returned by
+        the enumerate class subcommand
+
+
+.. _`Pywbemcli and the DMTF pull operations`:
+
+Pywbemcli and the DMTF pull operations
+--------------------------------------
+
+For DMTF CIM/XML operations that can return many objects the DMTF CIM/XML protocol
+allows two variations on the enumerate operations (enumerate and an operation
+sequence of OpenEnumerateInstances/PullInstances).
+
+While the pull operation may not be supported by all WBEM servers  they can be
+significantly more efficient when they are available.  Pywbem implements the
+client side of these operation and pywbemcli provides for the use of these
+operations through two general options:
+
+* ``--use-pull-operations`` - This option allows the user to select from the
+    the following alternatives:
+
+    * `either` - pywbemcli first tries the pull operation and if that fails
+      retries the operation with the corresponding non-pull operation. The
+      result of this first operation determines whether pull or the traditional
+      operation are used for any further requests during the current
+      pywbem interactive session. `either` is the default.
+
+    * ``yes`` - Forces the use of the pull operations and if those operations fail
+      generates an error.
+
+    * ``no`` - Forces the use of the non-pull operation.
+
+* ``--pull-max-cnt`` - Sets the maximum count of objects the server is allowed
+  to return for each open/pull operation. max_pull_cnt of 1000 objects is the
+  default size which from experience is a logical choice.
+
+  The one issue with using the the ``either`` choice is that there are limitations
+  with the original operations that do not exist with the pull operations:
+
+  * The original operations did not support the filtering of responses  with a
+    query language query (--FilterQueryLanguage and --FilterQuery) option which
+    passes a filter query to the WBEM server so that it filters the responses
+    before they are returned. This can greatly reduce the size of the responses
+    if effectively used but is used only when the pull operations are available
+    on the server and used with pywbemcli.
+
+  * The pull operations do not support some of the options that traditional
+    operations did including:
+
+    * IncludeQualifiers - Since even the traditional operations specification
+      deprecated this option and the user cannot depend on it being honored,
+      the most logical solution is to never use this option.
+
+    * LocalOnly - Since even the traditional operations specification deprecated
+      this options and the user cannot depend on it being honored by the
+      WBEM server the most logical soltuion is to never use this option
+
+
+.. _`Output formats`:
+
+Output formats
+--------------
+
+Pywbemcli supports various output formats for the results. The output format
+can be selected with the ``-o``\``--output-format`` option.
+
+The output formats fall into three groups however, not all formats are
+applicable to all subcommands:
+
+* **Table output formats** - There are a variety of table formats:ref:`Table formats`.
+* **CIM model formats** - These formats provide display of returned CIM objects in
+  formats that are specific to the CIM Model (ex. MOF, XML, etc.).
+  see:ref:`CIM object formats`.
+* **ASCII tree format** - This format option provides a tree display of outputs that
+  are logical to display as a tree.  Thus, the command ``pywbemcli class tree . . .``
+  which shows the hierarchy of the CIM classes defined by a WBEM server uses the
+  tree output format. See:ref:`ASCII tree format`.
+
+
+.. _`Table formats`:
+
+Table formats
+^^^^^^^^^^^^^
+
+The different variations of the table format define different
+formatting of the borders for tables or different ouput formats such as html.
+The following are examples of the table formats with a single command ``class
+find CIM_Foo``:
+
+* ``-o table``: Tables with a single-line border. This is the default:
+
+  .. code-block:: text
+
+    Find class CIM_Foo
+    +-------------+-----------------+
+    | Namespace   | Classname       |
+    |-------------+-----------------|
+    | root/cimv2  | CIM_Foo         |
+    | root/cimv2  | CIM_Foo_sub     |
+    | root/cimv2  | CIM_Foo_sub2    |
+    | root/cimv2  | CIM_Foo_sub_sub |
+    +-------------+-----------------+
+
+
+* ``-o simple``: Tables with a line between header row and data rows, but
+  otherwise without borders:
+
+  .. code-block:: text
+
+    Instances: CIM_Foo
+    InstanceID    IntegerProp
+    ------------  -------------
+    "CIM_Foo1"    1
+    "CIM_Foo2"    2
+    "CIM_Foo3"
+
+* ``-o plain``: Tables without borders:
+
+  .. code-block:: text
+
+    Instances: CIM_Foo
+    InstanceID    IntegerProp
+    "CIM_Foo1"    1
+    "CIM_Foo2"    2
+    "CIM_Foo3"
+
+* ``-o grid``: Tables without borders:
+
+  .. code-block:: text
+
+    Instances: CIM_Foo
+    +--------------+---------------+
+    | InstanceID   |   IntegerProp |
+    +==============+===============+
+    | "CIM_Foo1"   |             1 |
+    +--------------+---------------+
+
+
+* ``-o rst``: Tables in `reStructuredText`_ markup:
+
+  .. code-block:: text
+
+    Instances: CIM_Foo
+    ============  =============
+    InstanceID    IntegerProp
+    ============  =============
+    "CIM_Foo1"    1
+    "CIM_Foo2"    2
+    "CIM_Foo3"
+    ============  =============
+
+
+.. _`reStructuredText`: http://docutils.sourceforge.net/docs/user/rst/quickref.html#tables
+.. _`Mediawiki`: http://www.mediawiki.org/wiki/Help:Tables
+.. _`HTML`: https://www.w3.org/TR/html401/struct/tables.html
+.. _`LaTeX`: https://en.wikibooks.org/wiki/LaTeX/Tables
+.. _`JSON`: http://json.org/example.html
+
+
+.. _`CIM object formats`:
+
+CIM object formats
+^^^^^^^^^^^^^^^^^^
+
+The ouput of CIM objects allows multiple formats as follows:
+
+* ``-o mof``: Format for CIM classes, CIM instances, and CIM Parameters:
+
+MOF is the format used to define the models released by the DMTF and SNIA. It
+textually defines the components and structure and data of these elements:
+
+  .. code-block:: text
+
+    instance of CIM_Foo {
+       InstanceID = "CIM_Foo1";
+       IntegerProp = 1;
+    };
+
+* ``-o xml``: Alternate format for CIM classes and instances defined by DMTF.
+
+This is the format used in the DMTF CIM/XML protocol:
+
+  .. code-block:: text
+
+    <VALUE.OBJECTWITHLOCALPATH>
+        <LOCALINSTANCEPATH>
+            <LOCALNAMESPACEPATH>
+                <NAMESPACE NAME="root"/>
+                <NAMESPACE NAME="cimv2"/>
+            </LOCALNAMESPACEPATH>
+            <INSTANCENAME CLASSNAME="CIM_Foo">
+                <KEYBINDING NAME="InstanceID">
+                    <KEYVALUE VALUETYPE="string">CIM_Foo1</KEYVALUE>
+                </KEYBINDING>
+            </INSTANCENAME>
+        </LOCALINSTANCEPATH>
+        <INSTANCE CLASSNAME="CIM_Foo">
+            <PROPERTY NAME="InstanceID" PROPAGATED="false" TYPE="string">
+                <VALUE>CIM_Foo1</VALUE>
+            </PROPERTY>
+            <PROPERTY NAME="IntegerProp" PROPAGATED="false" TYPE="uint32">
+                <VALUE>1</VALUE>
+            </PROPERTY>
+        </INSTANCE>
+    </VALUE.OBJECTWITHLOCALPATH>
+
+* ``-o repr``: Python repr format of the objects.
+
+This is the structure and data of the pywbem Python objects representing these
+CIM objects and can be useful in understanding the pywbem interpretation of the
+CIM objects:
+
+  .. code-block:: text
+
+    CIMInstance(classname='CIM_Foo', path=CIMInstanceName(classname='CIM_Foo',
+        keybindings=NocaseDict({'InstanceID': 'CIM_Foo1'}), namespace='root/cimv2',
+        host=None),
+        properties=NocaseDict({
+          'InstanceID': CIMProperty(name='InstanceID',
+            value='CIM_Foo1', type='string', reference_class=None, embedded_object=None,
+            is_array=False, array_size=None, class_origin=None, propagated=False,
+            qualifiers=NocaseDict({})),
+          'IntegerProp': CIMProperty(name='IntegerProp', value=1, type='uint32',
+              reference_class=None, embedded_object=None, is_array=False,
+              array_size=None, class_origin=None, propagated=False,
+              qualifiers=NocaseDict({}))}), property_list=None,
+              qualifiers=NocaseDict({}))
+
+NOTE: The above is output as a single line and has been manually formatted for
+this documentation.
+
+.. _`ASCII tree format`:
+
+ASCII tree format
+^^^^^^^^^^^^^^^^^
+This output format it an ASCII based output that shows the tree structure of
+the results of certain subcommands.  It is used specifically to show the
+class class hiearchy tree as follows:
+
+.. code-block:: text
+
+  $pywbemcli -m tests/unit/simple_mock_model.mof class tree
+
+  root
+  +-- CIM_Foo
+      +-- CIM_Foo_sub
+      |   +-- CIM_Foo_sub_sub
+      +-- CIM_Foo_sub2
+
+This shows a very simple mock repository with 4 classes where CIM_Foo is the
+top level in the hierarchy, CIM_Foo_sub and CIM_Foo_sub2 are its subclasses, and
+CIM_Foo_sub_sub is the subclass of CIM_Foo_sub
+
+
+.. _`Pywbemcli defined logging`:
+
+Pywbemcli defined logging
+-------------------------
+
+Pywbemcli provides for logging to either a file or the standard error stream
+of information passing between the pywbemcli client and a WBEM server using the
+standard Python logging facility.
+
+Logging is configured and enabled using the ``--log`` general option on the
+commmand line or the `PYWBEMCLI_LOG` environment variable.
+
+Pywbemcli can log  operation calls that send
+requests to a WBEM server and their responses or the HTTP messages between
+the pywbemcli client and the WBEM server including both the pywbem APIs
+and their responses and the HTTP requests and responses.
+
+The default is no logging if the ``--log`` option is not specified with a
+configuration string.
+
+The general format of the ``--log`` option is a string with up to 3 fields
+(COMPONENT, DESTINATION, DETAIL):
+
+.. code-block:: text
+
+    LOG_CONFIG_STRING := CONFIG[,CONFIG]
+    CONFIG            := COMPONENT"="[DESTINATION[":"DETAIL]
+    COMPONENT         := ('all' / 'api' / 'http')
+    DESTINATION       := ('stderr' / 'file')
+    DETAIL            := ('all'/ 'path'/ 'summary')
+
+For example the following log configuration string logs only the pywbem API
+calls and responses summary information to a file and the HTTP requests and
+responses to stderr:
+
+.. code-block:: text
+
+      $ pywbemcli --log api=file:summary,http=stderr
+
+The COMPONENT field defines the component for which logging is enabled:
+
+  * `api` - Logs the calls to the pywbem methods that make requests to a
+    WBEM server. This logs both the requests and response including any
+    exceptions generated by error responses from the WBEM server.
+  * `http` - Logs the headers and data for HTTP requests and responses to the
+     WBEM server.
+  * `all` - (Default) Logs both the `api` and `http` components.
+
+The DESTINATION field specified the log destination:
+
+  * `stderr` - Log to stderr
+  * 'file' - (default) Log to the predefined pywbemcli file. The pywbemcli
+    log file is `pywbemcli.log` in the current directory.
+
+The DETAIL component of the log configuration string defines the level of
+logging information for the api and http components.  Because enormous quantities
+of information can be generated this option exists to limit the amount of
+information generated. The possible keywords are:
+
+  * `all` - (Default) Logs the full request including all input parameters and
+    the complete response including all data. Exceptions are fully logged.
+
+  * `paths` - Logs the full request but only the path component of the
+    `api` responses. This reduces the data included in the responses.
+    Exceptions are fully logged.
+
+  * `summary` - Logs the requests but only the count of objects received
+    in the response.  Exceptions are fully logged.
+
+The log output is routed to the output defined by DESTINATION and includes the
+information determined by the COMPONENT and DETAIL fields.
+
+For example, logging only of the summary  API information would look something
+like gisthe following:
+
+.. code-block:: text
+
+    $ pywbemcli -s http://localhost -u blah -p pw -l api=file:summary class enumerate -o
+
+produces log output for the class enumerate operation in the log file
+pywbemcli.log as follows showing the input parameters to the pywbem method
+EnumerateClassName and the number of objects in the response:
+
+.. code-block:: text
+
+    2019-07-09 18:27:22,103-pywbem.api.1-27716-Request:1-27716 EnumerateClassNames(ClassName=None, DeepInheritance=False, namespace=None)
+    2019-07-09 18:27:22,142-pywbem.api.1-27716-Return:1-27716 EnumerateClassNames(list of str; count=103)
+
+The format is::
+
+    <Date time>-<Component>.<ref:`connection id`>-<Direction>:<connection id> <PywbemOperation>(<data>)
+
+
+.. _`Pywbemcli connections file`:
+
+Pywbemcli connections file
+--------------------------
+
+Pywbemcli provides the capability to save the definition of parameters
+for connecting to WBEM servers identified by name using the ``connection``
+command-group (see:ref:`pywbemcli connection --help` and
+:ref:`Connection command-group`). Once defined, these named connections are
+saved in a a JSON formatted file(see :term:`connections file`) in the current
+directory from which pywbemcli was executed.
+
+To create a new persistent connection definition, pywbemcli should be executed with
+either the ``--server``, or the ``mock-server`` option, and the ``--name`` option and
+any other general parameters desired for the connection.  Then executing the
+``connection save`` COMMAND will save the new connection in the connections
+file. For example the following example creates a new connection in the
+interactive mode:
+
+.. code-block:: text
+
+    $ pywbemcli --server http://localhost --user usr1 -passowrd blah --name testconn
+    pywbemcli> connection list
+    Name: testconn
+      WBEMServer uri: http://localhost
+      Default_namespace: root/cimv2
+      User: usr1
+      Password: blah
+      Timeout: 30
+      Noverify: False
+      Certfile: None
+      Keyfile: None
+      use-pull-ops: either
+      pull-max-cnt: 1000
+      mock:
+      log: None
+
+    pywbemcli> connection save
+    pywbemcli> connection list
+
+    name       server uri        namespace    user         password      timeout  noverify    certfile    keyfile    log
+    ---------  ----------------  -----------  -----------  ----------  ---------  ----------  ----------  ---------  -----
+    testconn*  http://localhost  root/blah    me           blah               30  False
+
+Note: The * indicates that this is the current connection.
+
+Other connections can be added from either the command mode or interactive mode.
+
+    pywbemcli> connection add Ronald http://blah2 -u you -p xxx
+    pywbemcli> connection list
+    WBEMServer Connections:
+    name      server uri        namespace    user         password      timeout  noverify
+    --------  ----------------  -----------  -----------  ----------  ---------  ----------
+    Ronald    http://blah2      root/cimv2   you          xxx                    False
+    testconn  http://localhost  root/blah    kschopmeyer  test8play          30  False
+
+Connections can be deleted with the ``connection delete`` command either with
+the command argument containing the connection name or with no name provided so
+pywbemcli presents a list of connections::
+
+    $ pywbemcli connection delete Ronald
+
+or::
+
+    $ pywbemcli connection delete
+    Select a connection or CTRL_C to abort.
+    0: Ronald
+    1: testconn
+    Input integer between 0 and 1 or Ctrl-C to exit selection: 0
+    $

--- a/docs/pywbemclispecialfeatures.rst
+++ b/docs/pywbemclispecialfeatures.rst
@@ -20,7 +20,7 @@ Pywbemcli special command line features
 =======================================
 
 Pywbemcli includes several features in the syntax that are worth presenting
-in detail to help the user understand the background purpose and syntatic
+in detail to help the user understand the background purpose and syntactic
 implementation of the features. This includes:
 
 * The ability to execute either the pull or traditional operations with the
@@ -40,49 +40,49 @@ implementation of the features. This includes:
 Using pywbem Pull Operations from pywbemcli
 -------------------------------------------
 
-pywbem includes multiple ways to execute the enumerate instance type operations
-(Associators, References, EnumerateInstances, ExecQuery):
+Pywbem includes multiple ways to execute the enumerate instance type operations
+(``Associators``, ``References``,`` EnumerateInstances``, ``ExecQuery``):
 
-* The traditional operations (ex. EnumerateInstances)
-* The pull operations (ex. the pull sequence OpenEnumerateInstances, etc.)
-* An overlay of the above two operations called the Iter... operations where
-  each iter operation executes either the traditional or pull operation
+* The traditional operations (ex. ``EnumerateInstances``)
+* The pull operations (ex. the pull sequence ``OpenEnumerateInstances``, etc.)
+* An overlay of the above two operations called the ``Iter..``. operations where
+  each ``Iter..`` operation executes either the traditional or pull operation
   depending on a parameter of the connection.
 
-Pywbemcli implements these method calls to pywbem using the iter operations
-so that either pull operations or traditional operation can be used simply
-by changing a pywbemcli input parameter (``--use-pull-ops``).
+Pywbemcli implements these method calls to pywbem using the ``Iter...``
+operations so that either pull operations or traditional operation can be used
+simply by changing a pywbemcli input parameter (``--use-pull-ops``).
 
 Two options on the command line allow the user to either force the use of pull
 operations, of traditional operations, or to let pywbem try them both.
 
 The input parameter ``--use-pull-ops`` allows the choice of pull or traditional
 operations with the default being to allow pywbem to decide.  The input
-parameter `max_object_cnt` sets the `MaxObjectCount` variable on the operation
-request if the pull operations are to be set which tells the wbem server to
-limit the size of the response.  As an example::
+parameter ``max_object_cnt`` sets the ``MaxObjectCount`` variable on the operation
+request if the pull operations are to be set which tells the WBEM server to
+limit the size of the response.  For example::
 
     pywbemcli --server http/localhost use-pull-ops=yes max_object_cnt=10
 
 would force the use of the pull operations and return an error if the target
-server did not implement them and would set the MaxObjCount parameter on the
+server did not implement them and would set the ``MaxObjCount`` parameter on the
 api to 10, telling the server that a maximum of 10 object can be returned for
 each of the requests in an enumeration sequence.
 
-Since the default for use-pull-ops is `either`, normally pywbem first tries
+Since the default for use-pull-ops is ``either``, normally pywbem first tries
 the pull operation and then if that fails, the traditional operation.  That
-is probably the most logical setting for `use-pull-ops` unless you are
+is probably the most logical setting for ``use-pull-ops`` unless you are
 specifically testing the use of pull operations.
 
-Note that there is a special request `server test-pull` that will test if
+Note that there is a special request ``server test-pull`` that will test if
 a server implements the pull operations and for which of the possible operations
 pull is implemented.
 
-The following table defines which pywbemcli commands are used for the corresponding pywbem
-request operations
+The following table defines which pywbemcli commands are used for the
+corresponding pywbem request operations.
 
 =================================  ==============================================
-WBEM CIM-XML Operation             pywbemtools command-group command
+WBEM CIM-XML Operation             pywbemtools command-group & subcommand
 =================================  ==============================================
 EnumerateInstances                 instance enumerate INSTANCENAME
 EnumerateInstanceNames             instance enumerate INSTANCENAME --name_only
@@ -132,8 +132,9 @@ SetQualifier                       Not implemented
 DeleteQualifier                    Not Implemented
 =================================  ==============================================
 
-1. Iter operations are all used as the common code path by pywbemcli. It is
-these operations that determine whether the original operations (ex. EnumerateInstances)
+1. The pywbem ``Iter...`` operations are all used as the common code path by
+pywbemcli to access CIM instances from the WBEM server. It is these operations
+that determine whether the original operations (ex. ``EnumerateInstances``)
 
 
 .. _`Displaying CIM instances or CIM instance names`:
@@ -141,9 +142,9 @@ these operations that determine whether the original operations (ex. EnumerateIn
 Displaying CIM instances or CIM instance names
 ----------------------------------------------
 
-The pywbem API includes different WBEM operations (ex. EnumerateInstances and
-EnumerateInstanceNames) to request CIM objects or just their names. To
-simplify the overall CLI syntax pywbemcli combines these into a single
+The pywbem API includes different WBEM operations (ex. ``EnumerateInstances`` and
+``EnumerateInstanceNames``) to request CIM objects or just their names. To
+simplify the overall command line syntax pywbemcli combines these into a single
 subcommand (i.e. enumerate, references, associators) and includes an option
 (``-o,`` or ``--names-only``) that determines whether the instance names or
 instances are retrieved from the WBEM Server.


### PR DESCRIPTION
At this point I have three references that will not resolve 

1. Introductionline 89

2 and 3 mock_support 

:meth:`pywbem_mock.FakedWBEMConnection.add_cim_objects`

 (:meth:`pywbem_mock.method_callback_interface`)

Note that we included defintions for the sphinx intersphinx extension for pywbem and pywbem_mock and that they work with :class:


Update documentation

1, Add development section. Parallels pywbem

2. Update installation section

3. Minor changes for spelling, grammar