### PR TITLE
Fixes #251: Changed term subcommand to command

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -29,8 +29,8 @@ This documentation uses a few special terms to refer to Python types:
       ``mof`` , ``xml`` , ``repr`` , and ``txt`` .
 
    INSTANCENAME
-      an argument of several of the command-group ``instance`` subcommands that
-      allows two possible inputs based on another subcommand option( ``--interactive`` ).
+      an argument of several of the command-group ``instance`` commands that
+      allows two possible inputs based on another command option( ``--interactive`` ).
 
       When the ``interactive`` option is not set, the INSTANCENAME is a string
       representation of a CIMInstanceName must be formatted as defined by
@@ -128,12 +128,12 @@ This documentation uses a few special terms to refer to Python types:
    REPL
       Stands for "Read-Execute-Print-Loop" which is a term that denotes the
       pywbemcli shell interactive mode where multiple command-groups and
-      subcommands may be executed within the context of a connection defined
+      commands may be executed within the context of a connection defined
       by a set of general options.
 
    GLOB
       A pathname pattern pattern expansion used in Unix environments. It is
-      used by pywbemcli to expand classnames in the ``class find`` subcommand.
+      used by pywbemcli to expand classnames in the ``class find`` command.
       No tilde expansion is done, but ``*``, ``?``, and character ranges
       expressed with ``[]`` will be correctly matched.
 

--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -29,7 +29,7 @@ This documentation uses a few special terms to refer to Python types:
       ``mof`` , ``xml`` , ``repr`` , and ``txt`` .
 
    INSTANCENAME
-      an argument of several of the command-group ``instance`` commands that
+      an argument of several of the command group ``instance`` commands that
       allows two possible inputs based on another command option( ``--interactive`` ).
 
       When the ``interactive`` option is not set, the INSTANCENAME is a string
@@ -127,7 +127,7 @@ This documentation uses a few special terms to refer to Python types:
 
    REPL
       Stands for "Read-Execute-Print-Loop" which is a term that denotes the
-      pywbemcli shell interactive mode where multiple command-groups and
+      pywbemcli shell interactive mode where multiple command groups and
       commands may be executed within the context of a connection defined
       by a set of general options.
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -133,9 +133,9 @@ There are multiple types of tests in pywbem:
    to emulate a WBEM server, while unit tests exercise single modules without
    using access to a WBEM server.
 
-   Generally, the function tests are organized by the command-group so that
-   the function tests for the class command-group are in the file
-   test_class_subcmd.py
+   Generally, the function tests are organized by the command group  so that
+   the function tests for the class command group are in the file
+   ``test_class_subcmd.py``
 
 
    Tests are run by executing:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ The pywbemtools github page is: `https://github.com/pywbem/pywbemtools <https://
    introduction.rst
    pywbemclicmdlineinterface.rst
    pywbemcligeneraloptions.rst
-   pywbemclisubcommands.rst
+   pywbemclicommands.rst
    pywbemclicmdshelp.rst
    mock_support.rst
    development.rst

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -52,7 +52,7 @@ platforms. It provides functionality to:
 
 * Explore the CIM data of WBEM servers. It can manage/inspect the CIM model
   components including CIM classes, CIM instances, and CIM qualifiers and
-  execute CIM methods and queries on the WBEM server. It implements subcommands
+  execute CIM methods and queries on the WBEM server. It implements commands
   to execute the :term:`CIM-XML` operations defined in the DMTF specification
   CIM Operations Over HTTP (:term:`DSP0200`).
 

--- a/docs/pywbemclicmdlineinterface.rst
+++ b/docs/pywbemclicmdlineinterface.rst
@@ -28,31 +28,31 @@ The command line can contain the following components:
 * **general-options** - Options that apply to all commands.
   See :ref:`Pywbemcli command line general options` for infomation on the
   pywbemcli general options
-* **command-group** - A name of a group of subcommands.
-  See :ref:`Pywbemcli command groups, commands, and subcommands`
-* **command** - Alternative to command-group when there are no
-  subcommands.
-* **subcommand** - Command name within a command group
+* **command-group** - A name of a group of commands.
+  See :ref:`Pywbemcli command groups and commands`
+* **command** - A command name normally within a command-group.
+  There are however some special commands that exist outside of any
+  command-group; they are not in any command-group.
 * **args** - Arguments and options that are defined for a particular
-  command or subcommand. Options are proceeded by the characters '-' for the
+  command. Options are proceeded by the characters '-' for the
   short form or '--' for the long form. (ex. ``-n`` or ``--namespace``).
-  Arguments do not have a prefix and are the first string following the
-  command/subcommand name. (ex. ``pywbemcli class get CIM_Foo``. CIM_Foo is
-  an argument.)
+  Arguments do not have a ``-`` or ``--``prefix and follow the
+  command name. (ex. ``pywbemcli class get CIM_Foo``. CIM_Foo is
+  an argument.). Options include the ``-`` or ``--`` prefix.
 
 The syntax is:
 
 .. code-block:: text
 
-    pywbemcli <general-options> <command-group>|<command> <args>
+    pywbemcli <general-options> <command-group> <command> <args>
 
-    where:
-        command-group = <command> <subcommand>
+**NOTE:** pywbemcli has two special commands that are not a part of any
+command-group ``repl`` and ``help``.
 
-A command-group is the name of an object, referencing an entity (ex. ``class``
-refers to operation on CIM classes). The subcommands are generally actions on
-the objects defined by the command-group name. Thus ``class`` is a
-command-group name used to access CIM classes and ``get`` is a subcommand so:
+A command-group is the name of an object, (ex. ``class`` refers to operation on
+CIM classes). The commands are generally actions on the objects defined by the
+command-group name (``get``, ``list``, etc.). Thus ``class`` is a command-group
+name used to access CIM classes and ``get`` is a command so:
 
 .. code-block:: text
 
@@ -167,18 +167,18 @@ list of the supported commands.
     . . .
 
     Commands:
-      class      Command group to manage CIM Classes.
-      instance   Command Group to manage CIM instances.
-      qualifier  Command Group to manage CIM...
+      class      Command-group to manage CIM Classes.
+      instance   Command-Group to manage CIM instances.
+      qualifier  Command-Group to manage CIM...
       repl       Start an interactive shell.
-      server     Command group for server operations
+      server     Command-group for server operations
 
 The usage line in this help text shows the standalone command use. Within the
 pywbemcli shell (interactive mode), the ``pywbemcli`` word is omitted and the
-subcommand and options is typed in.
+command and options is typed in.
 
 Typing ``command-group --help``,  or ``command-group -h``, or ``command-group
-subcommand --help`` in the pywbemcli shell displays help information for the
+command --help`` in the pywbemcli shell displays help information for the
 specified pywbemcli command-group, for example:
 
 .. code-block:: text
@@ -254,6 +254,6 @@ completion:
     ... <shows the commands to select from>
 
     $ pywbemcli class <TAB><TAB>
-    ... <shows the class sub-commands to select from>
+    ... <shows the class commands to select from>
 
 

--- a/docs/pywbemclicmdlineinterface.rst
+++ b/docs/pywbemclicmdlineinterface.rst
@@ -28,11 +28,11 @@ The command line can contain the following components:
 * **general-options** - Options that apply to all commands.
   See :ref:`Pywbemcli command line general options` for infomation on the
   pywbemcli general options
-* **command-group** - A name of a group of commands.
+* **command group ** - A name of a group of commands.
   See :ref:`Pywbemcli command groups and commands`
-* **command** - A command name normally within a command-group.
+* **command** - A command name normally within a command group .
   There are however some special commands that exist outside of any
-  command-group; they are not in any command-group.
+  command group ; they are not in any command group .
 * **args** - Arguments and options that are defined for a particular
   command. Options are proceeded by the characters '-' for the
   short form or '--' for the long form. (ex. ``-n`` or ``--namespace``).
@@ -44,14 +44,14 @@ The syntax is:
 
 .. code-block:: text
 
-    pywbemcli <general-options> <command-group> <command> <args>
+    pywbemcli <general-options> <command group > <command> <args>
 
 **NOTE:** pywbemcli has two special commands that are not a part of any
-command-group ``repl`` and ``help``.
+command group  ``repl`` and ``help``.
 
-A command-group is the name of an object, (ex. ``class`` refers to operation on
+A command group  is the name of an object, (ex. ``class`` refers to operation on
 CIM classes). The commands are generally actions on the objects defined by the
-command-group name (``get``, ``list``, etc.). Thus ``class`` is a command-group
+command group  name (``get``, ``list``, etc.). Thus ``class`` is a command group
 name used to access CIM classes and ``get`` is a command so:
 
 .. code-block:: text
@@ -84,7 +84,7 @@ commands (for operating the pywbemcli shell), and external commands (that are
 executed in the standard shell for the user).
 
 This pywbemcli shell is started when the ``pywbemcli`` command is invoked
-without specifying any command-group or command:
+without specifying any command group  or command:
 
 .. code-block:: text
 
@@ -107,7 +107,7 @@ as the parameters for the connection to a WBEM server and values for the
 pywbemcli commands and arguments that can be typed in the pywbemcli shell.
 
 The pywbemcli commands that can be typed in the pywbemcli shell are the
-command or command-group that would follow the ``pywbemcli`` command and
+command or command group  that would follow the ``pywbemcli`` command and
 general options when used in `command mode`_. The following example
 starts a pywbemcli shell in interactive mode and executes several commands
 (ex. ``class enumerate -o``).
@@ -167,19 +167,19 @@ list of the supported commands.
     . . .
 
     Commands:
-      class      Command-group to manage CIM Classes.
-      instance   Command-Group to manage CIM instances.
-      qualifier  Command-Group to manage CIM...
+      class      Command group to manage CIM Classes.
+      instance   Command group to manage CIM instances.
+      qualifier  Command group to manage CIM...
       repl       Start an interactive shell.
-      server     Command-group for server operations
+      server     Command group for server operations
 
 The usage line in this help text shows the standalone command use. Within the
 pywbemcli shell (interactive mode), the ``pywbemcli`` word is omitted and the
 command and options is typed in.
 
-Typing ``command-group --help``,  or ``command-group -h``, or ``command-group
+Typing ``command group  --help``,  or ``command group  -h``, or ``command group
 command --help`` in the pywbemcli shell displays help information for the
-specified pywbemcli command-group, for example:
+specified pywbemcli command group , for example:
 
 .. code-block:: text
 
@@ -217,11 +217,11 @@ In command mode, the pywbemcli command performs its task and terminates
 like any other standalone non-interactive command.
 
 This mode is used when the pywbemcli command is invoked with a command or
-command-group name and arguments/options:
+command group  name and arguments/options:
 
 .. code-block:: text
 
-    $ pywbemcli [GENERAL-OPTIONS] COMMAND|COMMANDGROUP COMMAND] [ARGS...]
+    $ pywbemcli [GENERAL-OPTIONS] command|command group command] [ARGS...]
 
 The following example defines a WBEM server and then executes ``class enumerate``:
 
@@ -255,5 +255,8 @@ completion:
 
     $ pywbemcli class <TAB><TAB>
     ... <shows the class commands to select from>
+
+The documentation for the python CLI tool click contains information on other
+shell tab completion solutions.
 
 

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -5,11 +5,11 @@ pywbemcli Help Command Details
 ==============================
 
 
-This section defines the help output for each pywbemcli command group and subcommand.
+This section defines the help output for each pywbemcli command-group and command.
 
 
 
-The following defines the help output for the `pywbemcli  --help` subcommand
+The following defines the help output for the `pywbemcli  --help` command
 
 
 ::
@@ -33,7 +33,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
       * Maintain a persistent list of named connections to WBEM servers
         and execute operations on them by name.
 
-      Pywbemcli implements command groups and subcommands to execute the CIM-XML
+      Pywbemcli implements command groups and commands to execute the CIM-XML
       operations defined by the DMTF CIM Operations Over HTTP specification
       (DSP0200).
 
@@ -73,9 +73,10 @@ The following defines the help output for the `pywbemcli  --help` subcommand
       -d, --default-namespace NAMESPACE
                                       Default namespace to use in the target WBEM
                                       server if no namespace is defined in a
-                                      subcommand.
+                                      command.
                                       (EnvVar: PYWBEMCLI_NAME)
-                                      [Default: root/cimv2]
+                                      [Default:
+                                      root/cimv2]
       -u, --user USER                 User name for the WBEM server connection.
                                       (EnvVar: PYWBEMCLI_USER)
       -p, --password PASSWORD         Password for the WBEM server. Will be
@@ -93,9 +94,11 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       WBEM server during the TLS/SSL handshake for
                                       2 way authentication(EnvVar:
                                       PYWBEMCLI_CERTFILE).
-      -k, --keyfile FILE PATH         X.509 client private key file presented to
-                                      the WBEM server during the TLS/SSL handshake
-                                      for 2 way authentication.
+      -k, --keyfile FILE PATH         X.509 client private key file containing
+                                      private key belonging to tpublic key in
+                                      X.509 certificate ``--certfile``. Not
+                                      required if private key is part of
+                                      --certfile file. 
                                       (EnvVar:
                                       PYWBEMCLI_KEYFILE)
       --ca-certs TEXT                 File or directory containing certificates
@@ -114,7 +117,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
                                       /etc/ssl/certificates]
       -o, --output-format <choice>    Choice for command output data format.
                                       pywbemcli may override the format choice
-                                      depending on the command group and command
+                                      depending on the command-group and command
                                       since not all formats apply to all output
                                       data types. Choices further defined in
                                       pywbemcli documentation.
@@ -172,7 +175,7 @@ The following defines the help output for the `pywbemcli  --help` subcommand
       -h, --help                      Show this message and exit.
 
     Commands:
-      class       Command group for CIM classes.
+      class       Command-group for CIM classes.
       connection  Command group for persistent WBEM connections.
       help        Show help message for interactive mode.
       instance    Command group for CIM instances.
@@ -188,16 +191,16 @@ pywbemcli class --help
 
 
 
-The following defines the help output for the `pywbemcli class --help` subcommand
+The following defines the help output for the `pywbemcli class --help` command
 
 
 ::
 
     Usage: pywbemcli class [COMMAND-OPTIONS] COMMAND [ARGS]...
 
-      Command group for CIM classes.
+      Command-group for CIM classes.
 
-      This command group defines commands to inspect classes, to invoke methods
+      This command-group defines commands to inspect classes, to invoke methods
       on classes, and to delete classes.
 
       Creation and modification of classes is not currently supported.
@@ -210,14 +213,14 @@ The following defines the help output for the `pywbemcli class --help` subcomman
       -h, --help  Show this message and exit.
 
     Commands:
-      associators   Get the classes associated with a class.
+      associators   List the classes associated with a class.
       delete        Delete a class.
-      enumerate     Get the top classes or subclasses of a class in a namespace.
-      find          Get the classes with matching class names on the WBEM...
+      enumerate     List the top classes or subclasses of a class in a...
+      find          List the classes with matching class names on the server.
       get           Get a class.
       invokemethod  Invoke a method on a class.
-      references    Get the classes referencing a class.
-      tree          Get the subclass or superclass inheritance tree of a class.
+      references    List the classes referencing a class.
+      tree          Show the subclass or superclass inheritance tree of a class.
 
 
 .. _`pywbemcli class associators --help`:
@@ -227,14 +230,14 @@ pywbemcli class associators --help
 
 
 
-The following defines the help output for the `pywbemcli class associators --help` subcommand
+The following defines the help output for the `pywbemcli class associators --help` command
 
 
 ::
 
     Usage: pywbemcli class associators [COMMAND-OPTIONS] CLASSNAME
 
-      Get the classes associated with a class.
+      List the classes associated with a class.
 
       List the CIM classes that are associated with the specified class
       (CLASSNAME argument) or subclasses thereof in the specified CIM namespace
@@ -247,8 +250,11 @@ The following defines the help output for the `pywbemcli class associators --hel
       The --include-classorigin, --no-qualifiers, and --propertylist options
       determine which parts are included in each retrieved class.
 
