### PR TITLE
Fixes issue #247 Remove --sort option from class and instance  commands

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -270,7 +270,6 @@ The following defines the help output for the `pywbemcli class associators --hel
                                       empty string the server should return no
                                       properties.
       -o, --names-only                Retrieve only the returned object names.
-      -s, --sort                      Sort into alphabetical order by classname.
       -n, --namespace <name>          Namespace to use for this operation, instead
                                       of the default namespace of the connection
       -S, --summary                   Return only summary of objects (count).
@@ -358,7 +357,6 @@ The following defines the help output for the `pywbemcli class enumerate --help`
                                  result.On some WBEM operations, server may ignore
                                  this option.
       -o, --names-only           Retrieve only the returned object names.
-      -s, --sort                 Sort into alphabetical order by classname.
       -n, --namespace <name>     Namespace to use for this operation, instead of
                                  the default namespace of the connection
       -S, --summary              Return only summary of objects (count).
@@ -402,7 +400,6 @@ The following defines the help output for the `pywbemcli class find --help` subc
       the form <namespace>:<classname>
 
     Options:
-      -s, --sort              Sort into alphabetical order by classname.
       -n, --namespace <name>  Namespace(s) to use for this operation. If defined
                               only those namespaces are searched rather than all
                               available namespaces. ex: -n root/interop -n
@@ -546,7 +543,6 @@ The following defines the help output for the `pywbemcli class references --help
                                       empty string the server should return no
                                       properties.
       -o, --names-only                Retrieve only the returned object names.
-      -s, --sort                      Sort into alphabetical order by classname.
       -n, --namespace <name>          Namespace to use for this operation, instead
                                       of the default namespace of the connection
       -S, --summary                   Return only summary of objects (count).
@@ -1083,7 +1079,6 @@ The following defines the help output for the `pywbemcli instance associators --
       -o, --names-only                Retrieve only the returned object names.
       -n, --namespace <name>          Namespace to use for this operation, instead
                                       of the default namespace of the connection
-      -s, --sort                      Sort into alphabetical order by classname.
       -i, --interactive               If set, `INSTANCENAME` argument must be a
                                       class rather than an instance and user is
                                       presented with a list of instances of the
@@ -1288,7 +1283,6 @@ The following defines the help output for the `pywbemcli instance enumerate --he
       -n, --namespace <name>          Namespace to use for this operation, instead
                                       of the default namespace of the connection
       -o, --names-only                Retrieve only the returned object names.
-      -s, --sort                      Sort into alphabetical order by classname.
       -S, --summary                   Return only summary of objects (count).
       -f, --filter-query TEXT         A filter query to be passed to the server if
                                       the pull operations are used. If this option
@@ -1512,7 +1506,6 @@ The following defines the help output for the `pywbemcli instance query --help` 
                                       DMTF:CQL.
       -n, --namespace <name>          Namespace to use for this operation, instead
                                       of the default namespace of the connection
-      -s, --sort                      Sort into alphabetical order by classname.
       -S, --summary                   Return only summary of objects (count).
       -h, --help                      Show this message and exit.
 
