### PR TITLE
Fixes #248: Use of --output-format general option

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -112,7 +112,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       pywbemcli documentation.
                                       Choices: Table:
                                       [table|plain|simple|grid|psql|rst|html],
-                                      Object: [mof|xml|txt|tree]
+                                      Object: [mof|xml|repr|txt]
                                       [Default:
                                       "simple"]
       -U, --use-pull-ops [yes|no|either]

--- a/docs/pywbemcligeneraloptions.rst
+++ b/docs/pywbemcligeneraloptions.rst
@@ -366,7 +366,7 @@ Output formats
 Pywbemcli supports various output formats for the results. The output format
 can be selected with the ``--output-format/-o`` option.
 
-The output formats fall into three groups however, not all formats are
+The output formats fall into three groups. However, not all formats are
 applicable to all subcommands:
 
 * **Table formats** - The :ref:`Table formats` display the output as a table with
@@ -376,11 +376,33 @@ applicable to all subcommands:
   objects in formats specific to the CIM Model and also the pywbem implementation
   of the CIM model (ex. DMTF MOF and XML formats and pywbem repr and string
   formats).
-
 * **ASCII tree format** - The :ref:`ASCII tree format` provides a tree display
   of results that is logical to display as a tree.  Thus, the command
   ``pywbemcli class tree . . .`` which shows the hierarchy of the CIM classes
   defined by a WBEM server uses the tree output format.
+
+The goal of the ``--output-format`` general option is to define the prefered
+value for either the table output format or the CIM object format for the
+command or interactive session.
+
+Not all commands output in all possible formats.  There are be cases where
+even if the format set to a table format ``--output simple`` the display will
+be in the CIM model format. Some specific cases include:
+
+1. The output of the class commands enumerate, get, references, associators with
+   classes is always in one of the CIM model formats, not a table.
+
+2. Connection commands like ``list`` only output a table oriented
+   set of values, not CIM objects.  Therefore, they always output in table formats
+   and if the output_format is set to, for example, ``mof`` they still output
+   as a table using the default value of the table formats. If the the output
+   format definition is ``mof``, they will output in the default table format.
+
+3. The server commands only outputs table oriented information. not CIM
+   objects so the output is either the default or specified table format.
+
+3. The command ``class tree`` outputs a hiearchy of classes and therefore
+   the only defined output for this command is the ascii tree format.
 
 
 .. _`Table formats`:
@@ -578,13 +600,26 @@ CIM objects:
 NOTE: The above is output as a single line and has been manually formatted for
 this documentation.
 
+
+* ``-o txt``: Python str format of the objects.
+
+    This should be considered the output of last resort as it simply uses
+    the __str__ method of each command to output.
+
+    Thus, for example the a ``class enumerate`` of a model with only a single
+    class is of the form:
+
+    .. code-block:: text
+
+        CIMClass(classname='CIM_Foo', ...)
+
 .. _`ASCII tree format`:
 
 ASCII tree format
 ^^^^^^^^^^^^^^^^^
 This output format is an ASCII based output that shows the tree structure of
 the results of certain subcommands.  It is used specifically to show the
-class class hierarchy tree as follows:
+class class hierarchy tree from the command ``class tree`` as follows:
 
 .. code-block:: text
 

--- a/docs/pywbemclisubcommands.rst
+++ b/docs/pywbemclisubcommands.rst
@@ -622,9 +622,9 @@ The **instance** group defines subcommands that act on CIM instances including:
 
   See :ref:`pywbemcli instance references --help` for details.
 * **query** to execute an execquery with query string defined as an argument.
-  The QUERY argument must be a valid query defined for the ``--querylanguage``
+  The QUERY argument must be a valid query defined for the ``--query-language``
   option and available in the WBEM server being queried.  The default for
-  the ``--querylanguage`` option is DMTF:CQL but any query language and query
+  the ``--query-language`` option is DMTF:CQL but any query language and query
   will be passed to the server.
 
   It displays any instances returned in the defined formats or any exception
@@ -641,10 +641,10 @@ The **qualifier** command-group defines subcommands that act on
 CIMQualifierDeclaration entities in the WBEM server including:
 
 * **get** to get a single qualifier declaration defined by the ``QUALIFIERNAME``