-      In the output, the classes will formatted as defined by the --output-
-      format general option.
+      The --names-only option can be used to show only the class paths.
+
+      In the output, the classes and class paths will be formatted as defined by
+      the --output-format general option. Table formats on classes will be
+      replaced with MOF format.
 
       Examples:
 
@@ -309,7 +315,7 @@ pywbemcli class delete --help
 
 
 
-The following defines the help output for the `pywbemcli class delete --help` subcommand
+The following defines the help output for the `pywbemcli class delete --help` command
 
 
 ::
@@ -353,14 +359,14 @@ pywbemcli class enumerate --help
 
 
 
-The following defines the help output for the `pywbemcli class enumerate --help` subcommand
+The following defines the help output for the `pywbemcli class enumerate --help` command
 
 
 ::
 
     Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME
 
-      Get the top classes or subclasses of a class in a namespace.
+      List the top classes or subclasses of a class in a namespace.
 
       Enumerate CIM classes starting either at the top of the class hierarchy in
       the specified CIM namespace (--namespace option), or at the specified
@@ -374,8 +380,11 @@ The following defines the help output for the `pywbemcli class enumerate --help`
       The --deep-inheritance option defines whether or not the complete subclass
       hierarchy of the classes is retrieved.
 
-      In the output, the classes will formatted as defined by the --output-
-      format general option.
+      The --names-only option can be used to show only the class paths.
+
+      In the output, the classes and class paths will be formatted as defined by
+      the --output-format general option. Table formats on classes will be
+      replaced with MOF format.
 
       Examples:
 
@@ -408,14 +417,14 @@ pywbemcli class find --help
 
 
 
-The following defines the help output for the `pywbemcli class find --help` subcommand
+The following defines the help output for the `pywbemcli class find --help` command
 
 
 ::
 
     Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME-GLOB
 
-      Get the classes with matching class names on the WBEM server.
+      List the classes with matching class names on the server.
 
       Find the CIM classes whose class name matches the specified wildcard
       expression (CLASSNAME-GLOB argument) in all CIM namespaces of the WBEM
@@ -430,9 +439,6 @@ The following defines the help output for the `pywbemcli class find --help` subc
       For example, `pywbem_*` returns classes whose name begins with `PyWBEM_`,
       `pywbem_`, etc. '*system*' returns classes whose names include the case
       insensitive string `system`.
-
-      Output is in table format if table output specified. Otherwise it is in
-      the form <namespace>:<classname>
 
       In the output, the classes will formatted as defined by the --output-
       format general option if it specifies table output. Otherwise the classes
@@ -458,7 +464,7 @@ pywbemcli class get --help
 
 
 
-The following defines the help output for the `pywbemcli class get --help` subcommand
+The following defines the help output for the `pywbemcli class get --help` command
 
 
 ::
@@ -475,8 +481,8 @@ The following defines the help output for the `pywbemcli class get --help` subco
       --propertylist options determine which parts are included in each
       retrieved class.
 
-      In the output, the class will formatted as defined by the --output-format
-      general option.
+      In the output, the class will be formatted as defined by the --output-
+      format general option. Table formats are replaced with MOF format.
 
       Example:
 
@@ -513,7 +519,7 @@ pywbemcli class invokemethod --help
 
 
 
-The following defines the help output for the `pywbemcli class invokemethod --help` subcommand
+The following defines the help output for the `pywbemcli class invokemethod --help` command
 
 
 ::
@@ -557,14 +563,14 @@ pywbemcli class references --help
 
 
 
-The following defines the help output for the `pywbemcli class references --help` subcommand
+The following defines the help output for the `pywbemcli class references --help` command
 
 
 ::
 
     Usage: pywbemcli class references [COMMAND-OPTIONS] CLASSNAME
 
-      Get the classes referencing a class.
+      List the classes referencing a class.
 
       List the CIM (association) classes that reference the specified class
       (CLASSNAME argument) or subclasses thereof in the specified CIM namespace
