### PR TITLE
Fix issue #275 correct documentation/help for certfile, keyfile

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -88,10 +88,14 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       (EnvVar:
                                       PYWBEMCLI_TIMEOUT)
       -N, --no-verify                 If set, client does not verify WBEM server
-                                      certificate.(EnvVar: PYWBEMCLI_NO_VERIFY).
-      -c, --certfile TEXT             Server certfile. Ignored if --no-verify flag
-                                      set. (EnvVar: PYWBEMCLI_CERTFILE).
-      -k, --keyfile FILE PATH         Client private key file.
+                                      certificates.(EnvVar: PYWBEMCLI_NO_VERIFY).
+      -c, --certfile TEXT             X.509 client certificate presented to the
+                                      WBEM server during the TLS/SSL handshake for
+                                      2 way authentication(EnvVar:
+                                      PYWBEMCLI_CERTFILE).
+      -k, --keyfile FILE PATH         X.509 client private key file presented to
+                                      the WBEM server during the TLS/SSL handshake
+                                      for 2 way authentication.
                                       (EnvVar:
                                       PYWBEMCLI_KEYFILE)
       --ca-certs TEXT                 File or directory containing certificates

--- a/docs/pywbemcligeneraloptions.rst
+++ b/docs/pywbemcligeneraloptions.rst
@@ -140,10 +140,27 @@ Details`):
   See :ref:`Avoiding password prompts`.
 * **--no-verify/-n** - If set, client does not verify server certificate. Any
   certificate returned by the server is accepted.
-* **--certfile** - Server certificate file. Not used if ``--no-verify/-n`` set or
-  the connection does not use SSL (i.e. ``--server http://blah``)
-* **--keyfile** - Client private key file for the server to use to authenticate
-  the client if that is required by the WBEM server.
+* **--certfile** - X.509 client certificate to be presented to the
+  WBEM server along with the ``--keyfile`` option during the TLS/SSL handshake.
+  This parameter used only with HTTPS.  If None, no client certificate is
+  presented to the server, enabling 1-way authentication. Otherwise, the
+  client certificate is presented to the server, enabling 2-way (mutual)
+  authentication. This and the ``--keyfile`` are presented to the pywbem
+  :class:`pywbem.WBEMConnection` as a single parameter ``X-509``:
+
+  * ``--cert_file`` - The file path of a file containing an X.509 client
+    certificate.
+  * ``key_file`` - The file path of a file containing the private key belonging
+    to the public key that is part of the X.509 certificate file.
+
+  For more information on authentication types, see:
+  :https://pywbem.readthedocs.io/en/stable/client/security.html#authentication-types
+* **--keyfile** - Client private key file containing the private key belonging
+  to the public key that is part of the X.509 certificate. See ``--certfile``
+  for more information. Not required if the private key is part of the file
+  defined in ``--certfile``. Not allowed if ``--certfile`` option not provided.
+  Default: No client key file. Client private key should then be part of the
+  file defined by ``--certfile``.
 * **--output-format/-o** - Output format choice (Default: mof).
   Note that the actual output format may differ from this value because some
   subcommands only allow selected formats.  See :ref:`Output formats` for

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -105,16 +105,20 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    '(EnvVar: {ev})'.format(ev=PywbemServer.timeout_envvar))
 @click.option('-N', '--no-verify', is_flag=True,
               envvar=PywbemServer.no_verify_envvar,
-              help='If set, client does not verify WBEM server certificate.' +
+              help='If set, client does not verify WBEM server certificates.' +
                    '(EnvVar: {ev}).'.format(ev=PywbemServer.no_verify_envvar))
 @click.option('-c', '--certfile', type=str,
               envvar=PywbemServer.certfile_envvar,
-              help="Server certfile. Ignored if --no-verify flag set. " +
+              help='X.509 client certificate presented to the WBEM server '
+                   'during the TLS/SSL handshake for 2 way authentication' +
                    '(EnvVar: {ev}).'.format(ev=PywbemServer.certfile_envvar))
 @click.option('-k', '--keyfile', type=str,
               metavar='FILE PATH',
               envvar=PywbemServer.keyfile_envvar,
-              help='Client private key file.\n'
+              help='X.509 client private key file containing private key '
+                   'belonging to tpublic key in X.509 certificate '
+                   '``--certfile``. Not required if private key is part of '
+                   '--certfile file. \n'
                    '(EnvVar: {ev})'.format(ev=PywbemServer.keyfile_envvar))
 @click.option('--ca-certs', type=str,
               envvar=PywbemServer.ca_certs_envvar,
@@ -251,6 +255,11 @@ def cli(ctx, server, name, default_namespace, user, password, timeout,
             click.echo('The --name option "%s" and --server option "%s" '
                        'are mutually exclusive and may not be used '
                        'simultaneously' % (name, server), err=True)
+            raise click.Abort()
+
+        if keyfile and not certfile:
+            click.echo('The --keyfile option "%s" is allowed only if the '
+                       '--certfile option exists' % keyfile, err=True)
             raise click.Abort()
 
         # process mock_server option

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -109,10 +109,16 @@ Options:
                                   (EnvVar:
                                   PYWBEMCLI_TIMEOUT)
   -N, --no-verify                 If set, client does not verify WBEM server
-                                  certificate.(EnvVar: PYWBEMCLI_NO_VERIFY).
-  -c, --certfile TEXT             Server certfile. Ignored if --no-verify flag
-                                  set. (EnvVar: PYWBEMCLI_CERTFILE).
-  -k, --keyfile FILE PATH         Client private key file.
+                                  certificates.(EnvVar: PYWBEMCLI_NO_VERIFY).
+  -c, --certfile TEXT             X.509 client certificate presented to the
+                                  WBEM server during the TLS/SSL handshake for
+                                  2 way authentication(EnvVar:
+                                  PYWBEMCLI_CERTFILE).
+  -k, --keyfile FILE PATH         X.509 client private key file containing
+                                  private key belonging to tpublic key in
+                                  X.509 certificate ``--certfile``. Not
+                                  required if private key is part of
+                                  --certfile file.
                                   (EnvVar:
                                   PYWBEMCLI_KEYFILE)
   --ca-certs TEXT                 File or directory containing certificates
@@ -556,7 +562,6 @@ TEST_CASES = [
       'test': 'regex'},
      None, OK],
 
-
     ['Verify connection without server definition and subcommand that '
      ' requires connection fails.',
      {'subcmd': 'class',
@@ -567,6 +572,18 @@ TEST_CASES = [
                 '"connection select" to enable a connection',
       'rc': 1,
       'test': 'regex'},
+     None, OK],
+
+
+    ['Verify --keyfile allowed only if --certfile exists.',
+     {'subcmd': 'class',
+      'args': ['enumerate'],
+      'global': ['--keyfile', 'mykey.pem']},
+     {'stderr': ['The --keyfile option',
+                 'is allowed only if',
+                 'the --certfile option exists'],
+      'rc': 1,
+      'test': 'innows'},
      None, OK],
 
     #


### PR DESCRIPTION
The documentation and help were wrong.  I took what was
defined in pywbem documentation for the certfile and keyfile parameters
and put it into the help for the --certfile and --keyfile and the
general documentation for the same.

Added code to refuse keyfile if no certfile and added test for same.