-  argument from the namespace in the target WBEM server defined with this command  or
-  the default_namespace and display in the defined output format. The output
-  formats can be either one  of the :term:`CIM model output formats` or the
-  table formats` (see :ref:`Output formats`).
+  argument from the namespace in the target WBEM server defined with this
+  command  or the default_namespace and display in the defined output format.
+  The output formats can be either one  of the :term:`CIM model output formats`
+  or the table formats` (see :ref:`Output formats`).
 
   The following example gets the ``Key`` qualifier declaration from the
   default namespace:
@@ -934,15 +934,19 @@ The subcommands include:
 
     pywbemcli> connection add --name me --server http://localhost --user me --password mypw -no-verify
     pywbemcli> connection list
-    WBEMServer Connections:
-    +-----------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------+
-    | name      | server uri       | namespace   | user        | password   |   timeout | noverify   | certfile   | keyfile   | log   |
-    |-----------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------|
-    | me*       | http://localhost | root/cimv2  | me          | mypw       |           | True       |            |           |       |
-    | mock1     |                  | root/cimv2  |             |            |        30 | False      |            |           |       |
-    | mockassoc |                  | root/cimv2  |             |            |        30 | False      |            |           |       |
-    | op        | http://localhost | root/cimv2  | kschopmeyer | test8play  |        30 | True       |            |           |       |
-    +-----------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------+
+    WBEM server connections:
+    +--------------+------------------+-------------+-------------+-----------+------------+----------------------------------------+
+    | name         | server uri       | namespace   | user        |   timeout | noverify   | mock_server                            |
+    |--------------+------------------+-------------+-------------+-----------+------------+----------------------------------------|
+    | blahblah     | http://blah      | root/cimv2  |             |        45 | False      |                                        |
+    | mock1        |                  | root/cimv2  |             |           | False      | tests/unit/simple_mock_model.mof       |
+    | mockalltypes |                  | root/cimv2  |             |        30 | False      | tests/unit/all_types.mof               |
+    | mockassoc    |                  | root/cimv2  |             |        30 | False      | tests/unit/simple_assoc_mock_model.mof |
+    | mockext      |                  | root/cimv2  |             |        30 | False      | tests/unit/simple_mock_model_ext.mof   |
+    | op           | http://localhost | root/cimv2  | xxxxxxxxxxx |           | False      |                                        |
+    | test3        |                  | root/cimv2  |             |           | False      | tests/unit/simple_mock_model.mof       |
+    |              |                  |             |             |           |            | tests/unit/mock_confirm_y.py           |
+    +--------------+------------------+-------------+-------------+-----------+------------+----------------------------------------+
     pywbemcli>
 
   NOTE: The ``*`` on the name indicates the current connection, the one that

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -51,12 +51,10 @@ else:
 
 
 TABLE_FORMATS = ('table', 'plain', 'simple', 'grid', 'psql', 'rst', 'html')
-CIM_OBJECT_OUTPUT_FORMATS = ('mof', 'xml', 'txt', 'tree')
+CIM_OBJECT_OUTPUT_FORMATS = ('mof', 'xml', 'repr', 'txt')
 
-# TODO: ks for some reason extending one list with another causes a problem
-# in click with the help. Review with future versions
-OUTPUT_FORMATS = ('table', 'plain', 'simple', 'grid', 'psql', 'rst', 'html',
-                  'mof', 'xml', 'txt', 'tree')
+OUTPUT_FORMATS = [TABLE_FORMATS, CIM_OBJECT_OUTPUT_FORMATS]
+
 GENERAL_OPTIONS_METAVAR = '[GENERAL-OPTIONS]'
 CMD_OPTS_TXT = '[COMMAND-OPTIONS]'
 