@@ -577,8 +583,11 @@ The following defines the help output for the `pywbemcli class references --help
       The --include-classorigin, --no-qualifiers, and --propertylist options
       determine which parts are included in each retrieved class.
 
-      In the output, the classes will formatted as defined by the --output-
-      format general option.
+      The --names-only option can be used to show only the class paths.
+
+      In the output, the classes and class paths will be formatted as defined by
+      the --output-format general option. Table formats on classes will be
+      replaced with MOF format.
 
       Examples:
 
@@ -625,14 +634,14 @@ pywbemcli class tree --help
 
 
 
-The following defines the help output for the `pywbemcli class tree --help` subcommand
+The following defines the help output for the `pywbemcli class tree --help` command
 
 
 ::
 
     Usage: pywbemcli class tree [COMMAND-OPTIONS] CLASSNAME
 
-      Get the subclass or superclass inheritance tree of a class.
+      Show the subclass or superclass inheritance tree of a class.
 
       List the subclass or superclass hierarchy of a CIM class (CLASSNAME
       argument) or CIM namespace (--namespace option):
@@ -675,7 +684,7 @@ pywbemcli connection --help
 
 
 
-The following defines the help output for the `pywbemcli connection --help` subcommand
+The following defines the help output for the `pywbemcli connection --help` command
 
 
 ::
@@ -698,14 +707,14 @@ The following defines the help output for the `pywbemcli connection --help` subc
       -h, --help  Show this message and exit.
 
     Commands:
-      add     Create a new named WBEM connection.
-      delete  Delete a named WBEM connection.
-      export  Export the current connection information.
-      list    List the entries in the connections file.
-      save    Save current connection to connections file.
-      select  Select a connection from connections file.
-      show    Show current or NAME connection information.
-      test    Execute a predefined WBEM request.
+      add     Add a persistent WBEM connection from specified conn info.
+      delete  Delete a persistent WBEM connection.
+      export  Display the commands for exporting the current connection.
+      list    List the persistent WBEM connections.
+      save    Save current connection as a persistent WBEM connection.
+      select  Interactively select a persistent WBEM connection for use.
+      show    Show connection info of current or persistent WBEM connection.
+      test    Test current connection with a predefined WBEM request.
 
 
 .. _`pywbemcli connection add --help`:
@@ -715,17 +724,17 @@ pywbemcli connection add --help
 
 
 
-The following defines the help output for the `pywbemcli connection add --help` subcommand
+The following defines the help output for the `pywbemcli connection add --help` command
 
 
 ::
 
     Usage: pywbemcli connection add [COMMAND-OPTIONS]
 
-      Create a new named WBEM connection.
+      Add a persistent WBEM connection from specified conn info.
 
-      This subcommand creates and saves a named connection from the input
-      options in the connections file.
+      This command creates and saves a named connection from the input options
+      in the connections file.
 
       The new connection can be referenced by the name argument in the future.
       This connection object is capable of managing all of the properties
@@ -763,7 +772,7 @@ The following defines the help output for the `pywbemcli connection add --help` 
       -d, --default-namespace NAMESPACE
                                       Default namespace to use in the target WBEM
                                       server if no namespace is defined in the
-                                      subcommand (Default: root/cimv2).
+                                      command (Default: root/cimv2).
       -u, --user TEXT                 User name for the WBEM server connection.
       -p, --password TEXT             Password for the WBEM server. Will be
                                       requested as part  of initialization if user
@@ -829,14 +838,14 @@ pywbemcli connection delete --help
 
 
 
-The following defines the help output for the `pywbemcli connection delete --help` subcommand
+The following defines the help output for the `pywbemcli connection delete --help` command
 
 
 ::
 
     Usage: pywbemcli connection delete [COMMAND-OPTIONS] NAME
 
-      Delete a named WBEM connection.
+      Delete a persistent WBEM connection.
 
       Delete connection information from the persistent store for the connection
       defined by NAME. The NAME argument is optional.
@@ -859,17 +868,17 @@ pywbemcli connection export --help
 
 
 
-The following defines the help output for the `pywbemcli connection export --help` subcommand
+The following defines the help output for the `pywbemcli connection export --help` command
 
 
 ::
 
     Usage: pywbemcli connection export [COMMAND-OPTIONS]
 
-      Export the current connection information.
+      Display the commands for exporting the current connection.
 
       Creates an export statement for each connection variable and outputs the
-      statement to the conole.
+      statements to the console.
 
     Options:
       -h, --help  Show this message and exit.
@@ -882,17 +891,17 @@ pywbemcli connection list --help
 
 
 
-The following defines the help output for the `pywbemcli connection list --help` subcommand
+The following defines the help output for the `pywbemcli connection list --help` command
 
 
 ::
 
     Usage: pywbemcli connection list [COMMAND-OPTIONS]
 
-      List the entries in the connections file.
+      List the persistent WBEM connections.
 
-      This subcommand displays all entries in the connections file as a table
-      using the command line output_format to define the table format.
+      This command displays all entries in the connections file as a table using
+      the command line output_format to define the table format.
 
       An "*" after the name indicates the currently selected connection.
 
@@ -907,14 +916,14 @@ pywbemcli connection save --help
 
 
 
-The following defines the help output for the `pywbemcli connection save --help` subcommand
+The following defines the help output for the `pywbemcli connection save --help` command
 
 
 ::
 
     Usage: pywbemcli connection save [COMMAND-OPTIONS]
 
-      Save current connection to connections file.
+      Save current connection as a persistent WBEM connection.
 
       Saves the current connection to the connections file if it does not
       already exist in that file.
@@ -938,14 +947,14 @@ pywbemcli connection select --help
 
 
 
-The following defines the help output for the `pywbemcli connection select --help` subcommand
+The following defines the help output for the `pywbemcli connection select --help` command
 
 
 ::
 
     Usage: pywbemcli connection select [COMMAND-OPTIONS] NAME
 
-      Select a connection from connections file.
+      Interactively select a persistent WBEM connection for use.
 
       Selects a connection from the persistently stored set of named connections
       if NAME exists in the store. The NAME argument is optional.  If NAME not
@@ -971,16 +980,16 @@ pywbemcli connection show --help
 
 
 
-The following defines the help output for the `pywbemcli connection show --help` subcommand
+The following defines the help output for the `pywbemcli connection show --help` command
 
 
 ::
 
     Usage: pywbemcli connection show [COMMAND-OPTIONS] NAME
 
-      Show current or NAME connection information.
+      Show connection info of current or persistent WBEM connection.
 
-      This subcommand displays all the variables that make up the current WBEM
+      This command displays all the variables that make up the current WBEM
       connection if the optional NAME argument is NOT provided. If NAME not
       supplied, a list of connections from the connections definition file is
       presented with a prompt for the user to select a NAME.
@@ -999,14 +1008,14 @@ pywbemcli connection test --help
 
 
 
-The following defines the help output for the `pywbemcli connection test --help` subcommand
+The following defines the help output for the `pywbemcli connection test --help` command
 
 
 ::
 
     Usage: pywbemcli connection test [COMMAND-OPTIONS]
 
-      Execute a predefined WBEM request.
+      Test current connection with a predefined WBEM request.
 
       This executes a predefined request against the current WBEM server to
       confirm that the connection exists and is working.
@@ -1024,7 +1033,7 @@ pywbemcli help --help
 
 
 
-The following defines the help output for the `pywbemcli help --help` subcommand
+The following defines the help output for the `pywbemcli help --help` command
 
 
 ::
@@ -1044,7 +1053,7 @@ pywbemcli instance --help
 
 
 
-The following defines the help output for the `pywbemcli instance --help` subcommand
+The following defines the help output for the `pywbemcli instance --help` command
 
 
 ::
@@ -1053,7 +1062,7 @@ The following defines the help output for the `pywbemcli instance --help` subcom
 
       Command group for CIM instances.
 
-      This command group defines commands to inspect instances, to invoke
+      This command-group  defines commands to inspect instances, to invoke
       methods on instances, and to create and delete instances.
 
       Modification of instances is not currently supported.
@@ -1066,16 +1075,16 @@ The following defines the help output for the `pywbemcli instance --help` subcom
       -h, --help  Show this message and exit.
 
     Commands:
-      associators   Get the instances associated with an instance.
+      associators   List the instances associated with an instance.
       count         Count the instances of each class with matching class name.
       create        Create an instance of a class in a namespace.
       delete        Delete an instance of a class.
-      enumerate     Get the instances of a class.
+      enumerate     List the instances of a class.
       get           Get an instance of a class.
       invokemethod  Invoke a method on an instance.
       modify        Modify an instance of a class.
       query         Execute a query on instances in a namespace.
-      references    Get the instances referencing an instance.
+      references    List the instances referencing an instance.
 
 
 .. _`pywbemcli instance associators --help`:
@@ -1085,14 +1094,14 @@ pywbemcli instance associators --help
 
 
 
-The following defines the help output for the `pywbemcli instance associators --help` subcommand
+The following defines the help output for the `pywbemcli instance associators --help` command
 
 
 ::
 
     Usage: pywbemcli instance associators [COMMAND-OPTIONS] INSTANCENAME
 
-      Get the instances associated with an instance.
+      List the instances associated with an instance.
 
       List the CIM instances that are associated with the specified CIM
       instance, and display the returned instances, or instance paths if
@@ -1119,8 +1128,11 @@ The following defines the help output for the `pywbemcli instance associators --
       The --include-qualifiers, --include-classorigin, and --propertylist
       options determine which parts are included in each retrieved instance.
 
-      In the output, the instances will formatted as defined by the --output-
-      format general option.
+      The --names-only option can be used to show only the instance paths.
+
+      In the output, the instances and instance paths will be formatted as
+      defined by the --output-format general option. Table formats on instances
+      will be replaced with MOF format.
 
     Options:
       -a, --assoc-class <class name>  Filter by the association class name
@@ -1148,13 +1160,13 @@ The following defines the help output for the `pywbemcli instance associators --
                                       matches this parameter). Optional.
       -q, --include-qualifiers        If set, requests server to include
                                       qualifiers in the returned instances. This
-                                      subcommand may use either pull or
-                                      traditional operations depending on the
-                                      server and the "--use-pull" general option.
-                                      If pull operations are used, qualifiers will
-                                      not be included, even if this option is
-                                      specified. If traditional operations are
-                                      used, inclusion of qualifiers depends on the
+                                      command may use either pull or traditional
+                                      operations depending on the server and the "
+                                      --use-pull" general option. If pull
+                                      operations are used, qualifiers will not be
+                                      included, even if this option is specified.
+                                      If traditional operations are used,
+                                      inclusion of qualifiers depends on the
                                       server.
       -c, --include-classorigin       Request that server include classorigin in
                                       the result.On some WBEM operations, server
@@ -1199,7 +1211,7 @@ pywbemcli instance count --help
 
 
 
-The following defines the help output for the `pywbemcli instance count --help` subcommand
+The following defines the help output for the `pywbemcli instance count --help` command
 
 
 ::
@@ -1241,7 +1253,7 @@ pywbemcli instance create --help
 
 
 
-The following defines the help output for the `pywbemcli instance create --help` subcommand
+The following defines the help output for the `pywbemcli instance create --help` command
 
 
 ::
@@ -1287,7 +1299,7 @@ pywbemcli instance delete --help
 
 
 
-The following defines the help output for the `pywbemcli instance delete --help` subcommand
+The following defines the help output for the `pywbemcli instance delete --help` command
 
 
 ::
@@ -1328,14 +1340,14 @@ pywbemcli instance enumerate --help
 
 
 
-The following defines the help output for the `pywbemcli instance enumerate --help` subcommand
+The following defines the help output for the `pywbemcli instance enumerate --help` command
 
 
 ::
 
     Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME
 
-      Get the instances of a class.
+      List the instances of a class.
 
       Enumerate the CIM instances of the specified class (CLASSNAME argument),
       including instances of subclasses in the specified CIM namespace
@@ -1350,12 +1362,15 @@ The following defines the help output for the `pywbemcli instance enumerate --he
       classorigin, and --propertylist options determine which parts are included
       in each retrieved instance.
 
-      In the output, the instances will formatted as defined by the --output-
-      format general option.
+      The --names-only option can be used to show only the instance paths.
+
+      In the output, the instances and instance paths will be formatted as
+      defined by the --output-format general option. Table formats on instances
+      will be replaced with MOF format.
 
     Options:
       -l, --local-only                Show only local properties of the instances.
-                                      This subcommand may use either pull or
+                                      This command may use either pull or
                                       traditional operations depending on the
                                       server and the --use-pull general option. If
                                       pull operations are used, this parameters
@@ -1368,13 +1383,13 @@ The following defines the help output for the `pywbemcli instance enumerate --he
                                       target class are returned
       -q, --include-qualifiers        If set, requests server to include
                                       qualifiers in the returned instances. This
-                                      subcommand may use either pull or
-                                      traditional operations depending on the
-                                      server and the "--use-pull" general option.
-                                      If pull operations are used, qualifiers will
-                                      not be included, even if this option is
-                                      specified. If traditional operations are
-                                      used, inclusion of qualifiers depends on the
+                                      command may use either pull or traditional
+                                      operations depending on the server and the "
+                                      --use-pull" general option. If pull
+                                      operations are used, qualifiers will not be
+                                      included, even if this option is specified.
+                                      If traditional operations are used,
+                                      inclusion of qualifiers depends on the
                                       server.
       -c, --include-classorigin       Request that server include classorigin in
                                       the result.On some WBEM operations, server
@@ -1414,7 +1429,7 @@ pywbemcli instance get --help
 
 
 
-The following defines the help output for the `pywbemcli instance get --help` subcommand
+The following defines the help output for the `pywbemcli instance get --help` command
 
 
 ::
@@ -1477,7 +1492,7 @@ pywbemcli instance invokemethod --help
 
 
 
-The following defines the help output for the `pywbemcli instance invokemethod --help` subcommand
+The following defines the help output for the `pywbemcli instance invokemethod --help` command
 
 
 ::
@@ -1541,7 +1556,7 @@ pywbemcli instance modify --help
 
 
 
-The following defines the help output for the `pywbemcli instance modify --help` subcommand
+The following defines the help output for the `pywbemcli instance modify --help` command
 
 
 ::
@@ -1610,7 +1625,7 @@ pywbemcli instance query --help
 
 
 
-The following defines the help output for the `pywbemcli instance query --help` subcommand
+The following defines the help output for the `pywbemcli instance query --help` command
 
 
 ::
@@ -1643,14 +1658,14 @@ pywbemcli instance references --help
 
 
 
-The following defines the help output for the `pywbemcli instance references --help` subcommand
+The following defines the help output for the `pywbemcli instance references --help` command
 
 
 ::
 
     Usage: pywbemcli instance references [COMMAND-OPTIONS] INSTANCENAME
 
-      Get the instances referencing an instance.
+      List the instances referencing an instance.
 
       List the CIM (association) instances that reference the specified CIM
       instance, and display the returned instances, or instance paths if
@@ -1677,8 +1692,11 @@ The following defines the help output for the `pywbemcli instance references --h
       The --include-qualifiers, --include-classorigin, and --propertylist
       options determine which parts are included in each retrieved instance.
 
