### PR TITLE
Ks/#242d move sect22 to 3

### DIFF
--- a/docs/pywbemclicmdlineinterface.rst
+++ b/docs/pywbemclicmdlineinterface.rst
@@ -26,8 +26,11 @@ Pywbemcli provides a command line interface(CLI) interaction with WBEM servers.
 
 The command line can contain the following components:
 
-* **general-options** - see :ref:`Command line general options`
-* **command-group** - A name of a group of subcommands
+* **general-options** - Options that apply to all commands.
+  See :ref:`Pywbemcli command line general options` for infomation on the
+  pywbemcli general options
+* **command-group** - A name of a group of subcommands.
+  See :ref:`Pywbemcli command groups, commands, and subcommands`
 * **command** - Alternative to command-group when there are no
   subcommands.
 * **subcommand** - Command name within a command group
@@ -50,7 +53,9 @@ The syntax is:
 A command-group is the name of an object, referencing an entity (ex. ``class``
 refers to operation on CIM classes). The subcommands are generally actions on
 the objects defined by the command-group name. Thus ``class`` is a
-command-group name used to access CIM classes and ``get`` is a subcommand so::
+command-group name used to access CIM classes and ``get`` is a subcommand so:
+
+.. code-block:: text
 
     $ pywbemcli --output-format mof class get CIM_ManagedElement --namespace interop
 
@@ -72,7 +77,7 @@ Pywbemcli supports two modes of operation:
 .. _`Interactive mode`:
 
 Interactive mode
-^^^^^^^^^^^^^^^^
+----------------
 
 In interactive mode also known as :term:`REPL` mode, an interactive shell
 environment is within pywbemcli that allows typing pywbemcli commands, internal
@@ -207,13 +212,13 @@ using <up-arrow, down-arrow>.
 .. _`Command mode`:
 
 Command mode
-^^^^^^^^^^^^
+------------
 
 In command mode, the pywbemcli command performs its task and terminates
 like any other standalone non-interactive command.
 
 This mode is used when the pywbemcli command is invoked with a command or
-command-group name:
+command-group name and arguments/options:
 
 .. code-block:: text
 
@@ -252,58 +257,4 @@ completion:
     $ pywbemcli class <TAB><TAB>
     ... <shows the class sub-commands to select from>
 
-.. _`Command line general options`:
-
-Command line general options
-----------------------------
-
-The general options are entered before the command-group or command. They
-define:
-
-* Characteristics of the WBEM server against which the commands are to be
-  executed (i.e url, default-namespace, security paraemters, etc.)
-* Display and execution options that apply to multiple commands (i.e. output
-  formats, statistics keeping, etc.).
-
-For example the following enumerates the qualifier declarations and outputs the
-result as a ``simple`` table:
-
-.. code-block:: text
-
-    pywbemcli --output-format simple qualifier enumerate
-
-    or
-
-    pywbemcli -o simple qualifier enumerate
-
-In the interactive mode, the general options from the command line are defined
-once and retain their value through the execution of the interactive mode.
-
-However, they may be modified in the interactive mode by entering them before
-the COMMAND.  Thus, for example to display the qualifier declarations in
-interactive mode and as a table:
-
-.. code-block:: text
-
-   $ pywbemcli
-
-   pywbemcli> --output-format table qualifier enumerate
-
-    Qualifier Declarations
-    +-------------+---------+---------+---------+-----------+-----------------+
-    | Name        | Type    | Value   | Array   | Scopes    | Flavors         |
-    +=============+=========+=========+=========+===========+=================+
-    | Description | string  |         | False   | ANY       | EnableOverride  |
-    |             |         |         |         |           | ToSubclass      |
-    |             |         |         |         |           | Translatable    |
-    +-------------+---------+---------+---------+-----------+-----------------+
-    | Key         | boolean | False   | False   | PROPERTY  | DisableOverride |
-    |             |         |         |         | REFERENCE | ToSubclass      |
-    +-------------+---------+---------+---------+-----------+-----------------+
-
-   pywbemcli>
-
-**Note:** - With this use of the general options as part of an interactive mode
-command, general the options redefinition's is not be retained between command
-executions.
 

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -92,7 +92,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       set. (EnvVar: PYWBEMCLI_CERTFILE).
       -k, --keyfile FILE PATH         Client private key file. (EnvVar:
                                       PYWBEMCLI_KEYFILE).
-      --ca_certs TEXT                 File or directory containing certificates
+      --ca-certs TEXT                 File or directory containing certificates
                                       that will be matched against certificate
                                       received from WBEM server. Set --no-verify-
                                       cert option to bypass client verification of
@@ -223,19 +223,20 @@ The following defines the help output for the `pywbemcli class associators --hel
       Get the associated classes for CLASSNAME.
 
       Get the classes(or class names) that are associated with the CLASSNAME
-      argument filtered by the --assocclass, --resultclass, --role and
-      --resultrole options and modified by the other options.
+      argument filtered by the --assoc-class, --result-class, --role and
+      --result-role options and modified by the other options.
 
       Results are formatted as defined by the output format general option.
 
     Options:
-      -a, --assocclass <class name>   Filter by the association class name
+      -a, --assoc-class <class name>  Filter by the association class name
                                       provided. Each returned class (or class
                                       name) should be associated to the source
                                       class through this class or its subclasses.
                                       Optional.
-      -C, --resultclass <class name>  Filter by the association result class name
-                                      provided. Each returned class (or class
+      -C, --result-class <class name>
+                                      Filter the returned objects by the class
+                                      name provided. Each returned class (or class
                                       name) should be this class or one of its
                                       subclasses. Optional
       -r, --role <role name>          Filter by the role name provided. Each
@@ -244,7 +245,7 @@ The following defines the help output for the `pywbemcli class associators --hel
                                       through an association with this role
                                       (property name in the association that
                                       matches this parameter). Optional.
-      -R, --resultrole <role name>    Filter by the result role name provided.
+      -R, --result-role <role name>   Filter by the result role name provided.
                                       Each returned class (or class name)should be
                                       associated with the source class (CLASSNAME)
                                       through an association with returned object
@@ -255,7 +256,7 @@ The following defines the help output for the `pywbemcli class associators --hel
                                       qualifiers in the returned class(s). The
                                       default behavior is to request qualifiers in
                                       returned class(s).
-      -c, --includeclassorigin        Request that server include classorigin in
+      -c, --include-classorigin       Request that server include classorigin in
                                       the result.On some WBEM operations, server
                                       may ignore this option.
       -p, --propertylist <property name>
@@ -336,31 +337,32 @@ The following defines the help output for the `pywbemcli class enumerate --help`
 
       The output format is defined by the output-format general option.
 
-      The includeclassqualifiers, includeclassorigin options define optional
-      information to be included in the output.
+      The --local-only and --no-qualifiers options define optional information
+      to be included in the output.
 
-      The deepinheritance option defines whether the complete hiearchy is
-      retrieved or just the next level in the hiearchy.
+      The --deep-inheritance option defines whether the complete class hierarchy
+      is retrieved or just the next level in the hierarchy.
 
       Results are formatted as defined by the output format general option.
 
     Options:
-      -d, --deepinheritance     Return complete subclass hierarchy for this class
-                                if set. Otherwise retrieve only the next hierarchy
-                                level.
-      -l, --localonly           Show only local properties of the class.
-      --no-qualifiers           If set, request server to not include qualifiers
-                                in the returned class(s). The default behavior is
-                                to request qualifiers in returned class(s).
-      -c, --includeclassorigin  Request that server include classorigin in the
-                                result.On some WBEM operations, server may ignore
-                                this option.
-      -o, --names-only          Retrieve only the returned object names.
-      -s, --sort                Sort into alphabetical order by classname.
-      -n, --namespace <name>    Namespace to use for this operation, instead of
-                                the default namespace of the connection
-      -S, --summary             Return only summary of objects (count).
-      -h, --help                Show this message and exit.
+      -d, --deep-inheritance     If set, request server to return complete
+                                 subclass hiearchy for this class. The default is
+                                 False which requests only one level of
+                                 subclasses.
+      -l, --local-only           Show only local properties of the class(s).
+      --no-qualifiers            If set, request server to not include qualifiers
+                                 in the returned class(s). The default behavior is
+                                 to request qualifiers in returned class(s).
+      -c, --include-classorigin  Request that server include classorigin in the
+                                 result.On some WBEM operations, server may ignore
+                                 this option.
+      -o, --names-only           Retrieve only the returned object names.
+      -s, --sort                 Sort into alphabetical order by classname.
+      -n, --namespace <name>     Namespace to use for this operation, instead of
+                                 the default namespace of the connection
+      -S, --summary              Return only summary of objects (count).
+      -h, --help                 Show this message and exit.
 
 
 .. _`pywbemcli class find --help`:
@@ -431,18 +433,18 @@ The following defines the help output for the `pywbemcli class get --help` subco
       If the class is not found in the WBEM server, the server returns an
       exception.
 
-      The --includeclassorigin, --includeclassqualifiers, and --propertylist
-      options determine what parts of the class definition are retrieved.
+      The --include-classorigin, --no-qualifiers, and --propertylist options
+      determine what parts of the class definition are retrieved.
 
       Results are formatted as defined by the output format general option.
 
     Options:
-      -l, --localonly                 Show only local properties of the class.
+      -l, --local-only                Show only local properties of the class(s).
       --no-qualifiers                 If set, request server to not include
                                       qualifiers in the returned class(s). The
                                       default behavior is to request qualifiers in
                                       returned class(s).
-      -c, --includeclassorigin        Request that server include classorigin in
+      -c, --include-classorigin       Request that server include classorigin in
                                       the result.On some WBEM operations, server
                                       may ignore this option.
       -p, --propertylist <property name>
@@ -517,9 +519,10 @@ The following defines the help output for the `pywbemcli class references --help
       Results are displayed as defined by the output format general option.
 
     Options:
-      -R, --resultclass <class name>  Filter by the result classname provided.
-                                      Each returned class (or classname) should be
-                                      this class or its subclasses. Optional.
+      -R, --result-class <class name>
+                                      Filter by the classname provided. Each
+                                      returned class (or classname) should be this
+                                      class or its subclasses. Optional.
       -r, --role <role name>          Filter by the role name provided. Each
                                       returned class (or classname) should refer
                                       to the target class through a property with
@@ -529,7 +532,7 @@ The following defines the help output for the `pywbemcli class references --help
                                       qualifiers in the returned class(s). The
                                       default behavior is to request qualifiers in
                                       returned class(s).
-      -c, --includeclassorigin        Request that server include classorigin in
+      -c, --include-classorigin       Request that server include classorigin in
                                       the result.On some WBEM operations, server
                                       may ignore this option.
       -p, --propertylist <property name>
@@ -566,17 +569,18 @@ The following defines the help output for the `pywbemcli class tree --help` subc
 
       Display CIM class inheritance hierarchy tree.
 
-      Displays a tree of the class hiearchy to show superclasses and subclasses.
+      Displays a tree of the class hierarchy to show superclasses and
+      subclasses.
 
-      CLASSNAMe is an optional argument that defines the starting point for the
-      hiearchy display
+      CLASSNAME is an optional argument that defines the starting point for the
+      hierarchy display
 
-      If the --superclasses option not specified the hiearchy starting either at
-      the top most classes of the class hiearchy or at the class defined by
-      CLASSNAME is displayed.
+      If the --superclasses option is not specified, the hierarchy starting
+      either at the top most classes of the class hierarchy or at the class
+      defined by CLASSNAME is displayed.
 
-      if the --superclasses options is specified and a CLASSNAME is defined the
-      class hiearchy of superclasses leading to CLASSNAME is displayed.
+      If the --superclasses options is specified and a CLASSNAME is defined the
+      class hierarchy of superclasses leading to CLASSNAME is displayed.
 
       This is a separate subcommand because it is tied specifically to
       displaying in a tree format.so that the --output-format general option is
@@ -989,13 +993,13 @@ The following defines the help output for the `pywbemcli instance --help` subcom
 
     Commands:
       associators   Get associated instances or names.
-      count         Get instance count for classes.
+      count         Get CIM instance count for classes.
       create        Create a CIM instance of CLASSNAME.
       delete        Delete a single CIM instance.
       enumerate     Enumerate instances or names of CLASSNAME.
       get           Get a single CIMInstance.
       invokemethod  Invoke a CIM method on a CIMInstance.
-      modify        Modify an existing instance.
+      modify        Modify an existing CIM instance.
       query         Execute an execquery request.
       references    Get the reference instances or names.
 
@@ -1017,8 +1021,8 @@ The following defines the help output for the `pywbemcli instance associators --
       Get associated instances or names.
 
       Returns the associated instances or names (--names-only option) for the