@@ -1583,7 +1576,6 @@ The following defines the help output for the `pywbemcli instance references --h
       -o, --names-only                Retrieve only the returned object names.
       -n, --namespace <name>          Namespace to use for this operation, instead
                                       of the default namespace of the connection
-      -s, --sort                      Sort into alphabetical order by classname.
       -i, --interactive               If set, `INSTANCENAME` argument must be a
                                       class rather than an instance and user is
                                       presented with a list of instances of the

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -29,7 +29,7 @@ from ._common import display_cim_objects, filter_namelist, \
     resolve_propertylist, CMD_OPTS_TXT, TABLE_FORMATS, \
     format_table, process_invokemethod
 from ._common_options import propertylist_option, names_only_option, \
-    sort_option, includeclassorigin_option, namespace_option, add_options, \
+    includeclassorigin_option, namespace_option, add_options, \
     summary_objects_option
 
 from ._displaytree import display_class_tree
@@ -161,7 +161,6 @@ def class_invokemethod(context, classname, methodname, **options):
 @add_options(includeclassqualifiers_option)
 @add_options(includeclassorigin_option)
 @add_options(names_only_option)
-@add_options(sort_option)
 @add_options(namespace_option)
 @add_options(summary_objects_option)
 @click.pass_obj
@@ -204,7 +203,6 @@ def class_enumerate(context, classname, **options):
 @add_options(includeclassorigin_option)
 @add_options(propertylist_option)
 @add_options(names_only_option)
-@add_options(sort_option)
 @add_options(namespace_option)
 @add_options(summary_objects_option)
 @click.pass_obj
@@ -252,7 +250,6 @@ def class_references(context, classname, **options):
 @add_options(includeclassorigin_option)
 @add_options(propertylist_option)
 @add_options(names_only_option)
-@add_options(sort_option)
 @add_options(namespace_option)
 @add_options(summary_objects_option)
 @click.pass_obj
@@ -273,7 +270,6 @@ def class_associators(context, classname, **options):
 @class_group.command('find', options_metavar=CMD_OPTS_TXT)
 @click.argument('classname-glob', type=str, metavar='CLASSNAME-GLOB',
                 required=True)
-@add_options(sort_option)
 @click.option('-n', '--namespace', type=str, multiple=True,
               required=False, metavar='<name>',
               help='Namespace(s) to use for this operation. If defined only '
@@ -400,7 +396,7 @@ def cmd_class_enumerate(context, classname, options):
                 IncludeClassOrigin=options['include_classorigin'])
 
         display_cim_objects(context, results, context.output_format,
-                            summary=options['summary'], sort=options['sort'])
+                            summary=options['summary'], sort=True)
 
     except Error as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
@@ -429,7 +425,7 @@ def cmd_class_references(context, classname, options):
                 PropertyList=resolve_propertylist(options['propertylist']))
 
         display_cim_objects(context, results, context.output_format,
-                            summary=options['summary'], sort=options['sort'])
+                            summary=options['summary'], sort=True)
 
     except Error as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
@@ -462,7 +458,7 @@ def cmd_class_associators(context, classname, options):
                 PropertyList=resolve_propertylist(options['propertylist']))
 
         display_cim_objects(context, results, context.output_format,
-                            summary=options['summary'], sort=options['sort'])
+                            summary=options['summary'], sort=True)
 
     except Error as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
@@ -478,13 +474,12 @@ def cmd_class_find(context, classname_glob, options):
     else:
         try:
             ns_names = context.wbem_server.namespaces
+            ns_names.sort()
         except CIMError as ce:
             # allow processing to continue if no interop namespace
             if ce.status_code == CIM_ERR_NOT_FOUND:
                 click.echo('WARNING: %s' % ce)
                 ns_names = [context.conn.default_namespace]
-        if options['sort']:
-            ns_names.sort()
 
     try:
         names_dict = {}

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -27,7 +27,7 @@ from ._common import display_cim_objects, parse_wbemuri_str, \
     filter_namelist, CMD_OPTS_TXT, format_table, verify_operation, \
     process_invokemethod
 from ._common_options import propertylist_option, names_only_option, \
-    sort_option, includeclassorigin_option, namespace_option, add_options, \
+    includeclassorigin_option, namespace_option, add_options, \
     summary_objects_option, verify_option
 from .config import DEFAULT_QUERY_LANGUAGE
 
@@ -311,7 +311,6 @@ def instance_invokemethod(context, instancename, methodname, **options):
 @add_options(propertylist_option)
 @add_options(namespace_option)
 @add_options(names_only_option)
-@add_options(sort_option)
 @add_options(summary_objects_option)
 @add_options(filterquery_option)
 @add_options(filterquerylanguage_option)
@@ -352,7 +351,6 @@ def instance_enumerate(context, classname, **options):
 @add_options(propertylist_option)
 @add_options(names_only_option)
 @add_options(namespace_option)
-@add_options(sort_option)
 @add_options(interactive_option)
 @add_options(summary_objects_option)
 @add_options(filterquery_option)
@@ -410,7 +408,6 @@ def instance_references(context, instancename, **options):
 @add_options(propertylist_option)
 @add_options(names_only_option)
 @add_options(namespace_option)
-@add_options(sort_option)
 @add_options(interactive_option)
 @add_options(summary_objects_option)
 @add_options(filterquery_option)
@@ -444,7 +441,6 @@ def instance_associators(context, instancename, **options):
               help='Use the query language defined. '
                    '(Default: {of}.'.format(of=DEFAULT_QUERY_LANGUAGE))
 @add_options(namespace_option)
-@add_options(sort_option)
 @add_options(summary_objects_option)
 @click.pass_obj
 def instance_query(context, query, **options):
@@ -734,7 +730,7 @@ def cmd_instance_enumerate(context, classname, options):
                 PropertyList=resolve_propertylist(options['propertylist']))
 
         display_cim_objects(context, results, context.output_format,
-                            summary=options['summary'], sort=options['sort'])
+                            summary=options['summary'], sort=True)
 
     except (Error) as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
@@ -781,7 +777,7 @@ def cmd_instance_references(context, instancename, options):
                 PropertyList=resolve_propertylist(options['propertylist']))
 
         display_cim_objects(context, results, context.output_format,
-                            summary=options['summary'], sort=options['sort'])
+                            summary=options['summary'], sort=True)
 
     except (Error) as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
@@ -829,7 +825,7 @@ def cmd_instance_associators(context, instancename, options):
                 PropertyList=resolve_propertylist(options['propertylist']))
 
         display_cim_objects(context, results, context.output_format,
-                            summary=options['summary'], sort=options['sort'])
+                            summary=options['summary'], sort=True)
 
     except (Error) as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
@@ -922,7 +918,7 @@ def cmd_instance_query(context, query, options):
             MaxObjectCount=context.pull_max_cnt)
 
         display_cim_objects(context, results, context.output_format,
-                            summary=options['summary'], sort=options['sort'])
+                            summary=options['summary'], sort=True)
 
     except Error as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))

--- a/tests/unit/simple_mock_model_ext.mof
+++ b/tests/unit/simple_mock_model_ext.mof
@@ -97,6 +97,10 @@ instance of CIM_Foo as $foo2 {
 
 instance of CIM_Foo as $foo3 { InstanceID = "CIM_Foo3"; };
 
+instance of CIM_Foo as $foo3 { InstanceID = "CIM_Foo30"; };
+
+instance of CIM_Foo as $foo3 { InstanceID = "CIM_Foo31"; };
+
 // Additional instances behond simple_mof_model.mof
 
 instance of CIM_Foo_sub as $foosub1{
@@ -114,18 +118,23 @@ instance of CIM_Foo_sub as $foosub1{
     IntegerProp = 6;
     };
 
-instance of CIM_Foo_sub_sub as $foosubsub1{
-    InstanceID = "CIM_Foo_sub_sub1";
+instance of CIM_Foo_sub as $foosub1{
+    InstanceID = "CIM_Foo_sub3";
     IntegerProp = 7;
     };
 
 instance of CIM_Foo_sub_sub as $foosubsub1{
-    InstanceID = "CIM_Foo_sub_sub2";
+    InstanceID = "CIM_Foo_sub_sub1";
     IntegerProp = 8;
     };
 
 instance of CIM_Foo_sub_sub as $foosubsub1{
-    InstanceID = "CIM_Foo_sub_sub3";
+    InstanceID = "CIM_Foo_sub_sub2";
     IntegerProp = 9;
+    };
+
+instance of CIM_Foo_sub_sub as $foosubsub1{
+    InstanceID = "CIM_Foo_sub_sub3";
+    IntegerProp = 10;
 
     };

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -95,7 +95,7 @@ Options:
 """
 
 
-CLS_ENUM_HELP = """
+CLS_ENUMERATE_HELP = """
 Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME
 
   Enumerate classes from the WBEM server.
@@ -127,7 +127,6 @@ Options:
                              result.On some WBEM operations, server may ignore
                              this option.
   -o, --names-only           Retrieve only the returned object names.
-  -s, --sort                 Sort into alphabetical order by classname.
   -n, --namespace <name>     Namespace to use for this operation, instead of
                              the default namespace of the connection
   -S, --summary              Return only summary of objects (count).
@@ -160,7 +159,6 @@ Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME-GLOB
   the form <namespace>:<classname>
 
 Options:
-  -s, --sort              Sort into alphabetical order by classname.
   -n, --namespace <name>  Namespace(s) to use for this operation. If defined
                           only those namespaces are searched rather than all
                           available namespaces. ex: -n root/interop -n
@@ -264,7 +262,6 @@ Options:
                                   empty string the server should return no
                                   properties.
   -o, --names-only                Retrieve only the returned object names.
-  -s, --sort                      Sort into alphabetical order by classname.
   -n, --namespace <name>          Namespace to use for this operation, instead
                                   of the default namespace of the connection
   -S, --summary                   Return only summary of objects (count).
@@ -448,13 +445,13 @@ TEST_CASES = [
     #
     ['Verify class subcommand enumerate  --help response',
      ['enumerate', '--help'],
-     {'stdout': CLS_ENUM_HELP,
+     {'stdout': CLS_ENUMERATE_HELP,
       'test': 'linesnows'},
      None, OK],
 
     ['Verify class subcommand enumerate  -h response.',
      ['enumerate', '-h'],
-     {'stdout': CLS_ENUM_HELP,
+     {'stdout': CLS_ENUMERATE_HELP,
       'test': 'linesnows'},
      None, OK],
 
@@ -805,27 +802,10 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand find simple name in known namespace with -s',
-     ['find', 'CIM_*', '-n', 'root/cimv2', '-s'],
-     {'stdout': ["  root/cimv2:CIM_Foo",
-                 "  root/cimv2:CIM_Foo_sub",
-                 "  root/cimv2:CIM_Foo_sub2",
-                 "  root/cimv2:CIM_Foo_sub_sub"],
-      'test': 'lines'},
-     SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand find simple name in known namespace with --sort',
-     ['find', 'CIM_*', '-n', 'root/cimv2', '-s'],
-     {'stdout': ["  root/cimv2:CIM_Foo",
-                 "  root/cimv2:CIM_Foo_sub",
-                 "  root/cimv2:CIM_Foo_sub2",
-                 "  root/cimv2:CIM_Foo_sub_sub"],
-      'test': 'lines'},
-     SIMPLE_MOCK_FILE, OK],
-
-    ['Verify class subcommand find name in known namespace with -s, 0 grid',
+    ['Verify class subcommand find name in known namespace -o grid',
      {'global': ['-o', 'grid'],
-      'args': ['find', 'CIM_*', '-n', 'root/cimv2', '-s']},
+      'args': ['find', 'CIM_*', '-n', 'root/cimv2']},
      {'stdout': ['Find class CIM_*',
                  '+-------------+-----------------+',
                  '| Namespace   | Classname       |',
@@ -1151,14 +1131,14 @@ TEST_CASES = [
       'test': 'linesnows'},
      None, OK],
 
-    ['Verify class subcommand references simple request, -s',
-     ['references', 'TST_Person', '-s'],
+    ['Verify class subcommand references simple request',
+     ['references', 'TST_Person'],
      {'stdout': REFERENCES_CLASS_RTN_QUALS1,
       'test': 'linesnows'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand references simple request -o -s',
-     ['references', 'TST_Person', '-o', '-s'],
+    ['Verify class subcommand references simple request -o',
+     ['references', 'TST_Person', '-o'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Lineage',
                  '//FakedUrl/root/cimv2:TST_MemberOfFamilyCollection'],
       'test': 'linesnows'},

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -25,6 +25,7 @@ TEST_DIR = os.path.dirname(__file__)
 
 SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
 ASSOC_MOCK_FILE = 'simple_assoc_mock_model.mof'
+SIMPLE_MOCK_FILE_EXT = 'simple_mock_model_ext.mof'
 ALLTYPES_MOCK_FILE = 'all_types.mof'
 INVOKE_METHOD_MOCK_FILE = "simple_mock_invokemethod.py"
 MOCK_PROMPT_0_FILE = "mock_prompt_0.py"
@@ -115,7 +116,6 @@ Options:
   -n, --namespace <name>          Namespace to use for this operation, instead
                                   of the default namespace of the connection
   -o, --names-only                Retrieve only the returned object names.
-  -s, --sort                      Sort into alphabetical order by classname.
   -S, --summary                   Return only summary of objects (count).
   -f, --filter-query TEXT         A filter query to be passed to the server if
                                   the pull operations are used. If this option
@@ -326,7 +326,6 @@ Options:
   -o, --names-only                Retrieve only the returned object names.
   -n, --namespace <name>          Namespace to use for this operation, instead
                                   of the default namespace of the connection
-  -s, --sort                      Sort into alphabetical order by classname.
   -i, --interactive               If set, `INSTANCENAME` argument must be a
                                   class rather than an instance and user is
                                   presented with a list of instances of the
@@ -467,7 +466,6 @@ Options:
   -o, --names-only                Retrieve only the returned object names.
   -n, --namespace <name>          Namespace to use for this operation, instead
                                   of the default namespace of the connection
-  -s, --sort                      Sort into alphabetical order by classname.
   -i, --interactive               If set, `INSTANCENAME` argument must be a
                                   class rather than an instance and user is
                                   presented with a list of instances of the
@@ -550,7 +548,6 @@ Options:
                                   DMTF:CQL.
   -n, --namespace <name>          Namespace to use for this operation, instead
                                   of the default namespace of the connection
-  -s, --sort                      Sort into alphabetical order by classname.
   -S, --summary                   Return only summary of objects (count).
   -h, --help                      Show this message and exit.
 
@@ -635,41 +632,40 @@ InstanceID      IntegerProp
 """
 
 REF_INSTS = """instance of TST_Lineage {
-   InstanceID = "MikeSofi";
-   parent = "/root/cimv2:TST_Person.name=\\\"Mike\\\"";
-   child = "/root/cimv2:TST_Person.name=\\\"Sofi\\\"";
-};
-
-instance of TST_Lineage {
    InstanceID = "MikeGabi";
    parent = "/root/cimv2:TST_Person.name=\\\"Mike\\\"";
    child = "/root/cimv2:TST_Person.name=\\\"Gabi\\\"";
+};
+
+instance of TST_Lineage {
+   InstanceID = "MikeSofi";
+   parent = "/root/cimv2:TST_Person.name=\\\"Mike\\\"";
+   child = "/root/cimv2:TST_Person.name=\\\"Sofi\\\"";
 };
 
 instance of TST_MemberOfFamilyCollection {
    family = "/root/cimv2:TST_FamilyCollection.name=\\\"Family2\\\"";
    member = "/root/cimv2:TST_Person.name=\\\"Mike\\\"";
 };
-
 """
 
-ASSOC_INSTS = """instance of TST_Person {
-   name = "Sofi";
+ASSOC_INSTS = """instance of TST_FamilyCollection {
+   name = "Family2";
 };
 
 instance of TST_Person {
    name = "Gabi";
 };
 
-instance of TST_FamilyCollection {
-   name = "Family2";
+instance of TST_Person {
+   name = "Sofi";
 };
 
 """
 
 # pylint: enable=line-too-long
 
-OK = True    # mark tests OK when they execute correctly
+OK = True     # mark tests OK when they execute correctly
 RUN = True    # Mark OK = False and current test case being created RUN
 FAIL = False  # Any test currently FAILING or not tested yet
 
@@ -724,14 +720,6 @@ TEST_CASES = [
 
     ['Verify instance subcommand enumerate names CIM_Foo -o --namespace',
      ['enumerate', 'CIM_Foo', '-o', '--namespace', 'root/cimv2'],
-     {'stdout': ['', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
-                 '', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"',
-                 '', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo3"', ],
-      'test': 'lines'},
-     SIMPLE_MOCK_FILE, OK],
-
-    ['Verify instance subcommand enumerate names CIM_Foo -o --sort',
-     ['enumerate', 'CIM_Foo', '--names-only', '--sort'],
      {'stdout': ['', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
                  '', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"',
                  '', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo3"', ],
@@ -1572,23 +1560,23 @@ Instances: PyWBEM_AllTypes
      ['references', 'TST_Person.name="Mike"'],
      {'stdout': REF_INSTS,
       'rc': 0,
-      'test': 'lines'},
+      'test': 'lineswons'},
      ASSOC_MOCK_FILE, OK],
 
     ['Verify instance subcommand references, returns instances, explicit ns',
      ['references', 'TST_Person.name="Mike"', '-n', 'root/cimv2'],
      {'stdout': REF_INSTS,
       'rc': 0,
-      'test': 'lines'},
+      'test': 'lineswons'},
      ASSOC_MOCK_FILE, OK],
 
     ['Verify instance subcommand references -o, returns paths',
      ['references', 'TST_Person.name="Mike"', '-o'],
-     {'stdout': ['//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeSofi"',
+     {'stdout': ['"root/cimv2:TST_FamilyCollection.name=\\"Family2\\"",member',
+                 '=\"root/cimv2:TST_Person.name=\\"Mike\\""',
+                 '//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeSofi"',
                  '//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeGabi"',
-                 '//FakedUrl/root/cimv2:TST_MemberOfFamilyCollection.family',
-                 '"root/cimv2:TST_FamilyCollection.name=\\"Family2\\"",member',
-                 '=\"root/cimv2:TST_Person.name=\\"Mike\\""'],
+                 '//FakedUrl/root/cimv2:TST_MemberOfFamilyCollection.family'],
       'rc': 0,
       'test': 'in'},
      ASSOC_MOCK_FILE, OK],
@@ -1631,7 +1619,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand references -o, returns paths with resultclass '
      'valid returns paths sorted',
-     ['references', 'TST_Person.name="Mike"', '-o', '-s',
+     ['references', 'TST_Person.name="Mike"', '-o',
       '--resultclass', 'TST_Lineage'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeGabi"',
                  '//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeSofi"', ],
@@ -1798,12 +1786,11 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand associators -o, returns data',
      ['associators', 'TST_Person.name="Mike"', '-o'],
-     {'stdout': ['', '//FakedUrl/root/cimv2:TST_Person.name="Sofi"',
-                 '', '//FakedUrl/root/cimv2:TST_Person.name="Gabi"',
-                 '',
-                 '//FakedUrl/root/cimv2:TST_FamilyCollection.name="Family2"'],
+     {'stdout': ['//FakedUrl/root/cimv2:TST_FamilyCollection.name="Family2"'
+                 '//FakedUrl/root/cimv2:TST_Person.name="Gabi"',
+                 '//FakedUrl/root/cimv2:TST_Person.name="Sofi"'],
       'rc': 0,
-      'test': 'lines'},
+      'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
     ['Verify instance subcommand associators CIM_Foo with --use-pull-ops yes '
@@ -1829,8 +1816,6 @@ Instances: PyWBEM_AllTypes
                  r'TST_Person'],
       'test': 'regex'},
      ASSOC_MOCK_FILE, OK],
-
-
 
     # Invalid associators tests
 
@@ -1900,30 +1885,33 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-
-    ['Verify instance subcommand count, Return table of instances',
+    ['Verify instance subcommand count sorted, Return table of instances',
      ['count', 'CIM_*', '--sort'],
      {'stdout': ['Count of instances per class',
-                 '+---------+---------+',
-                 '| Class   |   count |',
-                 '|---------+---------|',
-                 '| CIM_Foo |       3 |',
-                 '+---------+---------+', ],
+                 '+-----------------+---------+',
+                 '| Class           |   count |',
+                 '|-----------------+---------|',
+                 '| CIM_Foo_sub_sub |       3 |',
+                 '| CIM_Foo_sub     |       4 |',
+                 '| CIM_Foo         |       5 |',
+                 '+-----------------+---------+'],
       'rc': 0,
       'test': 'lines'},
-     SIMPLE_MOCK_FILE, OK],
+     SIMPLE_MOCK_FILE_EXT, RUN],
 
-    ['Verify instance subcommand count, --sort. Return table of instances',
+    ['Verify instance subcommand count. Return table of instances',
      ['count', 'CIM_*'],
      {'stdout': ['Count of instances per class',
-                 '+---------+---------+',
-                 '| Class   |   count |',
-                 '|---------+---------|',
-                 '| CIM_Foo |       3 |',
-                 '+---------+---------+', ],
+                 '+-----------------+---------+',
+                 '| Class           |   count |',
+                 '|-----------------+---------|',
+                 '| CIM_Foo         |       5 |',
+                 '| CIM_Foo_sub     |       4 |',
+                 '| CIM_Foo_sub_sub |       3 |',
+                 '+-----------------+---------+'],
       'rc': 0,
       'test': 'lines'},
-     SIMPLE_MOCK_FILE, OK],
+     SIMPLE_MOCK_FILE_EXT, RUN],
 
     # TODO add subclass instances to the count test.
 


### PR DESCRIPTION
We had an optional --sort on a commands such as enumerate references,
associations for classes and instances.

Since there is no natural order(the server has no ordering requirements),
I concluded that there is no reason to make it an option. Removing the
option I set the sort to True so that the returned classes, classnames,
instances, and instancenames are always sorted before being displayed.