-      In the output, the instances will formatted as defined by the --output-
-      format general option.
+      The --names-only option can be used to show only the instance paths.
+
+      In the output, the instances and instance paths will be formatted as
+      defined by the --output-format general option. Table formats on instances
+      will be replaced with MOF format.
 
     Options:
       -R, --resultclass <class name>  Filter by the result class name provided.
@@ -1692,13 +1710,13 @@ The following defines the help output for the `pywbemcli instance references --h
                                       of this parameter. Optional.
       -q, --include-qualifiers        If set, requests server to include
                                       qualifiers in the returned instances. This
-                                      subcommand may use either pull or
-                                      traditional operations depending on the
-                                      server and the "--use-pull" general option.
-                                      If pull operations are used, qualifiers will
-                                      not be included, even if this option is
-                                      specified. If traditional operations are
-                                      used, inclusion of qualifiers depends on the
+                                      command may use either pull or traditional
+                                      operations depending on the server and the "
+                                      --use-pull" general option. If pull
+                                      operations are used, qualifiers will not be
+                                      included, even if this option is specified.
+                                      If traditional operations are used,
+                                      inclusion of qualifiers depends on the
                                       server.
       -c, --include-classorigin       Request that server include classorigin in
                                       the result.On some WBEM operations, server
@@ -1743,7 +1761,7 @@ pywbemcli qualifier --help
 
 
 
-The following defines the help output for the `pywbemcli qualifier --help` subcommand
+The following defines the help output for the `pywbemcli qualifier --help` command
 
 
 ::
@@ -1752,7 +1770,7 @@ The following defines the help output for the `pywbemcli qualifier --help` subco
 
       Command group for CIM qualifier declarations.
 
-      This command group defines commands to inspect qualifier declarations.
+      This command-group  defines commands to inspect qualifier declarations.
 
       Creation, modification and deletion of qualifier declarations is not
       currently supported.
@@ -1765,8 +1783,8 @@ The following defines the help output for the `pywbemcli qualifier --help` subco
       -h, --help  Show this message and exit.
 
     Commands:
-      enumerate  List the CIM qualifier declarations in a CIM namespace.
-      get        Get a CIM qualifier declaration.
+      enumerate  List the qualifier declarations in a namespace.
+      get        Get a qualifier declaration.
 
 
 .. _`pywbemcli qualifier enumerate --help`:
@@ -1776,14 +1794,14 @@ pywbemcli qualifier enumerate --help
 
 
 
-The following defines the help output for the `pywbemcli qualifier enumerate --help` subcommand
+The following defines the help output for the `pywbemcli qualifier enumerate --help` command
 
 
 ::
 
     Usage: pywbemcli qualifier enumerate [COMMAND-OPTIONS]
 
-      List the CIM qualifier declarations in a CIM namespace.
+      List the qualifier declarations in a namespace.
 
       Enumerate the CIM qualifier declarations in the specified CIM namespace
       (--namespace option). If no namespace was specified, the default namespace
@@ -1806,14 +1824,14 @@ pywbemcli qualifier get --help
 
 
 
-The following defines the help output for the `pywbemcli qualifier get --help` subcommand
+The following defines the help output for the `pywbemcli qualifier get --help` command
 
 
 ::
 
     Usage: pywbemcli qualifier get [COMMAND-OPTIONS] QUALIFIERNAME
 
-      Get a CIM qualifier declaration.
+      Get a qualifier declaration.
 
       Get a CIM qualifier declaration (QUALIFIERNAME argument) in a CIM
       namespace (--namespace option). If no namespace was specified, the default
@@ -1835,7 +1853,7 @@ pywbemcli repl --help
 
 
 
-The following defines the help output for the `pywbemcli repl --help` subcommand
+The following defines the help output for the `pywbemcli repl --help` command
 
 
 ::
@@ -1844,7 +1862,7 @@ The following defines the help output for the `pywbemcli repl --help` subcommand
 
       Enter interactive mode (default).
 
-      Enters the interactive mode where subcommands can be entered interactively
+      Enters the interactive mode where commands can be entered interactively
       and load the command history file.
 
       If no options are specified on the command line, the interactive mode is
@@ -1869,7 +1887,7 @@ pywbemcli server --help
 
 
 
-The following defines the help output for the `pywbemcli server --help` subcommand
+The following defines the help output for the `pywbemcli server --help` command
 
 
 ::
@@ -1890,13 +1908,13 @@ The following defines the help output for the `pywbemcli server --help` subcomma
       -h, --help  Show this message and exit.
 
     Commands:
-      brand             Display the brand of the server.
-      connection        Display connection info used by this server.
-      get-centralinsts  Get central instances of mgmt profiles on the server.
-      info              Display information about the server.
-      interop           Display the Interop namespace of the server.
-      namespaces        Display the namespaces of the server.
-      profiles          Display management profiles advertized by the server.
+      brand             Get the brand of the server.
+      connection        Get connection info used by this server.
+      get-centralinsts  List central instances of mgmt profiles on the server.
+      info              Get information about the server.
+      interop           Get the Interop namespace of the server.
+      namespaces        List the namespaces of the server.
+      profiles          List management profiles advertized by the server.
 
 
 .. _`pywbemcli server brand --help`:
@@ -1906,14 +1924,14 @@ pywbemcli server brand --help
 
 
 
-The following defines the help output for the `pywbemcli server brand --help` subcommand
+The following defines the help output for the `pywbemcli server brand --help` command
 
 
 ::
 
     Usage: pywbemcli server brand [COMMAND-OPTIONS]
 
-      Display the brand of the server.
+      Get the brand of the server.
 
       Brand information is defined by the server implementor and may or may not
       be available. Pywbem attempts to collect the brand information from
@@ -1930,19 +1948,19 @@ pywbemcli server connection --help
 
 
 
-The following defines the help output for the `pywbemcli server connection --help` subcommand
+The following defines the help output for the `pywbemcli server connection --help` command
 
 
 ::
 
     Usage: pywbemcli server connection [COMMAND-OPTIONS]
 
-      Display connection info used by this server.
+      Get connection info used by this server.
 
       Display the information about the connection used to connect to the WBEM
       server.
 
-      This is equivalent to the 'connection show' subcommand.
+      This is equivalent to the 'connection show' command.
 
     Options:
       -h, --help  Show this message and exit.
@@ -1955,14 +1973,14 @@ pywbemcli server get-centralinsts --help
 
 
 
-The following defines the help output for the `pywbemcli server get-centralinsts --help` subcommand
+The following defines the help output for the `pywbemcli server get-centralinsts --help` command
 
 
 ::
 
     Usage: pywbemcli server get-centralinsts [COMMAND-OPTIONS]
 
-      Get central instances of mgmt profiles on the server.
+      List central instances of mgmt profiles on the server.
 
       Retrieve the CIM instances that are central instances of the specified
       WBEM management profiles, and display these instances. By default, all
@@ -2008,14 +2026,14 @@ pywbemcli server info --help
 
 
 
-The following defines the help output for the `pywbemcli server info --help` subcommand
+The following defines the help output for the `pywbemcli server info --help` command
 
 
 ::
 
     Usage: pywbemcli server info [COMMAND-OPTIONS]
 
-      Display information about the server.
+      Get information about the server.
 
       The information includes CIM namespaces and server brand.
 
@@ -2030,14 +2048,14 @@ pywbemcli server interop --help
 
 
 
-The following defines the help output for the `pywbemcli server interop --help` subcommand
+The following defines the help output for the `pywbemcli server interop --help` command
 
 
 ::
 
     Usage: pywbemcli server interop [COMMAND-OPTIONS]
 
-      Display the Interop namespace of the server.
+      Get the Interop namespace of the server.
 
     Options:
       -h, --help  Show this message and exit.
@@ -2050,14 +2068,14 @@ pywbemcli server namespaces --help
 
 
 
-The following defines the help output for the `pywbemcli server namespaces --help` subcommand
+The following defines the help output for the `pywbemcli server namespaces --help` command
 
 
 ::
 
     Usage: pywbemcli server namespaces [COMMAND-OPTIONS]
 
-      Display the namespaces of the server.
+      List the namespaces of the server.
 
     Options:
       -s, --sort  Sort into alphabetical order by classname.
@@ -2071,14 +2089,14 @@ pywbemcli server profiles --help
 
 
 
-The following defines the help output for the `pywbemcli server profiles --help` subcommand
+The following defines the help output for the `pywbemcli server profiles --help` command
 
 
 ::
 
     Usage: pywbemcli server profiles [COMMAND-OPTIONS]
 
-      Display management profiles advertized by the server.
+      List management profiles advertized by the server.
 
       Retrieve the CIM instances representing the WBEM management profiles
       advertized by the WBEM server, and display information about each profile.

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -5,7 +5,7 @@ pywbemcli Help Command Details
 ==============================
 
 
-This section defines the help output for each pywbemcli command-group and command.
+This section defines the help output for each pywbemcli command group and command.
 
 
 
@@ -117,7 +117,7 @@ The following defines the help output for the `pywbemcli  --help` command
                                       /etc/ssl/certificates]
       -o, --output-format <choice>    Choice for command output data format.
                                       pywbemcli may override the format choice
-                                      depending on the command-group and command
+                                      depending on the command group and command
                                       since not all formats apply to all output
                                       data types. Choices further defined in
                                       pywbemcli documentation.
@@ -175,7 +175,7 @@ The following defines the help output for the `pywbemcli  --help` command
       -h, --help                      Show this message and exit.
 
     Commands:
-      class       Command-group for CIM classes.
+      class       Command group for CIM classes.
       connection  Command group for persistent WBEM connections.
       help        Show help message for interactive mode.
       instance    Command group for CIM instances.
@@ -198,9 +198,9 @@ The following defines the help output for the `pywbemcli class --help` command
 
     Usage: pywbemcli class [COMMAND-OPTIONS] COMMAND [ARGS]...
 
-      Command-group for CIM classes.
+      Command group for CIM classes.
 
-      This command-group defines commands to inspect classes, to invoke methods
+      This command group defines commands to inspect classes, to invoke methods
       on classes, and to delete classes.
 
       Creation and modification of classes is not currently supported.
@@ -1062,7 +1062,7 @@ The following defines the help output for the `pywbemcli instance --help` comman
 
       Command group for CIM instances.
 
-      This command-group  defines commands to inspect instances, to invoke
+      This command group  defines commands to inspect instances, to invoke
       methods on instances, and to create and delete instances.
 
       Modification of instances is not currently supported.
@@ -1770,7 +1770,8 @@ The following defines the help output for the `pywbemcli qualifier --help` comma
 
       Command group for CIM qualifier declarations.
 
-      This command-group  defines commands to inspect qualifier declarations.
+      This command group  defines commands to inspect CIM qualifier declarations
+      in the WBEM Server.
 
       Creation, modification and deletion of qualifier declarations is not
       currently supported.

--- a/docs/pywbemclicommands.rst
+++ b/docs/pywbemclicommands.rst
@@ -14,13 +14,13 @@
 ..
 
 
-.. _`Pywbemcli command groups, commands, and subcommands`:
+.. _`Pywbemcli command groups and commands`:
 
-Pywbemcli command groups, commands, and subcommands
-===================================================
+Pywbemcli command groups and commands
+=====================================
 
 This section defines the characteristics of each of the pywbemcli command
-groups and subcommands including examples.
+groups and commands including examples.
 
 The command syntax of pywbemcli is:
 
@@ -32,7 +32,7 @@ where:
 
 .. code-block:: text
 
-        cmd-group := <command> <subcommand>
+        cmd-group := <command-group name> <command>
 
 Within pywbemcli each command-group name is a noun, referencing an entity (ex.
 class, instance, server).
@@ -122,7 +122,7 @@ The following table defines which pywbemcli commands are used for the
 corresponding pywbem request operations.
 
 =================================  ==============================================
-WBEM CIM-XML Operation             pywbemcli command-group & subcommand
+WBEM CIM-XML Operation             pywbemcli command-group & command
 =================================  ==============================================
 **Instance Operations:**
 EnumerateInstances                 instance enumerate INSTANCENAME
@@ -181,7 +181,7 @@ Displaying CIM instances or CIM instance names
 The pywbem API includes different WBEM operations (ex. ``EnumerateInstances`` and
 ``EnumerateInstanceNames``) to request CIM objects or just their names. To
 simplify the overall command line syntax pywbemcli combines these into a single
-subcommand (i.e. ``enumerate``, ``references``, ``associators``) and includes
+command (i.e. ``enumerate``, ``references``, ``associators``) and includes
 an option (``-o,`` or ``--names-only``) that determines whether the instance
 names or instances are retrieved from the WBEM server.
 
@@ -218,7 +218,7 @@ Thus, for example an ``instance enumerate`` with and without the ``-o`` option:
 Interactively selecting INSTANCENAME
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Arguments like the INSTANCENAME on some of the instance group subcommands (
+Arguments like the INSTANCENAME on some of the instance group commands (
 ``get``, ``references``, ``associators``, etc) can be very difficult to correctly enter
 since it can involve multiple keybindings, use of quotation marks, etc.  To
 simplify this pywbemcli includes a option (``-i`` or ``--interactive``) on
@@ -245,15 +245,15 @@ from which an instance name can be chosen. The following is an example:
 Class command-group
 -------------------
 
-The **class** group defines subcommands that act on CIM classes. see
+The **class** group defines commands that act on CIM classes. see
 :ref:`pywbemcli class --help`. This group includes the following commands:
 
 * **associators** to retrieve the class associators classes or classnames if the
   (``-o``/``--names-only``) option is set for a class defined by the CLASSNAME
-  argument in the namespace with this subcommand or the default
+  argument in the namespace with this command or the default
   namespace and displayed in the defined format. If successful it displays the
   classes/classnames in the :term:`CIM model output formats` (see
-  :ref:`Output formats`). If unsuccesful it an exception. This subcommand
+  :ref:`Output formats`). If unsuccesful it an exception. This command
   returns the class associators, not the instance associators. The
   :ref:`Instance command-group` includes the corresponding associators
   operation for instances:
@@ -267,7 +267,7 @@ The **class** group defines subcommands that act on CIM classes. see
   See :ref:`pywbemcli class associators --help` for details.
 * **references** to get the class level reference classes or classnames for a
   class defined by the CLASSNAME argument in the default namespace or the namespace
-  defined with this subcommand displayed in the defined format. If successful
+  defined with this command displayed in the defined format. If successful
   it displays the classes/classnames in the :term:`CIM model output formats`
   (see :ref:`Output formats`). If unsuccesful it an exception.. This returns
   the class level references,not the instance references. The :ref:`Instance
