### PR TITLE
Improved help text of pywbemcli, pt 1; Changed querylanguage option

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -18,8 +18,8 @@ This documentation uses a few special terms to refer to Python types:
 .. glossary::
 
    CIM-XML
-     The name of the protocol used in the DMTF specification :term:`DSP0200`
-     that pywbem/pywbemcli use to communicate with WBEM servers.
+      The name of the protocol used in the DMTF specification :term:`DSP0200`
+      that pywbem/pywbemcli use to communicate with WBEM servers.
 
    CIM model output formats
       Several of the output formats defined and available in the
@@ -27,6 +27,7 @@ This documentation uses a few special terms to refer to Python types:
       of CIM objects(CIMClass, CIMInstance, CIMParameter, CIMMethod,
       CIMClassName and CIMInstanceName) This includes the format choices
       ``mof`` , ``xml`` , ``repr`` , and ``txt`` .
+
    INSTANCENAME
       an argument of several of the command-group ``instance`` subcommands that
       allows two possible inputs based on another subcommand option( ``--interactive`` ).
@@ -36,9 +37,9 @@ This documentation uses a few special terms to refer to Python types:
       :term:`WBEM-URI`
 
       Otherwise the INSTANCENAME should be a classname in which case pywbemcli
-        will get the instance names from the WBEM server and present a
-        selection list for the user to select an instance
-        name :ref:`Displaying CIM instances or CIM instance names`
+      will get the instance names from the WBEM server and present a
+      selection list for the user to select an instance
+      name :ref:`Displaying CIM instances or CIM instance names`
 
    connection id
       a string that uniquely identifies each :class:`pywbem.WBEMConnection`

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -86,7 +86,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
       -t, --timeout INTEGER           Client timeout completion of WBEM server
                                       operation in seconds.
                                       (EnvVar:
-                                      PYWBEMCLI_PYWBEMCLI_TIMEOUT)
+                                      PYWBEMCLI_TIMEOUT)
       -N, --no-verify                 If set, client does not verify WBEM server
                                       certificate.(EnvVar: PYWBEMCLI_NO_VERIFY).
       -c, --certfile TEXT             Server certfile. Ignored if --no-verify flag
@@ -130,7 +130,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       pywbemcli to use only the traditional non-
                                       pull operations.
                                       * "either": pywbemcli trys
-                                      first pull and then  traditional operations.
+                                      first pull and then traditional operations.
                                       (EnvVar: PYWBEMCLI_USE_PULL) [Default:
                                       either]
       --pull-max-cnt INTEGER          Maximium object count of objects to be
@@ -440,8 +440,8 @@ The following defines the help output for the `pywbemcli class find --help` subc
         class find CIM_Foo
 
     Options:
-      -n, --namespace <name>  Namespace(s) to use for this operation. If defined
-                              only those namespaces are searched rather than all
+      -n, --namespace <name>  Namespace to use for this operation. If defined only
+                              those namespaces are searched rather than all
                               available namespaces. ex: -n root/interop -n
                               root/cimv2
       -h, --help              Show this message and exit.
@@ -1146,12 +1146,12 @@ The following defines the help output for the `pywbemcli instance associators --
                                       qualifiers in the returned instances. This
                                       subcommand may use either pull or
                                       traditional operations depending on the
-                                      server and the "--use--pull-ops" general
-                                      option. If pull operations are used,
-                                      qualifiers will not be included, even if
-                                      this option is specified. If traditional
-                                      operations are used, inclusion of qualifiers
-                                      depends on the server.
+                                      server and the "--use-pull" general option.
+                                      If pull operations are used, qualifiers will
+                                      not be included, even if this option is
+                                      specified. If traditional operations are
+                                      used, inclusion of qualifiers depends on the
+                                      server.
       -c, --include-classorigin       Request that server include classorigin in
                                       the result.On some WBEM operations, server
                                       may ignore this option.
@@ -1366,12 +1366,12 @@ The following defines the help output for the `pywbemcli instance enumerate --he
                                       qualifiers in the returned instances. This
                                       subcommand may use either pull or
                                       traditional operations depending on the
-                                      server and the "--use--pull-ops" general
-                                      option. If pull operations are used,
-                                      qualifiers will not be included, even if
-                                      this option is specified. If traditional
-                                      operations are used, inclusion of qualifiers
-                                      depends on the server.
+                                      server and the "--use-pull" general option.
+                                      If pull operations are used, qualifiers will
+                                      not be included, even if this option is
+                                      specified. If traditional operations are
+                                      used, inclusion of qualifiers depends on the
+                                      server.
       -c, --include-classorigin       Request that server include classorigin in
                                       the result.On some WBEM operations, server
                                       may ignore this option.
@@ -1438,9 +1438,8 @@ The following defines the help output for the `pywbemcli instance get --help` su
       format general option.
 
     Options:
-      -l, --local-only                Request that server show only local
-                                      properties of the returned instance. Some
-                                      servers may not process this parameter.
+      -l, --local-only                Show only local properties of the instance.
+                                      Some servers may not process this parameter.
       -q, --include-qualifiers        If set, requests server to include
                                       qualifiers in the returned instances. Not
                                       all servers return qualifiers on instances
@@ -1691,12 +1690,12 @@ The following defines the help output for the `pywbemcli instance references --h
                                       qualifiers in the returned instances. This
                                       subcommand may use either pull or
                                       traditional operations depending on the
-                                      server and the "--use--pull-ops" general
-                                      option. If pull operations are used,
-                                      qualifiers will not be included, even if
-                                      this option is specified. If traditional
-                                      operations are used, inclusion of qualifiers
-                                      depends on the server.
+                                      server and the "--use-pull" general option.
+                                      If pull operations are used, qualifiers will
+                                      not be included, even if this option is
+                                      specified. If traditional operations are
+                                      used, inclusion of qualifiers depends on the
+                                      server.
       -c, --include-classorigin       Request that server include classorigin in
                                       the result.On some WBEM operations, server
                                       may ignore this option.

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -19,30 +19,29 @@ The following defines the help output for the `pywbemcli  --help` subcommand
       Pywbemcli is a command line WBEM client that uses the DMTF CIM-XML
       protocol to communicate with WBEM servers. Pywbemcli can:
 
-          * Manage the information in WBEM servers CIM objects using the
-            operations defined in the DMTF specification.  It can manage CIM
-            classes, CIM instances and CIM qualifier declarations in the WBEM
-            Server and execute CIM methods and queries on the server.
+      * Manage the information in WBEM servers CIM objects using the
+        operations defined in the DMTF specification.  It can manage CIM
+        classes, CIM instances and CIM qualifier declarations in the WBEM
+        Server and execute CIM methods and queries on the server.
 
-          * Inspect WBEM server characteristics including namespaces, registered
-            profiles, and other server information.
+      * Inspect WBEM server characteristics including namespaces, registered
+        profiles, and other server information.
 
-          * Capture detailed information on communication with the WBEM
-            server including time statistics and logs of the operations.
+      * Capture detailed information on communication with the WBEM
+        server including time statistics and logs of the operations.
 
-          * Maintain a persistent list of named WBEM servers and execute
-            operations on them by name.
+      * Maintain a persistent list of named connections to WBEM servers
+        and execute operations on them by name.
 
       Pywbemcli implements command groups and subcommands to execute the CIM-XML
-      operations defined by the DMTF CIM Operations Over HTTP
-      specification(DSP0201) specification.
+      operations defined by the DMTF CIM Operations Over HTTP specification
+      (DSP0200).
 
       The general options shown below can also be specified on any of the
       (sub)commands as well as the command line.
 
       For more detailed documentation, see:
 
-          https://pywbemtools.readthedocs.io/en/latest/
           https://pywbemtools.readthedocs.io/en/stable/
 
     Options:
@@ -58,30 +57,32 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       * Port: (optional)
                                       defines WBEM server port to be used
                                       [Defaults: 5988(HTTP) and 5989(HTTPS)].
-                                      Thhis option the --name option and the
-                                      --mock-server are mututally exclusive since
-                                      each defines a WBEM server.
-                                      (EnvVar:
-                                      PYWBEMCLI_SERVER).
+                                      This
+                                      option, the --name, and --mock-server are
+                                      mututally exclusive since each defines a
+                                      WBEM server.
+                                      (EnvVar: PYWBEMCLI_SERVER)
       -n, --name NAME                 Name for the connection.  If this option
                                       exists and the server option does not exist
                                       pywbemcli retrieves the connection
                                       information from the connections file
-                                      (pywbemcliservers.json). This option
-                                      --server  and --mock-server are mutually
-                                      exclusive since each defines a WBEM server
-                                      (EnvVar: PYWBEMCLI_NAME).
+                                      (pywbemcliservers.json). This option,
+                                      --server, and --mock-server are mutually
+                                      exclusive since each defines a WBEM server.
+                                      (EnvVar: PYWBEMCLI_NAME)
       -d, --default-namespace NAMESPACE
                                       Default namespace to use in the target WBEM
                                       server if no namespace is defined in a
-                                      subcommand(EnvVar: PYWBEMCLI_NAME)
-                                      []Default: root/cimv2].
-      -u, --user USER                 User name for the WBEM server connection.
+                                      subcommand.
                                       (EnvVar: PYWBEMCLI_NAME)
+                                      [Default: root/cimv2]
+      -u, --user USER                 User name for the WBEM server connection.
+                                      (EnvVar: PYWBEMCLI_USER)
       -p, --password PASSWORD         Password for the WBEM server. Will be
                                       requested as part  of initialization if user
                                       name exists and it is not  provided by this
-                                      option.(EnvVar: PYWBEMCLI_PASSWORD).
+                                      option.
+                                      (EnvVar: PYWBEMCLI_PASSWORD)
       -t, --timeout INTEGER           Client timeout completion of WBEM server
                                       operation in seconds.
                                       (EnvVar:
@@ -90,19 +91,22 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       certificate.(EnvVar: PYWBEMCLI_NO_VERIFY).
       -c, --certfile TEXT             Server certfile. Ignored if --no-verify flag
                                       set. (EnvVar: PYWBEMCLI_CERTFILE).
-      -k, --keyfile FILE PATH         Client private key file. (EnvVar:
-                                      PYWBEMCLI_KEYFILE).
+      -k, --keyfile FILE PATH         Client private key file.
+                                      (EnvVar:
+                                      PYWBEMCLI_KEYFILE)
       --ca-certs TEXT                 File or directory containing certificates
                                       that will be matched against certificate
                                       received from WBEM server. Set --no-verify
                                       option to bypass client verification of the
-                                      WBEM server certificate.  (EnvVar:
-                                      PYWBEMCLI_CA_CERTS).
+                                      WBEM server certificate.
+                                      (EnvVar:
+                                      PYWBEMCLI_CA_CERTS)
                                       [Default: Searches for
                                       matching certificates in the following
-                                      system directories: /etc/pki/ca-
-                                      trust/extracted/openssl/ca-bundle.trust.crt]
-                                      /etc/ssl/certs]
+                                      system directories:
+                                      /etc/pki/ca-
+                                      trust/extracted/openssl/ca-bundle.trust.crt,
+                                      /etc/ssl/certs,
                                       /etc/ssl/certificates]
       -o, --output-format <choice>    Choice for command output data format.
                                       pywbemcli may override the format choice
@@ -132,7 +136,8 @@ The following defines the help output for the `pywbemcli  --help` subcommand
       --pull-max-cnt INTEGER          Maximium object count of objects to be
                                       returned for each request if pull operations
                                       are used. Must be  a positive non-zero
-                                      integer.(EnvVar: PYWBEMCLI_PULL_MAX_CNT)
+                                      integer.
+                                      (EnvVar: PYWBEMCLI_PULL_MAX_CNT)
                                       [Default: 1000]
       -T, --timestats                 Show time statistics of WBEM server
                                       operations after each command execution.
@@ -152,23 +157,24 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       or Python file path used to populate the
                                       mock repository. This option may be used
                                       multiple times where each use defines a
-                                      single file_path.This parameter the --server
-                                      option and the --name option are mutually
-                                      exclusive since each defines a WBEM server.
-                                      See the pywbemtools documentation for more
-                                      information.(EnvVar: PYWBEMCLI_MOCK_SERVER).
+                                      single file_path.This option, --server, and
+                                      --name are mutually exclusive since each
+                                      defines a WBEM server. See the pywbemtools
+                                      documentation for more information.
+                                      (EnvVar:
+                                      PYWBEMCLI_MOCK_SERVER)
       --version                       Show the version of this command and the
                                       pywbem package and exit.
       -h, --help                      Show this message and exit.
 
     Commands:
-      class       Command group to manage CIM classes.
-      connection  Command group to manage WBEM connections.
+      class       Command group for CIM classes.
+      connection  Command group for persistent WBEM connections.
       help        Show help message for interactive mode.
-      instance    Command group to manage CIM instances.
-      qualifier   Command group to view QualifierDeclarations.
-      repl        Enter interactive (REPL) mode (default).
-      server      Command Group for WBEM server operations.
+      instance    Command group for CIM instances.
+      qualifier   Command group for CIM qualifier declarations.
+      repl        Enter interactive mode (default).
+      server      Command group for WBEM servers.
 
 
 .. _`pywbemcli class --help`:
@@ -185,24 +191,29 @@ The following defines the help output for the `pywbemcli class --help` subcomman
 
     Usage: pywbemcli class [COMMAND-OPTIONS] COMMAND [ARGS]...
 
-      Command group to manage CIM classes.
+      Command group for CIM classes.
+
+      This command group defines commands to inspect classes, to invoke methods
+      on classes, and to delete classes.
+
+      Creation and modification of classes is not currently supported.
 
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
-      command. These are NOT retained after the command is executed.
+      'class' keyword.
 
     Options:
       -h, --help  Show this message and exit.
 
     Commands:
-      associators   Get the associated classes for CLASSNAME.
-      delete        Delete a single CIM class.
-      enumerate     Enumerate classes from the WBEM server.
-      find          Find all classes that match CLASSNAME-GLOB.
-      get           Get and display a single CIM class.
-      invokemethod  Invoke the class method named methodname.
-      references    Get the reference classes for CLASSNAME.
-      tree          Display CIM class inheritance hierarchy tree.
+      associators   Get the classes associated with a class.
+      delete        Delete a class.
+      enumerate     Get the top classes or subclasses of a class in a namespace.
+      find          Get the classes with matching class names on the WBEM...
+      get           Get a class.
+      invokemethod  Invoke a method on a class.
+      references    Get the classes referencing a class.
+      tree          Get the subclass or superclass inheritance tree of a class.
 
 
 .. _`pywbemcli class associators --help`:
@@ -219,13 +230,25 @@ The following defines the help output for the `pywbemcli class associators --hel
 
     Usage: pywbemcli class associators [COMMAND-OPTIONS] CLASSNAME
 
-      Get the associated classes for CLASSNAME.
+      Get the classes associated with a class.
 
-      Get the classes(or class names) that are associated with the CLASSNAME
-      argument filtered by the --assoc-class, --result-class, --role and
-      --result-role options and modified by the other options.
+      List the CIM classes that are associated with the specified class
+      (CLASSNAME argument) or subclasses thereof in the specified CIM namespace
+      (--namespace option). If no namespace was specified, the default namespace
+      of the connection is used.
 
-      Results are formatted as defined by the output format general option.
+      The classes to be retrieved can be filtered by the --role, --result-role,
+      --assoc-class, and --result-class options.
+
+      The --include-classorigin, --no-qualifiers, and --propertylist options
+      determine which parts are included in each retrieved class.
+
+      In the output, the classes will formatted as defined by the --output-
+      format general option.
+
+      Examples:
+
+        pywbemcli -n myconn class associators CIM_Foo -n interop
 
     Options:
       -a, --assoc-class <class name>  Filter by the association class name
@@ -289,20 +312,26 @@ The following defines the help output for the `pywbemcli class delete --help` su
 
     Usage: pywbemcli class delete [COMMAND-OPTIONS] CLASSNAME
 
-      Delete a single CIM class.
+      Delete a class.
 
-      Deletes the CIM class defined by CLASSNAME from the WBEM server.
-
-      If the class has instances, the command is refused unless the --force
-      option is used. If --force is used, instances are also deleted.
+      Delete a CIM class (CLASSNAME argument) in a CIM namespace (--namespace
+      option). If no namespace was specified, the default namespace of the
+      connection is used.
 
       If the class has subclasses, the command is rejected.
 
-      WARNING: Removing classes from a WBEM server can cause damage to the
-      server. Use this with caution.  It can impact instance providers and other
-      components in the server.
+      If the class has instances, the command is rejected, unless the --force
+      option was specified, in which case the instances are also deleted.
 
-      Some servers may refuse the operation.
+      WARNING: Deleting classes can cause damage to the server: It can impact
+      instance providers and other components in the server. Use this with
+      command with caution.
+
+      Some servers may refuse the operation altogether.
+
+      Example:
+
+        pywbemcli -n myconn class delete CIM_Foo -n interop
 
     Options:
       -f, --force             Force the delete request to be issued even if there
@@ -327,21 +356,27 @@ The following defines the help output for the `pywbemcli class enumerate --help`
 
     Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME
 
-      Enumerate classes from the WBEM server.
+      Get the top classes or subclasses of a class in a namespace.
 
-      Enumerates the classes (or classnames) from the WBEM server starting
-      either at the top of the class hierarchy or from  the position in the
-      class hierarchy defined by `CLASSNAME` argument if provided.
+      Enumerate CIM classes starting either at the top of the class hierarchy in
+      the specified CIM namespace (--namespace option), or at the specified
+      class (CLASSNAME argument) in the specified namespace. If no namespace was
+      specified, the default namespace of the connection is used.
 
-      The output format is defined by the output-format general option.
+      The --local-only, --include-classorigin, --no-qualifiers, and
+      --propertylist options determine which parts are included in each
+      retrieved class.
 
-      The --local-only and --no-qualifiers options define optional information
-      to be included in the output.
+      The --deep-inheritance option defines whether or not the complete subclass
+      hierarchy of the classes is retrieved.
 
-      The --deep-inheritance option defines whether the complete class hierarchy
-      is retrieved or just the next level in the hierarchy.
+      In the output, the classes will formatted as defined by the --output-
+      format general option.
 
-      Results are formatted as defined by the output format general option.
+      Examples:
+
+        pywbemcli -n myconn class enumerate -n interop   pywbemcli -n myconn
+        class enumerate CIM_Foo -n interop
 
     Options:
       -d, --deep-inheritance     If set, request server to return complete
@@ -376,27 +411,33 @@ The following defines the help output for the `pywbemcli class find --help` subc
 
     Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME-GLOB
 
-      Find all classes that match CLASSNAME-GLOB.
+      Get the classes with matching class names on the WBEM server.
 
-      Find all classes in the namespace(s) of the target WBEM server that match
-      the CLASSNAME-GLOB regular expression argument and return the classnames.
-      The CLASSNAME-GLOB argument is required.
+      Find the CIM classes whose class name matches the specified wildcard
+      expression (CLASSNAME-GLOB argument) in all CIM namespaces of the WBEM
+      server, or in the specified namespace (--namespace option).
 
-      The CLASSNAME-GLOB argument may be either a complete classname or a
-      regular expression that can be matched to one or more classnames. To limit
-      the filter to a single classname, terminate the classname with $.
+      The CLASSNAME-GLOB argument is a wildcard expression that is matched on
+      the class names case insensitively. The special characters known from file
+      nme wildcarding are supported: `*` to match zero or more characters, and
+      `?` to match a single character. In order to not have the shell expand the
+      wildcards, the CLASSNAME-GLOB argument should be put in quotes.
 
-      The GLOB expression is anchored to the beginning of the CLASSNAME-GLOB, is
-      is case insensitive and uses the standard GLOB special characters (*(match
-      everything), ?(match single character)). Thus, `pywbem_*` returns all
-      classes that begin with `PyWBEM_`, `pywbem_`, etc. '.*system*' returns
-      classnames that include the case insensitive string `system`.
-
-      The namespace option limits the search to the defined namespaces.
-      Otherwise all namespaces in the target server are searched.
+      For example, `pywbem_*` returns classes whose name begins with `PyWBEM_`,
+      `pywbem_`, etc. '*system*' returns classes whose names include the case
+      insensitive string `system`.
 
       Output is in table format if table output specified. Otherwise it is in
       the form <namespace>:<classname>
+
+      In the output, the classes will formatted as defined by the --output-
+      format general option if it specifies table output. Otherwise the classes
+      will be in the form `<namespace>:<classname>`.
+
+      Examples:
+
+        pywbemcli -n myconn class find "CIM_*" -n interop   pywbemcli -n myconn
+        class find CIM_Foo
 
     Options:
       -n, --namespace <name>  Namespace(s) to use for this operation. If defined
@@ -420,19 +461,22 @@ The following defines the help output for the `pywbemcli class get --help` subco
 
     Usage: pywbemcli class get [COMMAND-OPTIONS] CLASSNAME
 
-      Get and display a single CIM class.
+      Get a class.
 
-      Get a single CIM class defined by the CLASSNAME argument from the WBEM
-      server and display it. Normally it is retrieved from the default namespace
-      in the server.
+      Get a CIM class (CLASSNAME argument) in a CIM namespace (--namespace
+      option). If no namespace was specified, the default namespace of the
+      connection is used.
 
-      If the class is not found in the WBEM server, the server returns an
-      exception.
+      The --local-only, --include-classorigin, --no-qualifiers, and
+      --propertylist options determine which parts are included in each
+      retrieved class.
 
-      The --include-classorigin, --no-qualifiers, and --propertylist options
-      determine what parts of the class definition are retrieved.
+      In the output, the class will formatted as defined by the --output-format
+      general option.
 
-      Results are formatted as defined by the output format general option.
+      Example:
+
+        pywbemcli -n myconn class get CIM_Foo -n interop
 
     Options:
       -l, --local-only                Show only local properties of the class(s).
@@ -472,17 +516,27 @@ The following defines the help output for the `pywbemcli class invokemethod --he
 
     Usage: pywbemcli class invokemethod [COMMAND-OPTIONS] CLASSNAME METHODNAME
 
-      Invoke the class method named methodname.
+      Invoke a method on a class.
 
-      This invokes the method named METHODNAME on the class named CLASSNAME.
+      Invoke a static CIM method (METHODNAME argument) on a CIM class (CLASSNAME
+      argument) in a CIM namespace (--namespace option), and display the method
+      return value and output parameters. If no namespace was specified, the
+      default namespace of the connection is used.
 
-      This is the class level invokemethod and uses only the class name on the
-      invoke.The subcommand `instance invokemethod` invokes methods based on
-      class name.
+      The method input parameters are specified using the --parameter option,
+      which can be specified multiple times.
 
-      Examples:
+      Pywbemcli retrieves the class definition from the server in order to
+      verify that the specified input parameters are consistent with the
+      parameter characteristics in the method definition.
 
-        pywbemcli invokemethod CIM_Foo methodx -p param1=9 -p param2=Fred
+      Use the 'instance invokemethod' command to invoke CIM methods on CIM
+      instances.
+
+      Example:
+
+        pywbemcli -n myconn class invokemethod CIM_Foo methodx -p p1=9 -p
+        p2=Fred
 
     Options:
       -p, --parameter parameter  Optional multiple method parameters of form
@@ -506,13 +560,25 @@ The following defines the help output for the `pywbemcli class references --help
 
     Usage: pywbemcli class references [COMMAND-OPTIONS] CLASSNAME
 
-      Get the reference classes for CLASSNAME.
+      Get the classes referencing a class.
 
-      Get the reference classes (or class names) for the CLASSNAME argument
-      filtered by the role and result class options and modified by the other
-      options.
+      List the CIM (association) classes that reference the specified class
+      (CLASSNAME argument) or subclasses thereof in the specified CIM namespace
+      (--namespace option). If no namespace was specified, the default namespace
+      of the connection is used.
 
-      Results are displayed as defined by the output format general option.
+      The classes to be retrieved can be filtered by the --role and --result-
+      class options.
+
+      The --include-classorigin, --no-qualifiers, and --propertylist options
+      determine which parts are included in each retrieved class.
+
+      In the output, the classes will formatted as defined by the --output-
+      format general option.
+
+      Examples:
+
+        pywbemcli -n myconn class references CIM_Foo -n interop
 
     Options:
       -R, --result-class <class name>
@@ -562,24 +628,32 @@ The following defines the help output for the `pywbemcli class tree --help` subc
 
     Usage: pywbemcli class tree [COMMAND-OPTIONS] CLASSNAME
 
-      Display CIM class inheritance hierarchy tree.
+      Get the subclass or superclass inheritance tree of a class.
 
-      Displays a tree of the class hierarchy to show superclasses and
-      subclasses.
+      List the subclass or superclass hierarchy of a CIM class (CLASSNAME
+      argument) or CIM namespace (--namespace option):
 
-      CLASSNAME is an optional argument that defines the starting point for the
-      hierarchy display
+      - If CLASSNAME is omitted, the complete class hierarchy of the specified
+      namespace is retrieved.
 
-      If the --superclasses option is not specified, the hierarchy starting
-      either at the top most classes of the class hierarchy or at the class
-      defined by CLASSNAME is displayed.
+      - If CLASSNAME is specified but not --superclasses, the class and its
+      subclass hierarchy in the specified namespace are retrieved.
 
-      If the --superclasses options is specified and a CLASSNAME is defined the
-      class hierarchy of superclasses leading to CLASSNAME is displayed.
+      - If CLASSNAME and --superclasses are specified, the class and its
+      superclass ancestry up to the top-level class in the specified namespace
+      are retrieved.
 
-      This is a separate subcommand because it is tied specifically to
-      displaying in a tree format.so that the --output-format general option is
-      ignored.
+      If no namespace was specified, the default namespace of the connection is
+      used.
+
+      In the output, the classes will formatted as a ASCII graphical tree; the
+      --output-format general option is ignored.
+
+      Examples:
+
+        pywbemcli -n myconn class tree -n interop   pywbemcli -n myconn class
+        tree CIM_Foo -n interop   pywbemcli -n myconn class tree CIM_Foo
+        --superclasses -n interop
 
     Options:
       -s, --superclasses      Display the superclasses to CLASSNAME as a tree.
@@ -604,26 +678,28 @@ The following defines the help output for the `pywbemcli connection --help` subc
 
     Usage: pywbemcli connection [COMMAND-OPTIONS] COMMAND [ARGS]...
 
-      Command group to manage WBEM connections.
+      Command group for persistent WBEM connections.
 
-      These command allow viewing and setting persistent connection definitions.
-      The connections are normally defined in the file pywbemcliconnections.json
-      in the current directory.
+      This command group defines commands to manage persistent WBEM connections
+      that have a name. The connections are stored in a connections file named
+      'pywbemcliservers.json' in the current directory. The connection name can
+      be used as a shorthand for the WBEM server via the '--name' general
+      option.
 
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
-      command. These are NOT retained after the command is executed.
+      'connection' keyword.
 
     Options:
       -h, --help  Show this message and exit.
 
     Commands:
       add     Create a new named WBEM connection.
-      delete  Delete connection information.
+      delete  Delete a named WBEM connection.
       export  Export the current connection information.
-      list    List the entries in the connection file.
-      save    Save current connection to repository.
-      select  Select a connection from defined connections.
+      list    List the entries in the connections file.
+      save    Save current connection to connections file.
+      select  Select a connection from connections file.
       show    Show current or NAME connection information.
       test    Execute a predefined WBEM request.
 
@@ -678,7 +754,7 @@ The following defines the help output for the `pywbemcli connection add --help` 
                                       [Defaults: 5988(HTTP) and 5989(HTTPS)].
       -n, --name NAME                 Required name for the connection(optional,
                                       see --server).  This is the name for this
-                                      defined WBEM server in the connection file
+                                      defined WBEM server in the connections file
                                       [required]
       -d, --default-namespace NAMESPACE
                                       Default namespace to use in the target WBEM
@@ -756,7 +832,7 @@ The following defines the help output for the `pywbemcli connection delete --hel
 
     Usage: pywbemcli connection delete [COMMAND-OPTIONS] NAME
 
-      Delete connection information.
+      Delete a named WBEM connection.
 
       Delete connection information from the persistent store for the connection
       defined by NAME. The NAME argument is optional.
@@ -786,7 +862,7 @@ The following defines the help output for the `pywbemcli connection export --hel
 
     Usage: pywbemcli connection export [COMMAND-OPTIONS]
 
-      Export  the current connection information.
+      Export the current connection information.
 
       Creates an export statement for each connection variable and outputs the
       statement to the conole.
@@ -809,11 +885,10 @@ The following defines the help output for the `pywbemcli connection list --help`
 
     Usage: pywbemcli connection list [COMMAND-OPTIONS]
 
-      List the entries in the connection file.
+      List the entries in the connections file.
 
-      This subcommand displays all entries in the connection file as a table
-      using the command line output_format to define the table format with
-      default of simple format.
+      This subcommand displays all entries in the connections file as a table
+      using the command line output_format to define the table format.
 
       An "*" after the name indicates the currently selected connection.
 
@@ -835,7 +910,7 @@ The following defines the help output for the `pywbemcli connection save --help`
 
     Usage: pywbemcli connection save [COMMAND-OPTIONS]
 
-      Save current connection to repository.
+      Save current connection to connections file.
 
       Saves the current connection to the connections file if it does not
       already exist in that file.
