### PR TITLE
Fixes #240: Correct conflict in setup

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,9 @@
 # Direct dependencies:
 
 # Unit test (imports into testcases):
-pytest>=3.3.0
+# pytest 5.0.0 requires Python version 3.5
+pytest>=3.3.0,<5.0.0; python_version <= '3.4'
+pytest>=3.3.0; python_version >= '3.5'
 funcsigs>=1.0.2; python_version == '2'
 
 # Note: python-coveralls 2.9.1 has requirement coverage==4.0.3, and therefore

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -53,7 +53,8 @@ click-spinner==0.1.8
 click-repl==0.1.6
 asciitree==0.3.3
 tabulate==0.8.2
-prompt-toolkit==2.0.1
+prompt-toolkit==1.0.15; python_version == '2.7'
+prompt-toolkit==2.0.1; python_version >= '3.4'
 
 # Indirect dependencies for install (not in requirements.txt)
 


### PR DESCRIPTION
Correct conflict between minimum-constraints.txt and requirements.txt
for pywbem_toolkit. We were specifying prompt-toolkit as >=2.0.1 in minimum whereas requirements defines it as < 2.0.0 for pywbem 2.7