@@ -296,7 +296,7 @@ The **class** group defines subcommands that act on CIM classes. see
   Pywbemcli will not delete a class that has subclasses.
   See :ref:`pywbemcli class delete --help` for details.
 * **enumerate** to enumerate classes or their classnames in the default
-  namespace or the namespace defined with this subcommand. If the CLASSNAME
+  namespace or the namespace defined with this command. If the CLASSNAME
   input property the enumeration starts at the subclasses of CLASSNAME. Otherwise
   it starts at the top of the class hierarchy if the
   ``--DeepInheritance``/``-d``  option is set it shows all the classes in the
@@ -319,7 +319,7 @@ The **class** group defines subcommands that act on CIM classes. see
   See :ref:`pywbemcli class enumerate --help` for details.
 * **find** to find classes in the target WBEM server across multiple namespaces.
   The input argument is a GLOB expression which is used to search the server
-  CIM namespaces for matching class names.  This subcommand uses a :term:`GLOB`
+  CIM namespaces for matching class names.  This command uses a :term:`GLOB`
   Unix style pathname pattern expansion on the classname to attempt to filter
   the names and namespaces of all of the classes in the WBEM server (or the
   namespaces defined with the ``--namespaces``/``-n`` option):
@@ -347,7 +347,7 @@ The **class** group defines subcommands that act on CIM classes. see
 
   See :ref:`pywbemcli class find --help` for details.
 * **get** to get a single class defined by the required CLASSNAME argument in the
-  default namespace or the namespace defined with this subcommand displayed in
+  default namespace or the namespace defined with this command displayed in
   the format defined by the ``--output-format``/``-o`` general option. If
   successul it displays the returned class, otherwise it displays the exception
   generated.  It can display the classes/classnames in the :term:`CIM model
@@ -397,7 +397,7 @@ The **class** group defines subcommands that act on CIM classes. see
 
   See :ref:`pywbemcli class get --help` for details.
 * **invokemethod** to invoke a method defined for the CLASSNAME argument. This
-  subcommand executes the invokemethod with a class name, not an instance name
+  command executes the invokemethod with a class name, not an instance name
   and any input parameters for the InvokeMethod defined with the
   ``--parameter``\`-p`` option. If successful it returns the method return
   value and output parameters received from the server. If unsuccessful it
@@ -405,7 +405,7 @@ The **class** group defines subcommands that act on CIM classes. see
   any returned CIM parameters in the :term:`CIM model
   output formats` (see :ref:`Output formats`)See :ref:`pywbemcli class invokemethod
   --help` for details.
-* **tree** to display the class hierarchy as a tree.  This subcommand
+* **tree** to display the class hierarchy as a tree.  This command
   outputs a tree format in ASCII defining the either the subclass or superclass
   hierarchy of the class name input parameter as a tree:
 
@@ -421,7 +421,7 @@ The **class** group defines subcommands that act on CIM classes. see
   It can show either the subclasses or the superclasses of the defined class
   using the (``--superclasses`` option).
 
-  This subcommand ignores the ``--output-format``\``-o' general option and
+  This command ignores the ``--output-format``\``-o' general option and
   always outputs the tree format.
 
   See :ref:`pywbemcli class tree --help` for details.
@@ -432,13 +432,13 @@ The **class** group defines subcommands that act on CIM classes. see
 Instance command-group
 ----------------------
 
-The **instance** group defines subcommands that act on CIM instances including:
+The **instance** group defines commands that act on CIM instances including:
 
 * **associators** to get the associator instances for the instance name defined
   as the :term:`INSTANCENAME` argument in the default namespace or the namespace defined with this
-  subcommand displayed in the defined format. If successful it returns the
+  command displayed in the defined format. If successful it returns the
   instances or instancenames associated with INSTANCENAME otherwise it returns any
-  exception generated by the response This subcommand displays the returned instances
+  exception generated by the response This command displays the returned instances
   or instance in the :term:`CIM model output formats` or the table formats` (see
   :ref:`Output formats`).:
 
@@ -482,13 +482,13 @@ The **instance** group defines subcommands that act on CIM instances including:
   subclasses.
 
   Count is useful to determine which classes in the environment are actually
-  implemented. However this subcommand can take a long time to execute because
+  implemented. However this command can take a long time to execute because
   it must a) enumerate all the classes in the namespaces, b) enumerate the
   instances for each class.
 
   See :ref:`pywbemcli instance count --help` for details.
 * **create** create a CIMInstance of the CLASSNAME argument in a namespace
-  defined with as an option to the subcommand or the default namespace in the
+  defined with as an option to the command or the default namespace in the
   WBEM server. The command build the CIMInstance from the class defined by
   CLASSNAME and the properties defined by the ``--property``\``-p`` option The
   properties are defined as name/value pairs, one property for each instance of
@@ -552,7 +552,7 @@ The **instance** group defines subcommands that act on CIM instances including:
   See :ref:`pywbemcli instance delete --help` for details.
 * **enumerate** to enumerate instances or their paths defined by the CLASSNAME
   argument in the namespace defined by ``-o``\``--namespace`` or the general option
-  ``-o``\``--default-namespace`` in the defined format. This subcommand displays the
+  ``-o``\``--default-namespace`` in the defined format. This command displays the
   returned instances or instance names in the :term:`CIM model output formats`
   or the table formats` (see :ref:`Output formats`).
 
@@ -574,7 +574,7 @@ The **instance** group defines subcommands that act on CIM instances including:
   See :ref:`pywbemcli instance enumerate --help` for details.
 * **get** to get a single CIM instance defined by the :term:`INSTANCENAME`
     argument from the default namespace or the namespace defined with the
-    subcommand displayed in the defined format. The form of :term:`INSTANCENAME` is
+    command displayed in the defined format. The form of :term:`INSTANCENAME` is
     determined by the ``--interactive`` option. It can display the returned
     instance in the :term:`CIM model output formats` or the table formats`
     (see :ref:`Output formats`). Otherwise it returns the received exception.
@@ -596,17 +596,17 @@ The **instance** group defines subcommands that act on CIM instances including:
 * **modify** modify an existing instance of the class defined by the CLASSNAME argument
   in the WBEM server  namespace defined by either the default namespace or
   namespace option. The user provides the definition of an instance in the same
-  form as the ``add`` subcommand but the instance must already exist in the
+  form as the ``add`` command but the instance must already exist in the
   WBEM server and the instance created from the command line must include all
   of the key properties so that it can be identified in the server.
 
-  If successful, this subcommand displays nothing, otherwise it displays the
+  If successful, this command displays nothing, otherwise it displays the
   received exception.
 
   See :ref:`pywbemcli instance modify --help` for details.
 * **references** to get the reference instances or paths for a
   instance defined as the :term:`INSTANCENAME` input argument in the default
-  namespace or the namespace defined with this subcommand displayed in the
+  namespace or the namespace defined with this command displayed in the
   defined format. It can display any returned instances in the
   :term:`CIM model output formats` or the table formats`
   (see :ref:`Output formats`). Otherwise it returns the received exception.:
@@ -637,7 +637,7 @@ The **instance** group defines subcommands that act on CIM instances including:
 Qualifier command-group
 -----------------------
 
-The **qualifier** command-group defines subcommands that act on
+The **qualifier** command-group defines commands that act on
 CIMQualifierDeclaration entities in the WBEM server including:
 
 * **get** to get a single qualifier declaration defined by the ``QUALIFIERNAME``
@@ -659,7 +659,7 @@ CIMQualifierDeclaration entities in the WBEM server including:
   See :ref:`pywbemcli qualifier get --help` for details.
 
 * **enumerate** to enumerate all qualifier declarations within the namespace
-  defined with this subcommand or the default namespace in the target WBEM
+  defined with this command or the default namespace in the target WBEM
   server . The output formats can be either one  of the
   :term:`CIM model output formats` or the table formats`
   (see :ref:`Output formats`).