@@ -866,7 +941,7 @@ The following defines the help output for the `pywbemcli connection select --hel
 
     Usage: pywbemcli connection select [COMMAND-OPTIONS] NAME
 
-      Select a connection from defined connections.
+      Select a connection from connections file.
 
       Selects a connection from the persistently stored set of named connections
       if NAME exists in the store. The NAME argument is optional.  If NAME not
@@ -901,13 +976,13 @@ The following defines the help output for the `pywbemcli connection show --help`
 
       Show current or NAME connection information.
 
-      This subcommand displays  all the variables that make up the current WBEM
+      This subcommand displays all the variables that make up the current WBEM
       connection if the optional NAME argument is NOT provided. If NAME not
       supplied, a list of connections from the connections definition file is
       presented with a prompt for the user to select a NAME.
 
-      The information on the     connection named is displayed if that name is
-      in the persistent repository.
+      The information on the connection named is displayed if that name is in
+      the persistent repository.
 
     Options:
       -h, --help  Show this message and exit.
@@ -972,30 +1047,31 @@ The following defines the help output for the `pywbemcli instance --help` subcom
 
     Usage: pywbemcli instance [COMMAND-OPTIONS] COMMAND [ARGS]...
 
-      Command group to manage CIM instances.
+      Command group for CIM instances.
 
-      This incudes functions to get, enumerate, create, modify, and delete
-      instances in a namspace and additional functions to get more general
-      information on instances (ex. counts) within the namespace
+      This command group defines commands to inspect instances, to invoke
+      methods on instances, and to create and delete instances.
+
+      Modification of instances is not currently supported.
 
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
-      command. These are NOT retained after the command is executed.
+      'instance' keyword.
 
     Options:
       -h, --help  Show this message and exit.
 
     Commands:
-      associators   Get associated instances or names.
-      count         Get CIM instance count for classes.
-      create        Create a CIM instance of CLASSNAME.
-      delete        Delete a single CIM instance.
-      enumerate     Enumerate instances or names of CLASSNAME.
-      get           Get a single CIMInstance.
-      invokemethod  Invoke a CIM method on a CIMInstance.
-      modify        Modify an existing CIM instance.
-      query         Execute an execquery request.
-      references    Get the reference instances or names.
+      associators   Get the instances associated with an instance.
+      count         Count the instances of each class with matching class name.
+      create        Create an instance of a class in a namespace.
+      delete        Delete an instance of a class.
+      enumerate     Get the instances of a class.
+      get           Get an instance of a class.
+      invokemethod  Invoke a method on an instance.
+      modify        Modify an instance of a class.
+      query         Execute a query on instances in a namespace.
+      references    Get the instances referencing an instance.
 
 
 .. _`pywbemcli instance associators --help`:
@@ -1012,20 +1088,35 @@ The following defines the help output for the `pywbemcli instance associators --
 
     Usage: pywbemcli instance associators [COMMAND-OPTIONS] INSTANCENAME
 
-      Get associated instances or names.
+      Get the instances associated with an instance.
 
-      Returns the associated instances or names (--names-only option) for the
-      `INSTANCENAME` argument filtered by the --assoc-class, --result-class,
-      --role and --result-role options.
+      List the CIM instances that are associated with the specified CIM
+      instance, and display the returned instances, or instance paths if
+      --names-only was specified.
 
-      INSTANCENAME must be a CIM instance name in the format defined by DMTF
-      `DSP0207`.
+      The CIM instance can be specified in two ways:
 
-      This may be executed interactively by providing only a classname and the
-      interactive option. Pywbemcli presents a list of instances in the class
-      from which one can be chosen as the target.
+      1. By specifying an untyped WBEM URI of an instance path in the
+      INSTANCENAME argument. The CIM namespace in which the instance is looked
+      up is the namespace specified in the WBEM URI, or otherwise the namespace
+      specified in the --namespace option, or otherwise the default namespace of
+      the connection. Any host name in the WBEM URI will be ignored.
 
-      Results are formatted as defined by the --output_format general option.
+      2. By specifying the --interactive option and a CIM class name in the
+      INSTANCENAME argument. The instances of the specified class are displayed
+      and the user is prompted for an index number to select an instance. The
+      CIM namespace in which the instances are looked up is the namespace
+      specified in the --namespace option, or otherwise the default namespace of
+      the connection.
+
+      The instances to be retrieved can be filtered by the --filter-query,
+      --role, --result-role, --assoc-class, and --result-class options.
+
+      The --include-qualifiers, --include-classorigin, and --propertylist
+      options determine which parts are included in each retrieved instance.
+
+      In the output, the instances will formatted as defined by the --output-
+      format general option.
 
     Options:
       -a, --assoc-class <class name>  Filter by the association class name
@@ -1111,28 +1202,25 @@ The following defines the help output for the `pywbemcli instance count --help` 
 
     Usage: pywbemcli instance count [COMMAND-OPTIONS] CLASSNAME-GLOB
 
-      Get CIM instance count for classes.
+      Count the instances of each class with matching class name.
 
-      Displays the count of instances for the classes defined by the `CLASSNAME-
-      GLOB` argument in one or more namespaces.
+      Display the count of the instances of each CIM class whose class name
+      matches the specified wildcard expression (CLASSNAME-GLOB) in all CIM
+      namespaces of the WBEM server, or in the specified namespace (--namespace
+      option).
 
-      The size of the response may be limited by CLASSNAME-GLOB argument which
-      defines a regular expression based on the desired class names so that only
-      classes that match the regex are counted. The CLASSNAME-GLOB argument is
-      optional.
+      The CLASSNAME-GLOB argument is a wildcard expression that is matched on
+      the class names case insensitively. The special characters known from file
+      nme wildcarding are supported: `*` to match zero or more characters, and
+      `?` to match a single character. In order to not have the shell expand the
+      wildcards, the CLASSNAME-GLOB argument should be put in quotes.
 
-      The CLASSNAME-GLOB argument may be either a complete classname or a
-      regular expression that can be matched to one or more classnames. To limit
-      the filter to a single classname, terminate the classname with $.
+      For example, `pywbem_*` returns classes whose name begins with `PyWBEM_`,
+      `pywbem_`, etc. '*system*' returns classes whose names include the case
+      insensitive string `system`.
 
-      The GLOB expression is anchored to the beginning of the CLASSNAME-GLOB, is
-      is case insensitive and uses the standard GLOB special characters (*(match
-      everything), ?(match single character)). Thus, `pywbem_*` returns all
-      classes that begin with `PyWBEM_`, `pywbem_`, etc. '.*system*' returns
-      classnames that include the case insensitive string `system`.
-
-      This operation can take a long time to execute since it enumerates all
-      classes in the namespace.
+      This operation can take a long time to execute since it potentially
+      enumerates all classes in all namespaces.
 
     Options:
       -s, --sort              Sort by instance count. Otherwise sorted by
@@ -1156,18 +1244,24 @@ The following defines the help output for the `pywbemcli instance create --help`
 
     Usage: pywbemcli instance create [COMMAND-OPTIONS] CLASSNAME
 
-      Create a CIM instance of CLASSNAME.
+      Create an instance of a class in a namespace.
 
-      Creates an instance of the class CLASSNAME with the properties defined in
-      the property option.
+      Create a CIM instance of the specified creation class (CLASSNAME argument)
+      in the specified CIM namespace (--namespace option), with the specified
+      properties (--property options) and display the CIM instance path of the
+      created instance. If no namespace was specified, the default namespace of
+      the connection is used.
 
-      Pywbemcli creates the new instance using CLASSNAME retrieved from the
-      current WBEM server as a template for property characteristics. Therefore
-      pywbemcli will generate an exception if CLASSNAME does not exist in the
-      current WBEM server or if the data definition in the properties options
-      does not match the properties characteristics defined the returned class.
+      The properties to be initialized and their new values are specified using
+      the --property option, which can be specified multiple times.
 
-      ex. pywbemcli instance create CIM_blah -p id=3 -p strp="bla bla", -p p3=3
+      Pywbemcli retrieves the class definition from the server in order to
+      verify that the specified properties are consistent with the property
+      characteristics in the class definition.
+
+      Example:
+
+        pywbemcli instance create CIM_blah -p id=3 -p strp="bla bla"
 
     Options:
       -P, --property name=value  Optional property names of the form name=value.
@@ -1196,15 +1290,22 @@ The following defines the help output for the `pywbemcli instance delete --help`
 
     Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME
 
-      Delete a single CIM instance.
+      Delete an instance of a class.
 
-      Delete the instanced defined by INSTANCENAME from the WBEM server.
+      The CIM instance to be deleted can be specified as follows:
 
-      This may be executed interactively by providing only a class name and the
-      interactive option.
+      1. By specifying an untyped WBEM URI of an instance path in the
+      INSTANCENAME argument. The CIM namespace in which the instance is looked
+      up is the namespace specified in the WBEM URI, or otherwise the namespace
+      specified in the --namespace option, or otherwise the default namespace of
+      the connection. Any host name in the WBEM URI will be ignored.
 
-      Otherwise the INSTANCENAME must be a CIM instance name in the format
-      defined by DMTF `DSP0207`.
+      2. By specifying the --interactive option and a CIM class name in the
+      INSTANCENAME argument. The instances of the specified class are displayed
+      and the user is prompted for an index number to select an instance. The
+      CIM namespace in which the instances are looked up is the namespace
+      specified in the --namespace option, or otherwise the default namespace of
+      the connection.
 
     Options:
       -i, --interactive       If set, `INSTANCENAME` argument must be a class
@@ -1230,16 +1331,23 @@ The following defines the help output for the `pywbemcli instance enumerate --he
 
     Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME
 
-      Enumerate instances or names of CLASSNAME.
+      Get the instances of a class.
 
-      Get CIMInstance or CIMInstanceName (--name_only option) objects from the
-      WBEMServer starting either at the top  of the hierarchy (if no CLASSNAME
-      provided) or from the CLASSNAME argument if provided.
+      Enumerate the CIM instances of the specified class (CLASSNAME argument),
+      including instances of subclasses in the specified CIM namespace
+      (--namespace option), and display the returned instances, or instance
+      paths if --names-only was specified. If no namespace was specified, the
+      default namespace of the connection is used.
 
-      Displays the returned instances in mof, xml, or table formats, or the
-      instance names as a string or XML formats (--names-only option).
+      The instances to be retrieved can be filtered by the --filter-query
+      option.
 
-      Results are formatted as defined by the --output_format general option.
+      The --local-only, --deep-inheritance, --include-qualifiers, --include-
+      classorigin, and --propertylist options determine which parts are included
+      in each retrieved instance.
+
+      In the output, the instances will formatted as defined by the --output-
+      format general option.
 
     Options:
       -l, --local-only                Show only local properties of the instances.
@@ -1309,23 +1417,25 @@ The following defines the help output for the `pywbemcli instance get --help` su
 
     Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME
 
-      Get a single CIMInstance.
+      Get an instance of a class.
 
-      Gets the instance defined by `INSTANCENAME` where `INSTANCENAME` must
-      resolve to the instance name of the desired instance. This may be supplied
-      directly as an untyped wbem_uri formatted string or through the
-      --interactive option. The wbemuri may contain the namespace or the
-      namespace can be supplied with the --namespace option. If no namespace is
-      supplied, the connection default namespace is used.  Any host name in the
-      wbem_uri is ignored.
+      The instance can be specified in two ways:
 
-      This method may be executed interactively by providing only a classname
-      and the interactive option (-i).
+      * By specifying an untyped WBEM URI of an instance path in the
+      INSTANCENAME   argument. The namespace in which the instance is looked up
+      is the   namespace specified in the WBEM URI, or otherwise the namespace
+      specified   in the --namespace option, or otherwise the default namespace
+      of the   connection. Any host name in the WBEM URI will be ignored.
 
-      Otherwise the INSTANCENAME must be a CIM instance name in the format
-      defined by DMTF `DSP0207`.
+      * By specifying the --interactive option and a class name in the
+      INSTANCENAME argument. The instances of the specified class are displayed
+      and the user is prompted for an index number to select an instance.   The
+      namespace in which the instances are looked up is the namespace
+      specified in the --namespace option, or otherwise the default namespace
+      of the connection.
 
-      Results are formatted as defined by the --output_format general option.
+      In the output, the instance will formatted as defined by the --output-
+      format general option.
 
     Options:
       -l, --local-only                Request that server show only local
@@ -1372,30 +1482,40 @@ The following defines the help output for the `pywbemcli instance invokemethod -
     Usage: pywbemcli instance invokemethod [COMMAND-OPTIONS] INSTANCENAME
                                            METHODNAME
 
-      Invoke a CIM method on a CIMInstance.
+      Invoke a method on an instance.
 
-      Invoke the method defined by INSTANCENAME and METHODNAME arguments with
-      parameters defined by the --parameter options.
+      Invoke a CIM method (METHODNAME argument) on a CIM instance with the
+      specified input parameters (--parameter options), and display the method
+      return value and output parameters.
 
-      This issues an instance level invokemethod request and displays the
-      results.
+      The CIM instance can be specified in two ways:
 
-      INSTANCENAME must be a CIM instance name in the format defined by  DMTF
-      `DSP0207`.
+      1. By specifying an untyped WBEM URI of an instance path in the
+      INSTANCENAME argument. The CIM namespace in which the instance is looked
+      up is the namespace specified in the WBEM URI, or otherwise the namespace
+      specified in the --namespace option, or otherwise the default namespace of
+      the connection. Any host name in the WBEM URI will be ignored.
 
-      Pywbemcli creates the method call using the class in INSTANCENAME
-      retrieved from the current WBEM server as a template for parameter
-      characteristics. Therefore pywbemcli will generate an exception if
-      CLASSNAME does not exist in the current WBEM server or if the data
-      definition in the parameter options does not match the parameter
-      characteristics defined the returned class.
+      2. By specifying the --interactive option and a CIM class name in the
+      INSTANCENAME argument. The instances of the specified class are displayed
+      and the user is prompted for an index number to select an instance. The
+      CIM namespace in which the instances are looked up is the namespace
+      specified in the --namespace option, or otherwise the default namespace of
+      the connection.
 
-      A class level invoke method is available as `pywbemcli class
-      invokemethod`.
+      The method input parameters are specified using the --parameter option,
+      which can be specified multiple times.
+
+      Pywbemcli retrieves the class definition of the creation class of the
+      instance from the server in order to verify that the specified input
+      parameters are consistent with the parameter characteristics in the method
+      definition.
+
+      Use the 'class invokemethod' command to invoke CIM methods on CIM classes.
 
       Example:
 
-      pywbmcli instance invokemethod  CIM_x.InstanceID='hi" methodx -p id=3
+        pywbemcli -n myconn instance invokemethod CIM_x.id='hi" methodx -p id=3
 
     Options:
       -p, --parameter name=value  Multiple definitions allowed, one for each
@@ -1425,23 +1545,29 @@ The following defines the help output for the `pywbemcli instance modify --help`
 
     Usage: pywbemcli instance modify [COMMAND-OPTIONS] INSTANCENAME
 
-      Modify an existing CIM instance.
+      Modify an instance of a class.
 
-      Modifies CIM instance defined by INSTANCENAME in the WBEM server using the
-      property names and values defined by the property option and the CIM class
-      defined by the instance name.  The --propertylist option if provided is
-      passed to the WBEM server as part of the ModifyInstance operation (the
-      WBEM server limits modifications to just those properties defined in the
-      property list).
+      The CIM instance to be modified can be specified in two ways:
 
-      INSTANCENAME must be a CIM instance name in the format defined by DMTF
-      `DSP0207`.
+      1. By specifying an untyped WBEM URI of an instance path in the
+      INSTANCENAME argument. The CIM namespace in which the instance is looked
+      up is the namespace specified in the WBEM URI, or otherwise the namespace
+      specified in the --namespace option, or otherwise the default namespace of
+      the connection. Any host name in the WBEM URI will be ignored.
 
-      Pywbemcli builds only properties defined with the --property option into
-      an instance based on the CIMClass and forwards that to the WBEM server
-      with the ModifyInstance method.
+      2. By specifying the --interactive option and a CIM class name in the
+      INSTANCENAME argument. The instances of the specified class are displayed
+      and the user is prompted for an index number to select an instance. The
+      CIM namespace in which the instances are looked up is the namespace
+      specified in the --namespace option, or otherwise the default namespace of
+      the connection.
 
-      ex. pywbemcli instance modify CIM_blah.fred=3 -p id=3 -p strp="bla bla"
+      The properties to be modified and their new values are specified using the
+      --property option, which can be specified multiple times.
+
+      Example:
+
+        pywbemcli instance modify CIM_blah.fred=3 -p id=3 -p strp="bla bla"
 
     Options:
       -P, --property name=value       Optional property names of the form
@@ -1488,17 +1614,17 @@ The following defines the help output for the `pywbemcli instance query --help` 
 
     Usage: pywbemcli instance query [COMMAND-OPTIONS] QUERY_STRING
 
-      Execute an execquery request.
+      Execute a query on instances in a namespace.
 
-      Executes a query request on the target WBEM server with the QUERY_STRING
-      argument and query language options.
+      Execute the specified query (QUERY_STRING argument) in the specified CIM
+      namespace (--namespace option), and display the returned instances. If no
+      namespace was specified, the default namespace of the connection is used.
 
-      The results of the query are displayed as mof or xml.
-
-      Results are formatted as defined by the --output_format general option.
+      In the output, the instances will formatted as defined by the --output-
+      format general option.
 
     Options:
-      -l, --querylanguage QUERY LANGUAGE
+      -l, --query-language QUERY LANGUAGE
                                       Use the query language defined. (Default:
                                       DMTF:CQL.
       -n, --namespace <name>          Namespace to use for this operation, instead
@@ -1521,21 +1647,35 @@ The following defines the help output for the `pywbemcli instance references --h
 
     Usage: pywbemcli instance references [COMMAND-OPTIONS] INSTANCENAME
 
-      Get the reference instances or names.
+      Get the instances referencing an instance.
 
-      Gets the reference instances or instance names(--names-only option) for a
-      target `INSTANCENAME` in the target WBEM server filtered by the `role` and
-      `resultclass` options.
+      List the CIM (association) instances that reference the specified CIM
+      instance, and display the returned instances, or instance paths if
+      --names-only was specified.
 
-      INSTANCENAME must be a CIM instance name in the format defined by DMTF
-      `DSP0207`.
+      The CIM instance can be specified in two ways:
 
-      This may be executed interactively by providing only a class name for
-      `INSTANCENAME` and the `interactive` option(-i). Pywbemcli presents a list
-      of instances names in the class from which you can be chosen as the
-      target.
+      1. By specifying an untyped WBEM URI of an instance path in the
+      INSTANCENAME argument. The CIM namespace in which the instance is looked
+      up is the namespace specified in the WBEM URI, or otherwise the namespace
+      specified in the --namespace option, or otherwise the default namespace of
+      the connection. Any host name in the WBEM URI will be ignored.
 
-      Results are formatted as defined by the --output_format general option.
+      2. By specifying the --interactive option and a CIM class name in the
+      INSTANCENAME argument. The instances of the specified class are displayed
+      and the user is prompted for an index number to select an instance. The
+      CIM namespace in which the instances are looked up is the namespace
+      specified in the --namespace option, or otherwise the default namespace of
+      the connection.
+
+      The instances to be retrieved can be filtered by the --filter-query,
+      --role and --result-class options.
+
+      The --include-qualifiers, --include-classorigin, and --propertylist
+      options determine which parts are included in each retrieved instance.
+
+      In the output, the instances will formatted as defined by the --output-
+      format general option.
 
     Options:
       -R, --resultclass <class name>  Filter by the result class name provided.
@@ -1545,7 +1685,7 @@ The following defines the help output for the `pywbemcli instance references --h
       -r, --role <role name>          Filter by the role name provided. Each
                                       returned instance (or instance name) should
                                       refer to the target instance through a
-                                      property with aname that matches the value
+                                      property with a name that matches the value
                                       of this parameter. Optional.
       -q, --include-qualifiers        If set, requests server to include
                                       qualifiers in the returned instances. This
@@ -1607,24 +1747,23 @@ The following defines the help output for the `pywbemcli qualifier --help` subco
 
     Usage: pywbemcli qualifier [COMMAND-OPTIONS] COMMAND [ARGS]...
 
-      Command group to view QualifierDeclarations.
+      Command group for CIM qualifier declarations.
 
-      Includes the capability to get and enumerate CIM qualifier declarations
-      defined in the WBEM server.
+      This command group defines commands to inspect qualifier declarations.
 
-      pywbemcli does not provide the capability to create or delete CIM
-      QualifierDeclarations
+      Creation, modification and deletion of qualifier declarations is not
+      currently supported.
 
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
-      command. These are NOT retained after the command is executed.
+      'qualifier' keyword.
 
     Options:
       -h, --help  Show this message and exit.
 
     Commands:
-      enumerate  Enumerate CIMQualifierDeclaractions.
-      get        Display CIMQualifierDeclaration.
+      enumerate  List the CIM qualifier declarations in a CIM namespace.
+      get        Get a CIM qualifier declaration.
 
 
 .. _`pywbemcli qualifier enumerate --help`:
@@ -1641,10 +1780,14 @@ The following defines the help output for the `pywbemcli qualifier enumerate --h
 
     Usage: pywbemcli qualifier enumerate [COMMAND-OPTIONS]
 
-      Enumerate CIMQualifierDeclaractions.
+      List the CIM qualifier declarations in a CIM namespace.
 
-      Displays all of the CIMQualifierDeclaration objects in the defined
-      namespace in the current WBEM server
+      Enumerate the CIM qualifier declarations in the specified CIM namespace
+      (--namespace option). If no namespace was specified, the default namespace
+      of the connection is used.
+
+      In the output, the qualifier declaration will formatted as defined by the
+      --output-format general option.
 
     Options:
       -n, --namespace <name>  Namespace to use for this operation, instead of the
@@ -1667,10 +1810,14 @@ The following defines the help output for the `pywbemcli qualifier get --help` s
 
     Usage: pywbemcli qualifier get [COMMAND-OPTIONS] QUALIFIERNAME
 
-      Display CIMQualifierDeclaration.
+      Get a CIM qualifier declaration.
 
-      Displays CIMQualifierDeclaration QUALIFIERNAME for the defined namespace
-      in the current WBEMServer
+      Get a CIM qualifier declaration (QUALIFIERNAME argument) in a CIM
+      namespace (--namespace option). If no namespace was specified, the default
+      namespace of the connection is used.
+
+      In the output, the qualifier declaration will formatted as defined by the
+      --output-format general option.
 
     Options:
       -n, --namespace <name>  Namespace to use for this operation, instead of the
@@ -1692,15 +1839,15 @@ The following defines the help output for the `pywbemcli repl --help` subcommand
 
     Usage: pywbemcli repl [OPTIONS]
 
-      Enter interactive (REPL) mode (default).
+      Enter interactive mode (default).
 
       Enters the interactive mode where subcommands can be entered interactively
       and load the command history file.
 
-      If no options are specified on the command line,  the interactive mode is
-      entered. The prompt is changed to `pywbemcli>' in the interactive mode.
+      If no options are specified on the command line, the interactive mode is
+      entered. The prompt is changed to 'pywbemcli>' in the interactive mode.
 
-      Pywbemcli may be terminated form this mode by entering <CTRL-D>, :q,
+      Pywbemcli may be terminated from this mode by entering <CTRL-D>, :q,
       :quit, :exit
 
       Parameters:
@@ -1726,27 +1873,27 @@ The following defines the help output for the `pywbemcli server --help` subcomma
 
     Usage: pywbemcli server [COMMAND-OPTIONS] COMMAND [ARGS]...
 
-      Command Group for WBEM server operations.
+      Command group for WBEM servers.
 
-      The server command-group defines commands to inspect and manage core
-      components of the server including namespaces, the interop namespace,
-      profiles, and access to profile central instances.
+      This command group defines commands to inspect and manage core components
+      of a WBEM server including server attributes, namespaces, the Interop
+      namespace, management profiles, and access to profile central instances.
 
       In addition to the command-specific options shown in this help text, the
       general options (see 'pywbemcli --help') can also be specified before the
-      command. These are NOT retained after the command is executed.
+      'server' keyword.
 
     Options:
       -h, --help  Show this message and exit.
 
     Commands:
-      brand             Display information on the WBEM server.
+      brand             Display the brand of the server.
       connection        Display connection info used by this server.
-      get-centralinsts  Display central instances in the WBEM server.
-      info              Display general information on the server.
-      interop           Display the server interop namespace name.
-      namespaces        Display the namespaces in the WBEM server.
-      profiles          Display registered profiles from the WBEM server.
+      get-centralinsts  Get central instances of mgmt profiles on the server.
+      info              Display information about the server.
+      interop           Display the Interop namespace of the server.
+      namespaces        Display the namespaces of the server.
+      profiles          Display management profiles advertized by the server.
 
 
 .. _`pywbemcli server brand --help`:
@@ -1763,10 +1910,11 @@ The following defines the help output for the `pywbemcli server brand --help` su
 
     Usage: pywbemcli server brand [COMMAND-OPTIONS]
 
-      Display information on the WBEM server.
+      Display the brand of the server.
 
-      Display brand information on the current server if it is available. This
-      is typically the definition of the server implementor.
+      Brand information is defined by the server implementor and may or may not
+      be available. Pywbem attempts to collect the brand information from
+      multiple sources.
 
     Options:
       -h, --help  Show this message and exit.
@@ -1788,10 +1936,10 @@ The following defines the help output for the `pywbemcli server connection --hel
 
       Display connection info used by this server.
 
-      Displays the connection information for the WBEM connection attached to
-      this server.  This includes uri, default namespace, etc.
+      Display the information about the connection used to connect to the WBEM
+      server.
 
-      This is equivalent to the connection show subcommand.
+      This is equivalent to the 'connection show' subcommand.
 
     Options:
       -h, --help  Show this message and exit.
@@ -1811,24 +1959,26 @@ The following defines the help output for the `pywbemcli server get-centralinsts
 
     Usage: pywbemcli server get-centralinsts [COMMAND-OPTIONS]
 
-      Display central instances in the WBEM server.
+      Get central instances of mgmt profiles on the server.
 
-      Displays central instances for management profiles registered in the
-      server. Displays management profiles that adher to to the central class
-      methodology with none of the extra parameters (ex. scoping_class)
+      Retrieve the CIM instances that are central instances of the specified
+      WBEM management profiles, and display these instances. By default, all
+      management profiles advertized on the server are used. The profiles can be
+      filtered by using the --organization and --profile options.
 
-      However, profiles that only use the scoping methodology require extra
-      information that is dependent on the profile itself. These profiles will
-      only be accessed when the correct values of central_class, scoping_class,
-      and scoping path for the particular profile is provided.
+      The central instances are determined using all methodologies defined in
+      DSP1033 V1.1 in the order of GetCentralInstances, central class, and
+      scoping class methodology.
 
-      This display may be filtered by the optional organization and profile name
-      options that define the organization for each profile (ex. SNIA) and the
-      name of the profile. This will display only the profiles that are
-      registered for the defined organization and/or name.
+      Profiles that only use the scoping class methodology require the
+      specification of the --central-class, --scoping-class, and --scoping-path
+      options because additional information is needed to perform the scoping
+      class methodology.
 
-      Profiles are display as a table showing the organization, name, and
-      version for each profile.
+      The retrieved central instances are displayed along with the organization,
+      name, and version of the profile they belong to, formatted as a table. The
+      --output-format general option is ignored unless it specifies a table
+      format.
 
     Options:
       -o, --organization <org name>   Filter by the defined organization. (ex. -o
@@ -1862,10 +2012,9 @@ The following defines the help output for the `pywbemcli server info --help` sub
 
     Usage: pywbemcli server info [COMMAND-OPTIONS]
 
-      Display general information on the server.
+      Display information about the server.
 
-      Displays general information on the current server includeing brand,
-      namespaces, etc.
+      The information includes CIM namespaces and server brand.
 
     Options:
       -h, --help  Show this message and exit.
@@ -1885,9 +2034,7 @@ The following defines the help output for the `pywbemcli server interop --help` 
 
     Usage: pywbemcli server interop [COMMAND-OPTIONS]
 
-      Display the server interop namespace name.
-
-      Displays the name of the interop namespace defined for the WBEM server.
+      Display the Interop namespace of the server.
 
     Options:
       -h, --help  Show this message and exit.
@@ -1907,7 +2054,7 @@ The following defines the help output for the `pywbemcli server namespaces --hel
 
     Usage: pywbemcli server namespaces [COMMAND-OPTIONS]
 
-      Display the namespaces in the WBEM server.
+      Display the namespaces of the server.
 
     Options:
       -s, --sort  Sort into alphabetical order by classname.
@@ -1928,19 +2075,19 @@ The following defines the help output for the `pywbemcli server profiles --help`
 
     Usage: pywbemcli server profiles [COMMAND-OPTIONS]
 
-      Display registered profiles from the WBEM server.
+      Display management profiles advertized by the server.
 
-      Displays the WBEM management profiles that have been registered for this
-      server.  Within the DMTF and SNIA these are the definition of management
-      functionality supported by the WBEM server.
+      Retrieve the CIM instances representing the WBEM management profiles
+      advertized by the WBEM server, and display information about each profile.
+      WBEM management profiles are defined by DMTF and SNIA and define the
+      management functionality that is available.
 
-      This display may be filtered by the optional organization and profile
-      options that define the organization for each profile (ex. SNIA) and the
-      name of the profile. This will display only the profiles that are
-      registered for the defined organization and/or profile name.
+      The retrieved profiles can be filtered using the --organization and
+      --profile options.
 
-      Profiles are displayed as a table showing the organization, name, and
-      version for each profile.
+      The output is formatted as a table showing the organization, name, and
+      version for each profile. The --output-format option is ignored unless it
+      specifies a table format.
 
     Options:
       -o, --organization <org name>  Filter by the defined organization. (ex. -o

--- a/docs/pywbemcligeneraloptions.rst
+++ b/docs/pywbemcligeneraloptions.rst
@@ -742,7 +742,7 @@ connections are persisted in a :term:`connections file` named
 `pywbemcli_connections.json` in the current directory. A connection has a name
 and defines all parameters necessary to connect to a WBEM server. Once defined
 these connections can be accessed with the general option ``--name`` or in the
-interactive mode the ``connection select` command.
+interactive mode the ``connection select`` command.
 
 A new persistent connection definition can be created  by executing
 pywbemcli with the ``connection add`` command. The options on this command will
@@ -872,4 +872,3 @@ or:
     name      server uri        namespace    user         timeout  noverify
     --------  ----------------  -----------  -----------  ---------  ----------
     testconn  http://localhost  root/blah    kschopmeyer         30  False
-

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -323,7 +323,7 @@ def class_associators(context, classname, **options):
                 required=True)
 @click.option('-n', '--namespace', type=str, multiple=True,
               required=False, metavar='<name>',
-              help='Namespace(s) to use for this operation. If defined only '
+              help='Namespace to use for this operation. If defined only '
               'those namespaces are searched rather than all available '
               'namespaces. ex: -n root/interop -n root/cimv2')
 @click.pass_obj

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -187,7 +187,7 @@ def class_invokemethod(context, classname, methodname, **options):
 @click.pass_obj
 def class_enumerate(context, classname, **options):
     """
-    Get the top classes in a namespace or subclasses of a class.
+    Get the top classes or subclasses of a class in a namespace.
 
     Enumerate CIM classes starting either at the top of the class hierarchy
     in the specified CIM namespace (--namespace option), or at the specified
@@ -199,7 +199,7 @@ def class_enumerate(context, classname, **options):
     class.
 
     The --deep-inheritance option defines whether or not the complete subclass
-    hierarchy of the classes is retrieved as well.
+    hierarchy of the classes is retrieved.
 
     In the output, the classes will formatted as defined by the --output-format
     general option.
@@ -329,7 +329,7 @@ def class_associators(context, classname, **options):
 @click.pass_obj
 def class_find(context, classname_glob, **options):
     """
-    Get the classes with matching class names on the server.
+    Get the classes with matching class names on the WBEM server.
 
     Find the CIM classes whose class name matches the specified wildcard
     expression (CLASSNAME-GLOB argument) in all CIM namespaces of the
@@ -389,7 +389,7 @@ def class_tree(context, classname, **options):
     If no namespace was specified, the default namespace of the connection is
     used.
 
-    In the output, the classes will formatted as an ascii tree, and the
+    In the output, the classes will formatted as a ASCII graphical tree; the
     --output-format general option is ignored.
 
     Examples:
@@ -469,8 +469,9 @@ def cmd_class_enumerate(context, classname, options):
 
 
 def cmd_class_references(context, classname, options):
-    """Execute the references request operation to get references for
-       the classname defined
+    """
+    Execute the references request operation to get references for
+    the classname defined
     """
     if options['namespace']:
         classname = CIMClassName(classname, namespace=options['namespace'])
@@ -498,8 +499,9 @@ def cmd_class_references(context, classname, options):
 
 
 def cmd_class_associators(context, classname, options):
-    """Execute the references request operation to get references for
-       the classname defined
+    """
+    Execute the references request operation to get references for
+    the classname defined
     """
     if options['namespace']:
         classname = CIMClassName(classname, namespace=options['namespace'])

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -42,15 +42,16 @@ from ._context_obj import ContextObj
 @cli.group('connection', options_metavar=CMD_OPTS_TXT)
 def connection_group():
     """
-    Command group to manage WBEM connections.
+    Command group for persistent WBEM connections.
 
-    These command allow viewing and setting persistent connection definitions.
-    The connections are normally defined in the file pywbemcliconnections.json
-    in the current directory.
+    This command group defines commands to manage persistent WBEM connections
+    that have a name. The connections are stored in a connections file named
+    'pywbemcliservers.json' in the current directory. The connection name can
+    be used as a shorthand for the WBEM server via the '--name' general option.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'pywbemcli --help') can also be specified before the
-    command. These are NOT retained after the command is executed.
+    'connection' keyword.
     """
     pass  # pylint: disable=unnecessary-pass
 
@@ -59,7 +60,7 @@ def connection_group():
 @click.pass_obj
 def connection_export(context):
     """
-    Export  the current connection information.
+    Export the current connection information.
 
     Creates an export statement for each connection variable and outputs
     the statement to the conole.
@@ -75,12 +76,12 @@ def connection_show(context, name):
     """
     Show current or NAME connection information.
 
-    This subcommand displays  all the variables that make up the current
+    This subcommand displays all the variables that make up the current
     WBEM connection if the optional NAME argument is NOT provided. If NAME not
     supplied, a list of connections from the connections definition file
     is presented with a prompt for the user to select a NAME.
 
-    The information on the     connection named is displayed if that name is in
+    The information on the connection named is displayed if that name is in
     the persistent repository.
     """
     context.execute_cmd(lambda: cmd_connection_show(context, name))

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -93,7 +93,7 @@ def connection_show(context, name):
 @click.pass_obj
 def connection_delete(context, name, **options):
     """
-    Delete connection information.
+    Delete a named WBEM connection.
 
     Delete connection information from the persistent store
     for the connection defined by NAME. The NAME argument is optional.
@@ -112,7 +112,7 @@ def connection_delete(context, name, **options):
 @click.pass_obj
 def connection_select(context, name):
     """
-    Select a connection from defined connections.
+    Select a connection from connections file.
 
     Selects a connection from the persistently stored set of named connections
     if NAME exists in the store. The NAME argument is optional.  If NAME not
@@ -144,7 +144,7 @@ def connection_select(context, name):
 @click.option('-n', '--name', type=str, metavar='NAME', required=True,
               help='Required name for the connection(optional, see --server).  '
                    'This is the name for this defined WBEM server in the'
-                   ' connection file')
+                   ' connections file')
 @click.option('-d', '--default-namespace', type=str,
               metavar='NAMESPACE',
               default=DEFAULT_NAMESPACE,
@@ -265,7 +265,7 @@ def connection_test(context):
 @click.pass_obj
 def connection_save(context, **options):
     """
-    Save current connection to repository.
+    Save current connection to connections file.
 
     Saves the current connection to the connections file if
     it does not already exist in that file.
@@ -280,11 +280,11 @@ def connection_save(context, **options):
 @click.pass_obj
 def connection_list(context):
     """
-    List the entries in the connection file.
+    List the entries in the connections file.
 
-    This subcommand displays all entries in the connection file as
+    This subcommand displays all entries in the connections file as
     a table using the command line output_format to define the
-    table format with default of simple format.
+    table format.
 
     An "*" after the name indicates the currently selected connection.
     """

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -50,7 +50,7 @@ includequalifiersenum_option = [              # pylint: disable=invalid-name
                  help='If set, requests server to include qualifiers in the '
                  'returned instances. This subcommand may use either pull '
                  'or traditional operations depending on the server '
-                 'and the "--use--pull-ops" general option. If pull operations '
+                 'and the "--use-pull" general option. If pull operations '
                  'are used, qualifiers will not be included, even if this '
                  'option is specified. If traditional operations are used, '
                  'inclusion of qualifiers depends on the server.')]