-      `INSTANCENAME` argument filtered by the --assocclass, --resultclass,
-      --role and --resultrole options.
+      `INSTANCENAME` argument filtered by the --assoc-class, --result-class,
+      --role and --result-role options.
 
       INSTANCENAME must be a CIM instance name in the format defined by DMTF
       `DSP0207`.
@@ -1030,12 +1034,13 @@ The following defines the help output for the `pywbemcli instance associators --
       Results are formatted as defined by the --output_format general option.
 
     Options:
-      -a, --assocclass <class name>   Filter by the association class name
+      -a, --assoc-class <class name>  Filter by the association class name
                                       provided.Each returned instance (or instance
                                       name) should be associated to the source
                                       instance through this class or its
                                       subclasses. Optional.
-      -c, --resultclass <class name>  Filter by the result class name provided.
+      -c, --result-class <class name>
+                                      Filter by the result class name provided.
                                       Each returned instance (or instance name)
                                       should be a member of this class or one of
                                       its subclasses. Optional
@@ -1045,14 +1050,14 @@ The following defines the help output for the `pywbemcli instance associators --
                                       (INSTANCENAME) through an association with
                                       this role (property name in the association
                                       that matches this parameter). Optional.
-      -R, --resultrole <role name>    Filter by the result role name provided.
+      -R, --result-role <role name>   Filter by the result role name provided.
                                       Each returned instance (or instance
                                       name)should be associated with the source
                                       instance name (`INSTANCENAME`) through an
                                       association with returned object having this
                                       role (property name in the association that
                                       matches this parameter). Optional.
-      -q, --includequalifiers         If set, requests server to include
+      -q, --include-qualifiers        If set, requests server to include
                                       qualifiers in the returned instances. This
                                       subcommand may use either pull or
                                       traditional operations depending on the
@@ -1062,8 +1067,9 @@ The following defines the help output for the `pywbemcli instance associators --
                                       this option is specified. If traditional
                                       operations are used, inclusion of qualifiers
                                       depends on the server.
-      -c, --includeclassorigin        Include class origin attribute in returned
-                                      instance(s).
+      -c, --include-classorigin       Request that server include classorigin in
+                                      the result.On some WBEM operations, server
+                                      may ignore this option.
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
                                       option not specified a Null property list is
@@ -1084,16 +1090,16 @@ The following defines the help output for the `pywbemcli instance associators --
                                       class from which the instance to process is
                                       selected.
       -S, --summary                   Return only summary of objects (count).
-      -f, --filterquery TEXT          A filter query to be passed to the server if
+      -f, --filter-query TEXT         A filter query to be passed to the server if
                                       the pull operations are used. If this option
-                                      is defined and the --filterquerylanguage is
-                                      None, pywbemcli assumes DMTF:FQL. If this
+                                      is defined and the --filter-query-language
+                                      is None, pywbemcli assumes DMTF:FQL. If this
                                       option is defined and the traditional
                                       operations are used, the filter is not sent
                                       to the server. See the documentation for
                                       more information. (Default: None)
-      --filterquerylanguage TEXT      A filterquery language to be used with a
-                                      filter query defined by --filterquery.
+      --filter-query-language TEXT    A filter-query language to be used with a
+                                      filter query defined by --filter-query.
                                       (Default: None)
       -h, --help                      Show this message and exit.
 
@@ -1112,7 +1118,7 @@ The following defines the help output for the `pywbemcli instance count --help` 
 
     Usage: pywbemcli instance count [COMMAND-OPTIONS] CLASSNAME-GLOB
 
-      Get instance count for classes.
+      Get CIM instance count for classes.
 
       Displays the count of instances for the classes defined by the `CLASSNAME-
       GLOB` argument in one or more namespaces.
@@ -1171,12 +1177,11 @@ The following defines the help output for the `pywbemcli instance create --help`
       ex. pywbemcli instance create CIM_blah -p id=3 -p strp="bla bla", -p p3=3
 
     Options:
-      -P, --property name=value  Optional property definitions of the form
-                                 name=value. Multiple definitions allowed, one for
-                                 each property to be included in the
-                                 createdinstance. Array property values defined by
-                                 comma-separated-values. EmbeddedInstance not
-                                 allowed.
+      -P, --property name=value  Optional property names of the form name=value.
+                                 Multiple definitions allowed, one for each
+                                 property to be included in the createdinstance.
+                                 Array property values defined by comma-separated-
+                                 values. EmbeddedInstance not allowed.
       -V, --verify               If set, The change is displayed and verification
                                  requested before the change is executed
       -n, --namespace <name>     Namespace to use for this operation, instead of
@@ -1238,26 +1243,26 @@ The following defines the help output for the `pywbemcli instance enumerate --he
       WBEMServer starting either at the top  of the hierarchy (if no CLASSNAME
       provided) or from the CLASSNAME argument if provided.
 
-      Displays the returned instances in mof, xml, or table formats or the
+      Displays the returned instances in mof, xml, or table formats, or the
       instance names as a string or XML formats (--names-only option).
 
       Results are formatted as defined by the --output_format general option.
 
     Options:
-      -l, --localonly                 Show only local properties of the instances.
+      -l, --local-only                Show only local properties of the instances.
                                       This subcommand may use either pull or
                                       traditional operations depending on the
-                                      server and the "--use--pull-ops" general
+                                      server and the --use-pull-ops general
                                       option. If pull operations are used, this
                                       parameters will not be included, even if
                                       specified. If traditional operations are
                                       used, some servers do not process the
                                       parameter.
-      -d, --deepinheritance           If set, requests server to return properties
+      -d, --deep-inheritance          If set, requests server to return properties
                                       in subclasses of the target instances class.
                                       If option not specified only properties from
                                       target class are returned
-      -q, --includequalifiers         If set, requests server to include
+      -q, --include-qualifiers        If set, requests server to include
                                       qualifiers in the returned instances. This
                                       subcommand may use either pull or
                                       traditional operations depending on the
@@ -1267,8 +1272,9 @@ The following defines the help output for the `pywbemcli instance enumerate --he
                                       this option is specified. If traditional
                                       operations are used, inclusion of qualifiers
                                       depends on the server.
-      -c, --includeclassorigin        Include class origin attribute in returned
-                                      instance(s).
+      -c, --include-classorigin       Request that server include classorigin in
+                                      the result.On some WBEM operations, server
+                                      may ignore this option.
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
                                       option not specified a Null property list is
@@ -1284,16 +1290,16 @@ The following defines the help output for the `pywbemcli instance enumerate --he
       -o, --names-only                Retrieve only the returned object names.
       -s, --sort                      Sort into alphabetical order by classname.
       -S, --summary                   Return only summary of objects (count).
-      -f, --filterquery TEXT          A filter query to be passed to the server if
+      -f, --filter-query TEXT         A filter query to be passed to the server if
                                       the pull operations are used. If this option
-                                      is defined and the --filterquerylanguage is
-                                      None, pywbemcli assumes DMTF:FQL. If this
+                                      is defined and the --filter-query-language
+                                      is None, pywbemcli assumes DMTF:FQL. If this
                                       option is defined and the traditional
                                       operations are used, the filter is not sent
                                       to the server. See the documentation for
                                       more information. (Default: None)
-      --filterquerylanguage TEXT      A filterquery language to be used with a
-                                      filter query defined by --filterquery.
+      --filter-query-language TEXT    A filter-query language to be used with a
+                                      filter query defined by --filter-query.
                                       (Default: None)
       -h, --help                      Show this message and exit.
 
@@ -1331,14 +1337,15 @@ The following defines the help output for the `pywbemcli instance get --help` su
       Results are formatted as defined by the --output_format general option.
 
     Options:
-      -l, --localonly                 Request that server show only local
+      -l, --local-only                Request that server show only local
                                       properties of the returned instance. Some
                                       servers may not process this parameter.
-      -q, --includequalifiers         If set, requests server to include
+      -q, --include-qualifiers        If set, requests server to include
                                       qualifiers in the returned instances. Not
                                       all servers return qualifiers on instances
-      -c, --includeclassorigin        Include class origin attribute in returned
-                                      instance(s).
+      -c, --include-classorigin       Request that server include classorigin in
+                                      the result.On some WBEM operations, server
+                                      may ignore this option.
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
                                       option not specified a Null property list is
@@ -1427,26 +1434,26 @@ The following defines the help output for the `pywbemcli instance modify --help`
 
     Usage: pywbemcli instance modify [COMMAND-OPTIONS] INSTANCENAME
 
-      Modify an existing instance.
+      Modify an existing CIM instance.
 
       Modifies CIM instance defined by INSTANCENAME in the WBEM server using the
       property names and values defined by the property option and the CIM class
-      defined by the instance name.  The propertylist option if provided is
-      passed to the WBEM server as part of the ModifyInstance operation
-      (normally the WBEM server limits modifications) to just those properties
-      defined in the property list.
+      defined by the instance name.  The --propertylist option if provided is
+      passed to the WBEM server as part of the ModifyInstance operation (the
+      WBEM server limits modifications to just those properties defined in the
+      property list).
 
       INSTANCENAME must be a CIM instance name in the format defined by DMTF
       `DSP0207`.
 
-      Pywbemcli builds only the properties defined with the --property option
-      into an instance based on the CIMClass and forwards that to the WBEM
-      server with the ModifyInstance method.
+      Pywbemcli builds only properties defined with the --property option into
+      an instance based on the CIMClass and forwards that to the WBEM server
+      with the ModifyInstance method.
 
       ex. pywbemcli instance modify CIM_blah.fred=3 -p id=3 -p strp="bla bla"
 
     Options:
-      -P, --property name=value       Optional property definitions of the form
+      -P, --property name=value       Optional property names of the form
                                       name=value. Multiple definitions allowed,
                                       one for each property to be included in the
                                       createdinstance. Array property values
@@ -1550,7 +1557,7 @@ The following defines the help output for the `pywbemcli instance references --h
                                       refer to the target instance through a
                                       property with aname that matches the value
                                       of this parameter. Optional.
-      -q, --includequalifiers         If set, requests server to include
+      -q, --include-qualifiers        If set, requests server to include
                                       qualifiers in the returned instances. This
                                       subcommand may use either pull or
                                       traditional operations depending on the
@@ -1560,8 +1567,9 @@ The following defines the help output for the `pywbemcli instance references --h
                                       this option is specified. If traditional
                                       operations are used, inclusion of qualifiers
                                       depends on the server.
-      -c, --includeclassorigin        Include class origin attribute in returned
-                                      instance(s).
+      -c, --include-classorigin       Request that server include classorigin in
+                                      the result.On some WBEM operations, server
+                                      may ignore this option.
       -p, --propertylist <property name>
                                       Define a propertylist for the request. If
                                       option not specified a Null property list is
@@ -1582,16 +1590,16 @@ The following defines the help output for the `pywbemcli instance references --h
                                       class from which the instance to process is
                                       selected.
       -S, --summary                   Return only summary of objects (count).
-      -f, --filterquery TEXT          A filter query to be passed to the server if
+      -f, --filter-query TEXT         A filter query to be passed to the server if
                                       the pull operations are used. If this option
-                                      is defined and the --filterquerylanguage is
-                                      None, pywbemcli assumes DMTF:FQL. If this
+                                      is defined and the --filter-query-language
+                                      is None, pywbemcli assumes DMTF:FQL. If this
                                       option is defined and the traditional
                                       operations are used, the filter is not sent
                                       to the server. See the documentation for
                                       more information. (Default: None)
-      --filterquerylanguage TEXT      A filterquery language to be used with a
-                                      filter query defined by --filterquery.
+      --filter-query-language TEXT    A filter-query language to be used with a
+                                      filter query defined by --filter-query.
                                       (Default: None)
       -h, --help                      Show this message and exit.
 
@@ -1731,6 +1739,10 @@ The following defines the help output for the `pywbemcli server --help` subcomma
 
       Command Group for WBEM server operations.
 
+      The server command-group defines commands to inspect and manage core
+      components of the server including namespaces, the interop namespace,
+      profiles, and access to profile central instances.
+
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
       command. These are NOT retained after the command is executed.
@@ -1739,13 +1751,13 @@ The following defines the help output for the `pywbemcli server --help` subcomma
       -h, --help  Show this message and exit.
 
     Commands:
-      brand         Display information on the server.
-      centralinsts  Display central instances in the WBEM server.
-      connection    Display connection info used by this server.
-      info          Display general information on the Server.
-      interop       Display the interop namespace name.
-      namespaces    Display the namespaces in the WBEM server.
-      profiles      Display registered profiles from the WBEM server.
+      brand             Display information on the WBEM server.
+      connection        Display connection info used by this server.
+      get-centralinsts  Display central instances in the WBEM server.
+      info              Display general information on the server.
+      interop           Display the server interop namespace name.
+      namespaces        Display the namespaces in the WBEM server.
+      profiles          Display registered profiles from the WBEM server.
 
 
 .. _`pywbemcli server brand --help`:
@@ -1762,64 +1774,13 @@ The following defines the help output for the `pywbemcli server brand --help` su
 
     Usage: pywbemcli server brand [COMMAND-OPTIONS]
 
-      Display information on the server.
+      Display information on the WBEM server.
 
       Display brand information on the current server if it is available. This
       is typically the definition of the server implementor.
 
     Options:
       -h, --help  Show this message and exit.
-
-
-.. _`pywbemcli server centralinsts --help`:
-
-pywbemcli server centralinsts --help
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-
-
-The following defines the help output for the `pywbemcli server centralinsts --help` subcommand
-
-
-::
-
-    Usage: pywbemcli server centralinsts [COMMAND-OPTIONS]
-
-      Display central instances in the WBEM server.
-
-      Displays central instances for management profiles registered in the
-      server. Displays management profiles that adher to to the central class
-      methodology with none of the extra parameters (ex. scoping_class)
-
-      However, profiles that only use the scoping methodology require extra
-      information that is dependent on the profile itself. These profiles will
-      only be accessed when the correct values of central_class, scoping_class,
-      and scoping path for the particular profile is provided.
-
-      This display may be filtered by the optional organization and profile name
-      options that define the organization for each profile (ex. SNIA) and the
-      name of the profile. This will display only the profiles that are
-      registered for the defined organization and/or name.
-
-      Profiles are display as a table showing the organization, name, and
-      version for each profile.
-
-    Options:
-      -o, --organization <org name>   Filter by the defined organization. (ex. -o
-                                      DMTF
-      -p, --profile <profile name>    Filter by the profile name. (ex. -p Array
-      -c, --central_class <classname>
-                                      Optional. Required only if profiles supports
-                                      only scopig methodology
-      -s, --scoping_class <classname>
-                                      Optional. Required only if profiles supports
-                                      only scopig methodology
-      -S, --scoping_path <pathname>   Optional. Required only if profiles supports
-                                      only scopig methodology. Multiples allowed
-      -r, --reference_direction [snia|dmtf]
-                                      Navigation direction for association.
-                                      [default: dmtf]
-      -h, --help                      Show this message and exit.
 
 
 .. _`pywbemcli server connection --help`:
@@ -1847,6 +1808,57 @@ The following defines the help output for the `pywbemcli server connection --hel
       -h, --help  Show this message and exit.
 
 
+.. _`pywbemcli server get-centralinsts --help`:
+
+pywbemcli server get-centralinsts --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+The following defines the help output for the `pywbemcli server get-centralinsts --help` subcommand
+
+
+::
+
+    Usage: pywbemcli server get-centralinsts [COMMAND-OPTIONS]
+
+      Display central instances in the WBEM server.
+
+      Displays central instances for management profiles registered in the
+      server. Displays management profiles that adher to to the central class
+      methodology with none of the extra parameters (ex. scoping_class)
+
+      However, profiles that only use the scoping methodology require extra
+      information that is dependent on the profile itself. These profiles will
+      only be accessed when the correct values of central_class, scoping_class,
+      and scoping path for the particular profile is provided.
+
+      This display may be filtered by the optional organization and profile name
+      options that define the organization for each profile (ex. SNIA) and the
+      name of the profile. This will display only the profiles that are
+      registered for the defined organization and/or name.
+
+      Profiles are display as a table showing the organization, name, and
+      version for each profile.
+
+    Options:
+      -o, --organization <org name>   Filter by the defined organization. (ex. -o
+                                      DMTF
+      -p, --profile <profile name>    Filter by the profile name. (ex. -p Array
+      -c, --central-class <classname>
+                                      Optional. Required only if profiles supports
+                                      only scopig methodology
+      -s, --scoping-class <classname>
+                                      Optional. Required only if profiles supports
+                                      only scopig methodology
+      -S, --scoping-path <pathname>   Optional. Required only if profiles supports
+                                      only scopig methodology. Multiples allowed
+      -r, --reference-direction [snia|dmtf]
+                                      Navigation direction for association.
+                                      [default: dmtf]
+      -h, --help                      Show this message and exit.
+
+
 .. _`pywbemcli server info --help`:
 
 pywbemcli server info --help
@@ -1861,7 +1873,7 @@ The following defines the help output for the `pywbemcli server info --help` sub
 
     Usage: pywbemcli server info [COMMAND-OPTIONS]
 
-      Display general information on the Server.
+      Display general information on the server.
 
       Displays general information on the current server includeing brand,
       namespaces, etc.
@@ -1884,7 +1896,7 @@ The following defines the help output for the `pywbemcli server interop --help` 
 
     Usage: pywbemcli server interop [COMMAND-OPTIONS]
 
-      Display the interop namespace name.
+      Display the server interop namespace name.
 
       Displays the name of the interop namespace defined for the WBEM server.
 

--- a/docs/pywbemcligeneraloptions.rst
+++ b/docs/pywbemcligeneraloptions.rst
@@ -3,9 +3,70 @@
 Pywbemcli command line general options
 ======================================
 
+
+.. _`General options overview`:
+
+General options overview
+------------------------
+
+The general options are entered before the command-group or command. They
+define:
+
+* Characteristics of the WBEM server against which the commands are to be
+  executed (i.e url, default-namespace, security parameters, etc.)
+* Execution options that apply to multiple commands (i.e. output
+  formats, statistics keeping, logging and using pull operations).
+* General options to show version, display additional information.
+
+For example the following enumerates the qualifier declarations and outputs the
+result as a ``simple`` table:
+
+.. code-block:: text
+
+    pywbemcli --output-format simple qualifier enumerate
+
+    or
+
+    pywbemcli -o simple qualifier enumerate
+
+In the interactive mode, the general options from the command line are defined
+once and retain their value throughout the execution of the interactive mode.
+
+However, they may be modified in the interactive mode by entering them before
+the COMMAND.  Thus, for example to display the qualifier declarations in
+interactive mode and as a table:
+
+.. code-block:: text
+
+   $ pywbemcli
+
+   pywbemcli> --output-format table qualifier enumerate
+
+    Qualifier Declarations
+    +-------------+---------+---------+---------+-----------+-----------------+
+    | Name        | Type    | Value   | Array   | Scopes    | Flavors         |
+    +=============+=========+=========+=========+===========+=================+
+    | Description | string  |         | False   | ANY       | EnableOverride  |
+    |             |         |         |         |           | ToSubclass      |
+    |             |         |         |         |           | Translatable    |
+    +-------------+---------+---------+---------+-----------+-----------------+
+    | Key         | boolean | False   | False   | PROPERTY  | DisableOverride |
+    |             |         |         |         | REFERENCE | ToSubclass      |
+    +-------------+---------+---------+---------+-----------+-----------------+
+
+   pywbemcli>
+
+**Note:** - When using the general options as part of an interactive mode
+command, general the options redefinition's are not be retained between command
+executions.
+
+
+General options descriptions
+----------------------------
+
 The pywbemcli command line options are as follows (See the help in
 pywbemcli and section :ref:`pywbemcli Help Command Details` for more precise
-information on each command-group arguments and options):
+information on each command arguments and options):
 
 * **--server/-s** - Host name or IP address of the WBEM server to which
   pywbemcli will connect in the format::
@@ -26,7 +87,15 @@ information on each command-group arguments and options):
 
   In the interactive mode this connection is not actually executed until a
   command or subcommand requiring access to the WBEM server is entered.
-  (EnvVar: PYWBEMCLI_SERVER)
+
+  Some example of this option are:
+
+    .. code-block:: text
+
+    https://localhost:15345 (http port 5989, host name localhost)
+    http://10.2.3.9 (port 5988, ipv4 ip address 10.2.3.9)
+    http://[2001:db8::1234-eth0] -(http port 5988 ipv6, zone id eth0)
+
 * **--name/-n** - The name of a WBEM server that is defined in the
   :term:`connection file`.  The server parameters for this connection name will
   be loaded from the :term:`connections file` to become the current WBEM
@@ -36,17 +105,20 @@ information on each command-group arguments and options):
   since each option defines a WBEM server for pywbemcli.
 
   A new WBEM server (``myserver``) may be defined and saved in the connection
-  file with a name defined as follows::
+  file with a name defined as follows:
+
+    .. code-block:: text
 
     $ pywbemcli add -s http://localhost --name myserver --user user --password password
 
-  To use an existing WBEM server named ``myserver`` in the defined connections::
+  To use an existing WBEM server named ``myserver`` in the defined connections:
+
+    .. code-block:: text
 
     $ pywbemcli --name myserver class get CIM_ManagedElement
 
   See :ref:`Connection command-group` for more information on managing
   connections.
-
 * **--default-namespace/-d** - Default :term:`CIM namespace` to use in the target
   WBEM server if no namespace is defined in a command. If not defined the
   pywbemcli default is ``root/cimv2``.  This is the namespace used on all
@@ -88,7 +160,6 @@ information on each command-group arguments and options):
   pull request if pull operations are used. This must be  a positive non-zero
   integer. Default is 1000. See :ref:`Pywbemcli and the DMTF pull operations`
   for more information on pull operations.
-
 * **--mock-server** - Defines one or more files that define a mock server that
   can be used to define a mock WBEM server in the pywbemcli process so that
   pywbemcli commands without access to a real server. When this option is used
@@ -143,8 +214,8 @@ PYWBEMCLI_DEFAULT_NAMESPACE     ``--default-namespace``
 PYWBEMCLI_TIMEOUT               ``--timeout``
 PYWBEMCLI_KEYFILE               ``--keyfile``
 PYWBEMCLI_CERTFILE              ``--certfile``
-PYWBEWCLI_CACERTS               ``--ca_certs``
-PYWBEMCLI_USE_PULL              ``--use_pull_ops``
+PYWBEWCLI_CACERTS               ``--ca-certs``
+PYWBEMCLI_USE_PULL              ``--use-pull-ops``
 PYWBEMCLI_PULL_MAX_CNT          ``--pull-max-cnt``
 PYWBEMCLI_STATS_ENABLED         ``--timestats``
 PYWBEMCLI_MOCK_SERVER           ``--mock-server``
@@ -296,18 +367,17 @@ operations through two general options:
     * ``no`` - Forces the use of the non-pull operation.
 
 * ``--pull-max-cnt`` - Sets the maximum count of objects the server is allowed
-  to return for each open/pull operation. max_pull_cnt of 1000 objects is the
+  to return for each open/pull operation. ``pull-max-cnt`` of 1000 objects is the
   default size which from experience is a logical choice.
 
-  The one issue with using the the ``either`` choice is that there are limitations
-  with the original operations that do not exist with the pull operations:
+  There are issues with using the the ``either`` choice as follows"
 
   * The original operations did not support the filtering of responses  with a
     query language query (``--FilterQueryLanguage`` and ``--FilterQuery``) option which
     passes a filter query to the WBEM server so that it filters the responses
     before they are returned. This can greatly reduce the size of the responses
     if effectively used but is used only when the pull operations are available
-    on the server and used with pywbemcli.
+    on the server.
 
   * The pull operations do not support some of the options that traditional
     operations did including:
@@ -332,7 +402,7 @@ can be selected with the ``-o``\``--output-format`` option.
 The output formats fall into three groups however, not all formats are
 applicable to all subcommands:
 
-* **Table output formats** - There are a variety of table formats:ref:`Table formats`.
+* **Table output formats** - There are a variety of table formats :ref:`Table formats`.
 * **CIM model formats** - These formats provide display of returned CIM objects in
   formats that are specific to the CIM Model (ex. MOF, XML, etc.).
   See :ref:`CIM object formats`.
@@ -427,12 +497,13 @@ find CIM_Foo``:
 CIM object formats
 ^^^^^^^^^^^^^^^^^^
 
-The ouput of CIM objects allows multiple formats as follows:
+The output of CIM objects allows multiple formats as follows:
 
 * ``-o mof``: Format for CIM classes, CIM instances, and CIM Parameters:
 
-MOF is the format used to define the models released by the DMTF and SNIA. It
-textually defines the components and structure and data of these elements:
+:term:`MOF` is the format used to define and document the CIM models released
+by the DMTF and SNIA. It textually defines the components and structure and
+data of CIM elements such as CIMClass, CIMInstance, etc.:
 
 .. code-block:: text
 
@@ -605,7 +676,7 @@ pywbemcli.log as follows showing the input parameters to the pywbem method
     2019-07-09 18:27:22,103-pywbem.api.1-27716-Request:1-27716 EnumerateClassNames(ClassName=None, DeepInheritance=False, namespace=None)
     2019-07-09 18:27:22,142-pywbem.api.1-27716-Return:1-27716 EnumerateClassNames(list of str; count=103)
 
-The format is::
+The format is:
 
 .. code-block:: text
 
@@ -658,7 +729,8 @@ new connection in the interactive mode:
 
 Note: The * indicates that this is the current connection.
 
-Other connections can be added from either the command mode or interactive mode.
+Other connections can be added from either the command mode or interactive mode
+using the add subcommand:
 
 .. code-block:: text
 

--- a/docs/pywbemclisubcommands.rst
+++ b/docs/pywbemclisubcommands.rst
@@ -22,15 +22,22 @@ Pywbemcli command groups, commands, and subcommands
 This section defines the characteristics of each of the pywbemcli command
 groups and subcommands including examples.
 
-The command syntax of pywbemcli is::
+The command syntax of pywbemcli is:
+
+.. code-block:: text
 
     $ pywbemcli <general-options> <cmd-group>|<command> <args>
 
-    where:
+where:
+
+.. code-block:: text
+
         cmd-group := <command> <subcommand>
 
 Within pywbemcli each command-group name is a noun, referencing an entity (ex.
 class, instance, server).
+
+.. code-block:: text
 
     $ pywbemcli -s http://localhost class get CIM_ManagedElement
 
@@ -178,7 +185,9 @@ subcommand (i.e. ``enumerate``, ``references``, ``associators``) and includes
 an option (``-o,`` or ``--names-only``) that determines whether the instance
 names or instances are retrieved from the WBEM server.
 
-Thus, for example an ``instance enumerate`` with and without the ``-o`` option::
+Thus, for example an ``instance enumerate`` with and without the ``-o`` option:
+
+.. code-block:: text
 
 
     $ pywbemcli --mock-server tests/unit/simple_mock_model.mof instance enumerate CIM_Foo
@@ -215,7 +224,9 @@ since it can involve multiple keybindings, use of quotation marks, etc.  To
 simplify this pywbemcli includes a option (``-i`` or ``--interactive``) on
 these commands that allows the user to specify only the class name, retrieves
 all the instance names from the server and presents the user with a select list
-from which an instance name can be chosen. The following is an example::
+from which an instance name can be chosen. The following is an example:
+
+.. code-block:: text
 
     $ pywbemcli --mock-server tests/unit/simple_mock_model.mof instance get CIM_Foo --interactive
     Pick Instance name to process
@@ -245,7 +256,9 @@ The **class** group defines subcommands that act on CIM classes. see
   :ref:`Output formats`). If unsuccesful it an exception. This subcommand
   returns the class associators, not the instance associators. The
   :ref:`Instance command-group` includes the corresponding associators
-  operation for instances::
+  operation for instances:
+
+  .. code-block:: text
 
       $ pywbemcli --name mockassoc class associators TST_Person --names_only
         //FakedUrl/root/cimv2:TST_Person
@@ -258,7 +271,9 @@ The **class** group defines subcommands that act on CIM classes. see
   it displays the classes/classnames in the :term:`CIM model output formats`
   (see :ref:`Output formats`). If unsuccesful it an exception.. This returns
   the class level references,not the instance references. The :ref:`Instance
-  command-group` includes a corresponding instance references operation::
+  command-group` includes a corresponding instance references operation:
+
+  .. code-block:: text
 
     $pywbemcli --mock-server mockassoc class references TST_Person --names-only
 
@@ -271,7 +286,9 @@ The **class** group defines subcommands that act on CIM classes. see
   conditions under which a class can be deleted from the server.  If successful
   it returns nothing, otherwise it displays an exception.
 
-  To delete the class ``CIM_Blah``::
+  To delete the class ``CIM_Blah``:
+
+  .. code-block:: text
 
     $ pywbemcli class delete CIM_blah
     $
@@ -288,7 +305,9 @@ The **class** group defines subcommands that act on CIM classes. see
   classes/classnames in the :term:`CIM model output formats` (see
   :ref:`Output formats`). The following example enumerates
   the class names starting at the root of the class hiearchy for a simple
-  mocked CIM schema definition::
+  mocked CIM schema definition:
+
+  .. code-block:: text
 
     $ pywbemcli --mock-server mockassoc class enumerate --names-only
     TST_Person
@@ -303,7 +322,9 @@ The **class** group defines subcommands that act on CIM classes. see
   CIM namespaces for matching class names.  This subcommand uses a :term:`GLOB`
   Unix style pathname pattern expansion on the classname to attempt to filter
   the names and namespaces of all of the classes in the WBEM server (or the
-  namespaces defined with the ``--namespaces``/``-n`` option)::
+  namespaces defined with the ``--namespaces``/``-n`` option):
+
+  .. code-block:: text
 
       $ pywbemcli> class find .*_WBEMS*
       root/PG_InterOp:CIM_WBEMServer
@@ -334,7 +355,9 @@ The **class** group defines subcommands that act on CIM classes. see
 
   The following example shows getting the MOF representation of the class
   ``CIM_Foo`` from a mock repository that is named mock1 in the
-  :term:`connections file`::
+  :term:`connections file`:
+
+  .. code-block:: text
 
       $ pywbemcli> --name mock1 class get CIM_Foo
 
@@ -384,7 +407,9 @@ The **class** group defines subcommands that act on CIM classes. see
   --help` for details.
 * **tree** to display the class hierarchy as a tree.  This subcommand
   outputs a tree format in ASCII defining the either the subclass or superclass
-  hierarchy of the class name input parameter as a tree::
+  hierarchy of the class name input parameter as a tree:
+
+  .. code-block:: text
 
       $ pywbemcli class tree CIM_Foo
 
@@ -415,7 +440,9 @@ The **instance** group defines subcommands that act on CIM instances including:
   instances or instancenames associated with INSTANCENAME otherwise it returns any
   exception generated by the response This subcommand displays the returned instances
   or instance in the :term:`CIM model output formats` or the table formats` (see
-  :ref:`Output formats`).::
+  :ref:`Output formats`).:
+
+  .. code-block:: text
 
     $ pywbemcli --name mockassoc instance references TST_Person --names-only --interactive
     Pick Instance name to process: 0
@@ -435,7 +462,9 @@ The **instance** group defines subcommands that act on CIM instances including:
     $
 
   See :ref:`pywbemcli instance associators --help` for details.
-* **count** count the number of CIM instances in a namespace. For example::
+* **count** count the number of CIM instances in a namespace. For example:
+
+  .. code-block:: text
 
         $ pywbemcli --name mockassoc instance count
         Count of instances per class
@@ -469,13 +498,17 @@ The **instance** group defines subcommands that act on CIM instances including:
   CIMProperty.
 
   For a single property in the new instance this is simply the `--property`` option
-  with the property name and value.:
+  with the property name and value:
+
+  .. code-block:: text
 
     --property <property-name>=<property-value"
 
     where quotes are only required if the value includes whitespace.
 
-  For array properties the values are defined separated by commas::
+  For array properties the values are defined separated by commas:
+
+  .. code-block:: text
 
     -p <property-name>=<value>(,<value>)
 
@@ -491,7 +524,8 @@ The **instance** group defines subcommands that act on CIM instances including:
 
   The following example creates an instance of the class TST_Blah with one
   scalar and one array property.
-  ::
+
+  .. code-block:: text
 
     $pywbemcli instance create TST_Blah InstancId="blah1", intprop=3, intarr=3,6,9
 
@@ -508,7 +542,9 @@ The **instance** group defines subcommands that act on CIM instances including:
 
   The following example deletes the instance defined by the explicit instance
   name (Note the extra backslash required to escape the double quote on the
-  terminal)::
+  terminal):
+
+  .. code-block:: text
 
     $ pywbemcli --name mockassoc instance delete root/cimv2:TST_Person.name=\"Saara\"
     $