@@ -695,15 +695,15 @@ CIMQualifierDeclaration entities in the WBEM server including:
 Server command-group
 --------------------
 
-The **server** command-group defines subcommands that interact with a WBEM
-server to access information about the WBEM server itself. These subcommands
+The **server** command-group defines commands that interact with a WBEM
+server to access information about the WBEM server itself. These commands
 are generally not namespace specific but access information about the server,
-namespaces, etc. The subcommands are:
+namespaces, etc. The commands are:
 
 * **brand** to get general information on the server.  Brand information is an
   attempt by pywbem and pywbemtools to determine the product that represents
   the WBEM server infrastructure.  Since that was not clearly defined in the DMTF
-  specifications, this subcommand may return strange results but it returns
+  specifications, this command may return strange results but it returns
   legitimate results for most servers:
 
   .. code-block:: text
@@ -733,7 +733,7 @@ namespaces, etc. The subcommands are:
     ca_certs: None
 
   See :ref:`pywbemcli server connection --help` for details.
-* **info** to get general information on the server.  This subcommand returns
+* **info** to get general information on the server.  This command returns
   information on the brand, namespaces, and other reasonable information on the
   WBEM server:
 
@@ -872,7 +872,7 @@ namespaces, etc. The subcommands are:
 Connection command-group
 ------------------------
 
-The **connection** command-group defines subcommands that provide for a
+The **connection** command-group defines commands that provide for a
 persistent file (:term:`connections file`) of WBEM server connection
 parameters and allow selecting entries in this file as well as adding entries
 to the file, deleting entries from the file and viewing WBEM servers defined in the
@@ -881,10 +881,10 @@ rather than through the detailed parameters of the connection.
 
 Connections in the :term:`connections file` can be created by:
 
-* Using the ``connection add`` subcommand. This allows defining the parameters
-  of a connection as a subcommand.
+* Using the ``connection add`` command. This allows defining the parameters
+  of a connection as a command.
 
-* Using the ``connection save`` subcommand with the current connection. This options
+* Using the ``connection save`` command with the current connection. This options
   uses the parameters current connection to define and save a connection in the
   connections file.
 
@@ -921,15 +921,15 @@ The :term:`connections file` is named ``pywbemcliservers.json`` in the directory
 in which pywbemcli is executed. The data is stored in JSON format within this
 file.  Multiple connection files may be maintained in separate directories.
 
-The subcommands include:
+The commands include:
 
-* **add** creates a new connection using the subcommand arguments and sets the new
-  connection as the current connection. This subcommand saves the
+* **add** creates a new connection using the command arguments and sets the new
+  connection as the current connection. This command saves the
   new connection to the :term:`connections file` (see ``connection save``).
 
   The following example shows creating a new connection from within the
   interactive mode of pywbemcli. The parameters for the connection are defined
-  through the input options for the subcommand. These use the same option names
+  through the input options for the command. These use the same option names
   as the corresponding general options to define the WBEM server:
 
   .. code-block:: text
@@ -957,7 +957,7 @@ The subcommands include:
 
   See :ref:`pywbemcli connection add --help` for details.
 * **delete** delete a specific connection by name or by selection. The following
-  example deletes the connection defined in the add subcommand above:
+  example deletes the connection defined in the add command above:
 
   .. code-block:: text
 
@@ -1030,7 +1030,7 @@ The subcommands include:
 
   See :ref:`pywbemcli connection select --help` for details.
 * **show** show information in the current connection.  See the the ``select``
-  above for an example of this subcommand.
+  above for an example of this command.
 
   See :ref:`pywbemcli connection show --help` for details.
 * **test** execute a single predefined operation on the current connection
@@ -1088,6 +1088,6 @@ Help command
 
 The help command provides information on special commands and controls that can
 be executed in the :ref:`interactive mode`. This is different from the
-``--help`` option that provides information on command groups, and subcommands.
+``--help`` option that provides information on command groups, and commands.
 
 

--- a/docs/pywbemclicommands.rst
+++ b/docs/pywbemclicommands.rst
@@ -32,9 +32,9 @@ where:
 
 .. code-block:: text
 
-        cmd-group := <command-group name> <command>
+        cmd-group := <command group  name> <command>
 
-Within pywbemcli each command-group name is a noun, referencing an entity (ex.
+Within pywbemcli each command group  name is a noun, referencing an entity (ex.
 class, instance, server).
 
 .. code-block:: text
@@ -122,7 +122,7 @@ The following table defines which pywbemcli commands are used for the
 corresponding pywbem request operations.
 
 =================================  ==============================================
-WBEM CIM-XML Operation             pywbemcli command-group & command
+WBEM CIM-XML Operation             pywbemcli command group  & command
 =================================  ==============================================
 **Instance Operations:**
 EnumerateInstances                 instance enumerate INSTANCENAME
@@ -240,9 +240,9 @@ from which an instance name can be chosen. The following is an example:
     };
 
 
-.. _`Class command-group`:
+.. _`Class command group`:
 
-Class command-group
+Class command group
 -------------------
 
 The **class** group defines commands that act on CIM classes. see
@@ -255,7 +255,7 @@ The **class** group defines commands that act on CIM classes. see
   classes/classnames in the :term:`CIM model output formats` (see
   :ref:`Output formats`). If unsuccesful it an exception. This command
   returns the class associators, not the instance associators. The
-  :ref:`Instance command-group` includes the corresponding associators
+  :ref:`Instance command group` includes the corresponding associators
   operation for instances:
 
   .. code-block:: text
@@ -266,12 +266,13 @@ The **class** group defines commands that act on CIM classes. see
 
   See :ref:`pywbemcli class associators --help` for details.
 * **references** to get the class level reference classes or classnames for a
-  class defined by the CLASSNAME argument in the default namespace or the namespace
-  defined with this command displayed in the defined format. If successful
-  it displays the classes/classnames in the :term:`CIM model output formats`
-  (see :ref:`Output formats`). If unsuccesful it an exception.. This returns
-  the class level references,not the instance references. The :ref:`Instance
-  command-group` includes a corresponding instance references operation:
+  class defined by the CLASSNAME argument in the default namespace or the
+  namespace defined with this command displayed in the defined format. If
+  successful it displays the classes/classnames in the :term:`CIM model output
+  formats` (see :ref:`Output formats`). If unsuccesful it an exception.. This
+  returns the class level references,not the instance references. The
+  :ref:`Instance command group` includes a corresponding instance references
+  operation:
 
   .. code-block:: text
 
@@ -427,9 +428,9 @@ The **class** group defines commands that act on CIM classes. see
   See :ref:`pywbemcli class tree --help` for details.
 
 
-.. _`Instance command-group`:
+.. _`Instance command group`:
 
-Instance command-group
+Instance command group
 ----------------------
 
 The **instance** group defines commands that act on CIM instances including:
@@ -632,12 +633,12 @@ The **instance** group defines commands that act on CIM instances including:
   output formats` or the table formats` (see :ref:`Output formats`)
   See :ref:`pywbemcli instance query --help` for details.
 
-.. _`qualifier command-group`:
+.. _`qualifier command group`:
 
-Qualifier command-group
+Qualifier command group
 -----------------------
 
-The **qualifier** command-group defines commands that act on
+The **qualifier** command group  defines commands that act on
 CIMQualifierDeclaration entities in the WBEM server including:
 
 * **get** to get a single qualifier declaration defined by the ``QUALIFIERNAME``
@@ -690,12 +691,12 @@ CIMQualifierDeclaration entities in the WBEM server including:
 
   See :ref:`pywbemcli qualifier enumerate --help` for details.
 
-.. _`Server command-group`:
+.. _`Server command group`:
 
-Server command-group
+Server command group
 --------------------
 
-The **server** command-group defines commands that interact with a WBEM
+The **server** command group  defines commands that interact with a WBEM
 server to access information about the WBEM server itself. These commands
 are generally not namespace specific but access information about the server,
 namespaces, etc. The commands are:
@@ -867,12 +868,12 @@ namespaces, etc. The commands are:
 
   See :ref:`pywbemcli server get-centralinsts --help` for details.
 
-.. _`Connection command-group`:
+.. _`Connection command group`:
 
-Connection command-group
+Connection command group
 ------------------------
 
-The **connection** command-group defines commands that provide for a
+The **connection** command group  defines commands that provide for a
 persistent file (:term:`connections file`) of WBEM server connection
 parameters and allow selecting entries in this file as well as adding entries
 to the file, deleting entries from the file and viewing WBEM servers defined in the
@@ -1070,7 +1071,7 @@ started in the :ref:`interactive mode` either by entering:
    Enter 'help' for help, <CTRL-D> or ':q' to exit pywbemcli.
    pywbemcli>
 
-or by executing the script without any command or command-group:
+or by executing the script without any command or command group :
 
   .. code-block:: text
 

--- a/docs/pywbemcligeneraloptions.rst
+++ b/docs/pywbemcligeneraloptions.rst
@@ -9,7 +9,7 @@ Pywbemcli command line general options
 General options overview
 ------------------------
 
-The general options are entered before the command-group or command. They
+The general options are entered before the command group  or command. They
 define:
 
 * Characteristics of the WBEM server against which the commands are to be
@@ -118,14 +118,14 @@ Details`):
      $ pywbemcli --name myserver class get CIM_ManagedElement
        <<... returns mof for CIM_ManagedElement>>>
 
-  See :ref:`Connection command-group` for more information on managing
+  See :ref:`Connection command group ` for more information on managing
   connections.
 * **--default-namespace/-d** - Default :term:`CIM namespace` to use in the target
   WBEM server if no namespace is defined in a command. If not defined the
   pywbemcli default is ``root/cimv2``.  This is the namespace used on all
   server operation requests unless a specific namespace is defined by:
 
-  * In the interactive mode prepending the command-group name with the
+  * In the interactive mode prepending the command group  name with the
     ``--namespace`` option.
   * Using the ``--namespace/-n`` command option to define a namespace
     on commands that specify this option.
@@ -743,7 +743,7 @@ pywbemcli.log as follows showing the input parameters to the pywbem method
 Pywbemcli persisted connection definitions
 ------------------------------------------
 
-Pywbemcli can manage connections via the :ref:`connection command-group`. These
+Pywbemcli can manage connections via the :ref:`connection command group `. These
 connections are persisted in a :term:`connections file` named
 `pywbemcli_connections.json` in the current directory. A connection has a name
 and defines all parameters necessary to connect to a WBEM server. Once defined

--- a/docs/pywbemcligeneraloptions.rst
+++ b/docs/pywbemcligeneraloptions.rst
@@ -86,7 +86,7 @@ Details`):
   ``--mock-server`` option since each defines a connection to a WBEM server.
 
   In the interactive mode this connection is not actually executed until a
-  command or subcommand requiring access to the WBEM server is entered.
+  command requiring access to the WBEM server is entered.
 
   Examples for the `URL` parameter of this option:
 