@@ -66,10 +66,8 @@ deepinheritance_option = [              # pylint: disable=invalid-name
 
 localonlyget_option = [              # pylint: disable=invalid-name
     click.option('-l', '--local-only', is_flag=True, required=False,
-                 help='Request that server show only local properties of the '
-                      'returned instance. Some servers may not process this '
-                      'parameter.')]
-
+                 help='Show only local properties of the instance. '
+                 'Some servers may not process this parameter.')]
 
 localonlyenum_option = [              # pylint: disable=invalid-name
     click.option('-l', '--local-only', is_flag=True, required=False,

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -125,15 +125,16 @@ filterquery_option = [              # pylint: disable=invalid-name
 @cli.group('instance', options_metavar=CMD_OPTS_TXT)
 def instance_group():
     """
-    Command group to manage CIM instances.
+    Command group for CIM instances.
 
-    This incudes functions to get, enumerate, create, modify, and delete
-    instances in a namspace and additional functions to get more general
-    information on instances (ex. counts) within the namespace
+    This command group defines commands to inspect instances, to invoke
+    methods on instances, and to create and delete instances.
+
+    Modification of instances is not currently supported.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'pywbemcli --help') can also be specified before the
-    command. These are NOT retained after the command is executed.
+    'instance' keyword.
     """
     pass  # pylint: disable=unnecessary-pass
 
@@ -149,23 +150,25 @@ def instance_group():
 @click.pass_obj
 def instance_get(context, instancename, **options):
     """
-    Get a single CIMInstance.
+    Get an instance.
 
-    Gets the instance defined by `INSTANCENAME` where `INSTANCENAME` must
-    resolve to the instance name of the desired instance. This may be supplied
-    directly as an untyped wbem_uri formatted string or through the
-    --interactive option. The wbemuri may contain the namespace or the namespace
-    can be supplied with the --namespace option. If no namespace is supplied,
-    the connection default namespace is used.  Any host name in the wbem_uri is
-    ignored.
+    The instance can be specified in two ways:
 
-    This method may be executed interactively by providing only a classname and
-    the interactive option (-i).
+    * By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
+      argument. The namespace in which the instance is looked up is the
+      namespace specified in the WBEM URI, or otherwise the namespace specified
+      in the --namespace option, or otherwise the default namespace of the
+      connection. Any host name in the WBEM URI will be ignored.
 
-    Otherwise the INSTANCENAME must be a CIM instance name in the format
-    defined by DMTF `DSP0207`.
+    * By specifying the --interactive option and a class name in the
+      INSTANCENAME argument. The instances of the specified class are displayed
+      and the user is prompted for an index number to select an instance.
+      The namespace in which the instances are looked up is the namespace
+      specified in the --namespace option, or otherwise the default namespace
+      of the connection.
 
-    Results are formatted as defined by the --output_format general option.
+    In the output, the instance will formatted as defined by the
+    --output-format general option.
     """
     context.execute_cmd(lambda: cmd_instance_get(context, instancename,
                                                  options))
@@ -178,15 +181,22 @@ def instance_get(context, instancename, **options):
 @click.pass_obj
 def instance_delete(context, instancename, **options):
     """
-    Delete a single CIM instance.
+    Delete an instance.
 
-    Delete the instanced defined by INSTANCENAME from the WBEM server.
+    The CIM instance to be deleted can be specified in two ways:
 
-    This may be executed interactively by providing only a class name and the
-    interactive option.
+    1. By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
+    argument. The CIM namespace in which the instance is looked up is the
+    namespace specified in the WBEM URI, or otherwise the namespace specified
+    in the --namespace option, or otherwise the default namespace of the
+    connection. Any host name in the WBEM URI will be ignored.
 
-    Otherwise the INSTANCENAME must be a CIM instance name in the format
-    defined by DMTF `DSP0207`.
+    2. By specifying the --interactive option and a CIM class name in the
+    INSTANCENAME argument. The instances of the specified class are displayed
+    and the user is prompted for an index number to select an instance.
+    The CIM namespace in which the instances are looked up is the namespace
+    specified in the --namespace option, or otherwise the default namespace
+    of the connection.
     """
     context.execute_cmd(lambda: cmd_instance_delete(context, instancename,
                                                     options))
@@ -200,18 +210,24 @@ def instance_delete(context, instancename, **options):
 @click.pass_obj
 def instance_create(context, classname, **options):
     """
-    Create a CIM instance of CLASSNAME.
+    Create an instance of a class in a namespace.
 
-    Creates an instance of the class CLASSNAME with the properties defined
-    in the property option.
+    Create a CIM instance of the specified creation class (CLASSNAME
+    argument) in the specified CIM namespace (--namespace option), with
+    the specified properties (--property options) and display the CIM instance
+    path of the created instance. If no namespace was specified, the default
+    namespace of the connection is used.
 
-    Pywbemcli creates the new instance using CLASSNAME retrieved from the
-    current WBEM server as a template for property characteristics. Therefore
-    pywbemcli will generate an exception if CLASSNAME does not exist in the
-    current WBEM server or if the data definition in the properties options
-    does not match the properties characteristics defined the returned class.
+    The properties to be initialized and their new values are specified using
+    the --property option, which can be specified multiple times.
 
-    ex. pywbemcli instance create CIM_blah -p id=3 -p strp="bla bla", -p p3=3
+    Pywbemcli retrieves the class definition from the server in order to
+    verify that the specified properties are consistent with the property
+    characteristics in the class definition.
+
+    Example:
+
+      pywbemcli instance create CIM_blah -p id=3 -p strp="bla bla"
     """
     context.execute_cmd(lambda: cmd_instance_create(context, classname,
                                                     options))
@@ -236,23 +252,29 @@ def instance_create(context, classname, **options):
 @click.pass_obj
 def instance_modify(context, instancename, **options):
     """
-    Modify an existing CIM instance.
+    Modify an instance.
 
-    Modifies CIM instance defined by INSTANCENAME in the WBEM server using the
-    property names and values defined by the property option and the CIM class
-    defined by the instance name.  The --propertylist option if provided is
-    passed to the WBEM server as part of the ModifyInstance operation
-    (the WBEM server limits modifications to just those properties defined in
-    the property list).
+    The CIM instance to be modified can be specified in two ways:
 
-    INSTANCENAME must be a CIM instance name in the format defined by DMTF
-    `DSP0207`.
+    1. By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
+    argument. The CIM namespace in which the instance is looked up is the
+    namespace specified in the WBEM URI, or otherwise the namespace specified
+    in the --namespace option, or otherwise the default namespace of the
+    connection. Any host name in the WBEM URI will be ignored.
 
-    Pywbemcli builds only properties defined with the --property option
-    into an instance based on the CIMClass and forwards that to the WBEM
-    server with the ModifyInstance method.
+    2. By specifying the --interactive option and a CIM class name in the
+    INSTANCENAME argument. The instances of the specified class are displayed
+    and the user is prompted for an index number to select an instance.
+    The CIM namespace in which the instances are looked up is the namespace
+    specified in the --namespace option, or otherwise the default namespace
+    of the connection.
 
-    ex. pywbemcli instance modify CIM_blah.fred=3 -p id=3 -p strp="bla bla"
+    The properties to be modified and their new values are specified using the
+    --property option, which can be specified multiple times.
+
+    Example:
+
+      pywbemcli instance modify CIM_blah.fred=3 -p id=3 -p strp="bla bla"
     """
     context.execute_cmd(lambda: cmd_instance_modify(context, instancename,
                                                     options))
@@ -272,29 +294,40 @@ def instance_modify(context, instancename, **options):
 @click.pass_obj
 def instance_invokemethod(context, instancename, methodname, **options):
     """
-    Invoke a CIM method on a CIMInstance.
+    Invoke a method on an instance.
 
-    Invoke the method defined by INSTANCENAME and METHODNAME arguments with
-    parameters defined by the --parameter options.
+    Invoke a CIM method (METHODNAME argument) on a CIM instance with the
+    specified input parameters (--parameter options), and display the method
+    return value and output parameters.
 
-    This issues an instance level invokemethod request and displays the
-    results.
+    The CIM instance can be specified in two ways:
 
-    INSTANCENAME must be a CIM instance name in the format defined by  DMTF
-    `DSP0207`.
+    1. By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
+    argument. The CIM namespace in which the instance is looked up is the
+    namespace specified in the WBEM URI, or otherwise the namespace specified
+    in the --namespace option, or otherwise the default namespace of the
+    connection. Any host name in the WBEM URI will be ignored.
 
-    Pywbemcli creates the method call using the class in INSTANCENAME retrieved
-    from the current WBEM server as a template for parameter characteristics.
-    Therefore pywbemcli will generate an exception if CLASSNAME does not exist
-    in the current WBEM server or if the data definition in the parameter
-    options does not match the parameter characteristics defined the returned
-    class.
+    2. By specifying the --interactive option and a CIM class name in the
+    INSTANCENAME argument. The instances of the specified class are displayed
+    and the user is prompted for an index number to select an instance.
+    The CIM namespace in which the instances are looked up is the namespace
+    specified in the --namespace option, or otherwise the default namespace
+    of the connection.
 
-    A class level invoke method is available as `pywbemcli class invokemethod`.
+    The method input parameters are specified using the --parameter option,
+    which can be specified multiple times.
+
+    Pywbemcli retrieves the class definition of the creation class of the
+    instance from the server in order to verify that the specified input
+    parameters are consistent with the parameter characteristics in the method
+    definition.
+
+    Use the 'class invokemethod' command to invoke CIM methods on CIM classes.
 
     Example:
 
-    pywbmcli instance invokemethod  CIM_x.InstanceID='hi" methodx -p id=3
+      pywbemcli -n myconn instance invokemethod CIM_x.id='hi" methodx -p id=3
     """
     context.execute_cmd(lambda: cmd_instance_invokemethod(context,
                                                           instancename,
@@ -317,17 +350,22 @@ def instance_invokemethod(context, instancename, methodname, **options):
 @click.pass_obj
 def instance_enumerate(context, classname, **options):
     """
-    Enumerate instances or names of CLASSNAME.
+    Get the instances of a class.
 
-    Get CIMInstance or CIMInstanceName (--name_only option) objects from
-    the WBEMServer starting either at the top  of the hierarchy (if no
-    CLASSNAME provided) or from the CLASSNAME argument if provided.
+    Enumerate the CIM instances of the specified class (CLASSNAME argument),
+    including instances of subclasses in the specified CIM namespace
+    (--namespace option), and display the returned instances, or instance paths
+    if --names-only was specified. If no namespace was specified, the default
+    namespace of the connection is used.
 
-    Displays the returned instances in mof, xml, or table formats, or the
-    instance names as a string or XML formats (--names-only option).
+    The instances to be retrieved can be filtered by the --filter-query option.
 
-    Results are formatted as defined by the --output_format general option.
+    The --local-only, --deep-inheritance, --include-qualifiers,
+    --include-classorigin, and --propertylist options determine which parts
+    are included in each retrieved instance.
 
+    In the output, the instances will formatted as defined by the
+    --output-format general option.
     """
     context.execute_cmd(lambda: cmd_instance_enumerate(context, classname,
                                                        options))
@@ -358,20 +396,35 @@ def instance_enumerate(context, classname, **options):
 @click.pass_obj
 def instance_references(context, instancename, **options):
     """
-    Get the reference instances or names.
+    Get the instances referencing an instance.
 
-    Gets the reference instances or instance names(--names-only option) for a
-    target `INSTANCENAME` in the target WBEM server filtered by the
-    `role` and `resultclass` options.
+    List the CIM (association) instances that reference the specified CIM
+    instance, and display the returned instances, or instance paths if
+    --names-only was specified.
 
-    INSTANCENAME must be a CIM instance name in the format defined by DMTF
-    `DSP0207`.
+    The CIM instance can be specified in two ways:
 
-    This may be executed interactively by providing only a class name for
-    `INSTANCENAME` and the `interactive` option(-i). Pywbemcli presents a list
-    of instances names in the class from which you can be chosen as the target.
+    1. By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
+    argument. The CIM namespace in which the instance is looked up is the
+    namespace specified in the WBEM URI, or otherwise the namespace specified
+    in the --namespace option, or otherwise the default namespace of the
+    connection. Any host name in the WBEM URI will be ignored.
 
-    Results are formatted as defined by the --output_format general option.
+    2. By specifying the --interactive option and a CIM class name in the
+    INSTANCENAME argument. The instances of the specified class are displayed
+    and the user is prompted for an index number to select an instance.
+    The CIM namespace in which the instances are looked up is the namespace
+    specified in the --namespace option, or otherwise the default namespace
+    of the connection.
+
+    The instances to be retrieved can be filtered by the --filter-query, --role
+    and --result-class options.
+
+    The --include-qualifiers, --include-classorigin, and --propertylist options
+    determine which parts are included in each retrieved instance.
+
+    In the output, the instances will formatted as defined by the
+    --output-format general option.
     """
     context.execute_cmd(lambda: cmd_instance_references(context, instancename,
                                                         options))
@@ -415,20 +468,35 @@ def instance_references(context, instancename, **options):
 @click.pass_obj
 def instance_associators(context, instancename, **options):
     """
-    Get associated instances or names.
+    Get the instances associated with an instance.
 
-    Returns the associated instances or names (--names-only option) for the
-    `INSTANCENAME` argument filtered by the --assoc-class, --result-class,
-    --role and --result-role options.
+    List the CIM instances that are associated with the specified CIM instance,
+    and display the returned instances, or instance paths if --names-only was
+    specified.
 
-    INSTANCENAME must be a CIM instance name in the format defined by DMTF
-    `DSP0207`.
+    The CIM instance can be specified in two ways:
 
-    This may be executed interactively by providing only a classname and the
-    interactive option. Pywbemcli presents a list of instances in the class
-    from which one can be chosen as the target.
+    1. By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
+    argument. The CIM namespace in which the instance is looked up is the
+    namespace specified in the WBEM URI, or otherwise the namespace specified
+    in the --namespace option, or otherwise the default namespace of the
+    connection. Any host name in the WBEM URI will be ignored.
 
-    Results are formatted as defined by the --output_format general option.
+    2. By specifying the --interactive option and a CIM class name in the
+    INSTANCENAME argument. The instances of the specified class are displayed
+    and the user is prompted for an index number to select an instance.
+    The CIM namespace in which the instances are looked up is the namespace
+    specified in the --namespace option, or otherwise the default namespace
+    of the connection.
+
+    The instances to be retrieved can be filtered by the --filter-query,
+    --role, --result-role, --assoc-class, and --result-class options.
+
+    The --include-qualifiers, --include-classorigin, and --propertylist options
+    determine which parts are included in each retrieved instance.
+
+    In the output, the instances will formatted as defined by the
+    --output-format general option.
     """
     context.execute_cmd(lambda: cmd_instance_associators(context, instancename,
                                                          options))
@@ -436,7 +504,7 @@ def instance_associators(context, instancename, **options):
 
 @instance_group.command('query', options_metavar=CMD_OPTS_TXT)
 @click.argument('query', type=str, required=True, metavar='QUERY_STRING')
-@click.option('-l', '--querylanguage', type=str, required=False,
+@click.option('-l', '--query-language', type=str, required=False,
               metavar='QUERY LANGUAGE', default=DEFAULT_QUERY_LANGUAGE,
               help='Use the query language defined. '
                    '(Default: {of}.'.format(of=DEFAULT_QUERY_LANGUAGE))
@@ -445,15 +513,14 @@ def instance_associators(context, instancename, **options):
 @click.pass_obj
 def instance_query(context, query, **options):
     """
-    Execute an execquery request.
+    Execute a query on instances in a namespace.
 
-    Executes a query request on the target WBEM server with the QUERY_STRING
-    argument and query language options.
+    Execute the specified query (QUERY_STRING argument) in the specified CIM
+    namespace (--namespace option), and display the returned instances. If no
+    namespace was specified, the default namespace of the connection is used.
 
-    The results of the query are displayed as mof or xml.
-
-    Results are formatted as defined by the --output_format general option.
-
+    In the output, the instances will formatted as defined by the
+    --output-format general option.
     """
     context.execute_cmd(lambda: cmd_instance_query(context, query, options))
 
@@ -467,29 +534,25 @@ def instance_query(context, query, **options):
 @click.pass_obj
 def instance_count(context, classname, **options):
     """
-    Get CIM instance count for classes.
+    Count the instances of each class with matching class name.
 
-    Displays the count of instances for the classes defined by the
-    `CLASSNAME-GLOB` argument in one or more namespaces.
+    Display the count of the instances of each CIM class whose class name
+    matches the specified wildcard expression (CLASSNAME-GLOB) in all CIM
+    namespaces of the WBEM server, or in the specified namespace
+    (--namespace option).
 
-    The size of the response may be limited by CLASSNAME-GLOB argument which
-    defines a regular expression based on the desired class names so that only
-    classes that match the regex are counted. The CLASSNAME-GLOB argument is
-    optional.
+    The CLASSNAME-GLOB argument is a wildcard expression that is matched on
+    the class names case insensitively. The special characters known from file
+    nme wildcarding are supported: `*` to match zero or more characters, and
+    `?` to match a single character. In order to not have the shell expand
+    the wildcards, the CLASSNAME-GLOB argument should be put in quotes.
 
-    The CLASSNAME-GLOB argument may be either a complete classname or a regular
-    expression that can be matched to one or more classnames. To limit the
-    filter to a single classname, terminate the classname with $.
+    For example, `pywbem_*` returns classes whose name begins with `PyWBEM_`,
+    `pywbem_`, etc. '*system*' returns classes whose names include the case
+    insensitive string `system`.
 
-    The GLOB expression is anchored to the beginning of the CLASSNAME-GLOB, is
-    is case insensitive and uses the standard GLOB special characters
-    (*(match everything), ?(match single character)).
-    Thus, `pywbem_*` returns all classes that begin with
-    `PyWBEM_`, `pywbem_`, etc. '.*system*' returns classnames that include
-    the case insensitive string `system`.
-
-    This operation can take a long time to execute since it enumerates all
-    classes in the namespace.
+    This operation can take a long time to execute since it potentially
+    enumerates all classes in all namespaces.
     """
     context.execute_cmd(lambda: cmd_instance_count(context, classname, options))
 

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -150,7 +150,7 @@ def instance_group():
 @click.pass_obj
 def instance_get(context, instancename, **options):
     """
-    Get an instance.
+    Get an instance of a class.
 
     The instance can be specified in two ways:
 
@@ -181,9 +181,9 @@ def instance_get(context, instancename, **options):
 @click.pass_obj
 def instance_delete(context, instancename, **options):
     """
-    Delete an instance.
+    Delete an instance of a class.
 
-    The CIM instance to be deleted can be specified in two ways:
+    The CIM instance to be deleted can be specified as follows:
 
     1. By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
     argument. The CIM namespace in which the instance is looked up is the
@@ -252,7 +252,7 @@ def instance_create(context, classname, **options):
 @click.pass_obj
 def instance_modify(context, instancename, **options):
     """
-    Modify an instance.
+    Modify an instance of a class.
 
     The CIM instance to be modified can be specified in two ways:
 
@@ -382,7 +382,7 @@ def instance_enumerate(context, classname, **options):
               metavar='<role name>',
               help='Filter by the role name provided. Each returned instance '
                    '(or instance name) should refer to the target instance '
-                   'through a property with aname that matches the value of '
+                   'through a property with a name that matches the value of '
                    'this parameter. Optional.')
 @add_options(includequalifiersenum_option)
 @add_options(includeclassorigin_option)
@@ -975,7 +975,7 @@ def cmd_instance_query(context, query, options):
 
     try:
         results = context.conn.PyWbemcliQueryInstances(
-            options['querylanguage'],
+            options['query_language'],
             query,
             namespace=options['namespace'],
             MaxObjectCount=context.pull_max_cnt)

--- a/pywbemtools/pywbemcli/_cmd_qualifier.py
+++ b/pywbemtools/pywbemcli/_cmd_qualifier.py
@@ -32,17 +32,16 @@ from ._common_options import namespace_option, add_options, \
 @cli.group('qualifier', options_metavar=CMD_OPTS_TXT)
 def qualifier_group():
     """
-    Command group to view QualifierDeclarations.
+    Command group for CIM qualifier declarations.
 
-    Includes the capability to get and enumerate CIM qualifier declarations
-    defined in the WBEM server.
+    This command group defines commands to inspect qualifier declarations.
 
-    pywbemcli does not provide the capability to create or delete CIM
-    QualifierDeclarations
+    Creation, modification and deletion of qualifier declarations is not
+    currently supported.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'pywbemcli --help') can also be specified before the
-    command. These are NOT retained after the command is executed.
+    'qualifier' keyword.
     """
     pass  # pylint: disable=unnecessary-pass
 
@@ -54,10 +53,14 @@ def qualifier_group():
 @click.pass_obj
 def qualifier_get(context, qualifiername, **options):
     """
-    Display CIMQualifierDeclaration.
+    Get a CIM qualifier declaration.
 
-    Displays CIMQualifierDeclaration QUALIFIERNAME for the defined namespace in
-    the current WBEMServer
+    Get a CIM qualifier declaration (QUALIFIERNAME argument) in a CIM
+    namespace (--namespace option). If no namespace was specified, the default
+    namespace of the connection is used.
+
+    In the output, the qualifier declaration will formatted as defined by the
+    --output-format general option.
     """
     context.execute_cmd(lambda: cmd_qualifier_get(context, qualifiername,
                                                   options))
@@ -69,10 +72,14 @@ def qualifier_get(context, qualifiername, **options):
 @click.pass_obj
 def qualifier_enumerate(context, **options):
     """
-    Enumerate CIMQualifierDeclaractions.
+    List the CIM qualifier declarations in a CIM namespace.
 
-    Displays all of the CIMQualifierDeclaration objects in the defined
-    namespace in the current WBEM server
+    Enumerate the CIM qualifier declarations in the specified CIM namespace
+    (--namespace option). If no namespace was specified, the default namespace
+    of the connection is used.
+
+    In the output, the qualifier declaration will formatted as defined by the
+    --output-format general option.
     """
     context.execute_cmd(lambda: cmd_qualifier_enumerate(context, options))
 

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -31,15 +31,15 @@ from ._common_options import add_options, sort_option
 @cli.group('server', options_metavar=CMD_OPTS_TXT)
 def server_group():
     """
-    Command Group for WBEM server operations.
+    Command group for WBEM servers.
 
-    The server command-group defines commands to inspect and manage core
-    components of the server including namespaces, the interop namespace,
-    profiles, and access to profile central instances.
+    This command group defines commands to inspect and manage core components
+    of a WBEM server including server attributes, namespaces, the Interop
+    namespace, management profiles, and access to profile central instances.
 
     In addition to the command-specific options shown in this help text, the
     general options (see 'pywbemcli --help') can also be specified before the
-    command. These are NOT retained after the command is executed.
+    'server' keyword.
     """
     pass  # pylint: disable=unnecessary-pass
 
@@ -49,7 +49,7 @@ def server_group():
 @click.pass_obj
 def server_namespaces(context, **options):
     """
-    Display the namespaces in the WBEM server.
+    Display the namespaces of the server.
     """
     # pylint: disable=too-many-function-args
     context.execute_cmd(lambda: cmd_server_namespaces(context, options))
@@ -59,10 +59,7 @@ def server_namespaces(context, **options):
 @click.pass_obj
 def server_interop(context):
     """
-    Display the server interop namespace name.
-
-    Displays the name of the interop namespace defined for the
-    WBEM server.
+    Display the Interop namespace of the server.
     """
     # pylint: disable=too-many-function-args
     context.execute_cmd(lambda: cmd_server_interop(context))
@@ -72,10 +69,11 @@ def server_interop(context):
 @click.pass_obj
 def server_brand(context):
     """
-    Display information on the WBEM server.
+    Display the brand of the server.
 
-    Display brand information on the current server if it is available.
-    This is typically the definition of the server implementor.
+    Brand information is defined by the server implementor and may or may
+    not be available. Pywbem attempts to collect the brand information from
+    multiple sources.
     """
     # pylint: disable=too-many-function-args
     context.execute_cmd(lambda: cmd_server_brand(context))
@@ -85,10 +83,9 @@ def server_brand(context):
 @click.pass_obj
 def server_info(context):
     """
-    Display general information on the server.
+    Display information about the server.
 
-    Displays general information on the current server includeing brand,
-    namespaces, etc.
+    The information includes CIM namespaces and server brand.
     """
     context.execute_cmd(lambda: cmd_server_info(context))
 
@@ -103,19 +100,19 @@ def server_info(context):
 @click.pass_obj
 def server_profiles(context, **options):
     """
-    Display registered profiles from the WBEM server.
+    Display management profiles advertized by the server.
 
-    Displays the WBEM management profiles that have been registered for this
-    server.  Within the DMTF and SNIA these are the definition of management
-    functionality supported by the WBEM server.
+    Retrieve the CIM instances representing the WBEM management profiles
+    advertized by the WBEM server, and display information about each profile.
+    WBEM management profiles are defined by DMTF and SNIA and define the
+    management functionality that is available.
 
-    This display may be filtered by the optional organization and profile
-    options that define the organization for each profile (ex. SNIA)
-    and the name of the profile. This will display only the profiles that
-    are registered for the defined organization and/or profile name.
+    The retrieved profiles can be filtered using the --organization and
+    --profile options.
 
-    Profiles are displayed as a table showing the organization, name, and
-    version for each profile.
+    The output is formatted as a table showing the organization, name, and
+    version for each profile. The --output-format option is ignored unless it
+    specifies a table format.
     """
     context.execute_cmd(lambda: cmd_server_profiles(context, options))
 
@@ -148,24 +145,26 @@ def server_profiles(context, **options):
 @click.pass_obj
 def server_centralinsts(context, **options):
     """
-    Display central instances in the WBEM server.
+    Get central instances of mgmt profiles on the server.
 
-    Displays central instances for management profiles registered in the
-    server. Displays management profiles that adher to to the central
-    class methodology with none of the extra parameters (ex. scoping_class)
+    Retrieve the CIM instances that are central instances of the specified
+    WBEM management profiles, and display these instances. By default, all
+    management profiles advertized on the server are used. The profiles
+    can be filtered by using the --organization and --profile options.
 
-    However, profiles that only use the scoping methodology require extra
-    information that is dependent on the profile itself. These profiles
-    will only be accessed when the correct values of central_class,
-    scoping_class, and scoping path for the particular profile is provided.
+    The central instances are determined using all methodologies defined
+    in DSP1033 V1.1 in the order of GetCentralInstances, central class,
+    and scoping class methodology.
 
-    This display may be filtered by the optional organization and profile
-    name options that define the organization for each profile (ex. SNIA)
-    and the name of the profile. This will display only the profiles that
-    are registered for the defined organization and/or name.
+    Profiles that only use the scoping class methodology require the
+    specification of the --central-class, --scoping-class, and --scoping-path
+    options because additional information is needed to perform the scoping
+    class methodology.
 
-    Profiles are display as a table showing the organization, name, and
-    version for each profile.
+    The retrieved central instances are displayed along with the organization,
+    name, and version of the profile they belong to, formatted as a table.
+    The --output-format general option is ignored unless it specifies a table
+    format.
     """
     context.execute_cmd(lambda: cmd_server_centralinsts(context, options))
 
@@ -176,10 +175,10 @@ def server_connection(context):
     """
     Display connection info used by this server.
 
-    Displays the connection information for the WBEM connection
-    attached to this server.  This includes uri, default namespace, etc.
+    Display the information about the connection used to connect to the
+    WBEM server.
 
-    This is equivalent to the connection show subcommand.
+    This is equivalent to the 'connection show' subcommand.
     """
     context.execute_cmd(lambda: cmd_server_connection(context))
 

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -133,33 +133,33 @@ def pick_one_from_list(context, options, title):
     TODO: Possible Future This could be replaced by the python pick library
     that would use curses for the selection process.
     """
-    try:
-        if context:
-            context.spinner.stop()
+    if context:
+        context.spinner.stop()
 
-        click.echo(title)
-        index = -1
-        for str_ in options:
-            index += 1
-            click.echo('%s: %s' % (index, str_))
-        selection = None
-        msg = 'Input integer between 0 and %s or Ctrl-C to exit selection: ' \
-            % index
-        while True:
-            try:
-                selection_txt = click.prompt(msg)
-                selection = int(selection_txt)
-                if 0 <= selection <= index:
-                    if context:
-                        context.spinner.start()
-                    return options[selection]
-            except ValueError:  # This causes the retry of the request
-                pass
-            except KeyboardInterrupt:
-                raise click.ClickException("Pick Aborted.")
-            click.echo('"%s" Invalid response %s' % (selection_txt, msg))
-    except Exception:
-        raise click.ClickException('Selection exception %s. Command Aborted')
+    click.echo(title)
+    index = -1
+    for str_ in options:
+        index += 1
+        click.echo('%s: %s' % (index, str_))
+    selection = None
+    msg = 'Input integer between 0 and %s or Ctrl-C to exit selection: ' \
+        % index
+    while True:
+        try:
+            selection_txt = click.prompt(msg)
+            selection = int(selection_txt)
+            if 0 <= selection <= index:
+                if context:
+                    context.spinner.start()
+                return options[selection]
+        except ValueError:  # This causes the retry of the request
+            pass
+        except KeyboardInterrupt:
+            raise click.ClickException("Pick Aborted. CTRL-C")
+        except Exception as ex:
+            raise click.ClickException(
+                'Selection exception: %s. Command Aborted' % ex)
+        click.echo('"%s" Invalid response %s' % (selection_txt, msg))
 
 
 def pick_instance(context, objectname, namespace=None):

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -65,9 +65,9 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    'literal IPV4 address (dotted), or literal IPV6 address\n'
                    '* Port: (optional) defines WBEM server port to be '
                    'used [Defaults: 5988(HTTP) and 5989(HTTPS)].\n'
-                   'Thhis option the --name option and the --mock-server are '
+                   'This option the --name option and the --mock-server are '
                    'mututally exclusive since each defines a WBEM server.\n' +
-                   '(EnvVar: {ev}).'.format(ev=PywbemServer.server_envvar))
+                   '(EnvVar: {ev})'.format(ev=PywbemServer.server_envvar))
 @click.option('-n', '--name', type=str,
               metavar='NAME',
               envvar=PywbemServer.name_envvar,
@@ -76,27 +76,27 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    'pywbemcli retrieves the connection information from the '
                    'connections file ' +
                    '({cf}). '.format(cf=DEFAULT_CONNECTIONS_FILE) +
-                   'This option --server  and --mock-server are mutually '
-                   'exclusive since each defines a WBEM server ' +
-                   '(EnvVar: {ev}).'.format(ev=PywbemServer.name_envvar))
+                   'This option, --server and --mock-server are mutually '
+                   'exclusive since each defines a WBEM server.\n' +
+                   '(EnvVar: {ev})'.format(ev=PywbemServer.name_envvar))
 @click.option('-d', '--default-namespace', type=str,
               metavar='NAMESPACE',
               envvar=PywbemServer.defaultnamespace_envvar,
               help='Default namespace to use in the target WBEM server if no '
-                   'namespace is defined in a subcommand' +
-                   '(EnvVar: {ev}) ' .format(ev=PywbemServer.name_envvar) +
-                   '[]Default: {of}].'.format(of=DEFAULT_NAMESPACE))
+                   'namespace is defined in a subcommand.\n' +
+                   '(EnvVar: {ev})\n' .format(ev=PywbemServer.name_envvar) +
+                   '[Default: {of}]'.format(of=DEFAULT_NAMESPACE))
 @click.option('-u', '--user', type=str, envvar=PywbemServer.user_envvar,
               metavar='USER',
-              help='User name for the WBEM server connection. ' +
-                   '(EnvVar: {ev}) ' .format(ev=PywbemServer.name_envvar))
+              help='User name for the WBEM server connection.\n' +
+                   '(EnvVar: {ev})' .format(ev=PywbemServer.user_envvar))
 @click.option('-p', '--password', type=str,
               metavar='PASSWORD',
               envvar=PywbemServer.password_envvar,
               help='Password for the WBEM server. Will be requested as part '
                    ' of initialization if user name exists and it is not '
-                   ' provided by this option.' +
-                   '(EnvVar: {ev}).'.format(ev=PywbemServer.password_envvar))
+                   ' provided by this option.\n' +
+                   '(EnvVar: {ev})'.format(ev=PywbemServer.password_envvar))
 @click.option('-t', '--timeout', type=click.IntRange(0, MAX_TIMEOUT),
               metavar='INTEGER',
               envvar=PywbemServer.timeout_envvar,
@@ -114,19 +114,18 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('-k', '--keyfile', type=str,
               metavar='FILE PATH',
               envvar=PywbemServer.keyfile_envvar,
-              help='Client private key file. '
-                   '(EnvVar: {}).'.format(PywbemServer.keyfile_envvar))
+              help='Client private key file.\n'
+                   '(EnvVar: {ev})'.format(ev=PywbemServer.keyfile_envvar))
 @click.option('--ca-certs', type=str,
               envvar=PywbemServer.ca_certs_envvar,
               help='File or directory containing certificates that will be '
                    'matched against certificate received from WBEM '
                    'server. Set --no-verify option to bypass '
-                   'client verification of the WBEM server certificate. '
-                   ' (EnvVar: PYWBEMCLI_CA_CERTS).\n'
+                   'client verification of the WBEM server certificate.\n'
+                   '(EnvVar: {ev})\n'.format(ev=PywbemServer.ca_certs_envvar) +
                    '[Default: Searches for matching certificates in the '
-                   'following system directories:'
-                   ' ' + ("\n".join("%s]" % p for p in
-                                    pywbem.DEFAULT_CA_CERT_PATHS)))
+                   'following system directories:\n' +
+                   ',\n'.join(pywbem.DEFAULT_CA_CERT_PATHS) + ']')
 @click.option('-o', '--output-format',
               metavar='<choice>',
               envvar=PywbemServer.timeout_envvar,
@@ -156,8 +155,9 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('--pull-max-cnt', type=int,
               help='Maximium object count of objects to be returned for '
                    'each request if pull operations are used. Must be  a '
-                   'positive non-zero integer.' +
-                   '(EnvVar: {}) '.format(PywbemServer.pull_max_cnt_envvar) +
+                   'positive non-zero integer.\n' +
+                   '(EnvVar: {ev})\n'.
+                   format(ev=PywbemServer.pull_max_cnt_envvar) +
                    '[Default: {}]'.format(DEFAULT_MAXPULLCNT))
 @click.option('-T', '--timestats', is_flag=True,
               help='Show time statistics of WBEM server operations after '
@@ -185,10 +185,12 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    'The option value defines a MOF or Python file path used to '
                    'populate the mock repository. This option may be used '
                    'multiple times where each use defines a single file_path.'
-                   'This parameter the --server option and the --name option '
+                   'This option, --server and --name '
                    'are mutually exclusive since each defines a WBEM server. '
-                   'See the pywbemtools documentation for more information.' +
-                   "(EnvVar: {}).".format(PywbemServer.mock_server_envvar))
+                   'See the pywbemtools documentation for more '
+                   'information.\n' +
+                   "(EnvVar: {ev})".
+                   format(ev=PywbemServer.mock_server_envvar))
 @click.version_option(
     message='%(prog)s, version %(version)s\n' + PYWBEM_VERSION,
     help='Show the version of this command and the pywbem package and exit.')