@@ -521,7 +557,9 @@ The **instance** group defines subcommands that act on CIM instances including:
   or the table formats` (see :ref:`Output formats`).
 
   The following example returns a two instanced to an ``instance enumerate``
-  command as MOF::
+  command as MOF:
+
+  .. code-block:: text
 
     $ pywbemcli --name mockassoc instance enumerate TST_FamilyCollection
 

--- a/docs/pywbemclisubcommands.rst
+++ b/docs/pywbemclisubcommands.rst
@@ -812,8 +812,9 @@ namespaces, etc. The subcommands are:
 
 
   See :ref:`pywbemcli server profiles --help` for details.
-* **centralinsts** to get the instance names of the central/scoping instances of
-  one or more :term:`WBEM management profile` s defined in the target WBEM server:
+* **get_centralinsts** to get the instance names of the central/scoping
+  instances of one or more :term:`WBEM management profile` s defined in the
+  target WBEM server:
 
   .. code-block:: text
 
@@ -826,7 +827,7 @@ namespaces, etc. The subcommands are:
     | DMTF:Computer System:1.0.0      | //leonard/test/TestProvider:Test_StorageSystem.Name="StorageSystemInstance1",CreationClassName="Test_StorageSystem"://leonard/test/TestProvider:Test_StorageSystem.Name="StorageSystemInstance2",CreationClassName="Test_StorageSystem" |
     +---------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-  See :ref:`pywbemcli server centralinsts --help` for details.
+  See :ref:`pywbemcli server get-centralinsts --help` for details.
 
 .. _`Connection command-group`:
 

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 """
 Click Command definition for the class command group which includes
-cmds for get, enumerate, associators, references, find, etc. of the objects
+commands for get, enumerate, associators, references, find, etc. of the objects
 CIMClass on a WBEM server
 """
 from __future__ import absolute_import
@@ -47,10 +47,14 @@ includeclassqualifiers_option = [              # pylint: disable=invalid-name
                       'request qualifiers in returned class(s).')]
 
 deepinheritance_option = [              # pylint: disable=invalid-name
-    click.option('-d', '--deepinheritance', is_flag=True, required=False,
+    click.option('-d', '--deep-inheritance', is_flag=True, required=False,
                  help='If set, request server to return complete subclass '
                       'hiearchy for this class. The default is False which '
                       'requests only one level of subclasses.')]
+
+localonly_option = [              # pylint: disable=invalid-name
+    click.option('-l', '--local-only', is_flag=True, required=False,
+                 help='Show only local properties of the class(s).')]
 
 
 @cli.group('class', options_metavar=CMD_OPTS_TXT)
@@ -67,8 +71,7 @@ def class_group():
 
 @class_group.command('get', options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True,)
-@click.option('-l', '--localonly', is_flag=True, required=False,
-              help='Show only local properties of the class.')
+@add_options(localonly_option)
 @add_options(includeclassqualifiers_option)
 @add_options(includeclassorigin_option)
 @add_options(propertylist_option)
@@ -85,7 +88,7 @@ def class_get(context, classname, **options):
     If the class is not found in the WBEM server, the server returns an
     exception.
 
-    The --includeclassorigin, --includeclassqualifiers, and --propertylist
+    The --include-classorigin, --no-qualifiers, and --propertylist
     options determine what parts of the class definition are retrieved.
 
     Results are formatted as defined by the output format general option.
@@ -153,11 +156,8 @@ def class_invokemethod(context, classname, methodname, **options):
 
 @class_group.command('enumerate', options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME', required=False)
-@click.option('-d', '--deepinheritance', is_flag=True, required=False,
-              help='Return complete subclass hierarchy for this class if '
-                   'set. Otherwise retrieve only the next hierarchy level.')
-@click.option('-l', '--localonly', is_flag=True, required=False,
-              help='Show only local properties of the class.')
+@add_options(deepinheritance_option)
+@add_options(localonly_option)
 @add_options(includeclassqualifiers_option)
 @add_options(includeclassorigin_option)
 @add_options(names_only_option)
@@ -175,11 +175,11 @@ def class_enumerate(context, classname, **options):
 
     The output format is defined by the output-format general option.
 
-    The includeclassqualifiers, includeclassorigin options define optional
+    The --local-only and --no-qualifiers options define optional
     information to be included in the output.
 
-    The deepinheritance option defines whether the complete hiearchy is
-    retrieved or just the next level in the hiearchy.
+    The --deep-inheritance option defines whether the complete class hierarchy
+    is retrieved or just the next level in the hierarchy.
 
     Results are formatted as defined by the output format general option.
     """
@@ -189,9 +189,9 @@ def class_enumerate(context, classname, **options):
 
 @class_group.command('references', options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True)
-@click.option('-R', '--resultclass', type=str, required=False,
+@click.option('-R', '--result-class', type=str, required=False,
               metavar='<class name>',
-              help='Filter by the result classname provided. Each returned '
+              help='Filter by the classname provided. Each returned '
                    'class (or classname) should be this class or its '
                    'subclasses. Optional.')
 @click.option('-r', '--role', type=str, required=False,
@@ -224,24 +224,24 @@ def class_references(context, classname, **options):
 
 @class_group.command('associators', options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True)
-@click.option('-a', '--assocclass', type=str, required=False,
+@click.option('-a', '--assoc-class', type=str, required=False,
               metavar='<class name>',
               help='Filter by the association class name provided. Each '
                    'returned class (or class name) should be associated to the '
                    'source class through this class or its subclasses. '
                    'Optional.')
-@click.option('-C', '--resultclass', type=str, required=False,
+@click.option('-C', '--result-class', type=str, required=False,
               metavar='<class name>',
-              help='Filter by the association result class name provided. Each '
-                   'returned class (or class name) should be this class or one '
-                   'of its subclasses. Optional')
+              help='Filter the returned objects by the class name provided. '
+                   'Each returned class (or class name) should be this class '
+                   'or one of its subclasses. Optional')
 @click.option('-r', '--role', type=str, required=False,
               metavar='<role name>',
               help='Filter by the role name provided. Each returned class '
               '(or class name)should be associated with the source class '
               '(CLASSNAME) through an association with this role (property '
               'name in the association that matches this parameter). Optional.')
-@click.option('-R', '--resultrole', type=str, required=False,
+@click.option('-R', '--result-role', type=str, required=False,
               metavar='<role name>',
               help='Filter by the result role name provided. Each returned '
               'class (or class name)should be associated with the source class '
@@ -261,8 +261,8 @@ def class_associators(context, classname, **options):
     Get the associated classes for CLASSNAME.
 
     Get the classes(or class names) that are associated with the CLASSNAME
-    argument filtered by the --assocclass, --resultclass, --role and
-    --resultrole options and modified by the other options.
+    argument filtered by the --assoc-class, --result-class, --role and
+    --result-role options and modified by the other options.
 
     Results are formatted as defined by the output format general option.
     """
@@ -321,17 +321,17 @@ def class_tree(context, classname, **options):
     """
     Display CIM class inheritance hierarchy tree.
 
-    Displays a tree of the class hiearchy to show superclasses and subclasses.
+    Displays a tree of the class hierarchy to show superclasses and subclasses.
 
-    CLASSNAMe is an optional argument that defines the starting point for the
-    hiearchy display
+    CLASSNAME is an optional argument that defines the starting point for the
+    hierarchy display
 
-    If the --superclasses option not specified the hiearchy starting either
-    at the top most classes of the class hiearchy or at the class defined by
+    If the --superclasses option is not specified, the hierarchy starting either
+    at the top most classes of the class hierarchy or at the class defined by
     CLASSNAME is displayed.
 
-    if the --superclasses options is specified and a CLASSNAME is defined
-    the class hiearchy of superclasses leading to CLASSNAME is displayed.
+    If the --superclasses options is specified and a CLASSNAME is defined
+    the class hierarchy of superclasses leading to CLASSNAME is displayed.
 
     This is a separate subcommand because it is tied specifically to displaying
     in a tree format.so that the --output-format general option is ignored.
@@ -349,7 +349,7 @@ def cmd_class_get(context, classname, options):
     """
     Get the class defined by the argument.
 
-    Gets the class defined by CLASSNAME from thw wbem server and displays
+    Gets the class defined by CLASSNAME from the WBEM server and displays
     the class. If the class cannot be found, the server returns a CIMError
     exception.
 
@@ -358,9 +358,9 @@ def cmd_class_get(context, classname, options):
         result_class = context.conn.GetClass(
             classname,
             namespace=options['namespace'],
-            LocalOnly=options['localonly'],
+            LocalOnly=options['local_only'],
             IncludeQualifiers=options['includequalifiers'],
-            IncludeClassOrigin=options['includeclassorigin'],
+            IncludeClassOrigin=options['include_classorigin'],
             PropertyList=resolve_propertylist(options['propertylist']))
 
         display_cim_objects(context, result_class,
@@ -371,7 +371,7 @@ def cmd_class_get(context, classname, options):
 
 def cmd_class_invokemethod(context, classname, methodname, options):
     """
-    Create an instance and submit to wbemserver
+    Create an instance and submit to a WBEM server
     """
     try:
         process_invokemethod(context, classname, methodname, options)
@@ -389,15 +389,15 @@ def cmd_class_enumerate(context, classname, options):
             results = context.conn.EnumerateClassNames(
                 ClassName=classname,
                 namespace=options['namespace'],
-                DeepInheritance=options['deepinheritance'])
+                DeepInheritance=options['deep_inheritance'])
         else:
             results = context.conn.EnumerateClasses(
                 ClassName=classname,
                 namespace=options['namespace'],
-                LocalOnly=options['localonly'],
-                DeepInheritance=options['deepinheritance'],
+                LocalOnly=options['local_only'],
+                DeepInheritance=options['deep_inheritance'],
                 IncludeQualifiers=options['includequalifiers'],
-                IncludeClassOrigin=options['includeclassorigin'])
+                IncludeClassOrigin=options['include_classorigin'])
 
         display_cim_objects(context, results, context.output_format,
                             summary=options['summary'], sort=options['sort'])
@@ -417,15 +417,15 @@ def cmd_class_references(context, classname, options):
         if options['names_only']:
             results = context.conn.ReferenceNames(
                 classname,
-                ResultClass=options['resultclass'],
+                ResultClass=options['result_class'],
                 Role=options['role'])
         else:
             results = context.conn.References(
                 classname,
-                ResultClass=options['resultclass'],
+                ResultClass=options['result_class'],
                 Role=options['role'],
                 IncludeQualifiers=options['includequalifiers'],
-                IncludeClassOrigin=options['includeclassorigin'],
+                IncludeClassOrigin=options['include_classorigin'],
                 PropertyList=resolve_propertylist(options['propertylist']))
 
         display_cim_objects(context, results, context.output_format,
@@ -446,19 +446,19 @@ def cmd_class_associators(context, classname, options):
         if options['names_only']:
             results = context.conn.AssociatorNames(
                 classname,
-                AssocClass=options['assocclass'],
+                AssocClass=options['assoc_class'],
                 Role=options['role'],
-                ResultClass=options['resultclass'],
-                ResultRole=options['resultrole'])
+                ResultClass=options['result_class'],
+                ResultRole=options['result_role'])
         else:
             results = context.conn.Associators(
                 classname,
-                AssocClass=options['assocclass'],
+                AssocClass=options['assoc_class'],
                 Role=options['role'],
-                ResultClass=options['resultclass'],
-                ResultRole=options['resultrole'],
+                ResultClass=options['result_class'],
+                ResultRole=options['result_role'],
                 IncludeQualifiers=options['includequalifiers'],
-                IncludeClassOrigin=options['includeclassorigin'],
+                IncludeClassOrigin=options['include_classorigin'],
                 PropertyList=resolve_propertylist(options['propertylist']))
 
         display_cim_objects(context, results, context.output_format,
@@ -560,7 +560,7 @@ def cmd_class_tree(context, classname, options):
 
 
 def cmd_class_delete(context, classname, options):
-    """Delete a class from the wbemserver repository"""
+    """Delete a class from the WBEM server repository"""
     if options['namespace']:
         classname = CIMClassName(classname, namespace=options['namespace'])
 

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -33,6 +33,10 @@ def server_group():
     """
     Command Group for WBEM server operations.
 
+    The server command-group defines commands to inspect and manage core
+    components of the server including namespaces, the interop namespace,
+    profiles, and access to profile central instances.
+
     In addition to the command-specific options shown in this help text, the
     general options (see 'pywbemcli --help') can also be specified before the
     command. These are NOT retained after the command is executed.
@@ -55,7 +59,7 @@ def server_namespaces(context, **options):
 @click.pass_obj
 def server_interop(context):
     """
-    Display the interop namespace name.
+    Display the server interop namespace name.
 
     Displays the name of the interop namespace defined for the
     WBEM server.
@@ -68,7 +72,7 @@ def server_interop(context):
 @click.pass_obj
 def server_brand(context):
     """
-    Display information on the server.
+    Display information on the WBEM server.
 
     Display brand information on the current server if it is available.
     This is typically the definition of the server implementor.
@@ -81,7 +85,7 @@ def server_brand(context):
 @click.pass_obj
 def server_info(context):
     """
-    Display general information on the Server.
+    Display general information on the server.
 
     Displays general information on the current server includeing brand,
     namespaces, etc.
@@ -116,27 +120,27 @@ def server_profiles(context, **options):
     context.execute_cmd(lambda: cmd_server_profiles(context, options))
 
 
-@server_group.command('centralinsts', options_metavar=CMD_OPTS_TXT)
+@server_group.command('get-centralinsts', options_metavar=CMD_OPTS_TXT)
 @click.option('-o', '--organization', type=str, required=False,
               metavar='<org name>',
               help='Filter by the defined organization. (ex. -o DMTF')
 @click.option('-p', '--profile', type=str, required=False,
               metavar='<profile name>',
               help='Filter by the profile name. (ex. -p Array')
-@click.option('-c', '--central_class', type=str, required=False,
+@click.option('-c', '--central-class', type=str, required=False,
               metavar='<classname>',
               help='Optional. Required only if profiles supports only '
               'scopig methodology')
-@click.option('-s', '--scoping_class', type=str, required=False,
+@click.option('-s', '--scoping-class', type=str, required=False,
               metavar='<classname>',
               help='Optional. Required only if profiles supports only '
               'scopig methodology')
-@click.option('-S', '--scoping_path', type=str, required=False,
+@click.option('-S', '--scoping-path', type=str, required=False,
               multiple=True,
               metavar='<pathname>',
               help='Optional. Required only if profiles supports only '
               'scopig methodology. Multiples allowed')
-@click.option('-r', '--reference_direction',
+@click.option('-r', '--reference-direction',
               type=click.Choice(['snia', 'dmtf']),
               default='dmtf',
               show_default=True,

--- a/pywbemtools/pywbemcli/_common_options.py
+++ b/pywbemtools/pywbemcli/_common_options.py
@@ -47,7 +47,7 @@ sort_option = [                            # pylint: disable=invalid-name
                  help='Sort into alphabetical order by classname.')]
 
 includeclassorigin_option = [            # pylint: disable=invalid-name
-    click.option('-c', '--includeclassorigin', is_flag=True,
+    click.option('-c', '--include-classorigin', is_flag=True,
                  required=False,
                  help='Request that server include classorigin in the result.'
                       'On some WBEM operations, server may ignore this '

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -116,7 +116,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
               envvar=PywbemServer.keyfile_envvar,
               help='Client private key file. '
                    '(EnvVar: {}).'.format(PywbemServer.keyfile_envvar))
-@click.option('--ca_certs', type=str,
+@click.option('--ca-certs', type=str,
               envvar=PywbemServer.ca_certs_envvar,
               help='File or directory containing certificates that will be '
                    'matched against certificate received from WBEM '

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -65,18 +65,18 @@ Usage: pywbemcli class get [COMMAND-OPTIONS] CLASSNAME
   If the class is not found in the WBEM server, the server returns an
   exception.
 
-  The --includeclassorigin, --includeclassqualifiers, and --propertylist
-  options determine what parts of the class definition are retrieved.
+  The --include-classorigin, --no-qualifiers, and --propertylist options
+  determine what parts of the class definition are retrieved.
 
   Results are formatted as defined by the output format general option.
 
 Options:
-  -l, --localonly                 Show only local properties of the class.
+  -l, --local-only                Show only local properties of the class(s).
   --no-qualifiers                 If set, request server to not include
                                   qualifiers in the returned class(s). The
                                   default behavior is to request qualifiers in
                                   returned class(s).
-  -c, --includeclassorigin        Request that server include classorigin in
+  -c, --include-classorigin       Request that server include classorigin in
                                   the result.On some WBEM operations, server
                                   may ignore this option.
   -p, --propertylist <property name>
@@ -106,31 +106,32 @@ Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME
 
   The output format is defined by the output-format general option.
 
-  The includeclassqualifiers, includeclassorigin options define optional
-  information to be included in the output.
+  The --local-only and --no-qualifiers options define optional information
+  to be included in the output.
 
-  The deepinheritance option defines whether the complete hiearchy is
-  retrieved or just the next level in the hiearchy.
+  The --deep-inheritance option defines whether the complete class hierarchy
+  is retrieved or just the next level in the hierarchy.
 
   Results are formatted as defined by the output format general option.
 
 Options:
-  -d, --deepinheritance     Return complete subclass hierarchy for this class
-                            if set. Otherwise retrieve only the next hierarchy
-                            level.
-  -l, --localonly           Show only local properties of the class.
-  --no-qualifiers           If set, request server to not include qualifiers
-                            in the returned class(s). The default behavior is
-                            to request qualifiers in returned class(s).
-  -c, --includeclassorigin  Request that server include classorigin in the
-                            result.On some WBEM operations, server may ignore
-                            this option.
-  -o, --names-only          Retrieve only the returned object names.
-  -s, --sort                Sort into alphabetical order by classname.
-  -n, --namespace <name>    Namespace to use for this operation, instead of
-                            the default namespace of the connection
-  -S, --summary             Return only summary of objects (count).
-  -h, --help                Show this message and exit.
+  -d, --deep-inheritance     If set, request server to return complete
+                             subclass hiearchy for this class. The default is
+                             False which requests only one level of
+                             subclasses.
+  -l, --local-only           Show only local properties of the class(s).
+  --no-qualifiers            If set, request server to not include qualifiers
+                             in the returned class(s). The default behavior is
+                             to request qualifiers in returned class(s).
+  -c, --include-classorigin  Request that server include classorigin in the
+                             result.On some WBEM operations, server may ignore
+                             this option.
+  -o, --names-only           Retrieve only the returned object names.
+  -s, --sort                 Sort into alphabetical order by classname.
+  -n, --namespace <name>     Namespace to use for this operation, instead of
+                             the default namespace of the connection
+  -S, --summary              Return only summary of objects (count).
+  -h, --help                 Show this message and exit.
 """
 
 CLASS_FIND_HELP = """
@@ -171,17 +172,18 @@ Usage: pywbemcli class tree [COMMAND-OPTIONS] CLASSNAME
 
   Display CIM class inheritance hierarchy tree.
 
-  Displays a tree of the class hiearchy to show superclasses and subclasses.
+  Displays a tree of the class hierarchy to show superclasses and
+  subclasses.
 
-  CLASSNAMe is an optional argument that defines the starting point for the
-  hiearchy display
+  CLASSNAME is an optional argument that defines the starting point for the
+  hierarchy display
 
-  If the --superclasses option not specified the hiearchy starting either at
-  the top most classes of the class hiearchy or at the class defined by
-  CLASSNAME is displayed.
+  If the --superclasses option is not specified, the hierarchy starting
+  either at the top most classes of the class hierarchy or at the class
+  defined by CLASSNAME is displayed.
 
-  if the --superclasses options is specified and a CLASSNAME is defined the
-  class hiearchy of superclasses leading to CLASSNAME is displayed.
+  If the --superclasses options is specified and a CLASSNAME is defined the
+  class hierarchy of superclasses leading to CLASSNAME is displayed.
 
   This is a separate subcommand because it is tied specifically to
   displaying in a tree format.so that the --output-format general option is
@@ -235,9 +237,10 @@ Usage: pywbemcli class references [COMMAND-OPTIONS] CLASSNAME
   Results are displayed as defined by the output format general option.
 
 Options:
-  -R, --resultclass <class name>  Filter by the result classname provided.
-                                  Each returned class (or classname) should be
-                                  this class or its subclasses. Optional.
+  -R, --result-class <class name>
+                                  Filter by the classname provided. Each
+                                  returned class (or classname) should be this
+                                  class or its subclasses. Optional.
   -r, --role <role name>          Filter by the role name provided. Each
                                   returned class (or classname) should refer
                                   to the target class through a property with
@@ -247,7 +250,7 @@ Options:
                                   qualifiers in the returned class(s). The
                                   default behavior is to request qualifiers in
                                   returned class(s).
-  -c, --includeclassorigin        Request that server include classorigin in
+  -c, --include-classorigin       Request that server include classorigin in
                                   the result.On some WBEM operations, server
                                   may ignore this option.
   -p, --propertylist <property name>
@@ -457,8 +460,8 @@ TEST_CASES = [
 
     ['Verify class subcommand enumerate CIM_Foo',
      ['enumerate', 'CIM_Foo'],
-     {'stdout': '   [Description ( "Subclass of CIM_Foo" )]',
-      'test': 'startswith'},
+     {'stdout': ['[Description ( "Subclass of CIM_Foo" )]', ],
+      'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify class subcommand enumerate CIM_Foo local only',
@@ -474,8 +477,8 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo localonly',
-     ['enumerate', 'CIM_Foo', '--localonly'],
+    ['Verify class subcommand enumerate CIM_Foo local-only',
+     ['enumerate', 'CIM_Foo', '--local-only'],
      {'stdout':
       '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
@@ -494,8 +497,8 @@ TEST_CASES = [
       'test': 'startswith'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo --deepinheritance',
-     ['enumerate', 'CIM_Foo', '--deepinheritance'],
+    ['Verify class subcommand enumerate CIM_Foo --deep-inheritance',
+     ['enumerate', 'CIM_Foo', '--deep-inheritance'],
      {'stdout':
       '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
@@ -508,8 +511,8 @@ TEST_CASES = [
       'test': 'startswith'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo --includeclassorigin',
-     ['enumerate', 'CIM_Foo', '--includeclassorigin'],
+    ['Verify class subcommand enumerate CIM_Foo --include-classorigin',
+     ['enumerate', 'CIM_Foo', '--include-classorigin'],
      {'stdout':
       '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
@@ -552,7 +555,7 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo names and deepinheritance',
+    ['Verify class subcommand enumerate CIM_Foo names and -d -o',
      ['enumerate', 'CIM_Foo', '-do'],
      {'stdout': ['CIM_Foo_sub', 'CIM_Foo_sub2', 'CIM_Foo_sub_sub'],
       'test': 'in'},
@@ -584,15 +587,15 @@ TEST_CASES = [
       'test': 'linesnows'},
      None, OK],
 
-    # subcommand get localonly option
-    ['Verify class subcommand get not localonly. Tests for property names',
+    # subcommand get local-only option
+    ['Verify class subcommand get not local-only. Tests for property names',
      ['get', 'CIM_Foo_sub2'],
      {'stdout': ['string cimfoo_sub2;', 'InstanceID', 'IntegerProp', 'Fuzzy',
                  'Key ( true )', 'IN ( false )'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand get localonly(-l)).',
+    ['Verify class subcommand get local-only(-l)).',
      ['get', 'CIM_Foo_sub2', '-l'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
                  '',
@@ -602,8 +605,8 @@ TEST_CASES = [
       'test': 'patterns'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand get localonly. Tests whole response',
-     ['get', 'CIM_Foo_sub2', '--localonly'],
+    ['Verify class subcommand get local-only. Tests whole response',
+     ['get', 'CIM_Foo_sub2', '--local-only'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
                  '',
                  '   string cimfoo_sub2;',
@@ -982,15 +985,14 @@ TEST_CASES = [
      {'stdout': ['Usage: pywbemcli class associators [COMMAND-OPTIONS] '
                  'CLASSNAME',
                  'Get the associated classes for CLASSNAME.',
-                 '-a, --assocclass <class name>   Filter by the association '
+                 '-a, --assoc-class <class name>  Filter by the association '
                  'class name',
-                 '-C, --resultclass <class name>  Filter by the association '
-                 'result class name',
+                 '-C, --result-class <class name>',
                  '-r, --role <role name>          Filter by the role name '
                  'provided.',
-                 '-R, --resultrole <role name>    Filter by the result role '
+                 '-R, --result-role <role name>   Filter by the result role '
                  'name provided.',
-                 '-c, --includeclassorigin', ],
+                 '-c, --include-classorigin', ],
       'test': 'in'},
      None, OK],
 
@@ -1035,10 +1037,10 @@ TEST_CASES = [
 
     ['Verify class subcommand associators request, all filters long',
      ['associators', 'TST_Person',
-      '--assocclass', 'TST_MemberOfFamilyCollection',
+      '--assoc-class', 'TST_MemberOfFamilyCollection',
       '--role', 'member',
-      '--resultrole', 'family',
-      '--resultclass', 'TST_Person'],
+      '--result-role', 'family',
+      '--result-class', 'TST_Person'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Person',
                  'class TST_Person {',
                  '',
@@ -1165,7 +1167,7 @@ TEST_CASES = [
     ['Verify class subcommand references request, all filters long',
      ['references', 'TST_Person',
       '--role', 'member',
-      '--resultclass', 'TST_MemberOfFamilyCollection'],
+      '--result-class', 'TST_MemberOfFamilyCollection'],
      {'stdout': REFERENCES_CLASS_RTN_QUALS2,
       'test': 'linesnows'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
@@ -1277,7 +1279,7 @@ TEST_CASES = [
 # TODO subcommand class delete. Extend this test to use stdin (delete, test)
 # namespace
 # TODO: add test for  errors: class invalid, namespace invalid
-# other tests.  Test localonly on top level
+# other tests.  Test local-only on top level
 
 
 # TODO the following two test classes should be removed as I believe they

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -113,7 +113,7 @@ Options:
                                   set. (EnvVar: PYWBEMCLI_CERTFILE).
   -k, --keyfile FILE PATH         Client private key file. (EnvVar:
                                   PYWBEMCLI_KEYFILE).
-  --ca_certs TEXT                 File or directory containing certificates
+  --ca-certs TEXT                 File or directory containing certificates
                                   that will be matched against certificate
                                   received from WBEM server. Set --no-verify-
                                   cert option to bypass client verification of

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -49,13 +49,13 @@ Options:
 
 Commands:
   associators   Get associated instances or names.
-  count         Get instance count for classes.
+  count         Get CIM instance count for classes.
   create        Create a CIM instance of CLASSNAME.
   delete        Delete a single CIM instance.
   enumerate     Enumerate instances or names of CLASSNAME.
   get           Get a single CIMInstance.
   invokemethod  Invoke a CIM method on a CIMInstance.
-  modify        Modify an existing instance.
+  modify        Modify an existing CIM instance.
   query         Execute an execquery request.
   references    Get the reference instances or names.
 """
@@ -70,26 +70,26 @@ Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME
   WBEMServer starting either at the top  of the hierarchy (if no CLASSNAME
   provided) or from the CLASSNAME argument if provided.
 
-  Displays the returned instances in mof, xml, or table formats or the
+  Displays the returned instances in mof, xml, or table formats, or the
   instance names as a string or XML formats (--names-only option).
 
   Results are formatted as defined by the --output_format general option.
 
 Options:
-  -l, --localonly                 Show only local properties of the instances.
+  -l, --local-only                Show only local properties of the instances.
                                   This subcommand may use either pull or
                                   traditional operations depending on the
-                                  server and the "--use--pull-ops" general
+                                  server and the --use-pull-ops general
                                   option. If pull operations are used, this
                                   parameters will not be included, even if
                                   specified. If traditional operations are
                                   used, some servers do not process the
                                   parameter.
-  -d, --deepinheritance           If set, requests server to return properties
+  -d, --deep-inheritance          If set, requests server to return properties
                                   in subclasses of the target instances class.
                                   If option not specified only properties from
                                   target class are returned
-  -q, --includequalifiers         If set, requests server to include
+  -q, --include-qualifiers        If set, requests server to include
                                   qualifiers in the returned instances. This
                                   subcommand may use either pull or
                                   traditional operations depending on the
@@ -99,8 +99,9 @@ Options:
                                   this option is specified. If traditional
                                   operations are used, inclusion of qualifiers
                                   depends on the server.
-  -c, --includeclassorigin        Include class origin attribute in returned
-                                  instance(s).
+  -c, --include-classorigin       Request that server include classorigin in
+                                  the result.On some WBEM operations, server
+                                  may ignore this option.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
                                   option not specified a Null property list is
@@ -116,19 +117,18 @@ Options:
   -o, --names-only                Retrieve only the returned object names.
   -s, --sort                      Sort into alphabetical order by classname.
   -S, --summary                   Return only summary of objects (count).
-  -f, --filterquery TEXT          A filter query to be passed to the server if
+  -f, --filter-query TEXT         A filter query to be passed to the server if
                                   the pull operations are used. If this option
-                                  is defined and the --filterquerylanguage is
-                                  None, pywbemcli assumes DMTF:FQL. If this
+                                  is defined and the --filter-query-language
+                                  is None, pywbemcli assumes DMTF:FQL. If this
                                   option is defined and the traditional
                                   operations are used, the filter is not sent
                                   to the server. See the documentation for
                                   more information. (Default: None)
-  --filterquerylanguage TEXT      A filterquery language to be used with a
-                                  filter query defined by --filterquery.
+  --filter-query-language TEXT    A filter-query language to be used with a
+                                  filter query defined by --filter-query.
                                   (Default: None)
   -h, --help                      Show this message and exit.
-
 """
 
 INST_GET_HELP = """
@@ -153,14 +153,15 @@ Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME
   Results are formatted as defined by the --output_format general option.
 
 Options:
-  -l, --localonly                 Request that server show only local
+  -l, --local-only                Request that server show only local
                                   properties of the returned instance. Some
                                   servers may not process this parameter.
-  -q, --includequalifiers         If set, requests server to include
+  -q, --include-qualifiers        If set, requests server to include
                                   qualifiers in the returned instances. Not
                                   all servers return qualifiers on instances
-  -c, --includeclassorigin        Include class origin attribute in returned
-                                  instance(s).
+  -c, --include-classorigin       Request that server include classorigin in
+                                  the result.On some WBEM operations, server
+                                  may ignore this option.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
                                   option not specified a Null property list is
@@ -199,18 +200,16 @@ Usage: pywbemcli instance create [COMMAND-OPTIONS] CLASSNAME
   ex. pywbemcli instance create CIM_blah -p id=3 -p strp="bla bla", -p p3=3
 
 Options:
-  -P, --property name=value  Optional property definitions of the form
-                             name=value. Multiple definitions allowed, one for
-                             each property to be included in the
-                             createdinstance. Array property values defined by
-                             comma-separated-values. EmbeddedInstance not
-                             allowed.
+  -P, --property name=value  Optional property names of the form name=value.
+                             Multiple definitions allowed, one for each
+                             property to be included in the createdinstance.
+                             Array property values defined by comma-separated-
+                             values. EmbeddedInstance not allowed.
   -V, --verify               If set, The change is displayed and verification
                              requested before the change is executed
   -n, --namespace <name>     Namespace to use for this operation, instead of
                              the default namespace of the connection
   -h, --help                 Show this message and exit.
-
 """
 
 INST_DELETE_HELP = """
@@ -240,7 +239,7 @@ Options:
 INST_COUNT_HELP = """
 Usage: pywbemcli instance count [COMMAND-OPTIONS] CLASSNAME-GLOB
 
-  Get instance count for classes.
+  Get CIM instance count for classes.
 
   Displays the count of instances for the classes defined by the `CLASSNAME-
   GLOB` argument in one or more namespaces.
@@ -301,7 +300,7 @@ Options:
                                   refer to the target instance through a
                                   property with aname that matches the value
                                   of this parameter. Optional.
-  -q, --includequalifiers         If set, requests server to include
+  -q, --include-qualifiers        If set, requests server to include
                                   qualifiers in the returned instances. This
                                   subcommand may use either pull or
                                   traditional operations depending on the
@@ -311,8 +310,9 @@ Options:
                                   this option is specified. If traditional
                                   operations are used, inclusion of qualifiers
                                   depends on the server.
-  -c, --includeclassorigin        Include class origin attribute in returned
-                                  instance(s).
+  -c, --include-classorigin       Request that server include classorigin in
+                                  the result.On some WBEM operations, server
+                                  may ignore this option.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
                                   option not specified a Null property list is
@@ -333,44 +333,43 @@ Options:
                                   class from which the instance to process is
                                   selected.
   -S, --summary                   Return only summary of objects (count).
-  -f, --filterquery TEXT          A filter query to be passed to the server if
+  -f, --filter-query TEXT         A filter query to be passed to the server if
                                   the pull operations are used. If this option
-                                  is defined and the --filterquerylanguage is
-                                  None, pywbemcli assumes DMTF:FQL. If this
+                                  is defined and the --filter-query-language
+                                  is None, pywbemcli assumes DMTF:FQL. If this
                                   option is defined and the traditional
                                   operations are used, the filter is not sent
                                   to the server. See the documentation for
                                   more information. (Default: None)
-  --filterquerylanguage TEXT      A filterquery language to be used with a
-                                  filter query defined by --filterquery.
+  --filter-query-language TEXT    A filter-query language to be used with a
+                                  filter query defined by --filter-query.
                                   (Default: None)
   -h, --help                      Show this message and exit.
-
 """
 
 INST_MODIFY_HELP = """
 Usage: pywbemcli instance modify [COMMAND-OPTIONS] INSTANCENAME
 
-  Modify an existing instance.
+  Modify an existing CIM instance.
 
   Modifies CIM instance defined by INSTANCENAME in the WBEM server using the
   property names and values defined by the property option and the CIM class
-  defined by the instance name.  The propertylist option if provided is
-  passed to the WBEM server as part of the ModifyInstance operation
-  (normally the WBEM server limits modifications) to just those properties
-  defined in the property list.
+  defined by the instance name.  The --propertylist option if provided is
+  passed to the WBEM server as part of the ModifyInstance operation (the
+  WBEM server limits modifications to just those properties defined in the
+  property list).
 
   INSTANCENAME must be a CIM instance name in the format defined by DMTF
   `DSP0207`.
 
-  Pywbemcli builds only the properties defined with the --property option
-  into an instance based on the CIMClass and forwards that to the WBEM
-  server with the ModifyInstance method.
+  Pywbemcli builds only properties defined with the --property option into
+  an instance based on the CIMClass and forwards that to the WBEM server
+  with the ModifyInstance method.
 
   ex. pywbemcli instance modify CIM_blah.fred=3 -p id=3 -p strp="bla bla"
 
 Options:
-  -P, --property name=value       Optional property definitions of the form
+  -P, --property name=value       Optional property names of the form
                                   name=value. Multiple definitions allowed,
                                   one for each property to be included in the
                                   createdinstance. Array property values
@@ -406,8 +405,8 @@ Usage: pywbemcli instance associators [COMMAND-OPTIONS] INSTANCENAME
   Get associated instances or names.
 
   Returns the associated instances or names (--names-only option) for the
-  `INSTANCENAME` argument filtered by the --assocclass, --resultclass,
-  --role and --resultrole options.
+  `INSTANCENAME` argument filtered by the --assoc-class, --result-class,
+  --role and --result-role options.
 
   INSTANCENAME must be a CIM instance name in the format defined by DMTF
   `DSP0207`.
@@ -419,12 +418,13 @@ Usage: pywbemcli instance associators [COMMAND-OPTIONS] INSTANCENAME
   Results are formatted as defined by the --output_format general option.
 
 Options:
-  -a, --assocclass <class name>   Filter by the association class name
+  -a, --assoc-class <class name>  Filter by the association class name
                                   provided.Each returned instance (or instance
                                   name) should be associated to the source
                                   instance through this class or its
                                   subclasses. Optional.
-  -c, --resultclass <class name>  Filter by the result class name provided.
+  -c, --result-class <class name>
+                                  Filter by the result class name provided.
                                   Each returned instance (or instance name)
                                   should be a member of this class or one of
                                   its subclasses. Optional
@@ -434,14 +434,14 @@ Options:
                                   (INSTANCENAME) through an association with
                                   this role (property name in the association
                                   that matches this parameter). Optional.
-  -R, --resultrole <role name>    Filter by the result role name provided.
+  -R, --result-role <role name>   Filter by the result role name provided.
                                   Each returned instance (or instance
                                   name)should be associated with the source
                                   instance name (`INSTANCENAME`) through an
                                   association with returned object having this
                                   role (property name in the association that
                                   matches this parameter). Optional.
-  -q, --includequalifiers         If set, requests server to include
+  -q, --include-qualifiers        If set, requests server to include
                                   qualifiers in the returned instances. This
                                   subcommand may use either pull or
                                   traditional operations depending on the
@@ -451,8 +451,9 @@ Options:
                                   this option is specified. If traditional
                                   operations are used, inclusion of qualifiers
                                   depends on the server.
-  -c, --includeclassorigin        Include class origin attribute in returned
-                                  instance(s).
+  -c, --include-classorigin       Request that server include classorigin in
+                                  the result.On some WBEM operations, server
+                                  may ignore this option.
   -p, --propertylist <property name>
                                   Define a propertylist for the request. If
                                   option not specified a Null property list is
@@ -473,16 +474,16 @@ Options:
                                   class from which the instance to process is
                                   selected.
   -S, --summary                   Return only summary of objects (count).
-  -f, --filterquery TEXT          A filter query to be passed to the server if
+  -f, --filter-query TEXT         A filter query to be passed to the server if
                                   the pull operations are used. If this option
-                                  is defined and the --filterquerylanguage is
-                                  None, pywbemcli assumes DMTF:FQL. If this
+                                  is defined and the --filter-query-language
+                                  is None, pywbemcli assumes DMTF:FQL. If this
                                   option is defined and the traditional
                                   operations are used, the filter is not sent
                                   to the server. See the documentation for
                                   more information. (Default: None)
-  --filterquerylanguage TEXT      A filterquery language to be used with a
-                                  filter query defined by --filterquery.
+  --filter-query-language TEXT    A filter-query language to be used with a
+                                  filter query defined by --filter-query.
                                   (Default: None)
   -h, --help                      Show this message and exit.
 """
@@ -737,15 +738,15 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate CIM_Foo --includequalifiers',
-     ['enumerate', 'CIM_Foo', '--includequalifiers'],
+    ['Verify instance subcommand enumerate CIM_Foo --include-qualifiers',
+     ['enumerate', 'CIM_Foo', '--include-qualifiers'],
      {'stdout': ENUM_INST_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate CIM_Foo includequalifiers and '
+    ['Verify instance subcommand enumerate CIM_Foo include-qualifiers and '
      ' --use-pull-ops no',
-     {'args': ['enumerate', 'CIM_Foo', '--includequalifiers'],
+     {'args': ['enumerate', 'CIM_Foo', '--include-qualifiers'],
       'global': ['--use-pull-ops', 'no']},
      {'stdout': ENUM_INST_RESP,
       'test': 'linesnows'},
@@ -753,7 +754,7 @@ TEST_CASES = [
 
     ['Verify instance subcommand enumerate CIM_Foo with --use-pull-ops yes and '
      '--pull_max_cnt=2',
-     {'args': ['enumerate', 'CIM_Foo', '--includequalifiers'],
+     {'args': ['enumerate', 'CIM_Foo', '--include-qualifiers'],
       'global': ['--use-pull-ops', 'yes', '--pull-max-cnt', '2', '--log',
                  'all=stderr']},
      {'stderr': [r'PullInstancesWithPath\(pull_inst_result_tuple\(context='
@@ -775,20 +776,20 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate deepinheritance CIM_Foo -d',
+    ['Verify instance subcommand enumerate deep-inheritance CIM_Foo -d',
      ['enumerate', 'CIM_Foo', '-d'],
      {'stdout': ENUM_INST_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate deepinheritance CIM_Foo '
-     '--deepinheritance',
-     ['enumerate', 'CIM_Foo', '--deepinheritance'],
+    ['Verify instance subcommand enumerate deep-inheritance CIM_Foo '
+     '--deep-inheritance',
+     ['enumerate', 'CIM_Foo', '--deep-inheritance'],
      {'stdout': ENUM_INST_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand -o grid enumerate deepinheritance CIM_Foo -d',
+    ['Verify instance subcommand -o grid enumerate deep-inheritance CIM_Foo -d',
      {'args': ['enumerate', 'CIM_Foo', '-d'],
       'global': ['--output-format', 'grid']},
      {'stdout': ENUM_INST_TABLE_RESP,
@@ -847,13 +848,13 @@ TEST_CASES = [
     # TODO: modify this to output log and test for info in return and log
 
     ['Verify instance subcommand enumerate with query.',
-     ['enumerate', 'CIM_Foo', '--filterquery', 'InstanceID = 3'],
+     ['enumerate', 'CIM_Foo', '--filter-query', 'InstanceID = 3'],
      {'stdout': ENUM_INST_RESP,
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance subcommand enumerate with query, traditional ops fails',
-     {'args': ['enumerate', 'CIM_Foo', '--filterquery', 'InstanceID = 3'],
+     {'args': ['enumerate', 'CIM_Foo', '--filter-query', 'InstanceID = 3'],
       'global': ['--use-pull-ops', 'no']},
      {'stderr': ["ValueError",
                  "EnumerateInstances does not support FilterQuery"],
@@ -892,10 +893,10 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    # TODO the following uses deepinheritance because of issue in pywbem_mock
+    # TODO the following uses deep-inheritance because of issue in pywbem_mock
     ['Verify subcommand enumerate with PyWBEM_AllTypes table with scalar '
      'properties returns instance with all property types',
-     {'args': ['enumerate', 'PyWBEM_AllTypes', '--deepinheritance',
+     {'args': ['enumerate', 'PyWBEM_AllTypes', '--deep-inheritance',
                '--propertylist',
                'instanceid,scalbool,scaluint32,scalsint32'],
       'global': ['--output-format', 'grid']},
@@ -913,7 +914,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify subcommand enumerate with PyWBEM_AllTypes with array properties '
      'returns instance with all property types',
-     {'args': ['enumerate', 'PyWBEM_AllTypes', '--deepinheritance',
+     {'args': ['enumerate', 'PyWBEM_AllTypes', '--deep-inheritance',
                '--propertylist',
                'instanceid,arraybool,arrayuint32,arraysint32'],
       'global': ['--output-format', 'grid']},
@@ -958,15 +959,15 @@ Instances: PyWBEM_AllTypes
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance subcommand enumerate fails invalid query language',
-     ['enumerate', 'CIM_Foo', '--filterquerylanguage', 'blah',
-      '--filterquery', 'InstanceID = 3'],
+     ['enumerate', 'CIM_Foo', '--filter-query-language', 'blah',
+      '--filter-query', 'InstanceID = 3'],
      {'stderr': ['CIMError', '14', 'CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED'],
       'rc': 1,
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance subcommand enumerate fails using traditional op',
-     {'args': ['enumerate', 'CIM_Foo', '--filterquery', 'InstanceID = 3'],
+     {'args': ['enumerate', 'CIM_Foo', '--filter-query', 'InstanceID = 3'],
       'global': ['--use-pull-ops', 'no']},
      {'stderr':
       ['ValueError', 'EnumerateInstances does not support FilterQuery'],
@@ -1018,9 +1019,9 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with instancename --localonly returns '
+    ['Verify instance subcommand get with instancename --local-only returns '
      ' data',
-     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--localonly'],
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--local-only'],
      {'stdout': ['instance of CIM_Foo {',
                  '   InstanceID = "CIM_Foo1";',
                  '   IntegerProp = 1;',
@@ -1030,9 +1031,9 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with instancename --includequalifiers '
+    ['Verify instance subcommand get with instancename --include-qualifiers '
      'returns data',
-     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--includequalifiers'],
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--include-qualifiers'],
      {'stdout': ['instance of CIM_Foo {',
                  '   InstanceID = "CIM_Foo1";',
                  '   IntegerProp = 1;',
@@ -1042,9 +1043,9 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with instancename --includequalifiers and '
-     'general --use-pull-ops returns data',
-     {'args': ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--includequalifiers'],
+    ['Verify instance subcommand get with instancename --include-qualifiers '
+     'and general --use-pull-ops returns data',
+     {'args': ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--include-qualifiers'],
       'global': ['--use-pull-ops', 'no']},
      {'stdout': ['instance of CIM_Foo {',
                  '   InstanceID = "CIM_Foo1";',
@@ -1683,15 +1684,15 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references --includequalifiers',
-     ['references', 'TST_Person.name="Mike"', '--includequalifiers'],
+    ['Verify instance subcommand references --include-qualifiers',
+     ['references', 'TST_Person.name="Mike"', '--include-qualifiers'],
      {'stdout': REF_INSTS,
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references includequalifiers and '
+    ['Verify instance subcommand references include-qualifiers and '
      ' --use-pull-ops no',
-     {'args': ['references', 'TST_Person.name="Mike"', '--includequalifiers'],
+     {'args': ['references', 'TST_Person.name="Mike"', '--include-qualifiers'],
       'global': ['--use-pull-ops', 'no']},
      {'stdout': REF_INSTS,
       'test': 'linesnows'},
@@ -1744,14 +1745,14 @@ Instances: PyWBEM_AllTypes
      [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
 
     ['Verify instance subcommand references with query.',
-     ['references', 'TST_Person.name="Mike"', '--filterquery',
+     ['references', 'TST_Person.name="Mike"', '--filter-query',
       'InstanceID = 3'],
      {'stdout': REF_INSTS,
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
     ['Verify instance subcommand references with query, traditional ops fails',
-     {'args': ['references', 'TST_Person.name="Mike"', '--filterquery',
+     {'args': ['references', 'TST_Person.name="Mike"', '--filter-query',
                'InstanceID = 3'],
       'global': ['--use-pull-ops', 'no']},
      {'stderr': ["ValueError:",
@@ -1779,16 +1780,17 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand associators, --includequalifiers',
-     ['associators', 'TST_Person.name="Mike"', '--includequalifiers'],
+    ['Verify instance subcommand associators, --include-qualifiers',
+     ['associators', 'TST_Person.name="Mike"', '--include-qualifiers'],
      {'stdout': ASSOC_INSTS,
       'rc': 0,
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand associators, --includequalifiers wo pull',
+    ['Verify instance subcommand associators, --include-qualifiers wo pull',
      {'global': ['--use-pull-ops', 'no'],
-      'args': ['associators', 'TST_Person.name="Mike"', '--includequalifiers']},
+      'args': ['associators', 'TST_Person.name="Mike"',
+               '--include-qualifiers']},
      {'stdout': ASSOC_INSTS,
       'rc': 0,
       'test': 'lines'},
@@ -1858,14 +1860,14 @@ Instances: PyWBEM_AllTypes
      [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
 
     ['Verify instance subcommand associators with query.',
-     ['associators', 'TST_Person.name="Mike"', '--filterquery',
+     ['associators', 'TST_Person.name="Mike"', '--filter-query',
       'InstanceID = 3'],
      {'stdout': ASSOC_INSTS,
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
     ['Verify instance subcommand associators with query, traditional ops',
-     {'args': ['associators', 'TST_Person.name="Mike"', '--filterquery',
+     {'args': ['associators', 'TST_Person.name="Mike"', '--filter-query',
                'InstanceID = 3'],
       'global': ['--use-pull-ops', 'no']},
      {'stderr': ["ValueError:",

--- a/tests/unit/test_log_option.py
+++ b/tests/unit/test_log_option.py
@@ -50,10 +50,10 @@ TEST_CASES = [
       'rc': 1},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify log of class subcommand get localonly. Test stdoit',
+    ['Verify log of class subcommand get local-only. Test stdoit',
      {'global': ['-l', 'all=stderr:summary'],
       'subcmd': 'class',
-      'args': ['get', 'CIM_Foo_sub2', '--localonly']},
+      'args': ['get', 'CIM_Foo_sub2', '--local-only']},
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
                  '',
                  '   string cimfoo_sub2;',
@@ -63,11 +63,11 @@ TEST_CASES = [
       'test': 'patterns'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify Log of class subcommand get localonly. test stderr'
+    ['Verify Log of class subcommand get local-only. test stderr'
      'Cannot test stderr and stdout in same test.',
      {'global': ['-l', 'all=stderr:summary'],
       'subcmd': 'class',
-      'args': ['get', 'CIM_Foo_sub2', '--localonly']},
+      'args': ['get', 'CIM_Foo_sub2', '--local-only']},
      {'stderr': [r'-pywbem.api.',
                  r'FakedWBEMConnection',
                  r'-Request:',
@@ -76,11 +76,11 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify log of class subcommand get localonly. Test stderr'
+    ['Verify log of class subcommand get local-only. Test stderr'
      'Cannot test stderr and stdout in same test.',
      {'global': ['-l', 'api=stderr:summary'],
       'subcmd': 'class',
-      'args': ['get', 'CIM_Foo_sub2', '--localonly']},
+      'args': ['get', 'CIM_Foo_sub2', '--local-only']},
      {'stderr': [r'-pywbem.api.',
                  r'FakedWBEMConnection',
                  r'-Request:',
@@ -89,12 +89,12 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify log http class subcommand get localonly. Should be no log because '
-     'mock does not use http'
+    ['Verify log http class subcommand get local-only. Should be no log '
+     'because mock does not use http'
      'Cannot test stderr and stdout in same test.',
      {'global': ['-l', 'http=stderr:summary'],
       'subcmd': 'class',
-      'args': ['get', 'CIM_Foo_sub2', '--localonly']},
+      'args': ['get', 'CIM_Foo_sub2', '--local-only']},
      {'stderr': [],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
@@ -103,7 +103,7 @@ TEST_CASES = [
      'same test.',
      {'global': ['-l', 'httpx=stderr'],
       'subcmd': 'class',
-      'args': ['get', 'CIM_Foo_sub2', '--localonly']},
+      'args': ['get', 'CIM_Foo_sub2', '--local-only']},
      {'stderr': ["Error: Logger configuration error. input: "],
       'rc': 1,
       'test': 'regex'},
@@ -112,7 +112,7 @@ TEST_CASES = [
     ['Verify log with error in definition. invalid type',
      {'global': ['-l', 'allx=stderr'],
       'subcmd': 'class',
-      'args': ['get', 'CIM_Foo_sub2', '--localonly']},
+      'args': ['get', 'CIM_Foo_sub2', '--local-only']},
      {'stderr': ["Error: Logger configuration error. input: allx=stderr. "
                  "Exception: Invalid simple logger name:"],
       'rc': 1,
@@ -124,7 +124,7 @@ TEST_CASES = [
      'same test.',
      {'global': ['-l'],
       'subcmd': 'class',
-      'args': ['get', 'CIM_Foo_sub2', '--localonly']},
+      'args': ['get', 'CIM_Foo_sub2', '--local-only']},
      {'stderr': ["Usage: pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS]"],
       'rc': 2,
       'test': 'in'},

--- a/tests/unit/test_server_subcmd.py
+++ b/tests/unit/test_server_subcmd.py
@@ -33,6 +33,10 @@ Usage: pywbemcli server [COMMAND-OPTIONS] COMMAND [ARGS]...
 
   Command Group for WBEM server operations.
 
+  The server command-group defines commands to inspect and manage core
+  components of the server including namespaces, the interop namespace,
+  profiles, and access to profile central instances.
+
   In addition to the command-specific options shown in this help text, the
   general options (see 'pywbemcli --help') can also be specified before the
   command. These are NOT retained after the command is executed.
@@ -41,20 +45,19 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  brand         Display information on the server.
-  centralinsts  Display central instances in the WBEM server.
-  connection    Display connection info used by this server.
-  info          Display general information on the Server.
-  interop       Display the interop namespace name.
-  namespaces    Display the namespaces in the WBEM server.
-  profiles      Display registered profiles from the WBEM server.
-
+  brand             Display information on the WBEM server.
+  connection        Display connection info used by this server.
+  get-centralinsts  Display central instances in the WBEM server.
+  info              Display general information on the server.
+  interop           Display the server interop namespace name.
+  namespaces        Display the namespaces in the WBEM server.
+  profiles          Display registered profiles from the WBEM server.
 """
 
 SVR_BRAND_HELP = """
 Usage: pywbemcli server brand [COMMAND-OPTIONS]
 
-  Display information on the server.
+  Display information on the WBEM server.
 
   Display brand information on the current server if it is available. This
   is typically the definition of the server implementor.
@@ -63,8 +66,8 @@ Options:
   -h, --help  Show this message and exit.
 """
 
-SVR_CENTRALINSTS_HELP = """
-Usage: pywbemcli server centralinsts [COMMAND-OPTIONS]
+SVR_GETCENTRALINSTS_HELP = """
+Usage: pywbemcli server get-centralinsts [COMMAND-OPTIONS]
 
   Display central instances in the WBEM server.
 
@@ -89,18 +92,19 @@ Options:
   -o, --organization <org name>   Filter by the defined organization. (ex. -o
                                   DMTF
   -p, --profile <profile name>    Filter by the profile name. (ex. -p Array
-  -c, --central_class <classname>
+  -c, --central-class <classname>
                                   Optional. Required only if profiles supports
                                   only scopig methodology
-  -s, --scoping_class <classname>
+  -s, --scoping-class <classname>
                                   Optional. Required only if profiles supports
                                   only scopig methodology
-  -S, --scoping_path <pathname>   Optional. Required only if profiles supports
+  -S, --scoping-path <pathname>   Optional. Required only if profiles supports
                                   only scopig methodology. Multiples allowed
-  -r, --reference_direction [snia|dmtf]
+  -r, --reference-direction [snia|dmtf]
                                   Navigation direction for association.
                                   [default: dmtf]
-  -h, --help                      Show this message and exit."""
+  -h, --help                      Show this message and exit.
+  """
 
 SVR_CONNECT_HELP = """
 Usage: pywbemcli  server connection [COMMAND-OPTIONS]
@@ -119,7 +123,7 @@ Options:
 SVR_INFO_HELP = """
 Usage: pywbemcli server info [COMMAND-OPTIONS]
 
-  Display general information on the Server.
+  Display general information on the server.
 
   Displays general information on the current server includeing brand,
   namespaces, etc.
@@ -131,7 +135,7 @@ Options:
 SVR_INTEROP_HELP = """
 Usage: pywbemcli server interop [COMMAND-OPTIONS]
 
-  Display the interop namespace name.
+  Display the server interop namespace name.
 
   Displays the name of the interop namespace defined for the WBEM server.
 
@@ -200,8 +204,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify class subcommand profiles  --help response',
-     ['centralinsts', '--help'],
-     {'stdout': SVR_CENTRALINSTS_HELP,
+     ['get-centralinsts', '--help'],
+     {'stdout': SVR_GETCENTRALINSTS_HELP,
       'test': 'linesnows'},
      None, OK],
 
@@ -357,8 +361,8 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify server subcommand centralinsts, ',
-     {'args': ['centralinsts', '-o', 'SNIA',
+    ['Verify server subcommand get-centralinsts, ',
+     {'args': ['get-centralinsts', '-o', 'SNIA',
                '-p', 'Server'],
       'global': ['-d', 'interop', '-o', 'simple']},
      {'stdout': ['Advertised Central Instances:',


### PR DESCRIPTION
Moved section 2.2 to section 3 per issue#242. Note that I also found some editorial issues and replaces all use of the :: with .. code-block: text because it is easier to see in the documentation.

This pr based on #244 and #245

No code changes in this pr, only changes to the doc files.