@@ -128,7 +128,7 @@ Details`):
   * In the interactive mode prepending the command-group name with the
     ``--namespace`` option.
   * Using the ``--namespace/-n`` command option to define a namespace
-    on subcommands that specify this option.
+    on commands that specify this option.
   * Executing a command that looks in multiple namespaces (ex. ``class find``).
 * **--user/-u** - User name for the WBEM server if a user name is required to
   authenticate the client.
@@ -163,7 +163,7 @@ Details`):
   file defined by ``--certfile``.
 * **--output-format/-o** - Output format choice (Default: mof).
   Note that the actual output format may differ from this value because some
-  subcommands only allow selected formats.  See :ref:`Output formats` for
+  commands only allow selected formats.  See :ref:`Output formats` for
   detailed information on the output formats.
 * **--use-pull-ops** [ ``yes`` | ``no`` | ``either`` ] - Determines
   whether the pull operations are used for ``EnumerateInstances``,
@@ -248,8 +248,7 @@ command line are not required and the value of the environment variable is
 used. If both the env var and the command line option are included the
 command line option overrides the environment variable with no warning.
 
-Environment variable options are not provided for command/subcommand
-options or arguments.
+Environment variable options are not provided for command options or arguments.
 
 In the following example, the second line accesses the server
 ``http://localhost`` defined by the export command:
@@ -295,7 +294,7 @@ For script integration, it is important to have a way to avoid the interactive
 password prompt. This can be done by storing the password string in an
 environment variable or specifying it on the command line.
 
-The ``pywbemcli`` command supports a ``connection export`` (sub-)command that
+The ``pywbemcli`` command supports a ``connection export`` command that
 outputs the (bash/windows) shell commands to set all needed environment variables:
 
 .. code-block:: text
@@ -797,7 +796,7 @@ new connection in the CLI command mode:
 Note: The * indicates that this is the current connection.
 
 Other connections can be added from either the command mode or interactive mode
-using the add subcommand:
+using the add command:
 
 .. code-block:: text
 

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Click Command definition for the class command group which includes
+Click Command definition for the class command-group which includes
 commands for get, enumerate, associators, references, find, etc. of the objects
 CIMClass on a WBEM server
 """
@@ -60,9 +60,9 @@ localonly_option = [              # pylint: disable=invalid-name
 @cli.group('class', options_metavar=CMD_OPTS_TXT)
 def class_group():
     """
-    Command group for CIM classes.
+    Command-group for CIM classes.
 
-    This command group defines commands to inspect classes, to invoke
+    This command-group defines commands to inspect classes, to invoke
     methods on classes, and to delete classes.
 
     Creation and modification of classes is not currently supported.
@@ -409,7 +409,7 @@ def class_tree(context, classname, **options):
 
 #####################################################################
 #
-#  Command functions for each of the subcommands in the class group
+#  Command functions for each of the commands in the class group
 #
 #####################################################################
 

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Click Command definition for the class command-group which includes
+Click Command definition for the class command group which includes
 commands for get, enumerate, associators, references, find, etc. of the objects
 CIMClass on a WBEM server
 """
@@ -60,9 +60,9 @@ localonly_option = [              # pylint: disable=invalid-name
 @cli.group('class', options_metavar=CMD_OPTS_TXT)
 def class_group():
     """
-    Command-group for CIM classes.
+    Command group for CIM classes.
 
-    This command-group defines commands to inspect classes, to invoke
+    This command group defines commands to inspect classes, to invoke
     methods on classes, and to delete classes.
 
     Creation and modification of classes is not currently supported.

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Click Command definition for the connection command-group  which includes
+Click Command definition for the connection command group  which includes
 cmds to list add, delete, show, and test server definitions in the
 connection information.  This also maintains a definition of servers on
 disk which is kept in sync with changes made with the add/delete commands.

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Click Command definition for the connection command group which includes
+Click Command definition for the connection command-group  which includes
 cmds to list add, delete, show, and test server definitions in the
 connection information.  This also maintains a definition of servers on
-disk which is kept in sync with changes made with the add/delete subcommands.
+disk which is kept in sync with changes made with the add/delete commands.
 """
 from __future__ import absolute_import
 
@@ -75,7 +75,7 @@ def connection_show(context, name):
     """
     Show connection info of current or persistent WBEM connection.
 
-    This subcommand displays all the variables that make up the current
+    This command displays all the variables that make up the current
     WBEM connection if the optional NAME argument is NOT provided. If NAME not
     supplied, a list of connections from the connections definition file
     is presented with a prompt for the user to select a NAME.
@@ -148,7 +148,7 @@ def connection_select(context, name):
               metavar='NAMESPACE',
               default=DEFAULT_NAMESPACE,
               help="Default namespace to use in the target WBEM server if no "
-                   "namespace is defined in the subcommand"
+                   "namespace is defined in the command"
                    " (Default: {of}).".format(of=DEFAULT_NAMESPACE))
 @click.option('-u', '--user', type=str,
               help="User name for the WBEM server connection. ")
@@ -218,7 +218,7 @@ def connection_add(context, **options):
     """
     Add a persistent WBEM connection from specified conn info.
 
-    This subcommand creates and saves a named connection from the
+    This command creates and saves a named connection from the
     input options in the connections file.
 
     The new connection can be referenced by the name argument in
@@ -281,7 +281,7 @@ def connection_list(context):
     """
     List the persistent WBEM connections.
 
-    This subcommand displays all entries in the connections file as
+    This command displays all entries in the connections file as
     a table using the command line output_format to define the
     table format.
 

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Click Command definition for the class command-group  which includes
+Click Command definition for the class command group  which includes
 cmds for get, enumerate, list of classes.
 """
 from __future__ import absolute_import, print_function
@@ -115,7 +115,7 @@ filterquery_option = [              # pylint: disable=invalid-name
 
 ##########################################################################
 #
-#   Click command-group  and command definitions
+#   Click command group  and command definitions
 #
 ###########################################################################
 
@@ -125,7 +125,7 @@ def instance_group():
     """
     Command group for CIM instances.
 
-    This command-group  defines commands to inspect instances, to invoke
+    This command group  defines commands to inspect instances, to invoke
     methods on instances, and to create and delete instances.
 
     Modification of instances is not currently supported.

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Click Command definition for the class command group which includes
+Click Command definition for the class command-group  which includes
 cmds for get, enumerate, list of classes.
 """
 from __future__ import absolute_import, print_function
@@ -48,7 +48,7 @@ includequalifiers_option = [              # pylint: disable=invalid-name
 includequalifiersenum_option = [              # pylint: disable=invalid-name
     click.option('-q', '--include-qualifiers', is_flag=True, required=False,
                  help='If set, requests server to include qualifiers in the '
-                 'returned instances. This subcommand may use either pull '
+                 'returned instances. This command may use either pull '
                  'or traditional operations depending on the server '
                  'and the "--use-pull" general option. If pull operations '
                  'are used, qualifiers will not be included, even if this '
@@ -72,7 +72,7 @@ localonlyget_option = [              # pylint: disable=invalid-name
 localonlyenum_option = [              # pylint: disable=invalid-name
     click.option('-l', '--local-only', is_flag=True, required=False,
                  help='Show only local properties of the instances. This '
-                      'subcommand may use either pull or traditional '
+                      'command may use either pull or traditional '
                       'operations depending on the server and the '
                       '--use-pull general option. If pull operations '
                       'are used, this parameters will not be included, even if '
@@ -115,7 +115,7 @@ filterquery_option = [              # pylint: disable=invalid-name
 
 ##########################################################################
 #
-#   Click command group and subcommand definitions
+#   Click command-group  and command definitions
 #
 ###########################################################################
 
@@ -125,7 +125,7 @@ def instance_group():
     """
     Command group for CIM instances.
 
-    This command group defines commands to inspect instances, to invoke
+    This command-group  defines commands to inspect instances, to invoke
     methods on instances, and to create and delete instances.
 
     Modification of instances is not currently supported.

--- a/pywbemtools/pywbemcli/_cmd_qualifier.py
+++ b/pywbemtools/pywbemcli/_cmd_qualifier.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Click Command definition for the qualifer command group which includes
+Click Command definition for the qualifer command-group  which includes
 cmds for get and enumerate for CIM qualifier types.
 """
 
@@ -34,7 +34,7 @@ def qualifier_group():
     """
     Command group for CIM qualifier declarations.
 
-    This command group defines commands to inspect qualifier declarations.
+    This command-group  defines commands to inspect qualifier declarations.
 
     Creation, modification and deletion of qualifier declarations is not
     currently supported.

--- a/pywbemtools/pywbemcli/_cmd_qualifier.py
+++ b/pywbemtools/pywbemcli/_cmd_qualifier.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Click Command definition for the qualifer command-group  which includes
+Click Command definition for the qualifer command group  which includes
 cmds for get and enumerate for CIM qualifier types.
 """
 
@@ -34,7 +34,8 @@ def qualifier_group():
     """
     Command group for CIM qualifier declarations.
 
-    This command-group  defines commands to inspect qualifier declarations.
+    This command group  defines commands to inspect CIM qualifier declarations
+    in the WBEM Server.
 
     Creation, modification and deletion of qualifier declarations is not
     currently supported.

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -178,7 +178,7 @@ def server_connection(context):
     Display the information about the connection used to connect to the
     WBEM server.
 
-    This is equivalent to the 'connection show' subcommand.
+    This is equivalent to the 'connection show' command.
     """
     context.execute_cmd(lambda: cmd_server_connection(context))
 

--- a/pywbemtools/pywbemcli/_common_options.py
+++ b/pywbemtools/pywbemcli/_common_options.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Defines click options that are used for multiple subcommands and that have
+Defines click options that are used for multiple scommands and that have
 the same definition throughout the environment.  This allows the characteristics
 and help to be defined once and used multiple times.
 """

--- a/pywbemtools/pywbemcli/_context_obj.py
+++ b/pywbemtools/pywbemcli/_context_obj.py
@@ -17,7 +17,7 @@
 pybemcli context object. This is the common object for click command calls for
 pywbemcli context information.
 