@@ -202,33 +204,32 @@ def cli(ctx, server, name, default_namespace, user, password, timeout,
     to communicate with WBEM servers. Pywbemcli can:
 
     \b
-        * Manage the information in WBEM servers CIM objects using the
-          operations defined in the DMTF specification.  It can manage CIM
-          classes, CIM instances and CIM qualifier declarations in the WBEM
-          Server and execute CIM methods and queries on the server.
+    * Manage the information in WBEM servers CIM objects using the
+      operations defined in the DMTF specification.  It can manage CIM
+      classes, CIM instances and CIM qualifier declarations in the WBEM
+      Server and execute CIM methods and queries on the server.
 
     \b
-        * Inspect WBEM server characteristics including namespaces, registered
-          profiles, and other server information.
+    * Inspect WBEM server characteristics including namespaces, registered
+      profiles, and other server information.
 
     \b
-        * Capture detailed information on communication with the WBEM
-          server including time statistics and logs of the operations.
+    * Capture detailed information on communication with the WBEM
+      server including time statistics and logs of the operations.
 
     \b
-        * Maintain a persistent list of named WBEM servers and execute
-          operations on them by name.
+    * Maintain a persistent list of named connections to WBEM servers
+      and execute operations on them by name.
 
     Pywbemcli implements command groups and subcommands to execute the CIM-XML
-    operations defined by the DMTF CIM Operations Over HTTP
-    specification(DSP0201) specification.
+    operations defined by the DMTF CIM Operations Over HTTP specification
+    (DSP0200).
 
     The general options shown below can also be specified on any of the
     (sub)commands as well as the command line.
 
     For more detailed documentation, see:
 
-        https://pywbemtools.readthedocs.io/en/latest/
         https://pywbemtools.readthedocs.io/en/stable/
     """
     # In interactive mode, general options specified in cmd line are used as
@@ -247,7 +248,7 @@ def cli(ctx, server, name, default_namespace, user, password, timeout,
         resolved_timestats = timestats or DEFAULT_TIMESTATS
 
         if server and name:
-            click.echo('The --name argument "%s" and --server argument "%s" '
+            click.echo('The --name option "%s" and --server option "%s" '
                        'are mutually exclusive and may not be used '
                        'simultaneously' % (name, server), err=True)
             raise click.Abort()
@@ -317,8 +318,8 @@ def cli(ctx, server, name, default_namespace, user, password, timeout,
             raise click.Abort()
 
         if resolved_mock_server and name:
-            click.echo('The --name argument "%s" and --,pcl+server argument '
-                       '"%s" are mutually exclusive and may not be used '
+            click.echo('The --name "%s" option and --server "%s" option '
+                       'are mutually exclusive and may not be used '
                        'simultaneiously' % (name, mock_server), err=True)
             raise click.Abort()
 
@@ -471,16 +472,16 @@ The following can be entered in interactive mode:
 @click.pass_context
 def repl(ctx):
     """
-    Enter interactive (REPL) mode (default).
+    Enter interactive mode (default).
 
     Enters the interactive mode where subcommands can be entered interactively
     and load the command history file.
 
-    If no options are specified on the command line,  the interactive mode
-    is entered. The prompt is changed to `pywbemcli>' in the interactive
+    If no options are specified on the command line, the interactive mode
+    is entered. The prompt is changed to 'pywbemcli>' in the interactive
     mode.
 
-    Pywbemcli may be terminated form this mode by entering
+    Pywbemcli may be terminated from this mode by entering
     <CTRL-D>, :q, :quit, :exit
 
     Parameters:

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -65,7 +65,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    'literal IPV4 address (dotted), or literal IPV6 address\n'
                    '* Port: (optional) defines WBEM server port to be '
                    'used [Defaults: 5988(HTTP) and 5989(HTTPS)].\n'
-                   'This option the --name option and the --mock-server are '
+                   'This option, the --name, and --mock-server are '
                    'mututally exclusive since each defines a WBEM server.\n' +
                    '(EnvVar: {ev})'.format(ev=PywbemServer.server_envvar))
 @click.option('-n', '--name', type=str,
@@ -76,7 +76,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    'pywbemcli retrieves the connection information from the '
                    'connections file ' +
                    '({cf}). '.format(cf=DEFAULT_CONNECTIONS_FILE) +
-                   'This option, --server and --mock-server are mutually '
+                   'This option, --server, and --mock-server are mutually '
                    'exclusive since each defines a WBEM server.\n' +
                    '(EnvVar: {ev})'.format(ev=PywbemServer.name_envvar))
 @click.option('-d', '--default-namespace', type=str,
@@ -102,7 +102,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
               envvar=PywbemServer.timeout_envvar,
               help='Client timeout completion of WBEM server operation in '
                    'seconds.\n' +
-                   '(EnvVar: PYWBEMCLI_{})'.format(PywbemServer.timeout_envvar))
+                   '(EnvVar: {ev})'.format(ev=PywbemServer.timeout_envvar))
 @click.option('-N', '--no-verify', is_flag=True,
               envvar=PywbemServer.no_verify_envvar,
               help='If set, client does not verify WBEM server certificate.' +
@@ -149,8 +149,8 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    '* "no": forces pywbemcli to use only the '
                    'traditional non-pull operations.\n'
                    '* "either": pywbemcli trys first pull and then '
-                   ' traditional operations.\n' +
-                   '(EnvVar: {}) '.format(PywbemServer.use_pull_envvar) +
+                   'traditional operations.\n' +
+                   '(EnvVar: {ev}) '.format(ev=PywbemServer.use_pull_envvar) +
                    '[Default: {}]'.format(DEFAULT_PULL_CHOICE))
 @click.option('--pull-max-cnt', type=int,
               help='Maximium object count of objects to be returned for '
@@ -185,7 +185,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    'The option value defines a MOF or Python file path used to '
                    'populate the mock repository. This option may be used '
                    'multiple times where each use defines a single file_path.'
-                   'This option, --server and --name '
+                   'This option, --server, and --name '
                    'are mutually exclusive since each defines a WBEM server. '
                    'See the pywbemtools documentation for more '
                    'information.\n' +
@@ -320,7 +320,7 @@ def cli(ctx, server, name, default_namespace, user, password, timeout,
         if resolved_mock_server and name:
             click.echo('The --name "%s" option and --server "%s" option '
                        'are mutually exclusive and may not be used '
-                       'simultaneiously' % (name, mock_server), err=True)
+                       'simultaneously' % (name, mock_server), err=True)
             raise click.Abort()
 
         if use_pull:

--- a/tests/unit/common_options_help_lines.py
+++ b/tests/unit/common_options_help_lines.py
@@ -1,0 +1,38 @@
+# Copyright 2018 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Defines those cmd line options that apply arross multiple command groups.
+"""
+
+CMD_OPTION_NAMES_ONLY_HELP_LINE = \
+    '-o, --names-only Retrieve only the returned object names.'
+
+CMD_OPTION_HELP_HELP_LINE = \
+    '-h, --help Show this message and exit.'
+
+CMD_OPTION_SUMMARY_HELP_LINE = \
+    '-S, --summary Return only summary of objects'
+
+CMD_OPTION_NAMESPACE_HELP_LINE = \
+    '-n, --namespace <name> Namespace to use for this operation'
+
+CMD_OPTION_PROPERTYLIST_HELP_LINE = \
+    '-p, --propertylist <property name> Define a propertylist'
+
+CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE = \
+    '-c, --include-classorigin Request that server include classorigin'
+
+CMD_VERIFY_OPTION_HELP_LINE = \
+    '-V, --verify If set, The change is displayed'

--- a/tests/unit/common_options_help_lines.py
+++ b/tests/unit/common_options_help_lines.py
@@ -13,26 +13,48 @@
 # limitations under the License.
 
 """
-Defines those cmd line options that apply arross multiple command groups.
-"""
+Defines the expected help text for command specific options that apply across
+multiple command groups.
 
-CMD_OPTION_NAMES_ONLY_HELP_LINE = \
-    '-o, --names-only Retrieve only the returned object names.'
+The expected help text strings are used with the 'innows' test, which is a
+whitespace-tolerant test for whether the expected text is in the actual text.
+"""
 
 CMD_OPTION_HELP_HELP_LINE = \
     '-h, --help Show this message and exit.'
 
-CMD_OPTION_SUMMARY_HELP_LINE = \
-    '-S, --summary Return only summary of objects'
+CMD_OPTION_INTERACTIVE_HELP_LINE = \
+    "-i, --interactive If set, `INSTANCENAME` argument must"
+
+CMD_OPTION_VERIFY_HELP_LINE = \
+    '-V, --verify If set, The change is displayed'
 
 CMD_OPTION_NAMESPACE_HELP_LINE = \
     '-n, --namespace <name> Namespace to use for this operation'
 
+CMD_OPTION_NAMES_ONLY_HELP_LINE = \
+    '-o, --names-only Retrieve only the returned object names.'
+
+CMD_OPTION_SUMMARY_HELP_LINE = \
+    '-S, --summary Return only summary of objects'
+
+CMD_OPTION_LOCAL_ONLY_HELP_LINE = \
+    '-l, --local-only Show only local properties'
+
 CMD_OPTION_PROPERTYLIST_HELP_LINE = \
     '-p, --propertylist <property name> Define a propertylist'
 
+CMD_OPTION_FILTER_QUERY_LINE = \
+    '-f, --filter-query TEXT A filter query to be passed to the server'
+
+CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE = \
+    '--filter-query-language TEXT A filter-query language to be used'
+
+CMD_OPTION_NO_QUALIFIERS_HELP_LINE = \
+    '--no-qualifiers If set, request server to not include qualifiers'
+
+CMD_OPTION_INCLUDE_QUALIFIERS_HELP_LINE = \
+    '-q, --include-qualifiers If set, requests server to include'
+
 CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE = \
     '-c, --include-classorigin Request that server include classorigin'
-
-CMD_VERIFY_OPTION_HELP_LINE = \
-    '-V, --verify If set, The change is displayed'

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -18,6 +18,10 @@ Tests the class subcommand
 import os
 import pytest
 from .cli_test_extensions import CLITestsBase
+from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
+    CMD_OPTION_HELP_HELP_LINE, CMD_OPTION_SUMMARY_HELP_LINE, \
+    CMD_OPTION_NAMESPACE_HELP_LINE, CMD_OPTION_PROPERTYLIST_HELP_LINE, \
+    CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE
 
 from .utils import execute_pywbemcli, assert_rc
 
@@ -36,27 +40,14 @@ CMD_OPTION_LOCAL_ONLY_HELP_LINE = \
 CMD_OPTION_NO_QUALIFIERS_HELP_LINE = \
     '--no-qualifiers If set, request server to not include qualifiers'
 
-CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE = \
-    '-c, --include-classorigin Request that server include classorigin'
-
-CMD_OPTION_PROPERTYLIST_HELP_LINE = \
-    '-p, --propertylist <property name> Define a propertylist'
-
-CMD_OPTION_NAMES_ONLY_HELP_LINE = \
-    '-o, --names-only Retrieve only the returned object names.'
-
-CMD_OPTION_NAMESPACE_HELP_LINE = \
-    '-n, --namespace <name> Namespace to use for this operation'
-
-CMD_OPTION_NAMESPACE_HELP_LINE = \
-    '-n, --namespace <name> Namespace to use for this operation'
-
-CMD_OPTION_SUMMARY_HELP_LINE = \
-    '-S, --summary Return only summary of objects'
-
-CMD_OPTION_HELP_HELP_LINE = \
-    '-h, --help Show this message and exit.'
-
+#
+# The following list define the help for each command in terms of particular
+# parts of lines that are to be tested.
+# For each test, try to include:
+# 1. The usage line and in particular the argument component
+# 2. The single
+# 2. The last line CMD_OPTION_HELP_HELP_LINE
+#
 CLASS_HELP_LINES = [
     'Usage: pywbemcli class [COMMAND-OPTIONS] COMMAND [ARGS]...',
     'Command group for CIM classes.',
@@ -76,7 +67,7 @@ CLASS_GET_HELP_LINES = [
 
 CLASS_ENUMERATE_HELP_LINES = [
     'Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME',
-    'Get the top classes in a namespace or subclasses of a class.',
+    'Get the top classes or subclasses of a class in a namespace.',
     '-d, --deep-inheritance If set, request server to return complete',
     CMD_OPTION_LOCAL_ONLY_HELP_LINE,
     CMD_OPTION_NO_QUALIFIERS_HELP_LINE,
@@ -89,7 +80,7 @@ CLASS_ENUMERATE_HELP_LINES = [
 
 CLASS_FIND_HELP_LINES = [
     'Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME-GLOB',
-    'Get the classes with matching class names on the server.',
+    'Get the classes with matching class names on the WBEM server.',
     '-n, --namespace <name> Namespace(s) to use for this operation',
     CMD_OPTION_HELP_HELP_LINE,
 ]

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -59,13 +59,13 @@ CMD_OPTION_HELP_HELP_LINE = \
 
 CLASS_HELP_LINES = [
     'Usage: pywbemcli class [COMMAND-OPTIONS] COMMAND [ARGS]...',
-    'Command group to manage CIM classes.',
+    'Command group for CIM classes.',
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
 CLASS_GET_HELP_LINES = [
     'Usage: pywbemcli class get [COMMAND-OPTIONS] CLASSNAME',
-    'Get and display a single CIM class.',
+    'Get a class.',
     CMD_OPTION_LOCAL_ONLY_HELP_LINE,
     CMD_OPTION_NO_QUALIFIERS_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
@@ -76,7 +76,7 @@ CLASS_GET_HELP_LINES = [
 
 CLASS_ENUMERATE_HELP_LINES = [
     'Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME',
-    'Enumerate classes from the WBEM server.',
+    'Get the top classes in a namespace or subclasses of a class.',
     '-d, --deep-inheritance If set, request server to return complete',
     CMD_OPTION_LOCAL_ONLY_HELP_LINE,
     CMD_OPTION_NO_QUALIFIERS_HELP_LINE,
@@ -89,14 +89,14 @@ CLASS_ENUMERATE_HELP_LINES = [
 
 CLASS_FIND_HELP_LINES = [
     'Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME-GLOB',
-    'Find all classes that match CLASSNAME-GLOB.',
+    'Get the classes with matching class names on the server.',
     '-n, --namespace <name> Namespace(s) to use for this operation',
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
 CLASS_TREE_HELP_LINES = [
     'Usage: pywbemcli class tree [COMMAND-OPTIONS] CLASSNAME',
-    'Display CIM class inheritance hierarchy tree.',
+    'Get the subclass or superclass inheritance tree of a class.',
     '-s, --superclasses Display the superclasses',
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
@@ -104,7 +104,7 @@ CLASS_TREE_HELP_LINES = [
 
 CLASS_DELETE_HELP_LINES = [
     'Usage: pywbemcli class delete [COMMAND-OPTIONS] CLASSNAME',
-    'Delete a single CIM class.',
+    'Delete a class.',
     '-f, --force Force the delete request',
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
@@ -112,7 +112,7 @@ CLASS_DELETE_HELP_LINES = [
 
 CLASS_ASSOCIATORS_HELP_LINES = [
     'Usage: pywbemcli class associators [COMMAND-OPTIONS] CLASSNAME',
-    'Get the associated classes for CLASSNAME.',
+    'Get the classes associated with a class.',
     '-a, --assoc-class <class name> Filter by the association class name',
     '-C, --result-class <class name> Filter the returned objects by the class '
     'name',
@@ -129,7 +129,7 @@ CLASS_ASSOCIATORS_HELP_LINES = [
 
 CLASS_REFERENCES_HELP_LINES = [
     'Usage: pywbemcli class references [COMMAND-OPTIONS] CLASSNAME',
-    'Get the reference classes for CLASSNAME.',
+    'Get the classes referencing a class.',
     '-R, --result-class <class name> Filter by the classname provided.',
     '-r, --role <role name> Filter by the role name provided.',
     CMD_OPTION_NO_QUALIFIERS_HELP_LINE,
@@ -144,7 +144,7 @@ CLASS_REFERENCES_HELP_LINES = [
 CLASS_INVOKEMETHOD_HELP_LINES = [
     'Usage: pywbemcli class invokemethod [COMMAND-OPTIONS] CLASSNAME '
     'METHODNAME',
-    'Invoke the class method named methodname.',
+    'Invoke a method on a class.',
     '-p, --parameter parameter Optional multiple method parameters of form',
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -21,7 +21,8 @@ from .cli_test_extensions import CLITestsBase
 from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
     CMD_OPTION_HELP_HELP_LINE, CMD_OPTION_SUMMARY_HELP_LINE, \
     CMD_OPTION_NAMESPACE_HELP_LINE, CMD_OPTION_PROPERTYLIST_HELP_LINE, \
-    CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE
+    CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE, \
+    CMD_OPTION_LOCAL_ONLY_HELP_LINE, CMD_OPTION_NO_QUALIFIERS_HELP_LINE
 
 from .utils import execute_pywbemcli, assert_rc
 
@@ -34,11 +35,6 @@ SIMPLE_MOCK_FILE_EXT = 'simple_mock_model_ext.mof'
 INVOKE_METHOD_MOCK_FILE = 'simple_mock_invokemethod.py'
 SIMPLE_ASSOC_MOCK_FILE = 'simple_assoc_mock_model.mof'
 
-CMD_OPTION_LOCAL_ONLY_HELP_LINE = \
-    '-l, --local-only Show only local properties'
-
-CMD_OPTION_NO_QUALIFIERS_HELP_LINE = \
-    '--no-qualifiers If set, request server to not include qualifiers'
 
 #
 # The following list define the help for each command in terms of particular
@@ -52,15 +48,36 @@ CLASS_HELP_LINES = [
     'Usage: pywbemcli class [COMMAND-OPTIONS] COMMAND [ARGS]...',
     'Command group for CIM classes.',
     CMD_OPTION_HELP_HELP_LINE,
+    'associators   Get the classes associated with a class.',
+    'delete        Delete a class.',
+    'enumerate     Get the top classes or subclasses of a class in a',
+    'find          Get the classes with matching class names on the',
+    'get           Get a class.',
+    'invokemethod  Invoke a method on a class.',
+    'references    Get the classes referencing a class.',
+    'tree          Get the subclass or superclass inheritance tree of a',
 ]
 
-CLASS_GET_HELP_LINES = [
-    'Usage: pywbemcli class get [COMMAND-OPTIONS] CLASSNAME',
-    'Get a class.',
-    CMD_OPTION_LOCAL_ONLY_HELP_LINE,
+CLASS_ASSOCIATORS_HELP_LINES = [
+    'Usage: pywbemcli class associators [COMMAND-OPTIONS] CLASSNAME',
+    'Get the classes associated with a class.',
+    '-a, --assoc-class <class name> Filter by the association class name',
+    '-C, --result-class <class name> Filter the returned objects by the class',
+    '-r, --role <role name> Filter by the role name',
+    '-R, --result-role <role name> Filter by the result role name',
     CMD_OPTION_NO_QUALIFIERS_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
+    CMD_OPTION_NAMES_ONLY_HELP_LINE,
+    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_SUMMARY_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+CLASS_DELETE_HELP_LINES = [
+    'Usage: pywbemcli class delete [COMMAND-OPTIONS] CLASSNAME',
+    'Delete a class.',
+    '-f, --force Force the delete request',
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
@@ -81,40 +98,27 @@ CLASS_ENUMERATE_HELP_LINES = [
 CLASS_FIND_HELP_LINES = [
     'Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME-GLOB',
     'Get the classes with matching class names on the WBEM server.',
-    '-n, --namespace <name> Namespace(s) to use for this operation',
-    CMD_OPTION_HELP_HELP_LINE,
-]
-
-CLASS_TREE_HELP_LINES = [
-    'Usage: pywbemcli class tree [COMMAND-OPTIONS] CLASSNAME',
-    'Get the subclass or superclass inheritance tree of a class.',
-    '-s, --superclasses Display the superclasses',
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-CLASS_DELETE_HELP_LINES = [
-    'Usage: pywbemcli class delete [COMMAND-OPTIONS] CLASSNAME',
-    'Delete a class.',
-    '-f, --force Force the delete request',
-    CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_OPTION_HELP_HELP_LINE,
-]
-
-CLASS_ASSOCIATORS_HELP_LINES = [
-    'Usage: pywbemcli class associators [COMMAND-OPTIONS] CLASSNAME',
-    'Get the classes associated with a class.',
-    '-a, --assoc-class <class name> Filter by the association class name',
-    '-C, --result-class <class name> Filter the returned objects by the class '
-    'name',
-    '-r, --role <role name> Filter by the role name',
-    '-R, --result-role <role name> Filter by the result role name',
+CLASS_GET_HELP_LINES = [
+    'Usage: pywbemcli class get [COMMAND-OPTIONS] CLASSNAME',
+    'Get a class.',
+    CMD_OPTION_LOCAL_ONLY_HELP_LINE,
     CMD_OPTION_NO_QUALIFIERS_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
-    CMD_OPTION_NAMES_ONLY_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_OPTION_SUMMARY_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+CLASS_INVOKEMETHOD_HELP_LINES = [
+    'Usage: pywbemcli class invokemethod [COMMAND-OPTIONS] CLASSNAME '
+    'METHODNAME',
+    'Invoke a method on a class.',
+    '-p, --parameter parameter Optional multiple method parameters of form',
+    CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
@@ -132,11 +136,10 @@ CLASS_REFERENCES_HELP_LINES = [
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-CLASS_INVOKEMETHOD_HELP_LINES = [
-    'Usage: pywbemcli class invokemethod [COMMAND-OPTIONS] CLASSNAME '
-    'METHODNAME',
-    'Invoke a method on a class.',
-    '-p, --parameter parameter Optional multiple method parameters of form',
+CLASS_TREE_HELP_LINES = [
+    'Usage: pywbemcli class tree [COMMAND-OPTIONS] CLASSNAME',
+    'Get the subclass or superclass inheritance tree of a class.',
+    '-s, --superclasses Display the superclasses',
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
@@ -308,13 +311,13 @@ TEST_CASES = [
     # mock - None or name of files (mof or .py),
     # condition - If True, the test is executed,  Otherwise it is skipped.
 
-    ['Verify class --help response (light)',
+    ['Verify class subcommand --help response',
      ['--help'],
      {'stdout': CLASS_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class -h response (light)',
+    ['Verify class subcommand -h response',
      ['-h'],
      {'stdout': CLASS_HELP_LINES,
       'test': 'innows'},
@@ -323,13 +326,13 @@ TEST_CASES = [
     #
     # Enumerate subcommand and its options
     #
-    ['Verify class subcommand enumerate --help response (light)',
+    ['Verify class subcommand enumerate --help response',
      ['enumerate', '--help'],
      {'stdout': CLASS_ENUMERATE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand enumerate -h response (light)',
+    ['Verify class subcommand enumerate -h response',
      ['enumerate', '-h'],
      {'stdout': CLASS_ENUMERATE_HELP_LINES,
       'test': 'innows'},
@@ -484,13 +487,13 @@ TEST_CASES = [
     #
     # Test class get
     #
-    ['Verify class subcommand get --help response (light)',
+    ['Verify class subcommand get --help response',
      ['get', '--help'],
      {'stdout': CLASS_GET_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand get -h response (light)',
+    ['Verify class subcommand get -h response',
      ['get', '-h'],
      {'stdout': CLASS_GET_HELP_LINES,
       'test': 'innows'},
@@ -689,13 +692,13 @@ TEST_CASES = [
     #
     # find subcommand
     #
-    ['Verify class subcommand find --help response (light)',
+    ['Verify class subcommand find --help response',
      ['find', '--help'],
      {'stdout': CLASS_FIND_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand find -h response (light)',
+    ['Verify class subcommand find -h response',
      ['find', '-h'],
      {'stdout': CLASS_FIND_HELP_LINES,
       'test': 'innows'},
@@ -775,13 +778,13 @@ TEST_CASES = [
     #
     # subcommand "class delete"
     #
-    ['Verify class subcommand delete --help response (light)',
+    ['Verify class subcommand delete --help response',
      ['delete', '--help'],
      {'stdout': CLASS_DELETE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand delete -h response (light)',
+    ['Verify class subcommand delete -h response',
      ['delete', '-h'],
      {'stdout': CLASS_DELETE_HELP_LINES,
       'test': 'innows'},
@@ -842,13 +845,13 @@ TEST_CASES = [
     #
     # subcommand "class tree"
     #
-    ['Verify class subcommand tree --help response (light)',
+    ['Verify class subcommand tree --help response',
      ['tree', '--help'],
      {'stdout': CLASS_TREE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand tree -h response (light)',
+    ['Verify class subcommand tree -h response',
      ['tree', '-h'],
      {'stdout': CLASS_TREE_HELP_LINES,
       'test': 'innows'},
@@ -913,13 +916,13 @@ TEST_CASES = [
     # associators subcommand tests
     #
     #
-    ['Verify class subcommand associators --help response (light)',
+    ['Verify class subcommand associators --help response',
      ['associators', '--help'],
      {'stdout': CLASS_ASSOCIATORS_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand associators -h response (light)',
+    ['Verify class subcommand associators -h response',
      ['associators', '-h'],
      {'stdout': CLASS_ASSOCIATORS_HELP_LINES,
       'test': 'innows'},
@@ -1074,13 +1077,13 @@ TEST_CASES = [
     #
     # references subcommand tests
     #
-    ['Verify class subcommand references --help response (light)',
+    ['Verify class subcommand references --help response',
      ['references', '--help'],
      {'stdout': CLASS_REFERENCES_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand references -h response (light)',
+    ['Verify class subcommand references -h response',
      ['references', '-h'],
      {'stdout': CLASS_REFERENCES_HELP_LINES,
       'test': 'innows'},
@@ -1133,13 +1136,13 @@ TEST_CASES = [
     #
     # invokemethod subcommand tests
     #
-    ['Verify class subcommand invokemethod --help response (light)',
+    ['Verify class subcommand invokemethod --help response',
      ['invokemethod', '--help'],
      {'stdout': CLASS_INVOKEMETHOD_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand invokemethod -h response (light)',
+    ['Verify class subcommand invokemethod -h response',
      ['invokemethod', '-h'],
      {'stdout': CLASS_INVOKEMETHOD_HELP_LINES,
       'test': 'innows'},

--- a/tests/unit/test_connection_subcmd.py
+++ b/tests/unit/test_connection_subcmd.py
@@ -23,6 +23,8 @@ import os
 import pytest
 
 from .cli_test_extensions import CLITestsBase
+from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE, \
+    CMD_VERIFY_OPTION_HELP_LINE
 
 SCRIPT_DIR = os.path.dirname(__file__)
 
@@ -41,256 +43,77 @@ TEST_DIR_REL = os.path.relpath(TEST_DIR)
 MOCK_FILE_PATH = os.path.join(TEST_DIR_REL, SIMPLE_MOCK_FILE)
 CONFIRM_FILE_PATH = os.path.join(TEST_DIR_REL, MOCK_CONFIRMY_FILE)
 
-CONN_HELP = """
-Usage: pywbemcli connection [COMMAND-OPTIONS] COMMAND [ARGS]...
+CONNECTION_HELP_LINE = [
+    'Usage: pywbemcli connection [COMMAND-OPTIONS] COMMAND [ARGS]...',
+    'Command group for persistent WBEM connections.',
+    CMD_OPTION_HELP_HELP_LINE,
+]
 
-  Command group to manage WBEM connections.
+CONNECTION_ADD_HELP_LINE = [
+    'Usage: pywbemcli connection add [COMMAND-OPTIONS]',
+    'Create a new named WBEM connection.',
+    '-s, --server SERVER Required hostname or IP address with scheme',
+    '-n, --name NAME Required name for the connection(optional',
+    '-d, --default-namespace NAMESPACE',
+    '-u, --user TEXT User name for the WBEM server connection',
+    '-p, --password TEXT Password for the WBEM server. Will be',
+    '-t, --timeout INTEGER RANGE     Operation timeout for the WBEM server in',
+    '-N, --noverify                  If set, client does not verify server',
+    '-k, --keyfile TEXT              Client private key file',
+    '-U, --use-pull-ops [yes|no|either]',
+    '--pull-max-cnt INTEGER          Maximium object count of objects',
+    '-l, --log COMP=DEST:DETAIL,...  Enable logging of CIM Operations',
+    '-m, --mock-server FILENAME      If this option is defined',
+    '--ca_certs TEXT                 File or directory containing',
+    CMD_VERIFY_OPTION_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
+]
 
-  These command allow viewing and setting persistent connection definitions.
-  The connections are normally defined in the file pywbemcliconnections.json
-  in the current directory.
+CONNECTION_DELETE_HELP_LINE = [
+    'Usage: pywbemcli connection delete [COMMAND-OPTIONS] NAME',
+    'Delete a named WBEM connection.',
+    CMD_VERIFY_OPTION_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
+]
 
-  In addition to the command-specific options shown in this help text, the
-  general options (see 'pywbemcli --help') can also be specified before the
-  command. These are NOT retained after the command is executed.
+CONNECTION_EXPORT_HELP_LINE = [
+    'Usage: pywbemcli connection export [COMMAND-OPTIONS]',
+    'Export the current connection information.',
+    CMD_OPTION_HELP_HELP_LINE,
+]
 
-Options:
-  -h, --help  Show this message and exit.
+CONNECTION_LIST_HELP_LINE = [
+    'Usage: pywbemcli connection list [COMMAND-OPTIONS]',
+    'List the entries in the connections file.',
+    'An "*" after the name indicates the currently selected',
+    CMD_OPTION_HELP_HELP_LINE
+]
 
-Commands:
-  add     Create a new named WBEM connection.
-  delete  Delete connection information.
-  export  Export the current connection information.
-  list    List the entries in the connection file.
-  save    Save current connection to repository.
-  select  Select a connection from defined connections.
-  show    Show current or NAME connection information.
-  test    Execute a predefined WBEM request.
-"""
+CONNECTION_SAVE_HELP_LINE = [
+    'Usage: pywbemcli connection save [COMMAND-OPTIONS]',
+    'Save current connection to connections file.',
+    '-n, --name Connection name  If defined, this changes the name of',
+    CMD_VERIFY_OPTION_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE
+]
 
-CONN_SHOW_HELP = """
-Usage: pywbemcli connection show [COMMAND-OPTIONS] NAME
+CONNECTION_SELECT_HELP_LINE = [
+    'Usage: pywbemcli connection select [COMMAND-OPTIONS] NAME',
+    'Select a connection from connections file.',
+    CMD_OPTION_HELP_HELP_LINE
+]
 
-  Show current or NAME connection information.
+CONNECTION_SHOW_HELP_LINE = [
+    'Usage: pywbemcli connection show [COMMAND-OPTIONS] NAME',
+    'Show current or NAME connection information.',
+    CMD_OPTION_HELP_HELP_LINE
+]
 
-  This subcommand displays  all the variables that make up the current WBEM
-  connection if the optional NAME argument is NOT provided. If NAME not
-  supplied, a list of connections from the connections definition file is
-  presented with a prompt for the user to select a NAME.
-
-  The information on the     connection named is displayed if that name is
-  in the persistent repository.
-
-Options:
-  -h, --help  Show this message and exit.
-"""
-
-CONN_DEL_HELP = """
-Usage: pywbemcli connection delete [COMMAND-OPTIONS] NAME
-
-  Delete connection information.
-
-  Delete connection information from the persistent store for the connection
-  defined by NAME. The NAME argument is optional.
-
-  If NAME not supplied, a select list presents the list of connection
-  definitions for selection.
-
-  Example:   connection delete blah
-
-Options:
-  -V, --verify  If set, The change is displayed and verification requested
-                before the change is executed
-  -h, --help    Show this message and exit.
-"""
-
-CONN_SAVE_HELP = """
-Usage: pywbemcli connection save [COMMAND-OPTIONS]
-
-  Save current connection to repository.
-
-  Saves the current connection to the connections file if it does not
-  already exist in that file.
-
-  This is useful when you have defined a connection on the command line and
-  want to set it into the connections file.
-
-Options:
-  -n, --name Connection name  If defined, this changes the name of the
-                              connection to be saved. This allows renaming the
-                              current connection as part of saving it.
-  -V, --verify                If set, The change is displayed and verification
-                              requested before the change is executed
-  -h, --help                  Show this message and exit.
-"""
-
-CONN_ADD_HELP = """
-Usage: pywbemcli connection add [COMMAND-OPTIONS]
-
-  Create a new named WBEM connection.
-
-  This subcommand creates and saves a named connection from the input
-  options in the connections file.
-
-  The new connection can be referenced by the name argument in the future.
-  This connection object is capable of managing all of the properties
-  defined for WBEMConnections.
-
-  The NAME and URI arguments MUST exist. They define the server uri and the
-  unique name under which this server connection information will be stored.
-  All other properties are optional.
-
-  Adding a connection does not the new connection as the current connection.
-  Use `connection select` to set a particular stored connection definition
-  as the current connection.
-
-  A new connection can also be defined by supplying the parameters on the
-  command line and using the `connection save` command to put it into the
-  connection repository.
-
-Options:
-  -s, --server SERVER             Required hostname or IP address with scheme
-                                  of the WBEM server in format:
-                                  [{scheme}://]{host}[:{port}]
-                                  * Scheme: must
-                                  be "https" or "http" [Default: "https"]
-                                  *
-                                  Host: defines short/fully qualified DNS
-                                  hostname, literal IPV4 address (dotted), or
-                                  literal IPV6 address
-                                  * Port: (optional)
-                                  defines WBEM server port to be used
-                                  [Defaults: 5988(HTTP) and 5989(HTTPS)].
-  -n, --name NAME                 Required name for the connection(optional,
-                                  see --server).  This is the name for this
-                                  defined WBEM server in the connection file
-                                  [required]
-  -d, --default-namespace NAMESPACE
-                                  Default namespace to use in the target WBEM
-                                  server if no namespace is defined in the
-                                  subcommand (Default: root/cimv2).
-  -u, --user TEXT                 User name for the WBEM server connection.
-  -p, --password TEXT             Password for the WBEM server. Will be
-                                  requested as part  of initialization if user
-                                  name exists and it is not  provided by this
-                                  option.
-  -t, --timeout INTEGER RANGE     Operation timeout for the WBEM server in
-                                  seconds. Default: 30
-  -N, --no-verify                  If set, client does not verify server
-                                  certificate.
-  -c, --certfile TEXT             Server certfile. Ignored if no-verify flag
-                                  set.
-  -k, --keyfile TEXT              Client private key file.
-  -U, --use-pull [yes|no|either]
-                                  Determines whether pull operations are used
-                                  for EnumerateInstances, AssociatorInstances,
-                                  ReferenceInstances, and ExecQuery
-                                  operations.
-                                  * "yes": pull operations
-                                  required; if server does not support pull,
-                                  the operation fails.
-                                  * "no": forces
-                                  pywbemcli to use only the traditional non-
-                                  pull operations.
-                                  * "either": pywbemcli trys
-                                  first pull and then  traditional operations.
-  --pull-max-cnt INTEGER          Maximium object count of objects to be
-                                  returned for each request if pull operations
-                                  are used. Must be  a positive non-zero
-                                  integer.[Default: 1000]
-  -l, --log COMP=DEST:DETAIL,...  Enable logging of CIM Operations and set a
-                                  component to destination, and detail level
-                                  (COMP: [api|http|all], Default: all) DEST:
-                                  [file|stderr], Default: file)
-                                  DETAIL:[all|paths|summary], Default: all)
-  -m, --mock-server FILENAME      If this option is defined, a mock WBEM
-                                  server is constructed as the target WBEM
-                                  server and the option value defines a MOF or
-                                  Python file to be used to populate the mock
-                                  repository. This option may be used multiple
-                                  times where each use defines a single file
-                                  or file_path.See the pywbemcli documentation
-                                  for more information.
-  --ca_certs TEXT                 File or directory containing certificates
-                                  that will be matched against a certificate
-                                  received from the WBEM server. Set the --no-
-                                  verify-cert option to bypass client
-                                  verification of the WBEM server certificate.
-                                  Default: Searches for matching certificates
-                                  in the following system directories:
-                                  /etc/pki/ca-trust/extracted/openssl/ca-
-                                  bundle.trust.crt
-                                  /etc/ssl/certs
-                                  /etc/ssl/certificates
-  -V, --verify                    If set, The change is displayed and
-                                  verification requested before the change is
-                                  executed
-  -h, --help                      Show this message and exit.
-"""
-
-CONN_LIST_HELP = """
-Usage: pywbemcli connection list [COMMAND-OPTIONS]
-
-  List the entries in the connection file.
-
-  This subcommand displays all entries in the connection file as a table
-  using the command line output_format to define the table format with
-  default of simple format.
-
-  An "*" after the name indicates the currently selected connection.
-
-Options:
-  -h, --help  Show this message and exit.
-"""
-
-CONN_TEST_HELP = """
-Usage: pywbemcli connection test [COMMAND-OPTIONS]
-
-  Execute a predefined WBEM request.
-
-  This executes a predefined request against the current WBEM server to
-  confirm that the connection exists and is working.
-
-  It executes EnumerateClassNames on the default namespace as the test.
-
-Options:
-  -h, --help  Show this message and exit.
-"""
-
-CONN_EXPORT_HELP = """
-Usage: pywbemcli connection export [COMMAND-OPTIONS]
-
-  Export  the current connection information.
-
-  Creates an export statement for each connection variable and outputs the
-  statement to the conole.
-
-Options:
-  -h, --help  Show this message and exit.
-"""
-
-CONN_SELECT_HELP = """
-Usage: pywbemcli connection select [COMMAND-OPTIONS] NAME
-
-  Select a connection from defined connections.
-
-  Selects a connection from the persistently stored set of named connections
-  if NAME exists in the store. The NAME argument is optional.  If NAME not
-  supplied, a list of connections from the connections definition file is
-  presented with a prompt for the user to select a NAME.
-
-  Select state is not persistent.
-
-  Examples:
-
-     connection select <name>    # select the defined <name>
-
-     connection select           # presents select list to pick connection
-
-Options:
-  -h, --help  Show this message and exit.
-"""
-
+CONNECTION_TEST_HELP_LINE = [
+    'Usage: pywbemcli connection test [COMMAND-OPTIONS]',
+    'Execute a predefined WBEM request.',
+    CMD_OPTION_HELP_HELP_LINE,
+]
 
 OK = True     # mark tests OK when they execute correctly
 RUN = True    # Mark OK = False and current test case being created RUN
@@ -310,56 +133,56 @@ TEST_CASES = [
 
     ['Verify connection subcommand help response',
      '--help',
-     {'stdout': CONN_HELP,
-      'test': 'linesnows'},
-     None, OK],
-
-    ['Verify connection subcommand show --help response',
-     ['show', '--help'],
-     {'stdout': CONN_SHOW_HELP,
-      'test': 'linesnows'},
-     None, OK],
-
-    ['Verify connection subcommand delete --help response',
-     ['delete', '--help'],
-     {'stdout': CONN_DEL_HELP,
-      'test': 'linesnows'},
-     None, OK],
-
-    ['Verify connection subcommand save --help response',
-     ['save', '--help'],
-     {'stdout': CONN_SAVE_HELP,
-      'test': 'linesnows'},
+     {'stdout': CONNECTION_HELP_LINE,
+      'test': 'innows'},
      None, OK],
 
     ['Verify connection subcommand add --help response',
      ['add', '--help'],
-     {'stdout': CONN_ADD_HELP,
-      'test': 'linesnows'},
+     {'stdout': CONNECTION_ADD_HELP_LINE,
+      'test': 'inows'},
      None, OK],
 
-    ['Verify connection subcommand list --help response',
-     ['list', '--help'],
-     {'stdout': CONN_LIST_HELP,
-      'test': 'linesnows'},
-     None, OK],
-
-    ['Verify connection subcommand test --help response',
-     ['test', '--help'],
-     {'stdout': CONN_TEST_HELP,
-      'test': 'linesnows'},
+    ['Verify connection subcommand delete --help response',
+     ['delete', '--help'],
+     {'stdout': CONNECTION_DELETE_HELP_LINE,
+      'test': 'innows'},
      None, OK],
 
     ['Verify connection subcommand export --help response',
      ['export', '--help'],
-     {'stdout': CONN_EXPORT_HELP,
-      'test': 'linesnows'},
+     {'stdout': CONNECTION_EXPORT_HELP_LINE,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection subcommand list --help response',
+     ['list', '--help'],
+     {'stdout': CONNECTION_LIST_HELP_LINE,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection subcommand save --help response',
+     ['save', '--help'],
+     {'stdout': CONNECTION_SAVE_HELP_LINE,
+      'test': 'innows'},
      None, OK],
 
     ['Verify connection subcommand select  --help response',
      ['select', '--help'],
-     {'stdout': CONN_SELECT_HELP,
-      'test': 'linesnows'},
+     {'stdout': CONNECTION_SELECT_HELP_LINE,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection subcommand show --help response',
+     ['show', '--help'],
+     {'stdout': CONNECTION_SHOW_HELP_LINE,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection subcommand test --help response',
+     ['test', '--help'],
+     {'stdout': CONNECTION_TEST_HELP_LINE,
+      'test': 'innows'},
      None, OK],
 
     # ['Verify connection subcommand new. test with show and delete  ',

--- a/tests/unit/test_connection_subcmd.py
+++ b/tests/unit/test_connection_subcmd.py
@@ -24,7 +24,7 @@ import pytest
 
 from .cli_test_extensions import CLITestsBase
 from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE, \
-    CMD_VERIFY_OPTION_HELP_LINE
+    CMD_OPTION_VERIFY_HELP_LINE
 
 SCRIPT_DIR = os.path.dirname(__file__)
 
@@ -43,13 +43,21 @@ TEST_DIR_REL = os.path.relpath(TEST_DIR)
 MOCK_FILE_PATH = os.path.join(TEST_DIR_REL, SIMPLE_MOCK_FILE)
 CONFIRM_FILE_PATH = os.path.join(TEST_DIR_REL, MOCK_CONFIRMY_FILE)
 
-CONNECTION_HELP_LINE = [
+CONNECTION_HELP_LINES = [
     'Usage: pywbemcli connection [COMMAND-OPTIONS] COMMAND [ARGS]...',
     'Command group for persistent WBEM connections.',
     CMD_OPTION_HELP_HELP_LINE,
+    'add     Create a new named WBEM connection.',
+    'delete  Delete a named WBEM connection.',
+    'export  Export the current connection information.',
+    'list    List the entries in the connections file.',
+    'save    Save current connection to connections file.',
+    'select  Select a connection from connections file.',
+    'show    Show current or NAME connection information.',
+    'test    Execute a predefined WBEM request.',
 ]
 
-CONNECTION_ADD_HELP_LINE = [
+CONNECTION_ADD_HELP_LINES = [
     'Usage: pywbemcli connection add [COMMAND-OPTIONS]',
     'Create a new named WBEM connection.',
     '-s, --server SERVER Required hostname or IP address with scheme',
@@ -57,59 +65,59 @@ CONNECTION_ADD_HELP_LINE = [
     '-d, --default-namespace NAMESPACE',
     '-u, --user TEXT User name for the WBEM server connection',
     '-p, --password TEXT Password for the WBEM server. Will be',
-    '-t, --timeout INTEGER RANGE     Operation timeout for the WBEM server in',
-    '-N, --noverify                  If set, client does not verify server',
-    '-k, --keyfile TEXT              Client private key file',
-    '-U, --use-pull-ops [yes|no|either]',
-    '--pull-max-cnt INTEGER          Maximium object count of objects',
-    '-l, --log COMP=DEST:DETAIL,...  Enable logging of CIM Operations',
-    '-m, --mock-server FILENAME      If this option is defined',
-    '--ca_certs TEXT                 File or directory containing',
-    CMD_VERIFY_OPTION_HELP_LINE,
+    '-t, --timeout INTEGER RANGE Operation timeout for the WBEM server in',
+    '-N, --no-verify If set, client does not verify server',
+    '-k, --keyfile TEXT Client private key file',
+    '-U, --use-pull [yes|no|either] Determines whether pull operations',
+    '--pull-max-cnt INTEGER Maximium object count of objects',
+    '-l, --log COMP=DEST:DETAIL,... Enable logging of CIM Operations',
+    '-m, --mock-server FILENAME If this option is defined',
+    '--ca_certs TEXT File or directory containing',
+    CMD_OPTION_VERIFY_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-CONNECTION_DELETE_HELP_LINE = [
+CONNECTION_DELETE_HELP_LINES = [
     'Usage: pywbemcli connection delete [COMMAND-OPTIONS] NAME',
     'Delete a named WBEM connection.',
-    CMD_VERIFY_OPTION_HELP_LINE,
+    CMD_OPTION_VERIFY_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-CONNECTION_EXPORT_HELP_LINE = [
+CONNECTION_EXPORT_HELP_LINES = [
     'Usage: pywbemcli connection export [COMMAND-OPTIONS]',
     'Export the current connection information.',
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-CONNECTION_LIST_HELP_LINE = [
+CONNECTION_LIST_HELP_LINES = [
     'Usage: pywbemcli connection list [COMMAND-OPTIONS]',
     'List the entries in the connections file.',
     'An "*" after the name indicates the currently selected',
     CMD_OPTION_HELP_HELP_LINE
 ]
 
-CONNECTION_SAVE_HELP_LINE = [
+CONNECTION_SAVE_HELP_LINES = [
     'Usage: pywbemcli connection save [COMMAND-OPTIONS]',
     'Save current connection to connections file.',
     '-n, --name Connection name  If defined, this changes the name of',
-    CMD_VERIFY_OPTION_HELP_LINE,
+    CMD_OPTION_VERIFY_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE
 ]
 
-CONNECTION_SELECT_HELP_LINE = [
+CONNECTION_SELECT_HELP_LINES = [
     'Usage: pywbemcli connection select [COMMAND-OPTIONS] NAME',
     'Select a connection from connections file.',
     CMD_OPTION_HELP_HELP_LINE
 ]
 
-CONNECTION_SHOW_HELP_LINE = [
+CONNECTION_SHOW_HELP_LINES = [
     'Usage: pywbemcli connection show [COMMAND-OPTIONS] NAME',
     'Show current or NAME connection information.',
     CMD_OPTION_HELP_HELP_LINE
 ]
 
-CONNECTION_TEST_HELP_LINE = [
+CONNECTION_TEST_HELP_LINES = [
     'Usage: pywbemcli connection test [COMMAND-OPTIONS]',
     'Execute a predefined WBEM request.',
     CMD_OPTION_HELP_HELP_LINE,
@@ -131,57 +139,111 @@ TEST_CASES = [
     # mock - None or name of files (mof or .py),
     # condition - If True, the test is executed,  Otherwise it is skipped.
 
-    ['Verify connection subcommand help response',
+    ['Verify connection subcommand --help response',
      '--help',
-     {'stdout': CONNECTION_HELP_LINE,
+     {'stdout': CONNECTION_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection subcommand -h response',
+     '-h',
+     {'stdout': CONNECTION_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     ['Verify connection subcommand add --help response',
      ['add', '--help'],
-     {'stdout': CONNECTION_ADD_HELP_LINE,
+     {'stdout': CONNECTION_ADD_HELP_LINES,
+      'test': 'inows'},
+     None, OK],
+
+    ['Verify connection subcommand add -h response',
+     ['add', '-h'],
+     {'stdout': CONNECTION_ADD_HELP_LINES,
       'test': 'inows'},
      None, OK],
 
     ['Verify connection subcommand delete --help response',
      ['delete', '--help'],
-     {'stdout': CONNECTION_DELETE_HELP_LINE,
+     {'stdout': CONNECTION_DELETE_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection subcommand delete -h response',
+     ['delete', '-h'],
+     {'stdout': CONNECTION_DELETE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     ['Verify connection subcommand export --help response',
      ['export', '--help'],
-     {'stdout': CONNECTION_EXPORT_HELP_LINE,
+     {'stdout': CONNECTION_EXPORT_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection subcommand export -h response',
+     ['export', '-h'],
+     {'stdout': CONNECTION_EXPORT_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     ['Verify connection subcommand list --help response',
      ['list', '--help'],
-     {'stdout': CONNECTION_LIST_HELP_LINE,
+     {'stdout': CONNECTION_LIST_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection subcommand list -h response',
+     ['list', '-h'],
+     {'stdout': CONNECTION_LIST_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     ['Verify connection subcommand save --help response',
      ['save', '--help'],
-     {'stdout': CONNECTION_SAVE_HELP_LINE,
+     {'stdout': CONNECTION_SAVE_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection subcommand save -h response',
+     ['save', '-h'],
+     {'stdout': CONNECTION_SAVE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     ['Verify connection subcommand select  --help response',
      ['select', '--help'],
-     {'stdout': CONNECTION_SELECT_HELP_LINE,
+     {'stdout': CONNECTION_SELECT_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection subcommand select  -h response',
+     ['select', '-h'],
+     {'stdout': CONNECTION_SELECT_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     ['Verify connection subcommand show --help response',
      ['show', '--help'],
-     {'stdout': CONNECTION_SHOW_HELP_LINE,
+     {'stdout': CONNECTION_SHOW_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection subcommand show -h response',
+     ['show', '-h'],
+     {'stdout': CONNECTION_SHOW_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     ['Verify connection subcommand test --help response',
      ['test', '--help'],
-     {'stdout': CONNECTION_TEST_HELP_LINE,
+     {'stdout': CONNECTION_TEST_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection subcommand test -h response',
+     ['test', '-h'],
+     {'stdout': CONNECTION_TEST_HELP_LINES,
       'test': 'innows'},
      None, OK],
 

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -243,7 +243,7 @@ TEST_CASES = [
       'test': 'regex'},
      None, OK],
 
-    ['Verify valid pull_ops parameter yes.',
+    ['Verify valid --use-pull option parameter yes.',
      {'global': ['-s', 'http://blah', '--use-pull', 'yes'],
       'subcmd': 'connection',
       'args': ['show']},
@@ -252,7 +252,7 @@ TEST_CASES = [
       'test': 'in'},
      None, OK],
 
-    ['Verify valid pull_ops parameter no.',
+    ['Verify valid --use-pull option parameter no.',
      {'global': ['-s', 'http://blah', '--use-pull', 'no'],
       'subcmd': 'connection',
       'args': ['show']},
@@ -261,7 +261,7 @@ TEST_CASES = [
       'test': 'in'},
      None, OK],
 
-    ['Verify valid --use-pull parameter.',
+    ['Verify valid --use-pull option parameter.',
      {'global': ['-s', 'http://blah', '--use-pull', 'either'],
       'subcmd': 'connection',
       'args': ['show']},
@@ -270,7 +270,7 @@ TEST_CASES = [
       'test': 'in'},
      None, OK],
 
-    ['Verify invalid --use-pull parameter fails.',
+    ['Verify invalid --use-pull option parameter fails.',
      {'global': ['-s', 'http://blah', '--use-pull', 'blah'],
       'subcmd': 'connection',
       'args': ['show']},
@@ -280,7 +280,7 @@ TEST_CASES = [
       'test': 'in'},
      None, OK],
 
-    ['Verify valid pull-max-cnt parameter.',
+    ['Verify valid --pull-max-cnt option parameter.',
      {'global': ['-s', 'http://blah', '--pull-max-cnt', '2000'],
       'subcmd': 'connection',
       'args': ['show']},
@@ -289,7 +289,7 @@ TEST_CASES = [
       'test': 'in'},
      None, OK],
 
-    ['Verify invalid pull-max-cnt parameter fails.',
+    ['Verify invalid --pull-max-cnt option parameter fails.',
      {'global': ['-s', 'http://blah', '--pull-max-cnt', 'blah'],
       'subcmd': 'connection',
       'args': ['show']},
@@ -659,7 +659,7 @@ TEST_CASES = [
 class TestGlobalOptions(CLITestsBase):
     """
     Test the global options including statistics,  --server,
-    --timeout, --use-pull_ops, --pull-max-cnt, --output-format
+    --timeout, --use-pull, --pull-max-cnt, --output-format
     """
     @pytest.mark.parametrize(
         "desc, inputs, exp_response, mock, condition", TEST_CASES)

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -40,30 +40,29 @@ Usage: pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS]...
   Pywbemcli is a command line WBEM client that uses the DMTF CIM-XML
   protocol to communicate with WBEM servers. Pywbemcli can:
 
-      * Manage the information in WBEM servers CIM objects using the
-        operations defined in the DMTF specification.  It can manage CIM
-        classes, CIM instances and CIM qualifier declarations in the WBEM
-        Server and execute CIM methods and queries on the server.
+  * Manage the information in WBEM servers CIM objects using the
+    operations defined in the DMTF specification.  It can manage CIM
+    classes, CIM instances and CIM qualifier declarations in the WBEM
+    Server and execute CIM methods and queries on the server.
 
-      * Inspect WBEM server characteristics including namespaces, registered
-        profiles, and other server information.
+  * Inspect WBEM server characteristics including namespaces, registered
+    profiles, and other server information.
 
-      * Capture detailed information on communication with the WBEM
-        server including time statistics and logs of the operations.
+  * Capture detailed information on communication with the WBEM
+    server including time statistics and logs of the operations.
 
-      * Maintain a persistent list of named WBEM servers and execute
-        operations on them by name.
+  * Maintain a persistent list of named connections to WBEM servers
+    and execute operations on them by name.
 
   Pywbemcli implements command groups and subcommands to execute the CIM-XML
-  operations defined by the DMTF CIM Operations Over HTTP
-  specification(DSP0201) specification.
+  operations defined by the DMTF CIM Operations Over HTTP specification
+  (DSP0200).
 
   The general options shown below can also be specified on any of the
   (sub)commands as well as the command line.
 
   For more detailed documentation, see:
 
-      https://pywbemtools.readthedocs.io/en/latest/
       https://pywbemtools.readthedocs.io/en/stable/
 
 Options:
@@ -79,51 +78,56 @@ Options:
                                   * Port: (optional)
                                   defines WBEM server port to be used
                                   [Defaults: 5988(HTTP) and 5989(HTTPS)].
-                                  Thhis option the --name option and the
-                                  --mock-server are mututally exclusive since
-                                  each defines a WBEM server.
-                                  (EnvVar:
-                                  PYWBEMCLI_SERVER).
+                                  This
+                                  option, the --name, and --mock-server are
+                                  mututally exclusive since each defines a
+                                  WBEM server.
+                                  (EnvVar: PYWBEMCLI_SERVER)
   -n, --name NAME                 Name for the connection.  If this option
                                   exists and the server option does not exist
                                   pywbemcli retrieves the connection
                                   information from the connections file
-                                  (pywbemcliservers.json). This option
-                                  --server  and --mock-server are mutually
-                                  exclusive since each defines a WBEM server
-                                  (EnvVar: PYWBEMCLI_NAME).
+                                  (pywbemcliservers.json). This option,
+                                  --server, and --mock-server are mutually
+                                  exclusive since each defines a WBEM server.
+                                  (EnvVar: PYWBEMCLI_NAME)
   -d, --default-namespace NAMESPACE
                                   Default namespace to use in the target WBEM
                                   server if no namespace is defined in a
-                                  subcommand(EnvVar: PYWBEMCLI_NAME)
-                                  []Default: root/cimv2].
-  -u, --user USER                 User name for the WBEM server connection.
+                                  subcommand.
                                   (EnvVar: PYWBEMCLI_NAME)
+                                  [Default: root/cimv2]
+  -u, --user USER                 User name for the WBEM server connection.
+                                  (EnvVar: PYWBEMCLI_USER)
   -p, --password PASSWORD         Password for the WBEM server. Will be
                                   requested as part  of initialization if user
                                   name exists and it is not  provided by this
-                                  option.(EnvVar: PYWBEMCLI_PASSWORD).
+                                  option.
+                                  (EnvVar: PYWBEMCLI_PASSWORD)
   -t, --timeout INTEGER           Client timeout completion of WBEM server
                                   operation in seconds.
                                   (EnvVar:
-                                  PYWBEMCLI_PYWBEMCLI_TIMEOUT)
+                                  PYWBEMCLI_TIMEOUT)
   -N, --no-verify                 If set, client does not verify WBEM server
                                   certificate.(EnvVar: PYWBEMCLI_NO_VERIFY).
   -c, --certfile TEXT             Server certfile. Ignored if --no-verify flag
                                   set. (EnvVar: PYWBEMCLI_CERTFILE).
-  -k, --keyfile FILE PATH         Client private key file. (EnvVar:
-                                  PYWBEMCLI_KEYFILE).
+  -k, --keyfile FILE PATH         Client private key file.
+                                  (EnvVar:
+                                  PYWBEMCLI_KEYFILE)
   --ca-certs TEXT                 File or directory containing certificates
                                   that will be matched against certificate
                                   received from WBEM server. Set --no-verify
                                   option to bypass client verification of the
-                                  WBEM server certificate.  (EnvVar:
-                                  PYWBEMCLI_CA_CERTS).
+                                  WBEM server certificate.
+                                  (EnvVar:
+                                  PYWBEMCLI_CA_CERTS)
                                   [Default: Searches for
                                   matching certificates in the following
-                                  system directories: /etc/pki/ca-
-                                  trust/extracted/openssl/ca-bundle.trust.crt]
-                                  /etc/ssl/certs]
+                                  system directories:
+                                  /etc/pki/ca-
+                                  trust/extracted/openssl/ca-bundle.trust.crt,
+                                  /etc/ssl/certs,
                                   /etc/ssl/certificates]
   -o, --output-format <choice>    Choice for command output data format.
                                   pywbemcli may override the format choice
@@ -147,13 +151,14 @@ Options:
                                   pywbemcli to use only the traditional non-
                                   pull operations.
                                   * "either": pywbemcli trys
-                                  first pull and then  traditional operations.
+                                  first pull and then traditional operations.
                                   (EnvVar: PYWBEMCLI_USE_PULL) [Default:
                                   either]
   --pull-max-cnt INTEGER          Maximium object count of objects to be
                                   returned for each request if pull operations
                                   are used. Must be  a positive non-zero
-                                  integer.(EnvVar: PYWBEMCLI_PULL_MAX_CNT)
+                                  integer.
+                                  (EnvVar: PYWBEMCLI_PULL_MAX_CNT)
                                   [Default: 1000]
   -T, --timestats                 Show time statistics of WBEM server
                                   operations after each command execution.
@@ -173,23 +178,24 @@ Options:
                                   or Python file path used to populate the
                                   mock repository. This option may be used
                                   multiple times where each use defines a
-                                  single file_path.This parameter the --server
-                                  option and the --name option are mutually
-                                  exclusive since each defines a WBEM server.
-                                  See the pywbemtools documentation for more
-                                  information.(EnvVar: PYWBEMCLI_MOCK_SERVER).
+                                  single file_path.This option, --server, and
+                                  --name are mutually exclusive since each
+                                  defines a WBEM server. See the pywbemtools
+                                  documentation for more information.
+                                  (EnvVar:
+                                  PYWBEMCLI_MOCK_SERVER)
   --version                       Show the version of this command and the
                                   pywbem package and exit.
   -h, --help                      Show this message and exit.
 
 Commands:
-  class       Command group to manage CIM classes.
-  connection  Command group to manage WBEM connections.
+  class       Command group for CIM classes.
+  connection  Command group for persistent WBEM connections.
   help        Show help message for interactive mode.
-  instance    Command group to manage CIM instances.
-  qualifier   Command group to view QualifierDeclarations.
-  repl        Enter interactive (REPL) mode (default).
-  server      Command Group for WBEM server operations.
+  instance    Command group for CIM instances.
+  qualifier   Command group for CIM qualifier declarations.
+  repl        Enter interactive mode (default).
+  server      Command group for WBEM servers.
 """
 
 
@@ -426,11 +432,11 @@ TEST_CASES = [
      {'global': ['-m', SIMPLE_MOCK_FILE_PATH, '--name', 'MyConnName'],
       'subcmd': 'connection',
       'args': ['show']},
-     {'stderr': [r'The --name argument',
-                 r'server argument',
-                 r'are mutually exclusive and may not be used simultaneiously'],
+     {'stderr': ['The --name "MyConnName" option',
+                 'server', 'option',
+                 'are mutually exclusive'],
       'rc': 1,
-      'test': 'regex'},
+      'test': 'innows'},
      None, OK],
 
     ['Verify --timestats',
@@ -441,7 +447,7 @@ TEST_CASES = [
                  '  Count    Exc    Time    ReqLen    ReplyLen  Operation',
                  'EnumerateClasses'],
       'rc': 0,
-      'test': 'regex'},
+      'test': 'innows'},
      None, OK],
 
 
@@ -453,7 +459,7 @@ TEST_CASES = [
                  '  Count    Exc    Time    ReqLen    ReplyLen  Operation',
                  'EnumerateClasses'],
       'rc': 0,
-      'test': 'regex'},
+      'test': 'innows'},
      None, OK],
 
 

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -23,8 +23,10 @@ from .cli_test_extensions import CLITestsBase
 from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
     CMD_OPTION_HELP_HELP_LINE, CMD_OPTION_SUMMARY_HELP_LINE, \
     CMD_OPTION_NAMESPACE_HELP_LINE, CMD_OPTION_PROPERTYLIST_HELP_LINE, \
-    CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE, \
-    CMD_VERIFY_OPTION_HELP_LINE
+    CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE, CMD_OPTION_VERIFY_HELP_LINE, \
+    CMD_OPTION_INCLUDE_QUALIFIERS_HELP_LINE, \
+    CMD_OPTION_INTERACTIVE_HELP_LINE, CMD_OPTION_FILTER_QUERY_LINE, \
+    CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE, CMD_OPTION_LOCAL_ONLY_HELP_LINE
 
 TEST_DIR = os.path.dirname(__file__)
 
@@ -37,32 +39,8 @@ MOCK_PROMPT_0_FILE = "mock_prompt_0.py"
 MOCK_CONFIRM_Y_FILE = "mock_confirm_y.py"
 MOCK_CONFIRM_N_FILE = "mock_confirm_n.py"
 
-CMD_OPTION_INCLUDE_QUALIFIERS_HELP_LINE = \
-    '-q, --include-qualifiers If set, requests server to include'
-
-CMD_OPTION_ROLE_LINE = \
-    '-r, --role <role name> Filter by the role name provided'
-
-CMD_OPTION_FILTER_QUERY_LINE = \
-    '-f, --filter-query TEXT A filter query to be passed to the server'
-
-CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE = \
-    '--filter-query-language TEXT A filter-query language to be used'
-
-CMD_INTERACTIVE_OPTION_HELP_LINE = \
-    "-i, --interactive If set, `INSTANCENAME` argument must"
-
-CMD_DEEPINHERITANCE_OPTION_HELP_LINE = \
-    '-d, --deep-inheritance If set, requests server to return properties'
-
-CMD_PROPERTY_OPTION_HELP_LINE = \
+INSTANCE_OPTION_PROPERTY_HELP_LINE = \
     '-P, --property name=value Optional property names of the form name=value',
-
-CMD_INCLUDEQUALIFIERS_OPTION_HELP_LINE = \
-    '-q, --include-qualifiers If set, requests server to include'
-
-CMD_LOCALONLY_OPTION_HELP_LINE = \
-    '-l, --local-only Show only local properties of the'
 
 #
 # The following list define the help for each command in terms of particular
@@ -73,61 +51,73 @@ CMD_LOCALONLY_OPTION_HELP_LINE = \
 # 2. The last line CMD_OPTION_HELP_HELP_LINE
 # Defined in alphabetical order
 
-INSTANCE_HELP_LINE = [
+INSTANCE_HELP_LINES = [
     'Usage: pywbemcli instance [COMMAND-OPTIONS] COMMAND [ARGS]...',
-    'Command group for persistent WBEM connections.',
+    'Command group for CIM instances.',
     CMD_OPTION_HELP_HELP_LINE,
+    'associators   Get the instances associated with an instance.',
+    'count         Count the instances of each class with matching class '
+    'name.',
+    'create        Create an instance of a class in a namespace.',
+    'delete        Delete an instance of a class.',
+    'enumerate     Get the instances of a class.',
+    'get           Get an instance of a class.',
+    'invokemethod  Invoke a method on an instance.',
+    'modify        Modify an instance of a class.',
+    'query         Execute a query on instances in a namespace.',
+    'references    Get the instances referencing an instance.',
 ]
 
-INSTANCE_ASSOCIATORS_HELP_LINE = [
+INSTANCE_ASSOCIATORS_HELP_LINES = [
     'Usage: pywbemcli  instance associators [COMMAND-OPTIONS] INSTANCENAME',
     'Get the instances associated with an instance.',
     '-a, --assoc-class <class name>  Filter by the association class name',
     '-c, --result-class <class name>',
     '-r, --role <role name> Filter by the role name provided. Each',
     '-R, --result-role <role name>   Filter by the result role name provided',
-    CMD_INCLUDEQUALIFIERS_OPTION_HELP_LINE,
+    CMD_OPTION_INCLUDE_QUALIFIERS_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
     CMD_OPTION_NAMES_ONLY_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_INTERACTIVE_OPTION_HELP_LINE,
+    CMD_OPTION_INTERACTIVE_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_FILTER_QUERY_LINE,
     CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-INSTANCE_COUNT_HELP_LINE = [
+INSTANCE_COUNT_HELP_LINES = [
     'Usage: pywbemcli  instance count [COMMAND-OPTIONS] CLASSNAME-GLOB',
     'Count the instances of each class with matching class name.',
+    '-s, --sort Sort by instance count.',
+    CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-INSTANCE_CREATE_HELP_LINE = [
+INSTANCE_CREATE_HELP_LINES = [
     'Usage: pywbemcli  instance create [COMMAND-OPTIONS] CLASSNAME',
     'Create an instance of a class in a namespace.',
-    CMD_PROPERTY_OPTION_HELP_LINE,
-    CMD_VERIFY_OPTION_HELP_LINE,
+    INSTANCE_OPTION_PROPERTY_HELP_LINE,
+    CMD_OPTION_VERIFY_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-INSTANCE_DELETE_HELP_LINE = [
+INSTANCE_DELETE_HELP_LINES = [
     'Usage: pywbemcli  instance delete [COMMAND-OPTIONS] INSTANCENAME',
     'Delete an instance of a class.',
-    CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_INTERACTIVE_OPTION_HELP_LINE,
+    CMD_OPTION_INTERACTIVE_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-INSTANCE_ENUMERATE_HELP_LINE = [
+INSTANCE_ENUMERATE_HELP_LINES = [
     'Usage: pywbemcli  instance enumerate [COMMAND-OPTIONS] CLASSNAME',
     'Get the instances of a class.',
-    CMD_LOCALONLY_OPTION_HELP_LINE,
-    CMD_DEEPINHERITANCE_OPTION_HELP_LINE,
-    CMD_INCLUDEQUALIFIERS_OPTION_HELP_LINE,
+    CMD_OPTION_LOCAL_ONLY_HELP_LINE,
+    '-d, --deep-inheritance If set, requests server to return properties',
+    CMD_OPTION_INCLUDE_QUALIFIERS_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
@@ -138,56 +128,59 @@ INSTANCE_ENUMERATE_HELP_LINE = [
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-INSTANCE_GET_HELP_LINE = [
+INSTANCE_GET_HELP_LINES = [
     'Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME',
     'Get an instance of a class.',
-    CMD_INCLUDEQUALIFIERS_OPTION_HELP_LINE,
+    CMD_OPTION_LOCAL_ONLY_HELP_LINE,
+    CMD_OPTION_INCLUDE_QUALIFIERS_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_INTERACTIVE_OPTION_HELP_LINE,
+    CMD_OPTION_INTERACTIVE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-INSTANCE_INVOKEMETHOD_HELP_LINE = [
+INSTANCE_INVOKEMETHOD_HELP_LINES = [
     'Usage: pywbemcli instance invokemethod [COMMAND-OPTIONS] INSTANCENAME '
     'METHODNAME',
     'Invoke a method on an instance.',
-    '-p, --parameter name=value',
+    '-p, --parameter name=value Multiple definitions allowed',
+    CMD_OPTION_INTERACTIVE_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_INTERACTIVE_OPTION_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-INSTANCE_MODIFY_HELP_LINE = [
+INSTANCE_MODIFY_HELP_LINES = [
     'Usage: pywbemcli instance modify [COMMAND-OPTIONS] INSTANCENAME',
     'Modify an instance of a class.',
-    CMD_PROPERTY_OPTION_HELP_LINE,
+    INSTANCE_OPTION_PROPERTY_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
-    CMD_VERIFY_OPTION_HELP_LINE,
+    CMD_OPTION_INTERACTIVE_HELP_LINE,
+    CMD_OPTION_VERIFY_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-INSTANCE_QUERY_HELP_LINE = [
+INSTANCE_QUERY_HELP_LINES = [
     'Usage: pywbemcli instance query [COMMAND-OPTIONS] INSTANCENAME',
     'Execute a query on instances in a namespace.',
-    '-l, --query-language QUERY LANGUAGE',
+    '-l, --query-language QUERY LANGUAGE Use the query language',
     CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-INSTANCE_REFERENCES_HELP_LINE = [
+INSTANCE_REFERENCES_HELP_LINES = [
     'Usage: pywbemcli instance references [COMMAND-OPTIONS] INSTANCENAME',
     'Get the instances referencing an instance.',
-    '-R, --resultclass <class name>  Filter by the result class name',
-    '-r, --role <role name>  Filter by the role name provided',
-    CMD_INCLUDEQUALIFIERS_OPTION_HELP_LINE,
+    '-R, --resultclass <class name> Filter by the result class name',
+    '-r, --role <role name> Filter by the role name provided',
+    CMD_OPTION_INCLUDE_QUALIFIERS_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
     CMD_OPTION_NAMES_ONLY_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_INTERACTIVE_OPTION_HELP_LINE,
+    CMD_OPTION_INTERACTIVE_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_FILTER_QUERY_LINE,
     CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE,
@@ -326,18 +319,30 @@ TEST_CASES = [
     #
     #   instance --help
     #
-    ['Verify instance subcommand help response',
+    ['Verify instance subcommand --help response',
      '--help',
-     {'stdout': INSTANCE_HELP_LINE,
+     {'stdout': INSTANCE_HELP_LINES,
+      'test': 'insnows'},
+     None, OK],
+
+    ['Verify instance subcommand -h response',
+     '-h',
+     {'stdout': INSTANCE_HELP_LINES,
       'test': 'insnows'},
      None, OK],
 
     #
     #  Instance Enumerate subcommand good responses
     #
-    ['Verify instance subcommand enumerate  --help response',
+    ['Verify instance subcommand enumerate --help response',
      ['enumerate', '--help'],
-     {'stdout': INSTANCE_ENUMERATE_HELP_LINE,
+     {'stdout': INSTANCE_ENUMERATE_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify instance subcommand enumerate -h response',
+     ['enumerate', '-h'],
+     {'stdout': INSTANCE_ENUMERATE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
@@ -610,9 +615,16 @@ Instances: PyWBEM_AllTypes
     #  instance get subcommand
     #
 
-    ['Verify instance subcommand get with instancename returns data',
+    ['Verify instance subcommand get --help response',
      ['get', '--help'],
-     {'stdout': INSTANCE_GET_HELP_LINE,
+     {'stdout': INSTANCE_GET_HELP_LINES,
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify instance subcommand get -h response',
+     ['get', '-h'],
+     {'stdout': INSTANCE_GET_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
@@ -811,9 +823,16 @@ Instances: PyWBEM_AllTypes
     #
     #  instance create subcommand
     #
-    ['Verify instance subcommand create, --help response',
+    ['Verify instance subcommand create --help response',
      ['create', '--help'],
-     {'stdout': INSTANCE_CREATE_HELP_LINE,
+     {'stdout': INSTANCE_CREATE_HELP_LINES,
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify instance subcommand create -h response',
+     ['create', '-h'],
+     {'stdout': INSTANCE_CREATE_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
@@ -945,9 +964,16 @@ Instances: PyWBEM_AllTypes
     #
     #  instance modify subcommand
     #
-    ['Verify instance subcommand modify, --help response',
+    ['Verify instance subcommand modify --help response',
      ['modify', '--help'],
-     {'stdout': INSTANCE_MODIFY_HELP_LINE,
+     {'stdout': INSTANCE_MODIFY_HELP_LINES,
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify instance subcommand modify -h response',
+     ['modify', '-h'],
+     {'stdout': INSTANCE_MODIFY_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
@@ -1110,9 +1136,16 @@ Instances: PyWBEM_AllTypes
     #
     #  instance delete subcommand
     #
-    ['Verify instance subcommand delete, --help response',
+    ['Verify instance subcommand delete --help response',
      ['delete', '--help'],
-     {'stdout': INSTANCE_DELETE_HELP_LINE,
+     {'stdout': INSTANCE_DELETE_HELP_LINES,
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify instance subcommand delete -h response',
+     ['delete', '-h'],
+     {'stdout': INSTANCE_DELETE_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
@@ -1192,9 +1225,16 @@ Instances: PyWBEM_AllTypes
     #
     #  instance references subcommand
     #
-    ['Verify instance subcommand references, --help response',
+    ['Verify instance subcommand references --help response',
      ['references', '--help'],
-     {'stdout': INSTANCE_REFERENCES_HELP_LINE,
+     {'stdout': INSTANCE_REFERENCES_HELP_LINES,
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify instance subcommand references -h response',
+     ['references', '-h'],
+     {'stdout': INSTANCE_REFERENCES_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
@@ -1397,9 +1437,16 @@ Instances: PyWBEM_AllTypes
     #
     #  instance associators subcommand
     #
-    ['Verify instance subcommand associators, --help response',
+    ['Verify instance subcommand associators --help response',
      ['associators', '--help'],
-     {'stdout': INSTANCE_ASSOCIATORS_HELP_LINE,
+     {'stdout': INSTANCE_ASSOCIATORS_HELP_LINES,
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify instance subcommand associators -h response',
+     ['associators', '-h'],
+     {'stdout': INSTANCE_ASSOCIATORS_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
@@ -1509,9 +1556,16 @@ Instances: PyWBEM_AllTypes
     #
     #  instance count subcommand
     #
-    ['Verify instance subcommand count, --help response',
+    ['Verify instance subcommand count --help response',
      ['count', '--help'],
-     {'stdout': INSTANCE_COUNT_HELP_LINE,
+     {'stdout': INSTANCE_COUNT_HELP_LINES,
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify instance subcommand count -h response',
+     ['count', '-h'],
+     {'stdout': INSTANCE_COUNT_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
@@ -1562,9 +1616,15 @@ Instances: PyWBEM_AllTypes
     #  instance invokemethod tests
     #
 
-    ['class subcommand invokemethod --help, . ',
+    ['class subcommand invokemethod --help',
      ['invokemethod', '--help'],
-     {'stdout': INSTANCE_INVOKEMETHOD_HELP_LINE,
+     {'stdout': INSTANCE_INVOKEMETHOD_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['class subcommand invokemethod -h',
+     ['invokemethod', '-h'],
+     {'stdout': INSTANCE_INVOKEMETHOD_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
@@ -1607,9 +1667,16 @@ Instances: PyWBEM_AllTypes
     #
     #  instance query subcommand. We have not implemented this command
     #
-    ['Verify instance subcommand query, --help response',
+    ['Verify instance subcommand query --help response',
      ['query', '--help'],
-     {'stdout': INSTANCE_QUERY_HELP_LINE,
+     {'stdout': INSTANCE_QUERY_HELP_LINES,
+      'rc': 0,
+      'test': 'linnows'},
+     None, OK],
+
+    ['Verify instance subcommand query -h response',
+     ['query', '-h'],
+     {'stdout': INSTANCE_QUERY_HELP_LINES,
       'rc': 0,
       'test': 'linnows'},
      None, OK],

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -20,6 +20,11 @@ from __future__ import absolute_import, print_function
 import os
 import pytest
 from .cli_test_extensions import CLITestsBase
+from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
+    CMD_OPTION_HELP_HELP_LINE, CMD_OPTION_SUMMARY_HELP_LINE, \
+    CMD_OPTION_NAMESPACE_HELP_LINE, CMD_OPTION_PROPERTYLIST_HELP_LINE, \
+    CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE, \
+    CMD_VERIFY_OPTION_HELP_LINE
 
 TEST_DIR = os.path.dirname(__file__)
 
@@ -32,528 +37,164 @@ MOCK_PROMPT_0_FILE = "mock_prompt_0.py"
 MOCK_CONFIRM_Y_FILE = "mock_confirm_y.py"
 MOCK_CONFIRM_N_FILE = "mock_confirm_n.py"
 
-INST_HELP = """
-Usage: pywbemcli instance [COMMAND-OPTIONS] COMMAND [ARGS]...
-
-  Command group to manage CIM instances.
-
-  This incudes functions to get, enumerate, create, modify, and delete
-  instances in a namspace and additional functions to get more general
-  information on instances (ex. counts) within the namespace
-
-  In addition to the command-specific options shown in this help text, the
-  general options (see 'pywbemcli --help') can also be specified before the
-  command. These are NOT retained after the command is executed.
-
-Options:
-  -h, --help  Show this message and exit.
-
-Commands:
-  associators   Get associated instances or names.
-  count         Get CIM instance count for classes.
-  create        Create a CIM instance of CLASSNAME.
-  delete        Delete a single CIM instance.
-  enumerate     Enumerate instances or names of CLASSNAME.
-  get           Get a single CIMInstance.
-  invokemethod  Invoke a CIM method on a CIMInstance.
-  modify        Modify an existing CIM instance.
-  query         Execute an execquery request.
-  references    Get the reference instances or names.
-"""
-
-# pylint: disable=line-too-long
-INST_ENUMERATE_HELP = """
-Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME
-
-  Enumerate instances or names of CLASSNAME.
-
-  Get CIMInstance or CIMInstanceName (--name_only option) objects from the
-  WBEMServer starting either at the top  of the hierarchy (if no CLASSNAME
-  provided) or from the CLASSNAME argument if provided.
-
-  Displays the returned instances in mof, xml, or table formats, or the
-  instance names as a string or XML formats (--names-only option).
-
-  Results are formatted as defined by the --output_format general option.
-
-Options:
-  -l, --local-only                Show only local properties of the instances.
-                                  This subcommand may use either pull or
-                                  traditional operations depending on the
-                                  server and the --use-pull general
-                                  option. If pull operations are used, this
-                                  parameters will not be included, even if
-                                  specified. If traditional operations are
-                                  used, some servers do not process the
-                                  parameter.
-  -d, --deep-inheritance          If set, requests server to return properties
-                                  in subclasses of the target instances class.
-                                  If option not specified only properties from
-                                  target class are returned
-  -q, --include-qualifiers        If set, requests server to include
-                                  qualifiers in the returned instances. This
-                                  subcommand may use either pull or
-                                  traditional operations depending on the
-                                  server and the "--use--pull-ops" general
-                                  option. If pull operations are used,
-                                  qualifiers will not be included, even if
-                                  this option is specified. If traditional
-                                  operations are used, inclusion of qualifiers
-                                  depends on the server.
-  -c, --include-classorigin       Request that server include classorigin in
-                                  the result.On some WBEM operations, server
-                                  may ignore this option.
-  -p, --propertylist <property name>
-                                  Define a propertylist for the request. If
-                                  option not specified a Null property list is
-                                  created and the server returns all
-                                  properties. Multiple properties may be
-                                  defined with either a comma separated list
-                                  or by using the option multiple times. (ex:
-                                  -p pn1 -p pn22 or -p pn1,pn2). If defined as
-                                  empty string the server should return no
-                                  properties.
-  -n, --namespace <name>          Namespace to use for this operation, instead
-                                  of the default namespace of the connection
-  -o, --names-only                Retrieve only the returned object names.
-  -S, --summary                   Return only summary of objects (count).
-  -f, --filter-query TEXT         A filter query to be passed to the server if
-                                  the pull operations are used. If this option
-                                  is defined and the --filter-query-language
-                                  is None, pywbemcli assumes DMTF:FQL. If this
-                                  option is defined and the traditional
-                                  operations are used, the filter is not sent
-                                  to the server. See the documentation for
-                                  more information. (Default: None)
-  --filter-query-language TEXT    A filter-query language to be used with a
-                                  filter query defined by --filter-query.
-                                  (Default: None)
-  -h, --help                      Show this message and exit.
-"""
-
-INST_GET_HELP = """
-Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME
-
-  Get a single CIMInstance.
-
-  Gets the instance defined by `INSTANCENAME` where `INSTANCENAME` must
-  resolve to the instance name of the desired instance. This may be supplied
-  directly as an untyped wbem_uri formatted string or through the
-  --interactive option. The wbemuri may contain the namespace or the
-  namespace can be supplied with the --namespace option. If no namespace is
-  supplied, the connection default namespace is used.  Any host name in the
-  wbem_uri is ignored.
-
-  This method may be executed interactively by providing only a classname
-  and the interactive option (-i).
-
-  Otherwise the INSTANCENAME must be a CIM instance name in the format
-  defined by DMTF `DSP0207`.
-
-  Results are formatted as defined by the --output_format general option.
-
-Options:
-  -l, --local-only                Request that server show only local
-                                  properties of the returned instance. Some
-                                  servers may not process this parameter.
-  -q, --include-qualifiers        If set, requests server to include
-                                  qualifiers in the returned instances. Not
-                                  all servers return qualifiers on instances
-  -c, --include-classorigin       Request that server include classorigin in
-                                  the result.On some WBEM operations, server
-                                  may ignore this option.
-  -p, --propertylist <property name>
-                                  Define a propertylist for the request. If
-                                  option not specified a Null property list is
-                                  created and the server returns all
-                                  properties. Multiple properties may be
-                                  defined with either a comma separated list
-                                  or by using the option multiple times. (ex:
-                                  -p pn1 -p pn22 or -p pn1,pn2). If defined as
-                                  empty string the server should return no
-                                  properties.
-  -n, --namespace <name>          Namespace to use for this operation, instead
-                                  of the default namespace of the connection
-  -i, --interactive               If set, `INSTANCENAME` argument must be a
-                                  class rather than an instance and user is
-                                  presented with a list of instances of the
-                                  class from which the instance to process is
-                                  selected.
-  -h, --help                      Show this message and exit.
-
-"""
-
-INST_CREATE_HELP = """
-Usage: pywbemcli instance create [COMMAND-OPTIONS] CLASSNAME
-
-  Create a CIM instance of CLASSNAME.
-
-  Creates an instance of the class CLASSNAME with the properties defined in
-  the property option.
-
-  Pywbemcli creates the new instance using CLASSNAME retrieved from the
-  current WBEM server as a template for property characteristics. Therefore
-  pywbemcli will generate an exception if CLASSNAME does not exist in the
-  current WBEM server or if the data definition in the properties options
-  does not match the properties characteristics defined the returned class.
-
-  ex. pywbemcli instance create CIM_blah -p id=3 -p strp="bla bla", -p p3=3
-
-Options:
-  -P, --property name=value  Optional property names of the form name=value.
-                             Multiple definitions allowed, one for each
-                             property to be included in the createdinstance.
-                             Array property values defined by comma-separated-
-                             values. EmbeddedInstance not allowed.
-  -V, --verify               If set, The change is displayed and verification
-                             requested before the change is executed
-  -n, --namespace <name>     Namespace to use for this operation, instead of
-                             the default namespace of the connection
-  -h, --help                 Show this message and exit.
-"""
-
-INST_DELETE_HELP = """
-Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME
-
-  Delete a single CIM instance.
-
-  Delete the instanced defined by INSTANCENAME from the WBEM server.
-
-  This may be executed interactively by providing only a class name and the
-  interactive option.
-
-  Otherwise the INSTANCENAME must be a CIM instance name in the format
-  defined by DMTF `DSP0207`.
-
-Options:
-  -i, --interactive       If set, `INSTANCENAME` argument must be a class
-                          rather than an instance and user is presented with a
-                          list of instances of the class from which the
-                          instance to process is selected.
-  -n, --namespace <name>  Namespace to use for this operation, instead of the
-                          default namespace of the connection
-  -h, --help              Show this message and exit.
-
-"""
-
-INST_COUNT_HELP = """
-Usage: pywbemcli instance count [COMMAND-OPTIONS] CLASSNAME-GLOB
-
-  Get CIM instance count for classes.
-
-  Displays the count of instances for the classes defined by the `CLASSNAME-
-  GLOB` argument in one or more namespaces.
-
-  The size of the response may be limited by CLASSNAME-GLOB argument which
-  defines a regular expression based on the desired class names so that only
-  classes that match the regex are counted. The CLASSNAME-GLOB argument is
-  optional.
-
-  The CLASSNAME-GLOB argument may be either a complete classname or a
-  regular expression that can be matched to one or more classnames. To limit
-  the filter to a single classname, terminate the classname with $.
-
-  The GLOB expression is anchored to the beginning of the CLASSNAME-GLOB, is
-  is case insensitive and uses the standard GLOB special characters (*(match
-  everything), ?(match single character)). Thus, `pywbem_*` returns all
-  classes that begin with `PyWBEM_`, `pywbem_`, etc. '.*system*' returns
-  classnames that include the case insensitive string `system`.
-
-  This operation can take a long time to execute since it enumerates all
-  classes in the namespace.
-
-Options:
-  -s, --sort              Sort by instance count. Otherwise sorted by
-                          classname
-  -n, --namespace <name>  Namespace to use for this operation, instead of the
-                          default namespace of the connection
-  -h, --help              Show this message and exit.
-
-"""
-
-INST_REFERENCES_HELP = """
-Usage: pywbemcli instance references [COMMAND-OPTIONS] INSTANCENAME
-
-  Get the reference instances or names.
-
-  Gets the reference instances or instance names(--names-only option) for a
-  target `INSTANCENAME` in the target WBEM server filtered by the `role` and
-  `resultclass` options.
-
-  INSTANCENAME must be a CIM instance name in the format defined by DMTF
-  `DSP0207`.
-
-  This may be executed interactively by providing only a class name for
-  `INSTANCENAME` and the `interactive` option(-i). Pywbemcli presents a list
-  of instances names in the class from which you can be chosen as the
-  target.
-
-  Results are formatted as defined by the --output_format general option.
-
-Options:
-  -R, --resultclass <class name>  Filter by the result class name provided.
-                                  Each returned instance (or instance name)
-                                  should be a member of this class or its
-                                  subclasses. Optional
-  -r, --role <role name>          Filter by the role name provided. Each
-                                  returned instance (or instance name) should
-                                  refer to the target instance through a
-                                  property with aname that matches the value
-                                  of this parameter. Optional.
-  -q, --include-qualifiers        If set, requests server to include
-                                  qualifiers in the returned instances. This
-                                  subcommand may use either pull or
-                                  traditional operations depending on the
-                                  server and the "--use--pull-ops" general
-                                  option. If pull operations are used,
-                                  qualifiers will not be included, even if
-                                  this option is specified. If traditional
-                                  operations are used, inclusion of qualifiers
-                                  depends on the server.
-  -c, --include-classorigin       Request that server include classorigin in
-                                  the result.On some WBEM operations, server
-                                  may ignore this option.
-  -p, --propertylist <property name>
-                                  Define a propertylist for the request. If
-                                  option not specified a Null property list is
-                                  created and the server returns all
-                                  properties. Multiple properties may be
-                                  defined with either a comma separated list
-                                  or by using the option multiple times. (ex:
-                                  -p pn1 -p pn22 or -p pn1,pn2). If defined as
-                                  empty string the server should return no
-                                  properties.
-  -o, --names-only                Retrieve only the returned object names.
-  -n, --namespace <name>          Namespace to use for this operation, instead
-                                  of the default namespace of the connection
-  -i, --interactive               If set, `INSTANCENAME` argument must be a
-                                  class rather than an instance and user is
-                                  presented with a list of instances of the
-                                  class from which the instance to process is
-                                  selected.
-  -S, --summary                   Return only summary of objects (count).
-  -f, --filter-query TEXT         A filter query to be passed to the server if
-                                  the pull operations are used. If this option
-                                  is defined and the --filter-query-language
-                                  is None, pywbemcli assumes DMTF:FQL. If this
-                                  option is defined and the traditional
-                                  operations are used, the filter is not sent
-                                  to the server. See the documentation for
-                                  more information. (Default: None)
-  --filter-query-language TEXT    A filter-query language to be used with a
-                                  filter query defined by --filter-query.
-                                  (Default: None)
-  -h, --help                      Show this message and exit.
-"""
-
-INST_MODIFY_HELP = """
-Usage: pywbemcli instance modify [COMMAND-OPTIONS] INSTANCENAME
-
-  Modify an existing CIM instance.
-
-  Modifies CIM instance defined by INSTANCENAME in the WBEM server using the
-  property names and values defined by the property option and the CIM class
-  defined by the instance name.  The --propertylist option if provided is
-  passed to the WBEM server as part of the ModifyInstance operation (the
-  WBEM server limits modifications to just those properties defined in the
-  property list).
-
-  INSTANCENAME must be a CIM instance name in the format defined by DMTF
-  `DSP0207`.
-
-  Pywbemcli builds only properties defined with the --property option into
-  an instance based on the CIMClass and forwards that to the WBEM server
-  with the ModifyInstance method.
-
-  ex. pywbemcli instance modify CIM_blah.fred=3 -p id=3 -p strp="bla bla"
-
-Options:
-  -P, --property name=value       Optional property names of the form
-                                  name=value. Multiple definitions allowed,
-                                  one for each property to be included in the
-                                  createdinstance. Array property values
-                                  defined by comma-separated-values.
-                                  EmbeddedInstance not allowed.
-  -p, --propertylist <property name>
-                                  Define a propertylist for the request. If
-                                  option not specified a Null property list is
-                                  created. Multiple properties may be defined
-                                  with either a comma separated list defining
-                                  the option multiple times. (ex: -p pn1 -p
-                                  pn22 or -p pn1,pn2). If defined as empty
-                                  string an empty propertylist is created. The
-                                  server uses the propertylist to limit
-                                  changes made to the instance to properties
-                                  in the propertylist.
-  -i, --interactive               If set, `INSTANCENAME` argument must be a
-                                  class rather than an instance and user is
-                                  presented with a list of instances of the
-                                  class from which the instance to process is
-                                  selected.
-  -V, --verify                    If set, The change is displayed and
-                                  verification requested before the change is
-                                  executed
-  -n, --namespace <name>          Namespace to use for this operation, instead
-                                  of the default namespace of the connection
-  -h, --help                      Show this message and exit.
-"""
-
-INST_ASSOCIATORS_HELP = """
-Usage: pywbemcli instance associators [COMMAND-OPTIONS] INSTANCENAME
-
-  Get associated instances or names.
-
-  Returns the associated instances or names (--names-only option) for the
-  `INSTANCENAME` argument filtered by the --assoc-class, --result-class,
-  --role and --result-role options.
-
-  INSTANCENAME must be a CIM instance name in the format defined by DMTF
-  `DSP0207`.
-
-  This may be executed interactively by providing only a classname and the
-  interactive option. Pywbemcli presents a list of instances in the class
-  from which one can be chosen as the target.
-
-  Results are formatted as defined by the --output_format general option.
-
-Options:
-  -a, --assoc-class <class name>  Filter by the association class name
-                                  provided.Each returned instance (or instance
-                                  name) should be associated to the source
-                                  instance through this class or its
-                                  subclasses. Optional.
-  -c, --result-class <class name>
-                                  Filter by the result class name provided.
-                                  Each returned instance (or instance name)
-                                  should be a member of this class or one of
-                                  its subclasses. Optional
-  -r, --role <role name>          Filter by the role name provided. Each
-                                  returned instance (or instance name)should
-                                  be associated with the source instance
-                                  (INSTANCENAME) through an association with
-                                  this role (property name in the association
-                                  that matches this parameter). Optional.
-  -R, --result-role <role name>   Filter by the result role name provided.
-                                  Each returned instance (or instance
-                                  name)should be associated with the source
-                                  instance name (`INSTANCENAME`) through an
-                                  association with returned object having this
-                                  role (property name in the association that
-                                  matches this parameter). Optional.
-  -q, --include-qualifiers        If set, requests server to include
-                                  qualifiers in the returned instances. This
-                                  subcommand may use either pull or
-                                  traditional operations depending on the
-                                  server and the "--use--pull-ops" general
-                                  option. If pull operations are used,
-                                  qualifiers will not be included, even if
-                                  this option is specified. If traditional
-                                  operations are used, inclusion of qualifiers
-                                  depends on the server.
-  -c, --include-classorigin       Request that server include classorigin in
-                                  the result.On some WBEM operations, server
-                                  may ignore this option.
-  -p, --propertylist <property name>
-                                  Define a propertylist for the request. If
-                                  option not specified a Null property list is
-                                  created and the server returns all
-                                  properties. Multiple properties may be
-                                  defined with either a comma separated list
-                                  or by using the option multiple times. (ex:
-                                  -p pn1 -p pn22 or -p pn1,pn2). If defined as
-                                  empty string the server should return no
-                                  properties.
-  -o, --names-only                Retrieve only the returned object names.
-  -n, --namespace <name>          Namespace to use for this operation, instead
-                                  of the default namespace of the connection
-  -i, --interactive               If set, `INSTANCENAME` argument must be a
-                                  class rather than an instance and user is
-                                  presented with a list of instances of the
-                                  class from which the instance to process is
-                                  selected.
-  -S, --summary                   Return only summary of objects (count).
-  -f, --filter-query TEXT         A filter query to be passed to the server if
-                                  the pull operations are used. If this option
-                                  is defined and the --filter-query-language
-                                  is None, pywbemcli assumes DMTF:FQL. If this
-                                  option is defined and the traditional
-                                  operations are used, the filter is not sent
-                                  to the server. See the documentation for
-                                  more information. (Default: None)
-  --filter-query-language TEXT    A filter-query language to be used with a
-                                  filter query defined by --filter-query.
-                                  (Default: None)
-  -h, --help                      Show this message and exit.
-"""
-
-INST_INVOKE_METHOD_HELP = """
-Usage: pywbemcli instance invokemethod [COMMAND-OPTIONS] INSTANCENAME
-                                       METHODNAME
-
-  Invoke a CIM method on a CIMInstance.
-
-  Invoke the method defined by INSTANCENAME and METHODNAME arguments with
-  parameters defined by the --parameter options.
-
-  This issues an instance level invokemethod request and displays the
-  results.
-
-  INSTANCENAME must be a CIM instance name in the format defined by  DMTF
-  `DSP0207`.
-
-  Pywbemcli creates the method call using the class in INSTANCENAME
-  retrieved from the current WBEM server as a template for parameter
-  characteristics. Therefore pywbemcli will generate an exception if
-  CLASSNAME does not exist in the current WBEM server or if the data
-  definition in the parameter options does not match the parameter
-  characteristics defined the returned class.
-
-  A class level invoke method is available as `pywbemcli class
-  invokemethod`.
-
-  Example:
-
-  pywbmcli instance invokemethod  CIM_x.InstanceID='hi" methodx -p id=3
-
-Options:
-  -p, --parameter name=value  Multiple definitions allowed, one for each
-                              parameter to be included in the new instance.
-                              Array parameter values defined by comma-
-                              separated-values. EmbeddedInstance not allowed.
-  -i, --interactive           If set, `INSTANCENAME` argument must be a class
-                              rather than an instance and user is presented
-                              with a list of instances of the class from which
-                              the instance to process is selected.
-  -n, --namespace <name>      Namespace to use for this operation, instead of
-                              the default namespace of the connection
-  -h, --help                  Show this message and exit.
-
-"""
-
-INST_QUERY_HELP = """
-Usage: pywbemcli instance query [COMMAND-OPTIONS] QUERY_STRING
-
-  Execute an execquery request.
-
-  Executes a query request on the target WBEM server with the QUERY_STRING
-  argument and query language options.
-
-  The results of the query are displayed as mof or xml.
-
-  Results are formatted as defined by the --output_format general option.
-
-Options:
-  -l, --querylanguage QUERY LANGUAGE
-                                  Use the query language defined. (Default:
-                                  DMTF:CQL.
-  -n, --namespace <name>          Namespace to use for this operation, instead
-                                  of the default namespace of the connection
-  -S, --summary                   Return only summary of objects (count).
-  -h, --help                      Show this message and exit.
-
-"""
-
-ENUM_INST_RESP = """instance of CIM_Foo {
+CMD_OPTION_INCLUDE_QUALIFIERS_HELP_LINE = \
+    '-q, --include-qualifiers If set, requests server to include'
+
+CMD_OPTION_ROLE_LINE = \
+    '-r, --role <role name> Filter by the role name provided'
+
+CMD_OPTION_FILTER_QUERY_LINE = \
+    '-f, --filter-query TEXT A filter query to be passed to the server'
+
+CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE = \
+    '--filter-query-language TEXT A filter-query language to be used'
+
+CMD_INTERACTIVE_OPTION_HELP_LINE = \
+    "-i, --interactive If set, `INSTANCENAME` argument must"
+
+CMD_DEEPINHERITANCE_OPTION_HELP_LINE = \
+    '-d, --deep-inheritance If set, requests server to return properties'
+
+CMD_PROPERTY_OPTION_HELP_LINE = \
+    '-P, --property name=value Optional property names of the form name=value',
+
+CMD_INCLUDEQUALIFIERS_OPTION_HELP_LINE = \
+    '-q, --include-qualifiers If set, requests server to include'
+
+CMD_LOCALONLY_OPTION_HELP_LINE = \
+    '-l, --local-only Show only local properties of the'
+
+#
+# The following list define the help for each command in terms of particular
+# parts of lines that are to be tested.
+# For each test, try to include:
+# 1. The usage line and in particular the argument component
+# 2. The single
+# 2. The last line CMD_OPTION_HELP_HELP_LINE
+# Defined in alphabetical order
+
+INSTANCE_HELP_LINE = [
+    'Usage: pywbemcli instance [COMMAND-OPTIONS] COMMAND [ARGS]...',
+    'Command group for persistent WBEM connections.',
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+INSTANCE_ASSOCIATORS_HELP_LINE = [
+    'Usage: pywbemcli  instance associators [COMMAND-OPTIONS] INSTANCENAME',
+    'Get the instances associated with an instance.',
+    '-a, --assoc-class <class name>  Filter by the association class name',
+    '-c, --result-class <class name>',
+    '-r, --role <role name> Filter by the role name provided. Each',
+    '-R, --result-role <role name>   Filter by the result role name provided',
+    CMD_INCLUDEQUALIFIERS_OPTION_HELP_LINE,
+    CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
+    CMD_OPTION_PROPERTYLIST_HELP_LINE,
+    CMD_OPTION_NAMES_ONLY_HELP_LINE,
+    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_INTERACTIVE_OPTION_HELP_LINE,
+    CMD_OPTION_SUMMARY_HELP_LINE,
+    CMD_OPTION_FILTER_QUERY_LINE,
+    CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+INSTANCE_COUNT_HELP_LINE = [
+    'Usage: pywbemcli  instance count [COMMAND-OPTIONS] CLASSNAME-GLOB',
+    'Count the instances of each class with matching class name.',
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+INSTANCE_CREATE_HELP_LINE = [
+    'Usage: pywbemcli  instance create [COMMAND-OPTIONS] CLASSNAME',
+    'Create an instance of a class in a namespace.',
+    CMD_PROPERTY_OPTION_HELP_LINE,
+    CMD_VERIFY_OPTION_HELP_LINE,
+    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+INSTANCE_DELETE_HELP_LINE = [
+    'Usage: pywbemcli  instance delete [COMMAND-OPTIONS] INSTANCENAME',
+    'Delete an instance of a class.',
+    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_INTERACTIVE_OPTION_HELP_LINE,
+    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+INSTANCE_ENUMERATE_HELP_LINE = [
+    'Usage: pywbemcli  instance enumerate [COMMAND-OPTIONS] CLASSNAME',
+    'Get the instances of a class.',
+    CMD_LOCALONLY_OPTION_HELP_LINE,
+    CMD_DEEPINHERITANCE_OPTION_HELP_LINE,
+    CMD_INCLUDEQUALIFIERS_OPTION_HELP_LINE,
+    CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
+    CMD_OPTION_PROPERTYLIST_HELP_LINE,
+    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_NAMES_ONLY_HELP_LINE,
+    CMD_OPTION_SUMMARY_HELP_LINE,
+    CMD_OPTION_FILTER_QUERY_LINE,
+    CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+INSTANCE_GET_HELP_LINE = [
+    'Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME',
+    'Get an instance of a class.',
+    CMD_INCLUDEQUALIFIERS_OPTION_HELP_LINE,
+    CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
+    CMD_OPTION_PROPERTYLIST_HELP_LINE,
+    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_INTERACTIVE_OPTION_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+INSTANCE_INVOKEMETHOD_HELP_LINE = [
+    'Usage: pywbemcli instance invokemethod [COMMAND-OPTIONS] INSTANCENAME '
+    'METHODNAME',
+    'Invoke a method on an instance.',
+    '-p, --parameter name=value',
+    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_INTERACTIVE_OPTION_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+INSTANCE_MODIFY_HELP_LINE = [
+    'Usage: pywbemcli instance modify [COMMAND-OPTIONS] INSTANCENAME',
+    'Modify an instance of a class.',
+    CMD_PROPERTY_OPTION_HELP_LINE,
+    CMD_OPTION_PROPERTYLIST_HELP_LINE,
+    CMD_VERIFY_OPTION_HELP_LINE,
+    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+INSTANCE_QUERY_HELP_LINE = [
+    'Usage: pywbemcli instance query [COMMAND-OPTIONS] INSTANCENAME',
+    'Execute a query on instances in a namespace.',
+    '-l, --query-language QUERY LANGUAGE',
+    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+INSTANCE_REFERENCES_HELP_LINE = [
+    'Usage: pywbemcli instance references [COMMAND-OPTIONS] INSTANCENAME',
+    'Get the instances referencing an instance.',
+    '-R, --resultclass <class name>  Filter by the result class name',
+    '-r, --role <role name>  Filter by the role name provided',
+    CMD_INCLUDEQUALIFIERS_OPTION_HELP_LINE,
+    CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
+    CMD_OPTION_PROPERTYLIST_HELP_LINE,
+    CMD_OPTION_NAMES_ONLY_HELP_LINE,
+    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_INTERACTIVE_OPTION_HELP_LINE,
+    CMD_OPTION_SUMMARY_HELP_LINE,
+    CMD_OPTION_FILTER_QUERY_LINE,
+    CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+ENUM_INSTANCE_RESP = """instance of CIM_Foo {
    InstanceID = "CIM_Foo1";
    IntegerProp = 1;
 };
@@ -569,7 +210,7 @@ instance of CIM_Foo {
 
 """
 
-GET_INST_ALL_TYPES = """instance of PyWBEM_AllTypes {
+GET_INSTANCE_ALL_TYPES = """instance of PyWBEM_AllTypes {
    InstanceId = "test_instance";
    scalBool = true;
    scalUint8 = 8;
@@ -601,7 +242,7 @@ GET_INST_ALL_TYPES = """instance of PyWBEM_AllTypes {
 
 """
 
-ENUM_INST_TABLE_RESP = """Instances: CIM_Foo
+ENUM_INSTANCE_TABLE_RESP = """Instances: CIM_Foo
 +--------------+---------------+
 | InstanceID   | IntegerProp   |
 +==============+===============+
@@ -625,7 +266,7 @@ ENUM_INSTNAME_TABLE_RESP = """InstanceNames: CIM_Foo
 +--------+-------------+----------------------------------------+
 """
 
-ENUM_INST_GET_TABLE_RESP = """Instances: CIM_Foo
+ENUM_INSTANCE_GET_TABLE_RESP = """Instances: CIM_Foo
 InstanceID      IntegerProp
 ------------  -------------
 "CIM_Foo1"                1
@@ -687,8 +328,8 @@ TEST_CASES = [
     #
     ['Verify instance subcommand help response',
      '--help',
-     {'stdout': INST_HELP,
-      'test': 'linesnows'},
+     {'stdout': INSTANCE_HELP_LINE,
+      'test': 'insnows'},
      None, OK],
 
     #
@@ -696,13 +337,13 @@ TEST_CASES = [
     #
     ['Verify instance subcommand enumerate  --help response',
      ['enumerate', '--help'],
-     {'stdout': INST_ENUMERATE_HELP,
-      'test': 'linesnows'},
+     {'stdout': INSTANCE_ENUMERATE_HELP_LINE,
+      'test': 'innows'},
      None, OK],
 
     ['Verify instance subcommand enumerate CIM_Foo',
      ['enumerate', 'CIM_Foo'],
-     {'stdout': ENUM_INST_RESP,
+     {'stdout': ENUM_INSTANCE_RESP,
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
@@ -730,7 +371,7 @@ TEST_CASES = [
 
     ['Verify instance subcommand enumerate CIM_Foo --include-qualifiers',
      ['enumerate', 'CIM_Foo', '--include-qualifiers'],
-     {'stdout': ENUM_INST_RESP,
+     {'stdout': ENUM_INSTANCE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
@@ -738,7 +379,7 @@ TEST_CASES = [
      ' --use-pull no',
      {'args': ['enumerate', 'CIM_Foo', '--include-qualifiers'],
       'global': ['--use-pull', 'no']},
-     {'stdout': ENUM_INST_RESP,
+     {'stdout': ENUM_INSTANCE_RESP,
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
@@ -768,21 +409,21 @@ TEST_CASES = [
 
     ['Verify instance subcommand enumerate deep-inheritance CIM_Foo -d',
      ['enumerate', 'CIM_Foo', '-d'],
-     {'stdout': ENUM_INST_RESP,
+     {'stdout': ENUM_INSTANCE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance subcommand enumerate deep-inheritance CIM_Foo '
      '--deep-inheritance',
      ['enumerate', 'CIM_Foo', '--deep-inheritance'],
-     {'stdout': ENUM_INST_RESP,
+     {'stdout': ENUM_INSTANCE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance subcommand -o grid enumerate deep-inheritance CIM_Foo -d',
      {'args': ['enumerate', 'CIM_Foo', '-d'],
       'global': ['--output-format', 'grid']},
-     {'stdout': ENUM_INST_TABLE_RESP,
+     {'stdout': ENUM_INSTANCE_TABLE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
@@ -839,7 +480,7 @@ TEST_CASES = [
 
     ['Verify instance subcommand enumerate with query.',
      ['enumerate', 'CIM_Foo', '--filter-query', 'InstanceID = 3'],
-     {'stdout': ENUM_INST_RESP,
+     {'stdout': ENUM_INSTANCE_RESP,
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
@@ -971,9 +612,9 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand get with instancename returns data',
      ['get', '--help'],
-     {'stdout': INST_GET_HELP,
+     {'stdout': INSTANCE_GET_HELP_LINE,
       'rc': 0,
-      'test': 'linesnows'},
+      'test': 'innows'},
      None, OK],
 
     ['Verify instance subcommand get with instancename returns data',
@@ -1106,7 +747,7 @@ Instances: PyWBEM_AllTypes
     ['Verify instance subcommand get with instancename PyWBEM_AllTypes'
      ' returns instance with all property types',
      ['get', 'PyWBEM_AllTypes.InstanceID="test_instance"'],
-     {'stdout': GET_INST_ALL_TYPES,
+     {'stdout': GET_INSTANCE_ALL_TYPES,
       'rc': 0,
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
@@ -1114,7 +755,7 @@ Instances: PyWBEM_AllTypes
     ['Verify instance subcommand -o grid get CIM_Foo',
      {'args': ['get', 'CIM_Foo.InstanceID="CIM_Foo1"'],
       'global': ['-o', 'simple']},
-     {'stdout': ENUM_INST_GET_TABLE_RESP,
+     {'stdout': ENUM_INSTANCE_GET_TABLE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
@@ -1172,9 +813,9 @@ Instances: PyWBEM_AllTypes
     #
     ['Verify instance subcommand create, --help response',
      ['create', '--help'],
-     {'stdout': INST_CREATE_HELP,
+     {'stdout': INSTANCE_CREATE_HELP_LINE,
       'rc': 0,
-      'test': 'linesnows'},
+      'test': 'innows'},
      None, OK],
 
     ['Verify instance subcommand create, new instance of CIM_Foo one property',
@@ -1306,9 +947,9 @@ Instances: PyWBEM_AllTypes
     #
     ['Verify instance subcommand modify, --help response',
      ['modify', '--help'],
-     {'stdout': INST_MODIFY_HELP,
+     {'stdout': INSTANCE_MODIFY_HELP_LINE,
       'rc': 0,
-      'test': 'linesnows'},
+      'test': 'innows'},
      None, OK],
 
     ['Verify instance subcommand modify, single good change',
@@ -1471,9 +1112,9 @@ Instances: PyWBEM_AllTypes
     #
     ['Verify instance subcommand delete, --help response',
      ['delete', '--help'],
-     {'stdout': INST_DELETE_HELP,
+     {'stdout': INSTANCE_DELETE_HELP_LINE,
       'rc': 0,
-      'test': 'linesnows'},
+      'test': 'innows'},
      None, OK],
 
     ['Verify instance subcommand delete, valid delete',
@@ -1553,9 +1194,9 @@ Instances: PyWBEM_AllTypes
     #
     ['Verify instance subcommand references, --help response',
      ['references', '--help'],
-     {'stdout': INST_REFERENCES_HELP,
+     {'stdout': INSTANCE_REFERENCES_HELP_LINE,
       'rc': 0,
-      'test': 'linesnows'},
+      'test': 'innows'},
      None, OK],
 
     ['Verify instance subcommand references, returns instances',
@@ -1758,9 +1399,9 @@ Instances: PyWBEM_AllTypes
     #
     ['Verify instance subcommand associators, --help response',
      ['associators', '--help'],
-     {'stdout': INST_ASSOCIATORS_HELP,
+     {'stdout': INSTANCE_ASSOCIATORS_HELP_LINE,
       'rc': 0,
-      'test': 'linesnows'},
+      'test': 'innows'},
      None, OK],
 
     ['Verify instance subcommand associators, returns instances',
@@ -1870,9 +1511,9 @@ Instances: PyWBEM_AllTypes
     #
     ['Verify instance subcommand count, --help response',
      ['count', '--help'],
-     {'stdout': INST_COUNT_HELP,
+     {'stdout': INSTANCE_COUNT_HELP_LINE,
       'rc': 0,
-      'test': 'linesnows'},
+      'test': 'innows'},
      None, OK],
 
     ['Verify instance subcommand count, Return table of instances',
@@ -1923,8 +1564,8 @@ Instances: PyWBEM_AllTypes
 
     ['class subcommand invokemethod --help, . ',
      ['invokemethod', '--help'],
-     {'stdout': INST_INVOKE_METHOD_HELP,
-      'test': 'linesnows'},
+     {'stdout': INSTANCE_INVOKEMETHOD_HELP_LINE,
+      'test': 'innows'},
      None, OK],
 
     ['Verify instance subcommand invokemethod',
@@ -1968,18 +1609,18 @@ Instances: PyWBEM_AllTypes
     #
     ['Verify instance subcommand query, --help response',
      ['query', '--help'],
-     {'stdout': INST_QUERY_HELP,
+     {'stdout': INSTANCE_QUERY_HELP_LINE,
       'rc': 0,
-      'test': 'linesnows'},
+      'test': 'linnows'},
      None, OK],
 
     ['Verify instance subcommand query execution. Returns error becasue '
      'mock does not support query',
      ['query', 'Select blah from blah'],
-     {'stderr': ['Error: CIMError: 14 (CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED): '
+     {'stderr': ['Error: CIMError: 14 (CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED): ',
                  "FilterQueryLanguage 'DMTF:CQL' not supported"],
       'rc': 1,
-      'test': 'in'},
+      'test': 'innows'},
      [SIMPLE_MOCK_FILE], OK],
 ]
 

--- a/tests/unit/test_qualdecl_subcmd.py
+++ b/tests/unit/test_qualdecl_subcmd.py
@@ -18,6 +18,8 @@ Tests the qualifier grop of  subcommands
 import os
 import pytest
 from .cli_test_extensions import CLITestsBase
+from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE, \
+    CMD_OPTION_NAMESPACE_HELP_LINE, CMD_OPTION_SUMMARY_HELP_LINE
 
 TEST_DIR = os.path.dirname(__file__)
 
@@ -25,41 +27,27 @@ TEST_DIR = os.path.dirname(__file__)
 # but not tied to the DMTF classes.
 SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
 
-# The following are common across multiple groups
-CMD_OPTION_HELP_HELP_LINE = \
-    '-h, --help Show this message and exit.'
-
-CMD_OPTION_NAMESPACE_HELP_LINE = \
-    '-n, --namespace <name> Namespace to use for this operation'
-
-CMD_OPTION_SUMMARY_HELP_LINE = \
-    '-S, --summary Return only summary of objects'
-
-# The following are particular to this group
-GRP_HELP_USAGE = \
-    'Usage: pywbemcli qualifier [COMMAND-OPTIONS] COMMAND [ARGS]...'
-
 QD_HELP_LINES = [
-    GRP_HELP_USAGE,
+    'Usage: pywbemcli qualifier [COMMAND-OPTIONS] COMMAND [ARGS]...'
     'Command group for CIM qualifier declarations.',
+    CMD_OPTION_HELP_HELP_LINE,
     'enumerate  List the CIM qualifier declarations in a CIM namespace.',
     'get        Get a CIM qualifier declaration.',
-    CMD_OPTION_HELP_HELP_LINE
 ]
 
-QD_ENUM_HELP_LINES = [
+QD_ENUMERATE_HELP_LINES = [
     'Usage: pywbemcli qualifier enumerate [COMMAND-OPTIONS]',
     'List the CIM qualifier declarations in a CIM namespace.',
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
-    CMD_OPTION_HELP_HELP_LINE
+    CMD_OPTION_HELP_HELP_LINE,
 ]
 
 QD_GET_HELP_LINES = [
     'Usage: pywbemcli qualifier get [COMMAND-OPTIONS] QUALIFIERNAME',
     "Get a CIM qualifier declaration.",
     CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_OPTION_HELP_HELP_LINE
+    CMD_OPTION_HELP_HELP_LINE,
 ]
 
 QD_ENUM_MOCK = """Qualifier Abstract : boolean = false,
@@ -177,25 +165,37 @@ TEST_CASES = [
     # mock - None or name of files (mof or .py),
     # condition - If True, the test is executed,  Otherwise it is skipped.
 
-    ['Verify qualifier subcommand help response',
+    ['Verify qualifier subcommand --help response',
      '--help',
      {'stdout': QD_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify qualifier subcommand enumerate  --help response',
+    ['Verify qualifier subcommand -h response',
+     '-h',
+     {'stdout': QD_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify qualifier subcommand enumerate --help response',
      ['enumerate', '--help'],
-     {'stdout': QD_ENUM_HELP_LINES,
+     {'stdout': QD_ENUMERATE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify qualifier subcommand enumerate  -h response.',
+    ['Verify qualifier subcommand enumerate -h response.',
      ['enumerate', '-h'],
-     {'stdout': QD_ENUM_HELP_LINES,
+     {'stdout': QD_ENUMERATE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify qualifier subcommand get  -h response.',
+    ['Verify qualifier subcommand get --help response.',
+     ['get', '--help'],
+     {'stdout': QD_GET_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify qualifier subcommand get -h response.',
      ['get', '-h'],
      {'stdout': QD_GET_HELP_LINES,
       'test': 'innows'},

--- a/tests/unit/test_qualdecl_subcmd.py
+++ b/tests/unit/test_qualdecl_subcmd.py
@@ -25,54 +25,42 @@ TEST_DIR = os.path.dirname(__file__)
 # but not tied to the DMTF classes.
 SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
 
-QD_HELP = """Usage: pywbemcli qualifier [COMMAND-OPTIONS] COMMAND [ARGS]...
+# The following are common across multiple groups
+CMD_OPTION_HELP_HELP_LINE = \
+    '-h, --help Show this message and exit.'
 
-  Command group to view QualifierDeclarations.
+CMD_OPTION_NAMESPACE_HELP_LINE = \
+    '-n, --namespace <name> Namespace to use for this operation'
 
-  Includes the capability to get and enumerate CIM qualifier declarations
-  defined in the WBEM server.
+CMD_OPTION_SUMMARY_HELP_LINE = \
+    '-S, --summary Return only summary of objects'
 
-  pywbemcli does not provide the capability to create or delete CIM
-  QualifierDeclarations
+# The following are particular to this group
+GRP_HELP_USAGE = \
+    'Usage: pywbemcli qualifier [COMMAND-OPTIONS] COMMAND [ARGS]...'
 
-  In addition to the command-specific options shown in this help text, the
-  general options (see 'pywbemcli --help') can also be specified before the
-  command. These are NOT retained after the command is executed.
+QD_HELP_LINES = [
+    GRP_HELP_USAGE,
+    'Command group for CIM qualifier declarations.',
+    'enumerate  List the CIM qualifier declarations in a CIM namespace.',
+    'get        Get a CIM qualifier declaration.',
+    CMD_OPTION_HELP_HELP_LINE
+]
 
-Options:
-  -h, --help  Show this message and exit.
+QD_ENUM_HELP_LINES = [
+    'Usage: pywbemcli qualifier enumerate [COMMAND-OPTIONS]',
+    'List the CIM qualifier declarations in a CIM namespace.',
+    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_SUMMARY_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE
+]
 
-Commands:
-  enumerate  Enumerate CIMQualifierDeclaractions.
-  get        Display CIMQualifierDeclaration.
-"""
-
-QD_ENUM_HELP = """Usage: pywbemcli qualifier enumerate [COMMAND-OPTIONS]
-
-  Enumerate CIMQualifierDeclaractions.
-
-  Displays all of the CIMQualifierDeclaration objects in the defined
-  namespace in the current WBEM server
-
-Options:
-  -n, --namespace <name>  Namespace to use for this operation, instead of the
-                          default namespace of the connection
-  -S, --summary           Return only summary of objects (count).
-  -h, --help              Show this message and exit.
-"""
-
-QD_GET_HELP = """Usage: pywbemcli qualifier get [COMMAND-OPTIONS] QUALIFIERNAME
-
-  Display CIMQualifierDeclaration.
-
-  Displays CIMQualifierDeclaration QUALIFIERNAME for the defined namespace
-  in the current WBEMServer
-
-Options:
-  -n, --namespace <name>  Namespace to use for this operation, instead of the
-                          default namespace of the connection
-  -h, --help              Show this message and exit.
-"""
+QD_GET_HELP_LINES = [
+    'Usage: pywbemcli qualifier get [COMMAND-OPTIONS] QUALIFIERNAME',
+    "Get a CIM qualifier declaration.",
+    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE
+]
 
 QD_ENUM_MOCK = """Qualifier Abstract : boolean = false,
     Scope(class, association, indication),
@@ -191,26 +179,26 @@ TEST_CASES = [
 
     ['Verify qualifier subcommand help response',
      '--help',
-     {'stdout': QD_HELP,
-      'test': 'linesnows'},
+     {'stdout': QD_HELP_LINES,
+      'test': 'innows'},
      None, OK],
 
     ['Verify qualifier subcommand enumerate  --help response',
      ['enumerate', '--help'],
-     {'stdout': QD_ENUM_HELP,
-      'test': 'linesnows'},
+     {'stdout': QD_ENUM_HELP_LINES,
+      'test': 'innows'},
      None, OK],
 
     ['Verify qualifier subcommand enumerate  -h response.',
      ['enumerate', '-h'],
-     {'stdout': QD_ENUM_HELP,
-      'test': 'linesnows'},
+     {'stdout': QD_ENUM_HELP_LINES,
+      'test': 'innows'},
      None, OK],
 
     ['Verify qualifier subcommand get  -h response.',
      ['get', '-h'],
-     {'stdout': QD_GET_HELP,
-      'test': 'linesnows'},
+     {'stdout': QD_GET_HELP_LINES,
+      'test': 'innows'},
      None, OK],
 
     ['Verify qualifier subcommand enumerate returns qual decls.',

--- a/tests/unit/test_server_subcmd.py
+++ b/tests/unit/test_server_subcmd.py
@@ -18,6 +18,7 @@ Tests the class subcommand
 import os
 import pytest
 from .cli_test_extensions import CLITestsBase
+from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
 
 TEST_DIR = os.path.dirname(__file__)
 
@@ -28,154 +29,68 @@ SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
 INVOKE_METHOD_MOCK_FILE = 'simple_mock_invokemethod.py'
 MOCK_SERVER_MODEL = os.path.join('utils', 'wbemserver_mock.py')
 
-SERVER_HELP = """
-Usage: pywbemcli server [COMMAND-OPTIONS] COMMAND [ARGS]...
+#
+# The following list define the help for each command in terms of particular
+# parts of lines that are to be tested.
+# For each test, try to include:
+# 1. The usage line and in particular the argument component
+# 2. The first line of the command comment (i.e. the summary sentence)
+# 3. The last line CMD_OPTION_HELP_HELP_LINE
+# 4. Each option including at least the long and short names
+SERVER_HELP_LINE = [
+    'Usage: pywbemcli server [COMMAND-OPTIONS]',
+    'Command group for WBEM servers.',
+    CMD_OPTION_HELP_HELP_LINE,
+]
 
-  Command Group for WBEM server operations.
+SERVER_BRAND_HELP_LINE = [
+    'Usage: pywbemcli server brand [COMMAND-OPTIONS]',
+    'Display the brand of the server.',
+    CMD_OPTION_HELP_HELP_LINE,
+]
 
-  The server command-group defines commands to inspect and manage core
-  components of the server including namespaces, the interop namespace,
-  profiles, and access to profile central instances.
+SERVER_CONNECTION_HELP_LINE = [
+    'Usage: pywbemcli server connection [COMMAND-OPTIONS]',
+    'Display connection info used by this server.',
+    CMD_OPTION_HELP_HELP_LINE,
+]
 
-  In addition to the command-specific options shown in this help text, the
-  general options (see 'pywbemcli --help') can also be specified before the
-  command. These are NOT retained after the command is executed.
+SERVER_GETCENTRALINSTS_HELP_LINE = [
+    'Usage: pywbemcli server get-centralinsts [COMMAND-OPTIONS]',
+    'Get central instances of mgmt profiles on the server.',
+    '-o, --organization <org name>   Filter by the defined organization',
+    '-p, --profile <profile name>    Filter by the profile name',
+    '-c, --central-class <classname>',
+    '-s, --scoping-class <classname>',
+    '-S, --scoping-path <pathname>   Optional. Required only if profiles',
+    '-r, --reference-direction [snia|dmtf]',
+    CMD_OPTION_HELP_HELP_LINE,
+]
 
-Options:
-  -h, --help  Show this message and exit.
+SERVER_INFO_HELP_LINE = [
+    'Usage: pywbemcli server info [COMMAND-OPTIONS]',
+    'Display information about the server.',
+    CMD_OPTION_HELP_HELP_LINE,
+]
 
-Commands:
-  brand             Display information on the WBEM server.
-  connection        Display connection info used by this server.
-  get-centralinsts  Display central instances in the WBEM server.
-  info              Display general information on the server.
-  interop           Display the server interop namespace name.
-  namespaces        Display the namespaces in the WBEM server.
-  profiles          Display registered profiles from the WBEM server.
-"""
+SERVER_INTEROP_HELP_LINE = [
+    'Usage: pywbemcli server interop [COMMAND-OPTIONS]',
+    'Display the Interop namespace of the server.',
+    CMD_OPTION_HELP_HELP_LINE,
+]
 
-SVR_BRAND_HELP = """
-Usage: pywbemcli server brand [COMMAND-OPTIONS]
+SERVER_NAMESPACES_HELP_LINE = [
+    'Usage: pywbemcli server namespaces [COMMAND-OPTIONS]',
+    'Display the namespaces of the server.',
+    CMD_OPTION_HELP_HELP_LINE,
+]
 
-  Display information on the WBEM server.
+SERVER_PROFILES_HELP_LINE = [
+    'Usage: pywbemcli server profiles [COMMAND-OPTIONS]',
+    'Display management profiles advertized by the server.',
+    CMD_OPTION_HELP_HELP_LINE,
+]
 
-  Display brand information on the current server if it is available. This
-  is typically the definition of the server implementor.
-
-Options:
-  -h, --help  Show this message and exit.
-"""
-
-SVR_GETCENTRALINSTS_HELP = """
-Usage: pywbemcli server get-centralinsts [COMMAND-OPTIONS]
-
-  Display central instances in the WBEM server.
-
-  Displays central instances for management profiles registered in the
-  server. Displays management profiles that adher to to the central class
-  methodology with none of the extra parameters (ex. scoping_class)
-
-  However, profiles that only use the scoping methodology require extra
-  information that is dependent on the profile itself. These profiles will
-  only be accessed when the correct values of central_class, scoping_class,
-  and scoping path for the particular profile is provided.
-
-  This display may be filtered by the optional organization and profile name
-  options that define the organization for each profile (ex. SNIA) and the
-  name of the profile. This will display only the profiles that are
-  registered for the defined organization and/or name.
-
-  Profiles are display as a table showing the organization, name, and
-  version for each profile.
-
-Options:
-  -o, --organization <org name>   Filter by the defined organization. (ex. -o
-                                  DMTF
-  -p, --profile <profile name>    Filter by the profile name. (ex. -p Array
-  -c, --central-class <classname>
-                                  Optional. Required only if profiles supports
-                                  only scopig methodology
-  -s, --scoping-class <classname>
-                                  Optional. Required only if profiles supports
-                                  only scopig methodology
-  -S, --scoping-path <pathname>   Optional. Required only if profiles supports
-                                  only scopig methodology. Multiples allowed
-  -r, --reference-direction [snia|dmtf]
-                                  Navigation direction for association.
-                                  [default: dmtf]
-  -h, --help                      Show this message and exit.
-  """
-
-SVR_CONNECT_HELP = """
-Usage: pywbemcli  server connection [COMMAND-OPTIONS]
-
-  Display connection info used by this server.
-
-  Displays the connection information for the WBEM connection attached to
-  this server.  This includes uri, default namespace, etc.
-
-  This is equivalent to the connection show subcommand.
-
-Options:
-  -h, --help  Show this message and exit.
-"""
-
-SVR_INFO_HELP = """
-Usage: pywbemcli server info [COMMAND-OPTIONS]
-
-  Display general information on the server.
-
-  Displays general information on the current server includeing brand,
-  namespaces, etc.
-
-Options:
-  -h, --help  Show this message and exit.
-"""
-
-SVR_INTEROP_HELP = """
-Usage: pywbemcli server interop [COMMAND-OPTIONS]
-
-  Display the server interop namespace name.
-
-  Displays the name of the interop namespace defined for the WBEM server.
-
-Options:
-  -h, --help  Show this message and exit.
-"""
-
-SVR_NAMESPACES_HELP = """
-Usage: pywbemcli server namespaces [COMMAND-OPTIONS]
-
-  Display the namespaces in the WBEM server.
-
-Options:
-  -s, --sort  Sort into alphabetical order by classname.
-  -h, --help  Show this message and exit.
-"""
-
-SVR_PROFILES_HELP = """
-Usage: pywbemcli server profiles [COMMAND-OPTIONS]
-
-  Display registered profiles from the WBEM server.
-
-  Displays the WBEM management profiles that have been registered for this
-  server.  Within the DMTF and SNIA these are the definition of management
-  functionality supported by the WBEM server.
-
-  This display may be filtered by the optional organization and profile
-  options that define the organization for each profile (ex. SNIA) and the
-  name of the profile. This will display only the profiles that are
-  registered for the defined organization and/or profile name.
-
-  Profiles are displayed as a table showing the organization, name, and
-  version for each profile.
-
-Options:
-  -o, --organization <org name>  Filter by the defined organization. (ex. -o
-                                 DMTF
-  -p, --profile <profile name>   Filter by the profile name. (ex. -p Array
-  -h, --help                     Show this message and exit.
-"""
 
 OK = True  # mark tests OK when they execute correctly
 RUN = True  # Mark OK = False and current test case being created RUN
@@ -193,50 +108,50 @@ TEST_CASES = [
 
     ['Verify server subcommand help response',
      '--help',
-     {'stdout': SERVER_HELP,
-      'test': 'linesnows'},
+     {'stdout': SERVER_HELP_LINE,
+      'test': 'innows'},
      None, OK],
 
     ['Verify server subcommand brand  --help response',
      ['brand', '--help'],
-     {'stdout': SVR_BRAND_HELP,
-      'test': 'linesnows'},
-     None, OK],
-
-    ['Verify class subcommand profiles  --help response',
-     ['get-centralinsts', '--help'],
-     {'stdout': SVR_GETCENTRALINSTS_HELP,
-      'test': 'linesnows'},
+     {'stdout': SERVER_BRAND_HELP_LINE,
+      'test': 'innows'},
      None, OK],
 
     ['Verify server subcommand connection --help response',
      ['connection', '--help'],
-     {'stdout': SVR_CONNECT_HELP,
-      'test': 'linesnows'},
+     {'stdout': SERVER_CONNECTION_HELP_LINE,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify server subcommand get-centralinsts  --help response',
+     ['get-centralinsts', '--help'],
+     {'stdout': SERVER_GETCENTRALINSTS_HELP_LINE,
+      'test': 'innows'},
      None, OK],
 
     ['Verify server subcommand info --help response',
      ['info', '--help'],
-     {'stdout': SVR_INFO_HELP,
-      'test': 'linesnows'},
+     {'stdout': SERVER_INFO_HELP_LINE,
+      'test': 'innows'},
      None, OK],
 
     ['Verify server subcommand interop --help response',
      ['interop', '--help'],
-     {'stdout': SVR_INTEROP_HELP,
-      'test': 'linesnows'},
+     {'stdout': SERVER_INTEROP_HELP_LINE,
+      'test': 'innows'},
      None, OK],
 
     ['Verify class subcommand namespaces --help response',
      ['namespaces', '--help'],
-     {'stdout': SVR_NAMESPACES_HELP,
-      'test': 'linesnows'},
+     {'stdout': SERVER_NAMESPACES_HELP_LINE,
+      'test': 'innows'},
      None, OK],
 
     ['Verify class subcommand profiles  --help response',
      ['profiles', '--help'],
-     {'stdout': SVR_PROFILES_HELP,
-      'test': 'linesnows'},
+     {'stdout': SERVER_PROFILES_HELP_LINE,
+      'test': 'innows'},
      None, OK],
 
     #

--- a/tests/unit/test_server_subcmd.py
+++ b/tests/unit/test_server_subcmd.py
@@ -37,55 +37,62 @@ MOCK_SERVER_MODEL = os.path.join('utils', 'wbemserver_mock.py')
 # 2. The first line of the command comment (i.e. the summary sentence)
 # 3. The last line CMD_OPTION_HELP_HELP_LINE
 # 4. Each option including at least the long and short names
-SERVER_HELP_LINE = [
+SERVER_HELP_LINES = [
     'Usage: pywbemcli server [COMMAND-OPTIONS]',
     'Command group for WBEM servers.',
     CMD_OPTION_HELP_HELP_LINE,
+    'brand             Display the brand of the server.',
+    'connection        Display connection info used by this server.',
+    'get-centralinsts  Get central instances of mgmt profiles on the server.',
+    'info              Display information about the server.',
+    'interop           Display the Interop namespace of the server.',
+    'namespaces        Display the namespaces of the server.',
+    'profiles          Display management profiles advertized by the server.',
 ]
 
-SERVER_BRAND_HELP_LINE = [
+SERVER_BRAND_HELP_LINES = [
     'Usage: pywbemcli server brand [COMMAND-OPTIONS]',
     'Display the brand of the server.',
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-SERVER_CONNECTION_HELP_LINE = [
+SERVER_CONNECTION_HELP_LINES = [
     'Usage: pywbemcli server connection [COMMAND-OPTIONS]',
     'Display connection info used by this server.',
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-SERVER_GETCENTRALINSTS_HELP_LINE = [
+SERVER_GETCENTRALINSTS_HELP_LINES = [
     'Usage: pywbemcli server get-centralinsts [COMMAND-OPTIONS]',
     'Get central instances of mgmt profiles on the server.',
-    '-o, --organization <org name>   Filter by the defined organization',
-    '-p, --profile <profile name>    Filter by the profile name',
-    '-c, --central-class <classname>',
-    '-s, --scoping-class <classname>',
-    '-S, --scoping-path <pathname>   Optional. Required only if profiles',
-    '-r, --reference-direction [snia|dmtf]',
+    '-o, --organization <org name> Filter by the defined organization',
+    '-p, --profile <profile name> Filter by the profile name',
+    '-c, --central-class <classname> Optional. Required only if profiles',
+    '-s, --scoping-class <classname> Optional. Required only if profiles',
+    '-S, --scoping-path <pathname> Optional. Required only if profiles',
+    '-r, --reference-direction [snia|dmtf] Navigation direction',
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-SERVER_INFO_HELP_LINE = [
+SERVER_INFO_HELP_LINES = [
     'Usage: pywbemcli server info [COMMAND-OPTIONS]',
     'Display information about the server.',
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-SERVER_INTEROP_HELP_LINE = [
+SERVER_INTEROP_HELP_LINES = [
     'Usage: pywbemcli server interop [COMMAND-OPTIONS]',
     'Display the Interop namespace of the server.',
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-SERVER_NAMESPACES_HELP_LINE = [
+SERVER_NAMESPACES_HELP_LINES = [
     'Usage: pywbemcli server namespaces [COMMAND-OPTIONS]',
     'Display the namespaces of the server.',
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-SERVER_PROFILES_HELP_LINE = [
+SERVER_PROFILES_HELP_LINES = [
     'Usage: pywbemcli server profiles [COMMAND-OPTIONS]',
     'Display management profiles advertized by the server.',
     CMD_OPTION_HELP_HELP_LINE,
@@ -106,51 +113,99 @@ TEST_CASES = [
     # mock - None or name of files (mof or .py),
     # condition - If True, the test is executed,  Otherwise it is skipped.
 
-    ['Verify server subcommand help response',
+    ['Verify server subcommand --help response',
      '--help',
-     {'stdout': SERVER_HELP_LINE,
+     {'stdout': SERVER_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify server subcommand -h response',
+     '-h',
+     {'stdout': SERVER_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     ['Verify server subcommand brand  --help response',
      ['brand', '--help'],
-     {'stdout': SERVER_BRAND_HELP_LINE,
+     {'stdout': SERVER_BRAND_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify server subcommand brand  -h response',
+     ['brand', '-h'],
+     {'stdout': SERVER_BRAND_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     ['Verify server subcommand connection --help response',
      ['connection', '--help'],
-     {'stdout': SERVER_CONNECTION_HELP_LINE,
+     {'stdout': SERVER_CONNECTION_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify server subcommand connection -h response',
+     ['connection', '-h'],
+     {'stdout': SERVER_CONNECTION_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     ['Verify server subcommand get-centralinsts  --help response',
      ['get-centralinsts', '--help'],
-     {'stdout': SERVER_GETCENTRALINSTS_HELP_LINE,
+     {'stdout': SERVER_GETCENTRALINSTS_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify server subcommand get-centralinsts  -h response',
+     ['get-centralinsts', '-h'],
+     {'stdout': SERVER_GETCENTRALINSTS_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     ['Verify server subcommand info --help response',
      ['info', '--help'],
-     {'stdout': SERVER_INFO_HELP_LINE,
+     {'stdout': SERVER_INFO_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify server subcommand info -h response',
+     ['info', '-h'],
+     {'stdout': SERVER_INFO_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     ['Verify server subcommand interop --help response',
      ['interop', '--help'],
-     {'stdout': SERVER_INTEROP_HELP_LINE,
+     {'stdout': SERVER_INTEROP_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand namespaces --help response',
+    ['Verify server subcommand interop -h response',
+     ['interop', '-h'],
+     {'stdout': SERVER_INTEROP_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify server subcommand namespaces --help response',
      ['namespaces', '--help'],
-     {'stdout': SERVER_NAMESPACES_HELP_LINE,
+     {'stdout': SERVER_NAMESPACES_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand profiles  --help response',
+    ['Verify server subcommand namespaces -h response',
+     ['namespaces', '-h'],
+     {'stdout': SERVER_NAMESPACES_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify server subcommand profiles --help response',
      ['profiles', '--help'],
-     {'stdout': SERVER_PROFILES_HELP_LINE,
+     {'stdout': SERVER_PROFILES_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify server subcommand profiles -h response',
+     ['profiles', '-h'],
+     {'stdout': SERVER_PROFILES_HELP_LINES,
       'test': 'innows'},
      None, OK],
 


### PR DESCRIPTION
**Note:** This PR is complete for the help text changes but not for adjusting the corresponding test cases. At this point, only the test cases for the ' class' command group have been adjusted. That is why it currently fails the CI tests. The test cases for the other commands and command groups will need to be adjusted once PR #267 has been completed to cover all of them. Nevertheless, the changed help texts should be reviewed.

For details, see the commit message.
Ready for review, considering the note above.

COMMENT: Karl: I completed the tests for the whole environment.  The one thing I have done is to review to be sure I have all options shows for the instance tests.

We have most, but I need to review to assure that they are complete