@@ -866,13 +864,14 @@ def display_cim_objects(context, cim_objects, output_format=None, summary=False,
             click.echo(repr(object_))
         except AttributeError:
             raise click.ClickException('"repr" display of %r failed' % object_)
+
     elif output_format == 'txt':
         try:
             click.echo(object_)
         except AttributeError:
             raise click.ClickException('"txt" display of %r failed' % object_)
-    elif output_format == 'tree':
-        raise click.ClickException('Tree output format not allowed')
+    # elif output_format == 'tree':
+    #    raise click.ClickException('Tree output format not allowed')
     else:
         raise click.ClickException('Invalid output format %s' %
                                    output_format)

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -564,6 +564,32 @@ TEST_CASES = [
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
+
+    ['Verify class subcommand get with xml output format).',
+     {'args': ['enumerate'],
+      'global': ['--output-format', 'repr']},
+     {'stdout': [r"CIMClass\(classname='CIM_Foo', superclass=None,",
+                 r"'InstanceID': CIMProperty\(name='InstanceID', value=None,"],
+      'test': 'regex'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify class subcommand get with repr output format).',
+     {'args': ['enumerate'],
+      'global': ['--output-format', 'txt']},
+     {'stdout': ["CIMClass(classname='CIM_Foo', ...)"],
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+
+    ['Verify class subcommand get with repr output format).',
+     {'args': ['enumerate'],
+      'global': ['--output-format', 'xml']},
+     {'stdout': ['<CLASS NAME="CIM_Foo">',
+                 '<PROPERTY NAME="InstanceID"',
+                 '<PROPERTY NAME="IntegerProp" PROPAGATED="false"',
+                 '<METHOD NAME="DeleteNothing" PROPAGATED="false"'],
+      'test': 'regex'},
+     SIMPLE_MOCK_FILE, OK],
     #
     # Enumerate errors
     #
@@ -699,6 +725,33 @@ TEST_CASES = [
                  '};',
                  '', ],
       'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify class subcommand get with xml output format).',
+     {'args': ['get', 'CIM_Foo'],
+      'global': ['--output-format', 'repr']},
+     {'stdout': [r"CIMClass\(classname='CIM_Foo', superclass=None,",
+                 r"'InstanceID': CIMProperty\(name='InstanceID', value=None,"],
+      'test': 'regex'},
+     SIMPLE_MOCK_FILE, OK],
+
+
+    ['Verify class subcommand get with repr output format).',
+     {'args': ['get', 'CIM_Foo'],
+      'global': ['--output-format', 'txt']},
+     {'stdout': ["CIMClass(classname='CIM_Foo', ...)"],
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+
+    ['Verify class subcommand get with repr output format).',
+     {'args': ['get', 'CIM_Foo'],
+      'global': ['--output-format', 'xml']},
+     {'stdout': ['<CLASS NAME="CIM_Foo">',
+                 '<PROPERTY NAME="InstanceID"',
+                 '<PROPERTY NAME="IntegerProp" PROPAGATED="false"',
+                 '<METHOD NAME="DeleteNothing" PROPAGATED="false"'],
+      'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
     # pylint: enable=line-too-long

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -133,7 +133,7 @@ Options:
                                   pywbemcli documentation.
                                   Choices: Table:
                                   [table|plain|simple|grid|psql|rst|html],
-                                  Object: [mof|xml|txt|tree]
+                                  Object: [mof|xml|repr|txt]
                                   [Default:
                                   "simple"]
   -U, --use-pull-ops [yes|no|either]

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -663,6 +663,8 @@ instance of TST_Person {
 
 """
 
+# TODO: Add tests for output format xml, repr, txt
+
 # pylint: enable=line-too-long
 
 OK = True     # mark tests OK when they execute correctly

--- a/tests/unit/test_qualdecl_subcmd.py
+++ b/tests/unit/test_qualdecl_subcmd.py
@@ -170,6 +170,8 @@ QD_TBL_GET_OUT = """Qualifier Declarations
 +----------+---------+---------+---------+-------------+----------------+
 """
 
+# TODO: Add tests for xml, repr, txt formats.
+
 # The following variables are used to control tests executed during
 # development of tests
 OK = True      # set to OK for tests passed. Set OK = False to execute one test


### PR DESCRIPTION
Fixed documentation to reflect the above and further explain the cases
where the output format general option is honored and ignored.

Found two issues in the output formatting for CIM objects:

1. The repr format was documented and implemented but somewhere we removed
it from the list of available formats. Added it back.

2. The txt format was in the list Set it up. It essentially just
outputs the __str__ for each object.

3. The xml, repr, txt formats had not been tested.  Added tests for the
class command group and TODO for qualdecl and instance tests.
ee
4. The tree format showed up in the list but we never did implement it
that way. It was implemented as the only output for the class tree
command. Removed it from list of output formats
