### PR TITLE
Fixes issue #258, #259, table output of instance names

### DIFF
--- a/docs/pywbemcligeneraloptions.rst
+++ b/docs/pywbemcligeneraloptions.rst
@@ -138,7 +138,7 @@ Details`):
   the password.  If passwords are saved into the :term:`connections file` they
   are not encrypted in the file.
   See :ref:`Avoiding password prompts`.
-* **--noverify/-n** - If set, client does not verify server certificate. Any
+* **--no-verify/-n** - If set, client does not verify server certificate. Any
   certificate returned by the server is accepted.
 * **--certfile** - Server certificate file. Not used if ``--no-verify/-n`` set or
   the connection does not use SSL (i.e. ``--server http://blah``)
@@ -759,25 +759,26 @@ session, the user can work with multiple WBEM servers. The server that was defin
 when pywbemcli was started or the server selected by ``connection select`` is the
 current server.
 
-For example the following example creates a new connection in the CLI command
-mode:
+For example the following example of a pywbemcli interactive session creates a
+new connection in the CLI command mode:
 
 .. code-block:: text
 
-    $ pywbemcli connection add --server http://localhost --user usr1 -password blah --name testconn
+    $ pywbemcli
+    pywbemcli> connection add --server http://localhost --user usr1 -password blah --name testconn
     pywbemcli> connection show
-    Name: testconn
-      WBEMServer uri: http://localhost
-      Default_namespace: root/cimv2
-      User: usr1
-      Password: blah
-      Timeout: 30
-      Noverify: False
-      Certfile: None
-      Keyfile: None
-      use-pull-ops: either
+    name: testconn
+      server: http://localhost
+      default-namespace: root/cimv2
+      user: usr1
+      password: blah
+      timeout: None
+      no-verify: False
+      certfile: None
+      keyfile: None
+      use-pull: None
       pull-max-cnt: 1000
-      mock:
+      mock-server:
       log: None
 
     pywbemcli> connection list

--- a/docs/pywbemclisubcommands.rst
+++ b/docs/pywbemclisubcommands.rst
@@ -938,7 +938,7 @@ The subcommands include:
     pywbemcli> connection list
     WBEM server connections:
     +--------------+------------------+-------------+-------------+-----------+------------+----------------------------------------+
-    | name         | server uri       | namespace   | user        |   timeout | noverify   | mock_server                            |
+    | name         | server uri       | namespace   | user        |   timeout | no-verify  | mock_server                            |
     |--------------+------------------+-------------+-------------+-----------+------------+----------------------------------------|
     | blahblah     | http://blah      | root/cimv2  |             |        45 | False      |                                        |
     | mock1        |                  | root/cimv2  |             |           | False      | tests/unit/simple_mock_model.mof       |
@@ -1004,27 +1004,29 @@ The subcommands include:
     pywbemcli> connection list
     WBEMServer Connections:
     +------------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------+
-    | name       | server uri       | namespace   | user        | password   |   timeout | noverify   | certfile   | keyfile   | log   |
+    | name       | server uri       | namespace   | user        | password   |   timeout | no-verify  | certfile   | keyfile   | log   |
     |------------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------|
     | mock1      |                  | root/cimv2  |             |            |        30 | False      |            |           |       |
     | mockassoc* |                  | root/cimv2  |             |            |        30 | False      |            |           |       |
     | op         | http://localhost | root/cimv2  | kschopmeyer | test8play  |        30 | True       |            |           |       |
     +------------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------+
+
     $ pywbemcli> connection show
 
-    Name: mockassoc
-      WBEMServer uri: None
-      Default_namespace: root/cimv2
-      User: None
-      Password: None
-      Timeout: 30
-      Noverify: False
-      Certfile: None
-      Keyfile: None
-      use_pull: either
+    name: mockassoc
+      server: None
+      default-namespace: root/cimv2
+      user: None
+      password: None
+      timeout: 30
+      no-verify: False
+      certfile: None
+      keyfile: None
+      use-pull: either
       pull-max-cnt: 1000
-      mock: tests/unit/simple_assoc_mock_model.mof
+      mock-server: tests/unit/simple_assoc_mock_model.mof
       log: None
+
 
   See :ref:`pywbemcli connection select --help` for details.
 * **show** show information in the current connection.  See the the ``select``

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -613,17 +613,6 @@ ENUM_INST_TABLE_RESP = """Instances: CIM_Foo
 +--------------+---------------+
 """
 
-ENUM_INSTNAME_TABLE_RESP = """InstanceNames: CIM_Foo
-+--------+-------------+----------------------------------------+
-| host   | namespace   | keybindings                            |
-+========+=============+========================================+
-|        | root/cimv2  | NocaseDict({'InstanceID': 'CIM_Foo1'}) |
-+--------+-------------+----------------------------------------+
-|        | root/cimv2  | NocaseDict({'InstanceID': 'CIM_Foo2'}) |
-+--------+-------------+----------------------------------------+
-|        | root/cimv2  | NocaseDict({'InstanceID': 'CIM_Foo3'}) |
-+--------+-------------+----------------------------------------+
-"""
 
 ENUM_INST_GET_TABLE_RESP = """Instances: CIM_Foo
 InstanceID      IntegerProp
@@ -789,7 +778,17 @@ TEST_CASES = [
     ['Verify instance subcommand -o grid enumerate di CIM_Foo -d -o',
      {'args': ['enumerate', 'CIM_Foo', '-d', '-o'],
       'global': ['--output-format', 'grid']},
-     {'stdout': ENUM_INSTNAME_TABLE_RESP,
+     {'stdout': """InstanceNames: CIM_Foo
++--------+-------------+---------+-----------------------+
+| host   | namespace   | class   | keysbindings          |
++========+=============+=========+=======================+
+|        | root/cimv2  | CIM_Foo | InstanceID="CIM_Foo1" |
++--------+-------------+---------+-----------------------+
+|        | root/cimv2  | CIM_Foo | InstanceID="CIM_Foo2" |
++--------+-------------+---------+-----------------------+
+|        | root/cimv2  | CIM_Foo | InstanceID="CIM_Foo3" |
++--------+-------------+---------+-----------------------+
+""",
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
@@ -853,17 +852,18 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
 
-    ['Verify subcommand enumerate with CIM_Foo summary table output',
+    ['Verify subcommand enumerate with CIM_Foo inst name table output',
      {'args': ['enumerate', 'CIM_Foo', '--names-only'],
       'global': ['--output-format', 'table']},
      {'stdout': """InstanceNames: CIM_Foo
-+--------+-------------+----------------------------------------+
-| host   | namespace   | keybindings                            |
-|--------+-------------+----------------------------------------|
-|        | root/cimv2  | NocaseDict({'InstanceID': 'CIM_Foo1'}) |
-|        | root/cimv2  | NocaseDict({'InstanceID': 'CIM_Foo2'}) |
-|        | root/cimv2  | NocaseDict({'InstanceID': 'CIM_Foo3'}) |
-+--------+-------------+----------------------------------------+
++--------+-------------+---------+-----------------------+
+| host   | namespace   | class   | keysbindings          |
+|--------+-------------+---------+-----------------------|
+|        | root/cimv2  | CIM_Foo | InstanceID="CIM_Foo1" |
+|        | root/cimv2  | CIM_Foo | InstanceID="CIM_Foo2" |
+|        | root/cimv2  | CIM_Foo | InstanceID="CIM_Foo3" |
++--------+-------------+---------+-----------------------+
+
 """,
       'rc': 0,
       'test': 'linesnows'},


### PR DESCRIPTION
Originally the instance enumerate with -o and table output_format was just outputting
the repr output of the keybindings.  Replaced this with a table preparer that

1. Includes separating the class from the keybindings and putting into
its own table entry. The table now shows host, namespace, class,
keybindings.

2. Formatting the keybindings based on to_wbemuri() and further, if the
result is greater than the width of the table we want (terminal width)
reformatting the keybindings into multiple rows.

The table output now looks like:

```
   InstanceNames: CIM_Foo
   +--------+-------------+---------+-----------------------+
   | host   | namespace   | class   | keysbindings          |
   +========+=============+=========+=======================+
   |        | root/cimv2  | CIM_Foo | InstanceID="CIM_Foo1" |
   +--------+-------------+---------+-----------------------+
   |        | root/cimv2  | CIM_Foo | InstanceID="CIM_Foo2" |
   +--------+-------------+---------+-----------------------+
   |        | root/cimv2  | CIM_Foo | InstanceID="CIM_Foo3" |
   +--------+-------------+---------+-----------------------+


Adds test for the new format.

Fixes issues from the change of --noverify

Fixes a couple of issues in the documentation with the change yesterday
from --noverify to --no-verify