-It contains data that is set in the top level and used in subcommand calls
+It contains data that is set in the top level and used in command calls
 
 This object is attached to the Click Context in pywbemcli.py
 """
@@ -35,7 +35,7 @@ class ContextObj(object):  # pylint: disable=useless-object-inheritance
         Manage the pywbemcli context that is carried within the Click
         context object in the obj parameter. This is the object that
         communicates between the cli commands and command groups. It contains
-        the information that is common to the multiple click subcommands
+        the information that is common to the multiple click commands
     """
     # pylint: disable=unused-argument
     def __init__(self, pywbem_server, output_format, use_pull,
@@ -136,7 +136,7 @@ class ContextObj(object):  # pylint: disable=useless-object-inheritance
                     self.conn.statistics.enable()
             return self._pywbem_server.wbem_server
         else:
-            raise click.ClickException('No server defined for subcommand '
+            raise click.ClickException('No server defined for command '
                                        'that requires server. Define a server '
                                        'with "--server", "--mock-server", or '
                                        '"--name" general options; or in '
@@ -179,8 +179,8 @@ class ContextObj(object):  # pylint: disable=useless-object-inheritance
         WBEM server object has not been created it is created so that this wbem
         server can be used for interactive commands.
 
-        This method is called by every subcommand execution to setup and
-        execute the command. Thus, each subcommand has the line similar to:
+        This method is called by every command execution to setup and
+        execute the command. Thus, each command has the line similar to:
 
         context.execute_cmd(lambda: cmd_instance_query(context, query, options))
         """

--- a/pywbemtools/pywbemcli/_displaytree.py
+++ b/pywbemtools/pywbemcli/_displaytree.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Click Command definition for the qualifer command-group  which includes
+Click Command definition for the qualifer command group  which includes
 cmds for get and enumerate for CIM qualifier types.
 """
 

--- a/pywbemtools/pywbemcli/_displaytree.py
+++ b/pywbemtools/pywbemcli/_displaytree.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Click Command definition for the qualifer command group which includes
+Click Command definition for the qualifer command-group  which includes
 cmds for get and enumerate for CIM qualifier types.
 """
 

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -135,7 +135,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
               envvar=PywbemServer.timeout_envvar,
               help='Choice for command output data format. '
                    'pywbemcli may override the format choice depending on the '
-                   'command-group and command since not all formats apply to '
+                   'command group and command since not all formats apply to '
                    'all output data types. Choices further defined in '
                    'pywbemcli documentation.\n' +
                    'Choices: Table: [{tb}], Object: [{ob}]\n'

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -83,7 +83,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
               metavar='NAMESPACE',
               envvar=PywbemServer.defaultnamespace_envvar,
               help='Default namespace to use in the target WBEM server if no '
-                   'namespace is defined in a subcommand.\n' +
+                   'namespace is defined in a command.\n' +
                    '(EnvVar: {ev})\n' .format(ev=PywbemServer.name_envvar) +
                    '[Default: {of}]'.format(of=DEFAULT_NAMESPACE))
 @click.option('-u', '--user', type=str, envvar=PywbemServer.user_envvar,
@@ -135,7 +135,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
               envvar=PywbemServer.timeout_envvar,
               help='Choice for command output data format. '
                    'pywbemcli may override the format choice depending on the '
-                   'command group and command since not all formats apply to '
+                   'command-group and command since not all formats apply to '
                    'all output data types. Choices further defined in '
                    'pywbemcli documentation.\n' +
                    'Choices: Table: [{tb}], Object: [{ob}]\n'
@@ -225,7 +225,7 @@ def cli(ctx, server, name, default_namespace, user, password, timeout,
     * Maintain a persistent list of named connections to WBEM servers
       and execute operations on them by name.
 
-    Pywbemcli implements command groups and subcommands to execute the CIM-XML
+    Pywbemcli implements command groups and commands to execute the CIM-XML
     operations defined by the DMTF CIM Operations Over HTTP specification
     (DSP0200).
 
@@ -483,7 +483,7 @@ def repl(ctx):
     """
     Enter interactive mode (default).
 
-    Enters the interactive mode where subcommands can be entered interactively
+    Enters the interactive mode where commands can be entered interactively
     and load the command history file.
 
     If no options are specified on the command line, the interactive mode

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -46,7 +46,7 @@ SIMPLE_ASSOC_MOCK_FILE = 'simple_assoc_mock_model.mof'
 #
 CLASS_HELP_LINES = [
     'Usage: pywbemcli class [COMMAND-OPTIONS] COMMAND [ARGS]...',
-    'Command-group for CIM classes.',
+    'Command group for CIM classes.',
     CMD_OPTION_HELP_HELP_LINE,
     'associators   List the classes associated with a class.',
     'delete        Delete a class.',

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -46,7 +46,7 @@ SIMPLE_ASSOC_MOCK_FILE = 'simple_assoc_mock_model.mof'
 #
 CLASS_HELP_LINES = [
     'Usage: pywbemcli class [COMMAND-OPTIONS] COMMAND [ARGS]...',
-    'Command group for CIM classes.',
+    'Command-group for CIM classes.',
     CMD_OPTION_HELP_HELP_LINE,
     'associators   List the classes associated with a class.',
     'delete        Delete a class.',

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -54,7 +54,7 @@ Usage: pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS]...
   * Maintain a persistent list of named connections to WBEM servers
     and execute operations on them by name.
 
-  Pywbemcli implements command groups and subcommands to execute the CIM-XML
+  Pywbemcli implements command groups and commands to execute the CIM-XML
   operations defined by the DMTF CIM Operations Over HTTP specification
   (DSP0200).
 
@@ -94,9 +94,10 @@ Options:
   -d, --default-namespace NAMESPACE
                                   Default namespace to use in the target WBEM
                                   server if no namespace is defined in a
-                                  subcommand.
+                                  command.
                                   (EnvVar: PYWBEMCLI_NAME)
-                                  [Default: root/cimv2]
+                                  [Default:
+                                  root/cimv2]
   -u, --user USER                 User name for the WBEM server connection.
                                   (EnvVar: PYWBEMCLI_USER)
   -p, --password PASSWORD         Password for the WBEM server. Will be
@@ -137,7 +138,7 @@ Options:
                                   /etc/ssl/certificates]
   -o, --output-format <choice>    Choice for command output data format.
                                   pywbemcli may override the format choice
-                                  depending on the command group and command
+                                  depending on the command-group and command
                                   since not all formats apply to all output
                                   data types. Choices further defined in
                                   pywbemcli documentation.
@@ -195,7 +196,7 @@ Options:
   -h, --help                      Show this message and exit.
 
 Commands:
-  class       Command group for CIM classes.
+  class       Command-group for CIM classes.
   connection  Command group for persistent WBEM connections.
   help        Show help message for interactive mode.
   instance    Command group for CIM instances.
@@ -557,21 +558,22 @@ TEST_CASES = [
     ['Verify connection already deleted.',
      {'subcmd': 'connection',
       'args': ['delete', 'globaltest1']},
-     {'stderr': "Error: globaltest1 not a defined connection name",
+     {'stderr': "globaltest1 not a defined connection name",
       'rc': 1,
-      'test': 'regex'},
+      'test': 'innows'},
      None, OK],
 
     ['Verify connection without server definition and subcommand that '
      ' requires connection fails.',
      {'subcmd': 'class',
       'args': ['enumerate']},
-     {'stderr': 'No server defined for subcommand that requires server. '
-                'Define a server with "--server", "--mock-server", or '
-                '"--name" general options; or in interactive mode, use '
-                '"connection select" to enable a connection',
+     {'stderr': ['No server defined for command that requires server. ',
+                 'Define a server with "--server", "--mock-server", or ',
+                 '"--name" general options; or in interactive mode, use ',
+                 '"connection select" or "connection add" to define a '
+                 'connection'],
       'rc': 1,
-      'test': 'regex'},
+      'test': 'innows'},
      None, OK],
 
 

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -138,7 +138,7 @@ Options:
                                   /etc/ssl/certificates]
   -o, --output-format <choice>    Choice for command output data format.
                                   pywbemcli may override the format choice
-                                  depending on the command-group and command
+                                  depending on the command group and command
                                   since not all formats apply to all output
                                   data types. Choices further defined in
                                   pywbemcli documentation.
@@ -196,7 +196,7 @@ Options:
   -h, --help                      Show this message and exit.
 
 Commands:
-  class       Command-group for CIM classes.
+  class       Command group for CIM classes.
   connection  Command group for persistent WBEM connections.
   help        Show help message for interactive mode.
   instance    Command group for CIM instances.

--- a/tools/click_help_capture.py
+++ b/tools/click_help_capture.py
@@ -145,7 +145,7 @@ def get_subcmd_group_names(script_cmd, script_name, cmd):
     Execute the script with defined command and help and get the
     groups defined for that help.
 
-    returns list of command-groups/commands
+    returns list of command groups/commands
     """
     command = '%s %s --help' % (script_cmd, cmd)
     # Disable python warnings for script call.
@@ -222,7 +222,7 @@ def create_help_cmd_list(script_cmd, script_name):
     if USE_RST:
         print(rst_headline("%s Help Command Details" % script_name, 2))
         print('\nThis section defines the help output for each %s '
-              'command-group and command.\n' % script_name)
+              'command group and command.\n' % script_name)
 
     for name in help_groups_result:
         command_name = '%s %s --help' % (script_name, name)

--- a/tools/click_help_capture.py
+++ b/tools/click_help_capture.py
@@ -5,8 +5,8 @@ This tool can capture the help outputs from a click application and output
 the result either as text or in restructured text format.
 
 It executes the click script --help and recursively scrapes all of the
-subcommands from the output, generating an output that is the help text for
-every groupt/subcommand in the script.
+commands from the output, generating an output that is the help text for
+every group/command in the script.
 
 All output is to stdout.
 
@@ -78,7 +78,7 @@ def rst_headline(title, level):
     except IndexError:
         level_char = '='
 
-    # output anchor in form .. _`smicli subcommands`:
+    # output anchor in form .. _`smicli commands`:
     anchor = '.. _`%s`:' % title
     title_marker = level_char * len(title)
     if level == 0:
@@ -142,10 +142,10 @@ def cmd_exists(cmd):
 
 def get_subcmd_group_names(script_cmd, script_name, cmd):
     """
-    Execute the script with defined subcommand and help and get the
+    Execute the script with defined command and help and get the
     groups defined for that help.
 
-    returns list of subcommands/groups
+    returns list of command-groups/commands
     """
     command = '%s %s --help' % (script_cmd, cmd)
     # Disable python warnings for script call.
@@ -179,7 +179,7 @@ def get_subcmd_group_names(script_cmd, script_name, cmd):
     group_state = False
     for line in lines:
         if group_state and line:
-            # split line into list of words and get first word as subcommand
+            # split line into list of words and get first word as command
             words = line.split()
             group_list.append(words[0])
 
@@ -191,7 +191,7 @@ def get_subcmd_group_names(script_cmd, script_name, cmd):
 
 def get_subgroup_names(group_name, script_cmd, script_name):
     """
-    Get all the subcommands for the help_group_name defined on input.
+    Get all the commands for the help_group_name defined on input.
     Executes script and extracts groups after line with 'Commands'
     """
     subcmds_list = get_subcmd_group_names(script_cmd, script_name, group_name)
@@ -222,7 +222,7 @@ def create_help_cmd_list(script_cmd, script_name):
     if USE_RST:
         print(rst_headline("%s Help Command Details" % script_name, 2))
         print('\nThis section defines the help output for each %s '
-              'command group and subcommand.\n' % script_name)
+              'command-group and command.\n' % script_name)
 
     for name in help_groups_result:
         command_name = '%s %s --help' % (script_name, name)
@@ -233,7 +233,7 @@ def create_help_cmd_list(script_cmd, script_name):
             if name:
                 print(rst_headline(command_name, level))
             print('\n%s\n' % '\nThe following defines the help output for the '
-                  '`%s` subcommand\n' % command_name)
+                  '`%s` command\n' % command_name)
             print_rst_verbatum_text(out.decode())
         else:
             print('%s\n%s COMMAND: %s' %


### PR DESCRIPTION
Eliminated all use of subcommand in the help, code, and documentation.

Everything is either a command-group or a command.

Whether we change to object/action or leave it like it is, this makes
the whole thing much simpler.

The only subcommand usage in pywbemcli now is a click functtion
invokde_subcommand that probably started the whole command/subcommand
ruckus.

Changed the name of the doc file pywbemclisubcommands.rst to
pywbemclicommands.rst

Note this involve changes to doc, pywbemcli code, and the tests.

This only resolves part of the issue raised with innsue # 251.  In addition, that issue requests::

1. change "command-group "to "object"

2. Change command to "action"

3. Extend the general syntax definition for what is now <args> to <options> <args>
