### PR TITLE
Ks/#250 replace short options

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -231,21 +231,22 @@ The following defines the help output for the `pywbemcli class associators --hel
         pywbemcli -n myconn class associators CIM_Foo -n interop
 
     Options:
-      -a, --assoc-class CLASSNAME     Filter the result set by association class
+      --ac, --assoc-class CLASSNAME   Filter the result set by association class
                                       name. Subclasses of the specified class also
                                       match.
-      -C, --result-class CLASSNAME    Filter the result set by result class name.
+      --rc, --result-class CLASSNAME  Filter the result set by result class name.
                                       Subclasses of the specified class also
                                       match.
       -r, --role PROPERTYNAME         Filter the result set by source end role
                                       name.
-      -R, --result-role PROPERTYNAME  Filter the result set by far end role name.
-      --no-qualifiers                 Do not include qualifiers in the returned
+      --rr, --result-role PROPERTYNAME
+                                      Filter the result set by far end role name.
+      --nq, --no-qualifiers           Do not include qualifiers in the returned
                                       class(es). Default: Include qualifiers.
-      -c, --include-classorigin       Include class origin information in the
+      --ico, --include-classorigin    Include class origin information in the
                                       returned class(es). Default: Do not include
                                       class origin information.
-      -p, --propertylist PROPERTYLIST
+      --pl, --propertylist PROPERTYLIST
                                       Filter the properties included in the
                                       returned object(s). Multiple properties may
                                       be specified with either a comma-separated
@@ -254,12 +255,12 @@ The following defines the help output for the `pywbemcli class associators --hel
                                       not in the object(s) will be ignored. The
                                       empty string will include no properties.
                                       Default: Do not filter properties.
-      -o, --names-only                Retrieve only the object paths (names).
+      --no, --names-only              Retrieve only the object paths (names).
                                       Default: Retrieve the complete objects
                                       including object paths.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
                                       of the default namespace of the connection.
-      -S, --summary                   Show only a summary (count) of the objects.
+      -s, --summary                   Show only a summary (count) of the objects.
       -h, --help                      Show this message and exit.
 
 
@@ -349,24 +350,24 @@ The following defines the help output for the `pywbemcli class enumerate --help`
         pywbemcli -n myconn class enumerate CIM_Foo -n interop
 
     Options:
-      -d, --deep-inheritance     Include the complete subclass hierarchy of the
-                                 requested classes in the result set. Default: Do
-                                 not include subclasses.
-      -l, --local-only           Do not include superclass properties and methods
-                                 in the returned class(es). Default: Include
-                                 superclass properties and methods.
-      --no-qualifiers            Do not include qualifiers in the returned
-                                 class(es). Default: Include qualifiers.
-      -c, --include-classorigin  Include class origin information in the returned
-                                 class(es). Default: Do not include class origin
-                                 information.
-      -o, --names-only           Retrieve only the object paths (names). Default:
-                                 Retrieve the complete objects including object
-                                 paths.
-      -n, --namespace NAMESPACE  Namespace to use for this command, instead of the
-                                 default namespace of the connection.
-      -S, --summary              Show only a summary (count) of the objects.
-      -h, --help                 Show this message and exit.
+      -d, --deep-inheritance        Include the complete subclass hierarchy of the
+                                    requested classes in the result set. Default:
+                                    Do not include subclasses.
+      -l, --local-only              Do not include superclass properties and
+                                    methods in the returned class(es). Default:
+                                    Include superclass properties and methods.
+      --nq, --no-qualifiers         Do not include qualifiers in the returned
+                                    class(es). Default: Include qualifiers.
+      --ico, --include-classorigin  Include class origin information in the
+                                    returned class(es). Default: Do not include
+                                    class origin information.
+      --no, --names-only            Retrieve only the object paths (names).
+                                    Default: Retrieve the complete objects
+                                    including object paths.
+      -n, --namespace NAMESPACE     Namespace to use for this command, instead of
+                                    the default namespace of the connection.
+      -s, --summary                 Show only a summary (count) of the objects.
+      -h, --help                    Show this message and exit.
 
 
 .. _`pywbemcli class find --help`:
@@ -451,12 +452,12 @@ The following defines the help output for the `pywbemcli class get --help` comma
       -l, --local-only                Do not include superclass properties and
                                       methods in the returned class(es). Default:
                                       Include superclass properties and methods.
-      --no-qualifiers                 Do not include qualifiers in the returned
+      --nq, --no-qualifiers           Do not include qualifiers in the returned
                                       class(es). Default: Include qualifiers.
-      -c, --include-classorigin       Include class origin information in the
+      --ico, --include-classorigin    Include class origin information in the
                                       returned class(es). Default: Do not include
                                       class origin information.
-      -p, --propertylist PROPERTYLIST
+      --pl, --propertylist PROPERTYLIST
                                       Filter the properties included in the
                                       returned object(s). Multiple properties may
                                       be specified with either a comma-separated
@@ -554,17 +555,17 @@ The following defines the help output for the `pywbemcli class references --help
         pywbemcli -n myconn class references CIM_Foo -n interop
 
     Options:
-      -R, --result-class CLASSNAME    Filter the result set by result class name.
+      --rc, --result-class CLASSNAME  Filter the result set by result class name.
                                       Subclasses of the specified class also
                                       match.
       -r, --role PROPERTYNAME         Filter the result set by source end role
                                       name.
-      --no-qualifiers                 Do not include qualifiers in the returned
+      --nq, --no-qualifiers           Do not include qualifiers in the returned
                                       class(es). Default: Include qualifiers.
-      -c, --include-classorigin       Include class origin information in the
+      --ico, --include-classorigin    Include class origin information in the
                                       returned class(es). Default: Do not include
                                       class origin information.
-      -p, --propertylist PROPERTYLIST
+      --pl, --propertylist PROPERTYLIST
                                       Filter the properties included in the
                                       returned object(s). Multiple properties may
                                       be specified with either a comma-separated
@@ -573,12 +574,12 @@ The following defines the help output for the `pywbemcli class references --help
                                       not in the object(s) will be ignored. The
                                       empty string will include no properties.
                                       Default: Do not filter properties.
-      -o, --names-only                Retrieve only the object paths (names).
+      --no, --names-only              Retrieve only the object paths (names).
                                       Default: Retrieve the complete objects
                                       including object paths.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
                                       of the default namespace of the connection.
-      -S, --summary                   Show only a summary (count) of the objects.
+      -s, --summary                   Show only a summary (count) of the objects.
       -h, --help                      Show this message and exit.
 
 
@@ -1108,25 +1109,26 @@ The following defines the help output for the `pywbemcli instance associators --
       will be replaced with MOF format.
 
     Options:
-      -a, --assoc-class CLASSNAME     Filter the result set by association class
+      --ac, --assoc-class CLASSNAME   Filter the result set by association class
                                       name. Subclasses of the specified class also
                                       match.
-      -C, --result-class CLASSNAME    Filter the result set by result class name.
+      --rc, --result-class CLASSNAME  Filter the result set by result class name.
                                       Subclasses of the specified class also
                                       match.
       -r, --role PROPERTYNAME         Filter the result set by source end role
                                       name.
-      -R, --result-role PROPERTYNAME  Filter the result set by far end role name.
-      -q, --include-qualifiers        When traditional operations are used,
+      --rr, --result-role PROPERTYNAME
+                                      Filter the result set by far end role name.
+      --iq, --include-qualifiers      When traditional operations are used,
                                       include qualifiers in the returned
                                       instances. Some servers may ignore this
                                       option. By default, and when pull operations
                                       are used, qualifiers will never be included.
-      -c, --include-classorigin       Include class origin information in the
+      --ico, --include-classorigin    Include class origin information in the
                                       returned instance(s). Some servers may
                                       ignore this option. Default: Do not include
                                       class origin information.
-      -p, --propertylist PROPERTYLIST
+      --pl, --propertylist PROPERTYLIST
                                       Filter the properties included in the
                                       returned object(s). Multiple properties may
                                       be specified with either a comma-separated
@@ -1135,7 +1137,7 @@ The following defines the help output for the `pywbemcli instance associators --
                                       not in the object(s) will be ignored. The
                                       empty string will include no properties.
                                       Default: Do not filter properties.
-      -o, --names-only                Retrieve only the object paths (names).
+      --no, --names-only              Retrieve only the object paths (names).
                                       Default: Retrieve the complete objects
                                       including object paths.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
@@ -1144,7 +1146,7 @@ The following defines the help output for the `pywbemcli instance associators --
                                       list. If used, the INSTANCENAME argument
                                       must be a class name, and the instances of
                                       that class are presented.
-      -S, --summary                   Show only a summary (count) of the objects.
+      -s, --summary                   Show only a summary (count) of the objects.
       -f, --filter-query QUERY-STRING
                                       When pull operations are used, filter the
                                       instances in the result via a filter query.
@@ -1334,16 +1336,16 @@ The following defines the help output for the `pywbemcli instance enumerate --he
       -d, --deep-inheritance          Include subclass properties in the returned
                                       instances. Default: Do not include subclass
                                       properties.
-      -q, --include-qualifiers        When traditional operations are used,
+      --iq, --include-qualifiers      When traditional operations are used,
                                       include qualifiers in the returned
                                       instances. Some servers may ignore this
                                       option. By default, and when pull operations
                                       are used, qualifiers will never be included.
-      -c, --include-classorigin       Include class origin information in the
+      --ico, --include-classorigin    Include class origin information in the
                                       returned instance(s). Some servers may
                                       ignore this option. Default: Do not include
                                       class origin information.
-      -p, --propertylist PROPERTYLIST
+      --pl, --propertylist PROPERTYLIST
                                       Filter the properties included in the
                                       returned object(s). Multiple properties may
                                       be specified with either a comma-separated
@@ -1354,10 +1356,10 @@ The following defines the help output for the `pywbemcli instance enumerate --he
                                       Default: Do not filter properties.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
                                       of the default namespace of the connection.
-      -o, --names-only                Retrieve only the object paths (names).
+      --no, --names-only              Retrieve only the object paths (names).
                                       Default: Retrieve the complete objects
                                       including object paths.
-      -S, --summary                   Show only a summary (count) of the objects.
+      -s, --summary                   Show only a summary (count) of the objects.
       -f, --filter-query QUERY-STRING
                                       When pull operations are used, filter the
                                       instances in the result via a filter query.
@@ -1408,15 +1410,15 @@ The following defines the help output for the `pywbemcli instance get --help` co
                                       returned instance. Some servers may ignore
                                       this option. Default: Include superclass
                                       properties.
-      -q, --include-qualifiers        Include qualifiers in the returned instance.
+      --iq, --include-qualifiers      Include qualifiers in the returned instance.
                                       Not all servers return qualifiers on
                                       instances. Default: Do not include
                                       qualifiers.
-      -c, --include-classorigin       Include class origin information in the
+      --ico, --include-classorigin    Include class origin information in the
                                       returned instance(s). Some servers may
                                       ignore this option. Default: Do not include
                                       class origin information.
-      -p, --propertylist PROPERTYLIST
+      --pl, --propertylist PROPERTYLIST
                                       Filter the properties included in the
                                       returned object(s). Multiple properties may
                                       be specified with either a comma-separated
@@ -1549,7 +1551,7 @@ The following defines the help output for the `pywbemcli instance modify --help`
                                       specified as a comma-separated list;
                                       embedded instances are not supported.
                                       Default: No properties modified.
-      -p, --propertylist PROPERTYLIST
+      --pl, --propertylist PROPERTYLIST
                                       Reduce the properties to be modified (as per
                                       --property) to a specific property list.
                                       Multiple properties may be specified with
@@ -1595,12 +1597,12 @@ The following defines the help output for the `pywbemcli instance query --help` 
       format general option.
 
     Options:
-      -l, --query-language QUERY-LANGUAGE
+      --ql, --query-language QUERY-LANGUAGE
                                       The query language to be used with --query.
                                       Default: DMTF:CQL.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
                                       of the default namespace of the connection.
-      -S, --summary                   Show only a summary (count) of the objects.
+      -s, --summary                   Show only a summary (count) of the objects.
       -h, --help                      Show this message and exit.
 
 
@@ -1652,21 +1654,21 @@ The following defines the help output for the `pywbemcli instance references --h
       will be replaced with MOF format.
 
     Options:
-      -R, --result-class CLASSNAME    Filter the result set by result class name.
+      --rc, --result-class CLASSNAME  Filter the result set by result class name.
                                       Subclasses of the specified class also
                                       match.
       -r, --role PROPERTYNAME         Filter the result set by source end role
                                       name.
-      -q, --include-qualifiers        When traditional operations are used,
+      --iq, --include-qualifiers      When traditional operations are used,
                                       include qualifiers in the returned
                                       instances. Some servers may ignore this
                                       option. By default, and when pull operations
                                       are used, qualifiers will never be included.
-      -c, --include-classorigin       Include class origin information in the
+      --ico, --include-classorigin    Include class origin information in the
                                       returned instance(s). Some servers may
                                       ignore this option. Default: Do not include
                                       class origin information.
-      -p, --propertylist PROPERTYLIST
+      --pl, --propertylist PROPERTYLIST
                                       Filter the properties included in the
                                       returned object(s). Multiple properties may
                                       be specified with either a comma-separated
@@ -1675,7 +1677,7 @@ The following defines the help output for the `pywbemcli instance references --h
                                       not in the object(s) will be ignored. The
                                       empty string will include no properties.
                                       Default: Do not filter properties.
-      -o, --names-only                Retrieve only the object paths (names).
+      --no, --names-only              Retrieve only the object paths (names).
                                       Default: Retrieve the complete objects
                                       including object paths.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
@@ -1684,7 +1686,7 @@ The following defines the help output for the `pywbemcli instance references --h
                                       list. If used, the INSTANCENAME argument
                                       must be a class name, and the instances of
                                       that class are presented.
-      -S, --summary                   Show only a summary (count) of the objects.
+      -s, --summary                   Show only a summary (count) of the objects.
       -f, --filter-query QUERY-STRING
                                       When pull operations are used, filter the
                                       instances in the result via a filter query.
@@ -1756,7 +1758,7 @@ The following defines the help output for the `pywbemcli qualifier enumerate --h
     Options:
       -n, --namespace NAMESPACE  Namespace to use for this command, instead of the
                                  default namespace of the connection.
-      -S, --summary              Show only a summary (count) of the objects.
+      -s, --summary              Show only a summary (count) of the objects.
       -h, --help                 Show this message and exit.
 
 

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -1807,19 +1807,14 @@ The following defines the help output for the `pywbemcli repl --help` command
 
       Enter interactive mode (default).
 
-      Enters the interactive mode where commands can be entered interactively
-      and load the command history file.
+      Enter the interactive mode where pywbemcli commands can be entered
+      interactively. The prompt is changed to 'pywbemcli>'.
 
-      If no options are specified on the command line, the interactive mode is
-      entered. The prompt is changed to 'pywbemcli>' in the interactive mode.
+      Command history is supported. The command history is stored in a file
+      ~/.pywbemcli_history.
 
       Pywbemcli may be terminated from this mode by entering <CTRL-D>, :q,
       :quit, :exit
-
-      Parameters:
-
-        ctx (:class:`click.Context`): The click context object. Created by the
-        ``@click.pass_context`` decorator.
 
     Options:
       -h, --help  Show this message and exit.
@@ -1958,7 +1953,7 @@ The following defines the help output for the `pywbemcli server get-centralinsts
                                       only scopig methodology
       --sp, --scoping-path CLASSLIST  Optional. Required only if profiles supports
                                       only scopig methodology. Multiples allowed
-      -r, --reference-direction [snia|dmtf]
+      --rd, --reference-direction [snia|dmtf]
                                       Navigation direction for association.
                                       [default: dmtf]
       -h, --help                      Show this message and exit.

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -350,10 +350,10 @@ The following defines the help output for the `pywbemcli class enumerate --help`
         pywbemcli -n myconn class enumerate CIM_Foo -n interop
 
     Options:
-      -d, --deep-inheritance        Include the complete subclass hierarchy of the
+      --di, --deep-inheritance      Include the complete subclass hierarchy of the
                                     requested classes in the result set. Default:
                                     Do not include subclasses.
-      -l, --local-only              Do not include superclass properties and
+      --lo, --local-only            Do not include superclass properties and
                                     methods in the returned class(es). Default:
                                     Include superclass properties and methods.
       --nq, --no-qualifiers         Do not include qualifiers in the returned
@@ -449,7 +449,7 @@ The following defines the help output for the `pywbemcli class get --help` comma
         pywbemcli -n myconn class get CIM_Foo -n interop
 
     Options:
-      -l, --local-only                Do not include superclass properties and
+      --lo, --local-only              Do not include superclass properties and
                                       methods in the returned class(es). Default:
                                       Include superclass properties and methods.
       --nq, --no-qualifiers           Do not include qualifiers in the returned
@@ -1147,12 +1147,12 @@ The following defines the help output for the `pywbemcli instance associators --
                                       must be a class name, and the instances of
                                       that class are presented.
       -s, --summary                   Show only a summary (count) of the objects.
-      -f, --filter-query QUERY-STRING
+      --fq, --filter-query QUERY-STRING
                                       When pull operations are used, filter the
                                       instances in the result via a filter query.
                                       By default, and when traditional operations
                                       are used, no such filtering takes place.
-      --filter-query-language QUERY-LANGUAGE
+      --fql, --filter-query-language QUERY-LANGUAGE
                                       The filter query language to be used with
                                       --filter-query. Default: DMTF:FQL.
       -h, --help                      Show this message and exit.
@@ -1234,7 +1234,7 @@ The following defines the help output for the `pywbemcli instance create --help`
         pywbemcli instance create CIM_blah -P id=3 -P arr="bla bla",foo
 
     Options:
-      -P, --property PROPERTYNAME=VALUE
+      -p, --property PROPERTYNAME=VALUE
                                       Initial property value for the new instance.
                                       May be specified multiple times. Array
                                       property values are specified as a comma-
@@ -1327,13 +1327,13 @@ The following defines the help output for the `pywbemcli instance enumerate --he
       will be replaced with MOF format.
 
     Options:
-      -l, --local-only                When traditional operations are used, do not
+      --lo, --local-only              When traditional operations are used, do not
                                       include superclass properties in the
                                       returned instances. Some servers may ignore
                                       this option. By default, and when pull
                                       operations are used, superclass properties
                                       will always be included.
-      -d, --deep-inheritance          Include subclass properties in the returned
+      --di, --deep-inheritance        Include subclass properties in the returned
                                       instances. Default: Do not include subclass
                                       properties.
       --iq, --include-qualifiers      When traditional operations are used,
@@ -1360,12 +1360,12 @@ The following defines the help output for the `pywbemcli instance enumerate --he
                                       Default: Retrieve the complete objects
                                       including object paths.
       -s, --summary                   Show only a summary (count) of the objects.
-      -f, --filter-query QUERY-STRING
+      --fq, --filter-query QUERY-STRING
                                       When pull operations are used, filter the
                                       instances in the result via a filter query.
                                       By default, and when traditional operations
                                       are used, no such filtering takes place.
-      --filter-query-language QUERY-LANGUAGE
+      --fql, --filter-query-language QUERY-LANGUAGE
                                       The filter query language to be used with
                                       --filter-query. Default: DMTF:FQL.
       -h, --help                      Show this message and exit.
@@ -1406,7 +1406,7 @@ The following defines the help output for the `pywbemcli instance get --help` co
       format general option.
 
     Options:
-      -l, --local-only                Do not include superclass properties in the
+      --lo, --local-only              Do not include superclass properties in the
                                       returned instance. Some servers may ignore
                                       this option. Default: Include superclass
                                       properties.
@@ -1544,7 +1544,7 @@ The following defines the help output for the `pywbemcli instance modify --help`
         pywbemcli instance modify CIM_blah.fred=3 -P id=3 -P arr="bla bla",foo
 
     Options:
-      -P, --property PROPERTYNAME=VALUE
+      -p, --property PROPERTYNAME=VALUE
                                       Property to be modified, with its new value.
                                       May be specified once for each property to
                                       be modified. Array property values are
@@ -1687,12 +1687,12 @@ The following defines the help output for the `pywbemcli instance references --h
                                       must be a class name, and the instances of
                                       that class are presented.
       -s, --summary                   Show only a summary (count) of the objects.
-      -f, --filter-query QUERY-STRING
+      --fq, --filter-query QUERY-STRING
                                       When pull operations are used, filter the
                                       instances in the result via a filter query.
                                       By default, and when traditional operations
                                       are used, no such filtering takes place.
-      --filter-query-language QUERY-LANGUAGE
+      --fql, --filter-query-language QUERY-LANGUAGE
                                       The filter query language to be used with
                                       --filter-query. Default: DMTF:FQL.
       -h, --help                      Show this message and exit.
@@ -1950,11 +1950,13 @@ The following defines the help output for the `pywbemcli server get-centralinsts
       -o, --organization ORG-NAME     Filter by the defined organization. (ex. -o
                                       DMTF
       -p, --profile PROFILE-NAME      Filter by the profile name. (ex. -p Array
-      -c, --central-class CLASSNAME   Optional. Required only if profiles supports
+      --cc, --central-class CLASSNAME
+                                      Optional. Required only if profiles supports
                                       only scopig methodology
-      -s, --scoping-class CLASSNAME   Optional. Required only if profiles supports
+      --sc, --scoping-class CLASSNAME
+                                      Optional. Required only if profiles supports
                                       only scopig methodology
-      -S, --scoping-path CLASSLIST    Optional. Required only if profiles supports
+      --sp, --scoping-path CLASSLIST  Optional. Required only if profiles supports
                                       only scopig methodology. Multiples allowed
       -r, --reference-direction [snia|dmtf]
                                       Navigation direction for association.

--- a/docs/pywbemclicommands.rst
+++ b/docs/pywbemclicommands.rst
@@ -83,30 +83,30 @@ WBEM CIM-XML Operation             pywbemcli command group & command
 =================================  ==============================================
 **Instance Operations:**
 EnumerateInstances                 instance enumerate INSTANCENAME
-EnumerateInstanceNames             instance enumerate INSTANCENAME --names_only
+EnumerateInstanceNames             instance enumerate INSTANCENAME --name_only
 GetInstance                        instance get INSTANCENAME
 ModifyInstance                     instance modify
 CreateInstance                     instance create
 DeleteInstance                     instance delete INSTANCENAME
 Associators(instance)              instance associators INSTANCENAME
 Associators(class)                 class associators CLASSNAME
-AssociatorNames(instance)          instance associators INSTANCENAME --names_only
-AssociatorNames(class)             class associators CLASSNAME --names_only
+AssociatorNames(instance)          instance associators INSTANCENAME --name_only
+AssociatorNames(class)             class associators CLASSNAME --name_only
 References(instance)               instance references INSTANCENAME
 References(class)                  class references CLASSNAME
-ReferenceNames(instance)           instance references INSTANCENAME --names_only
-ReferenceNames(class)              class references CLASSNAME --names_only
-InvokeMethod                       instance invokemethod INSTANCENAME --names_only
-ReferenceNames                     class invokemethod CLASSNAME --names_only
+ReferenceNames(instance)           instance references INSTANCENAME --name_only
+ReferenceNames(class)              class references CLASSNAME --name_only
+InvokeMethod                       instance invokemethod INSTANCENAME --name_only
+ReferenceNames                     class invokemethod CLASSNAME --name_only
 ExecQuery                          instance query
 **Pull Operations:**               Option --use-pull ``either`` or ``yes``
 OpenEnumerateInstances             instance enumerate INSTANCENAME
-OpenEnumerateInstancePaths         instance enumerate INSTANCENAME --names_only
+OpenEnumerateInstancePaths         instance enumerate INSTANCENAME --name_only
 OpenAssociatorInstances            instance associators INSTANCENAME
-OpenAssociatorInstancePaths        instance associators INSTANCENAME --names_only
+OpenAssociatorInstancePaths        instance associators INSTANCENAME --name_only
 OpenReferenceInstances             instance references INSTANCENAME
-OpenReferenceInstancePaths         instance references INSTANCENAME --names_only
-OpenQueryInstances                 instance references INSTANCENAME --names_only
+OpenReferenceInstancePaths         instance references INSTANCENAME --name_only
+OpenQueryInstances                 instance references INSTANCENAME --name_only
 PullInstancesWithPath              part of pull sequence
 PullInstancePaths                  part of pull sequence
 PullInstances                      part of pull sequence
@@ -243,6 +243,68 @@ Examples for Windows command processor:
    pywbemcli instance get /MY_Foo.InstanceID="%value%"
    pywbemcli instance get /MY_CS.CreationClassName="MY_CS",Name="MyComp"
    pywbemcli instance get /MY_LogEntry.Timestamp="20190901183853.762122+120"
+
+
+.. _`Specifying CIM property and parameter values`:
+
+Specifying CIM property and parameter values
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+TODO: Change to reference the commands
+TODO: Rewrite this to more completely define the value in terms of CIM types.
+
+The ``instance create``, ``instance modify``, ``class invokemethod``, and
+``instance invokemethod`` commands define the values of properties and parameters that
+are to be sent to the WBEM server.
+
+For a single property or parameter this is the `--property/-p`` or
+``parameter/-p`` option with the name and value in the form:
+
+.. code-block:: text
+
+    -p <name>=<value>
+
+where:
+
+* <name> is the name of the of the property or parameter.
+* <value> is the value of the property or parameter The values represent the
+  value of CIM types (ex. Uint32, String, etc.) or arrays of these types.
+
+TODO: This needs to be expanded to cover all CIM types.
+
+Since the WBEM server (and pywbem) requires that each property/parameter be
+typed to be created, pywbemcli retrieves the CIM class from the WBEM Server to
+determine the CIM type and arrayness required to define a CIMProperty. The
+value of each option argument contains the value as a string or numeric value.
+For numeric values, the creation will fail if the values of the numeric exceeds
+the range of the CIM type for the property defined in the class (ex. -3 for
+Uint32).
+
+Quotes around the value are only required if the value includes whitespace. See
+[#fbackslash]_ for information on use of backslashes in formating property
+argument values.
+
+The following are examples of scalar property definitions:
+
+.. code-block:: text
+
+    -p p1=SomeText
+    -p p2=\"Text with space\"
+    -p pint=3
+    -p psint=-3
+
+  For array properties the values are defined separated by commas:
+
+  .. code-block:: text
+
+    -p <property-name>=<value>(,<value>)
+
+  For example:
+
+  .. code-block:: text
+
+    -p strarray=abc,def,ghjk
+    -p strarray2=\"ab c\",def
 
 
 .. _`Interactively selecting INSTANCENAME`:
@@ -436,11 +498,21 @@ The **class** group defines commands that act on CIM classes. see
 * **invokemethod** to invoke a method defined for the CLASSNAME argument. This
   command executes the invokemethod with a class name, not an instance name
   and any input parameters for the InvokeMethod defined with the
-  ``--parameter`` \ ``-p`` option. If successful it returns the method return
-  value and output parameters received from the server. If unsuccessful it
-  displays the exception generated. It displays the return value as an integer and
-  any returned CIM parameters in the
-  :term:`CIM object output formats` (see :ref:`Output formats`).
+  ``--parameter`` \ ``-p`` option.
+
+  The ``invokemethod`` command requires CLASSNAME and METHODNAME arguments to
+  define the class and method to be invoked and optionally a``--parameter``
+  option for each parameter that is to be attached to the request to be sent to
+  the WBEM server.
+
+  The syntax of the ``--parameter`` option is defined in :ref:`Specifying CIM
+  property and parameter values`.
+
+  If successful it returns the method return value and output parameters
+  received from the server. If unsuccessful it displays the exception
+  generated. It displays the return value as an integer and any returned CIM
+  parameters in the :term:`CIM object output formats` (see :ref:`Output
+  formats`).
   See :ref:`pywbemcli class invokemethod --help` for details.
 * **tree** to display the class hierarchy as a tree.  This command
   outputs a tree format in ASCII defining the either the subclass or superclass
@@ -531,49 +603,8 @@ The **instance** group defines commands that act on CIM instances including:
   properties are defined as name/value pairs, one property for each instance of
   the ``--property`` option.
 
-  The ``--property`` argument value component defines the value of the
-  property. Since the WBEM server (and pywbem) requires that each property be
-  typed, pywbemcli uses the CIMClass defined by CLASSNAME retrieved from the
-  WBEM server to define the type required to define the CIMProperty. The value
-  argument contains just the value itself in the form of a string or numeric
-  value. For numeric values, the creation will fail if the values of the
-  numeric exceeds the range of the CIM type for the property defined in the
-  class (ex. -3 for Uint32).
-
-  See [#fbackslash]_ for information on use of backslashes in formating
-  property argument values:
-
-  For a single property in the new instance this is simply the `--property``
-  option with the property name and value:
-
-  .. code-block:: text
-
-    --property <property-name>=<property-value
-
-    where quotes around the value are only required if the value includes
-    whitespace.
-
-  The following are examples of scalar property definitions:
-
-  .. code-block:: text
-
-    -p p1=SomeText
-    -p p2=\"Text with space\"
-    -p pint=3
-    -p psint=-3
-
-  For array properties the values are defined separated by commas:
-
-  .. code-block:: text
-
-    -p <property-name>=<value>(,<value>)
-
-  For example:
-
-  .. code-block:: text
-
-    -p strarray=abc,def,ghjk
-    -p strarray2=\"ab c\",def
+  The syntax of the ``--property`` is documented in
+  :ref:`Specifying CIM property and parameter values`.
 
   The following is an example with three properties, ``InstanceId`` a scalar
   string property, ``IntProp`` a scalar numeric property, and ``IntArr`` an
@@ -656,6 +687,19 @@ The **instance** group defines commands that act on CIM instances including:
 
   See :ref:`pywbemcli instance get --help` for details.
 * **invokemethod** to invoke a method defined for the class argument.
+  The ``invokemethod`` command requires INSTANCENAME and METHODNAME arguments to
+  define the instance and method to be invoked and optionally a``--parameter\-p``
+  option for each   parameter that is to be attached to the request to be sent
+  to the WBEM server.
+
+  The syntax of the ``--parameter`` option is defined in :ref:`Specifying CIM
+  property and parameter values`.
+
+  If successful it returns the method return value and output parameters
+  received from the server. If unsuccessful it displays the exception
+  generated. It displays the return value as an integer and any returned CIM
+  parameters in the :term:`CIM object output formats` (see :ref:`Output
+  formats`).
   See :ref:`pywbemcli instance invokemethod --help` for details.
 * **modify** modify an existing instance of the class defined by the CLASSNAME argument
   in the WBEM server  namespace defined by either the default namespace or
@@ -1152,13 +1196,38 @@ Help command
 ------------
 
 The help command provides information on special commands and controls that can
-be executed in the :ref:`interactive mode`. This is different from the
-``--help`` option that provides information on command groups, and commands.
+be executed in the :ref:`interactive mode` including:
 
-.. _`Footnotes`:
+* executing shell commands,
+* exiting pywbemcli,
+* getting help on commands,
+* viewing interactive mode command history.
 
-Footnotes
----------
+This is different from the ``--help`` option that provides information on
+command groups, and commands.
+
+.. code-block:: text
+
+    $ pywbemcli help
+
+    The following can be entered in interactive mode:
+
+      <pywbemcli-cmd>             Execute pywbemcli command <pywbemcli-cmd>.
+      !<shell-cmd>                Execute shell command <shell-cmd>.
+
+      <CTRL-D>, :q, :quit, :exit  Exit interactive mode.
+
+      <TAB>                       Tab completion (can be used anywhere).
+      -h, --help                  Show pywbemcli general help message, including a
+                                  list of pywbemcli commands.
+      <pywbemcli-cmd> --help      Show help message for pywbemcli command
+                                  <pywbemcli-cmd>.
+      help                        Show this help message.
+      :?, :h, :help               Show help message about interactive mode.
+      <up-arrow, down-arrow>      View pwbemcli command history:
+
+
+.. rubric:: Footnotes
 
 .. [#fbackslash] Note that the UNIX-like shells interpret single and double quotes in a certain
     way and remove them before passing the arguments on to the program invoked.

--- a/docs/pywbemclicommands.rst
+++ b/docs/pywbemclicommands.rst
@@ -37,18 +37,18 @@ where:
 Within pywbemcli each command group name is a noun, referencing an entity (ex.
 class, instance, server).
 
+This example defines a command to get the class ``CIM_ManagedElement`` from the
+current target server and display it in the default output format (MOF).
+
 .. code-block:: text
 
     $ pywbemcli -s http://localhost class get CIM_ManagedElement
-
-defines a command to get the class ``CIM_ManagedElement`` from the current
-target server and display it in the defined output format.
 
 The pywbemcli command groups and commands are described below and the help
 output from pywbemcli for each command documented in :ref:`pywbemcli Help
 Command Details`
 
-**NOTE:** Many of the examples below use :ref:`--mock-server general option`
+**NOTE:** Many of the examples below use the :ref:`--mock-server general option`
 with mock files that are located in the pywbemtools tests/unit subdirectory
 to generate known results.
 
@@ -61,10 +61,10 @@ Pywbemcli includes several features in the command syntax that are worth
 presenting in detail to help the user understand the background, purpose and
 syntactic implementation of the features. This includes:
 
-* The ability to receive either CIM instances or CIM instance names with only
-  a change of an option on the commands that request CIM instances. The option
-  ``-o`` or ``--names-only`` defines whether only the instance name or the complete
-  object will be displayed.
+* The ability to receive either CIM instances or classes or only their names
+  with only a change of an option on the commands that request CIM instances or
+  classes. The option ``-no`` \ ``--names-only`` defines whether only the  name
+  or the complete object will be displayed.
 
 * The ability to interactively select the data from a list presented by
   pywbemcli for certain objects rather than typing in long names the full name.
@@ -83,30 +83,30 @@ WBEM CIM-XML Operation             pywbemcli command group & command
 =================================  ==============================================
 **Instance Operations:**
 EnumerateInstances                 instance enumerate INSTANCENAME
-EnumerateInstanceNames             instance enumerate INSTANCENAME --name_only
+EnumerateInstanceNames             instance enumerate INSTANCENAME --names_only
 GetInstance                        instance get INSTANCENAME
 ModifyInstance                     instance modify
 CreateInstance                     instance create
 DeleteInstance                     instance delete INSTANCENAME
 Associators(instance)              instance associators INSTANCENAME
 Associators(class)                 class associators CLASSNAME
-AssociatorNames(instance)          instance associators INSTANCENAME --name_only
-AssociatorNames(class)             class associators CLASSNAME --name_only
+AssociatorNames(instance)          instance associators INSTANCENAME --names_only
+AssociatorNames(class)             class associators CLASSNAME --names_only
 References(instance)               instance references INSTANCENAME
 References(class)                  class references CLASSNAME
-ReferenceNames(instance)           instance references INSTANCENAME --name_only
-ReferenceNames(class)              class references CLASSNAME --name_only
-InvokeMethod                       instance invokemethod INSTANCENAME --name_only
-ReferenceNames                     class invokemethod CLASSNAME --name_only
+ReferenceNames(instance)           instance references INSTANCENAME --names_only
+ReferenceNames(class)              class references CLASSNAME --names_only
+InvokeMethod                       instance invokemethod INSTANCENAME --names_only
+ReferenceNames                     class invokemethod CLASSNAME --names_only
 ExecQuery                          instance query
 **Pull Operations:**               Option --use-pull ``either`` or ``yes``
 OpenEnumerateInstances             instance enumerate INSTANCENAME
-OpenEnumerateInstancePaths         instance enumerate INSTANCENAME --name_only
+OpenEnumerateInstancePaths         instance enumerate INSTANCENAME --names_only
 OpenAssociatorInstances            instance associators INSTANCENAME
-OpenAssociatorInstancePaths        instance associators INSTANCENAME --name_only
+OpenAssociatorInstancePaths        instance associators INSTANCENAME --names_only
 OpenReferenceInstances             instance references INSTANCENAME
-OpenReferenceInstancePaths         instance references INSTANCENAME --name_only
-OpenQueryInstances                 instance references INSTANCENAME --name_only
+OpenReferenceInstancePaths         instance references INSTANCENAME --names_only
+OpenQueryInstances                 instance references INSTANCENAME --names_only
 PullInstancesWithPath              part of pull sequence
 PullInstancePaths                  part of pull sequence
 PullInstances                      part of pull sequence
@@ -126,19 +126,21 @@ DeleteQualifier                    Not Implemented
 =================================  ==============================================
 
 
-.. _`Displaying CIM instances or CIM instance names`:
+.. _`Displaying CIM instances/classes or their names`:
 
-Displaying CIM instances or CIM instance names
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Displaying CIM instances/classes or their names
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The pywbem API includes different WBEM operations (ex. ``EnumerateInstances`` and
-``EnumerateInstanceNames``) to request CIM objects or just their names. To
-simplify the overall command line syntax pywbemcli combines these into a single
-command (i.e. ``enumerate``, ``references``, ``associators``) and includes
-an option (``-o,`` or ``--names-only``) that determines whether the instance
-names or instances are retrieved from the WBEM server.
+The pywbem API includes different WBEM operations (ex. ``EnumerateInstances``,
+``EnumerateInstanceNames``, ``EnumerateClasses``, and ``EnumerateClassNames``)
+to request CIM objects or just their names. To simplify the overall command
+line syntax pywbemcli combines these into a single command (i.e. ``enumerate``,
+``references``, ``associators``)  in the :ref:`class command group` and the
+:ref:`instance command group` and includes an option (``--no,`` or
+``--names-only``) that determines whether the names or the CIM objects are
+retrieved from the WBEM server.
 
-Thus, for example an ``instance enumerate`` with and without the ``-o`` option:
+Thus, for example an ``instance enumerate`` with and without the ``--no`` option:
 
 .. code-block:: text
 
@@ -158,7 +160,7 @@ Thus, for example an ``instance enumerate`` with and without the ``-o`` option:
        InstanceID = "CIM_Foo3";
     };
 
-    $ pywbemcli --mock-server tests/unit/simple_mock_model.mof instance enumerate CIM_Foo -o
+    $ pywbemcli --mock-server tests/unit/simple_mock_model.mof instance enumerate CIM_Foo --no
 
     root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"
 
@@ -178,6 +180,7 @@ namespace of a WBEM server.
 The format used by pywbemcli for specifying INSTANCENAME arguments on the
 command line is an untyped WBEM URI for instance paths as defined in
 :term:`DSP0207`.
+
 Because pywbemcli always works with a single WBEM server at a time, the
 authority component of the WBEM URI is never specified in an INSTANCENAME.
 Because the namespace type of the WBEM URI (e.g. http or https) is not relevant
@@ -216,17 +219,8 @@ where:
 * escaped_INSTANCENAME is a backslash-escaped INSTANCENAME where at
   least backslash and double quote characters are backslash-escaped
 
-Note that the UNIX-like shells interpret single and double quotes in a certain
-way and remove them before passing the arguments on to the program invoked.
-Because the single and double quotes in INSTANCENAME need to be passed on to
-pywbemcli, they need to be protected from removal by the shell.
-This can be achieved by putting INSTANCENAME into single quotes if it only
-includes double quotes, or into double quotes if it only includes single quotes.
-If there is a mix of single and double quotes in INSTANCENAME, or if shell
-variables need to be expanded, this can be achieved by backslash-escaping any
-double quotes in INSTANCENAME, and putting it into double quotes.
-
-Examples for UNIX-like shells:
+Examples for UNIX-like shells. See [#fbackslash]_ for information on use of
+backslashes:
 
 .. code-block:: text
 
@@ -342,7 +336,7 @@ The **class** group defines commands that act on CIM classes. see
   namespace or the namespace defined with this command. If the CLASSNAME
   input property the enumeration starts at the subclasses of CLASSNAME. Otherwise
   it starts at the top of the class hierarchy if the
-  ``--DeepInheritance``/``-d``  option is set it shows all the classes in the
+  ``--DeepInheritance``/``--di``  option is set it shows all the classes in the
   hierarchy, not just the next level of the hierarchy. Otherwise it only
   enumerates one level of the class hierarchy.  It can display the
   classes/classnames in the :term:`CIM object output formats` (see
@@ -535,19 +529,38 @@ The **instance** group defines commands that act on CIM instances including:
   WBEM server. The command build the CIMInstance from the class defined by
   CLASSNAME and the properties defined by the ``--property``\``-p`` option The
   properties are defined as name/value pairs, one property for each instance of
-  the ``--property`` option. Since the WBEM server (and pywbem) requires that
-  each property be typed, pywbemtools uses the CIMClass defined by CLASSNAME
-  retrieved from the WBEM server to define the type required to define the
-  CIMProperty.
+  the ``--property`` option.
 
-  For a single property in the new instance this is simply the `--property`` option
-  with the property name and value:
+  The ``--property`` argument value component defines the value of the
+  property. Since the WBEM server (and pywbem) requires that each property be
+  typed, pywbemcli uses the CIMClass defined by CLASSNAME retrieved from the
+  WBEM server to define the type required to define the CIMProperty. The value
+  argument contains just the value itself in the form of a string or numeric
+  value. For numeric values, the creation will fail if the values of the
+  numeric exceeds the range of the CIM type for the property defined in the
+  class (ex. -3 for Uint32).
+
+  See [#fbackslash]_ for information on use of backslashes in formating
+  property argument values:
+
+  For a single property in the new instance this is simply the `--property``
+  option with the property name and value:
 
   .. code-block:: text
 
-    --property <property-name>=<property-value"
+    --property <property-name>=<property-value
 
-    where quotes are only required if the value includes whitespace.
+    where quotes around the value are only required if the value includes
+    whitespace.
+
+  The following are examples of scalar property definitions:
+
+  .. code-block:: text
+
+    -p p1=SomeText
+    -p p2=\"Text with space\"
+    -p pint=3
+    -p psint=-3
 
   For array properties the values are defined separated by commas:
 
@@ -555,22 +568,30 @@ The **instance** group defines commands that act on CIM instances including:
 
     -p <property-name>=<value>(,<value>)
 
-  An example with two properties, InstanceId a scalar string property and intarr
-  an array integer property. Note that the --property value does not determine
-  the property type. However, generally integers and float values are used for
-  integer and float property types.
+  For example:
+
+  .. code-block:: text
+
+    -p strarray=abc,def,ghjk
+    -p strarray2=\"ab c\",def
+
+  The following is an example with three properties, ``InstanceId`` a scalar
+  string property, ``IntProp`` a scalar numeric property, and ``IntArr`` an
+  array integer property. Note that the ``--property/-p`` value does not
+  determine the property type.  ``IntProp`` and ``IntArr`` could be any of the
+  numeric types (Unint32, Sint32, etc.) However, generally integers and float
+  values are used for integer and float property types.
+
+  .. code-block:: text
+
+    $pywbemcli instance create TST_Blah -p InstancId=blah1 -p IntProp=3 -p IntArr=3,6,9
+
+    $pywbemcli instance create TST_Blah -p InstancId=\"blah 2\" -p IntProp=3 -p IntArr=3,6,9
 
   If the create is successful, the server defined CIM Instance path is displayed.
   If the operation fails, the exception is displayed. If there is a descrepency
   between the defined properties and the CIMClass property characteristics
   pywbemcli generates an exception.
-
-  The following example creates an instance of the class TST_Blah with one
-  scalar and one array property.
-
-  .. code-block:: text
-
-    $pywbemcli instance create TST_Blah InstancId="blah1", intprop=3, intarr=3,6,9
 
   See :ref:`pywbemcli instance create --help` for details.
 * **delete** delete an instance defined by the :term:`INSTANCENAME` argument
@@ -581,7 +602,7 @@ The **instance** group defines commands that act on CIM instances including:
     * a string representation of a CIMInstanceName as defined by a :term:`WBEM URI`
     * A class name in which case pywbemcli will get the instance names from the
       WBEM server and present a selection list for the user to select an
-      instance name :ref:`Displaying CIM instances or CIM instance names`
+      instance name.
 
   The following example deletes the instance defined by the explicit instance
   name (Note the extra backslash required to escape the double quote on the
@@ -594,8 +615,8 @@ The **instance** group defines commands that act on CIM instances including:
 
   See :ref:`pywbemcli instance delete --help` for details.
 * **enumerate** to enumerate instances or their paths defined by the CLASSNAME
-  argument in the namespace defined by ``-o``\``--namespace`` or the general option
-  ``-o``\``--default-namespace`` in the defined format. This command displays the
+  argument in the namespace defined by ``-n``\``--namespace`` or the general option
+  ``-d``\``--default-namespace`` in the defined format. This command displays the
   returned instances or instance names in the :term:`CIM object output formats`
   or the table formats` (see :ref:`Output formats`).
 
@@ -1133,3 +1154,18 @@ Help command
 The help command provides information on special commands and controls that can
 be executed in the :ref:`interactive mode`. This is different from the
 ``--help`` option that provides information on command groups, and commands.
+
+.. _`Footnotes`:
+
+Footnotes
+---------
+
+.. [#fbackslash] Note that the UNIX-like shells interpret single and double quotes in a certain
+    way and remove them before passing the arguments on to the program invoked.
+    Because the single and double quotes in INSTANCENAME need to be passed on to
+    pywbemcli, they need to be protected from removal by the shell.
+    This can be achieved by putting INSTANCENAME into single quotes if it only
+    includes double quotes, or into double quotes if it only includes single quotes.
+    If there is a mix of single and double quotes in INSTANCENAME, or if shell
+    variables need to be expanded, this can be achieved by backslash-escaping any
+    double quotes in INSTANCENAME, and putting it into double quotes.

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -40,7 +40,7 @@ from ._displaytree import display_class_tree
 #
 
 no_qualifiers_class_option = [              # pylint: disable=invalid-name
-    click.option('--no-qualifiers', 'includequalifiers', is_flag=True,
+    click.option('--nq', '--no-qualifiers', 'no_qualifiers', is_flag=True,
                  default=True,
                  help='Do not include qualifiers in the returned class(es). '
                       'Default: Include qualifiers.')]
@@ -226,11 +226,10 @@ def class_enumerate(context, classname, **options):
 
 @class_group.command('references', options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True)
-@click.option('--rc', '--result-class', type=str, required=False,
-              metavar='<class name>',
-              help='Filter by the classname provided. Each returned '
-                   'class (or classname) should be this class or its '
-                   'subclasses. Optional.')
+@click.option('--rc', '--result-class', 'result_class', type=str,
+              required=False, metavar='CLASSNAME',
+              help='Filter the result set by result class name. '
+                   'Subclasses of the specified class also match.')
 @click.option('-r', '--role', type=str, required=False,
               metavar='PROPERTYNAME',
               help='Filter the result set by source end role name.')
@@ -272,32 +271,23 @@ def class_references(context, classname, **options):
 
 @class_group.command('associators', options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True)
-@click.option('--ac', '--assoc-class', type=str, required=False,
-              metavar='<class name>',
-              help='Filter by the association class name provided. Each '
-                   'returned class (or class name) should be associated to the '
-                   'source class through this class or its subclasses. '
-                   'Optional.')
-@click.option('--rc', '--result-class', type=str, required=False,
-              metavar='<class name>',
-              help='Filter the returned objects by the class name provided. '
-                   'Each returned class (or class name) should be this class '
-                   'or one of its subclasses. Optional')
+@click.option('--ac', '--assoc-class', 'assoc_class', type=str, required=False,
+              metavar='CLASSNAME',
+              help='Filter the result set by association class name. '
+                   'Subclasses of the specified class also match.')
+@click.option('--rc', '--result-class', 'result_class', type=str,
+              required=False,
+              metavar='CLASSNAME',
+              help='Filter the result set by result class name. '
+                   'Subclasses of the specified class also match.')
 @click.option('-r', '--role', type=str, required=False,
-              metavar='<role name>',
-              help='Filter by the role name provided. Each returned class '
-              '(or class name)should be associated with the source class '
-              '(CLASSNAME) through an association with this role (property '
-              'name in the association that matches this parameter). Optional.')
-@click.option('--rr', '--result-role', type=str, required=False,
-              metavar='<role name>',
-              help='Filter by the result role name provided. Each returned '
-              'class (or class name)should be associated with the source class '
-              '(CLASSNAME) through an association with returned object having '
-              'this role (property name in the association that matches this '
-              'parameter). Optional.')
-@add_options(includeclassqualifiers_option)
-@add_options(includeclassorigin_option)
+              metavar='PROPERTYNAME',
+              help='Filter the result set by source end role name.')
+@click.option('--rr', '--result-role', 'result_role', type=str, required=False,
+              metavar='PROPERTYNAME',
+              help='Filter the result set by far end role name.')
+@add_options(no_qualifiers_class_option)
+@add_options(include_classorigin_class_option)
 @add_options(propertylist_option)
 @add_options(names_only_option)
 @add_options(namespace_option)
@@ -435,7 +425,7 @@ def cmd_class_get(context, classname, options):
             classname,
             namespace=options['namespace'],
             LocalOnly=options['local_only'],
-            IncludeQualifiers=options['includequalifiers'],
+            IncludeQualifiers=options['no_qualifiers'],
             IncludeClassOrigin=options['include_classorigin'],
             PropertyList=resolve_propertylist(options['propertylist']))
 
@@ -472,7 +462,7 @@ def cmd_class_enumerate(context, classname, options):
                 namespace=options['namespace'],
                 LocalOnly=options['local_only'],
                 DeepInheritance=options['deep_inheritance'],
-                IncludeQualifiers=options['includequalifiers'],
+                IncludeQualifiers=options['no_qualifiers'],
                 IncludeClassOrigin=options['include_classorigin'])
 
         display_cim_objects(context, results, context.output_format,
@@ -501,7 +491,7 @@ def cmd_class_references(context, classname, options):
                 classname,
                 ResultClass=options['result_class'],
                 Role=options['role'],
-                IncludeQualifiers=options['includequalifiers'],
+                IncludeQualifiers=options['no_qualifiers'],
                 IncludeClassOrigin=options['include_classorigin'],
                 PropertyList=resolve_propertylist(options['propertylist']))
 
@@ -535,7 +525,7 @@ def cmd_class_associators(context, classname, options):
                 Role=options['role'],
                 ResultClass=options['result_class'],
                 ResultRole=options['result_role'],
-                IncludeQualifiers=options['includequalifiers'],
+                IncludeQualifiers=options['no_qualifiers'],
                 IncludeClassOrigin=options['include_classorigin'],
                 PropertyList=resolve_propertylist(options['propertylist']))
 

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -39,6 +39,11 @@ from ._displaytree import display_class_tree
 #   Common option definitions for class group
 #
 
+# NOTE: A number of the options use double-dash as the short form.  In those
+# cases, a third definition of the options without the double-dash defines
+# the corresponding option name, ex. 'include_qualifiers'. It should be
+# defined with underscore and not dash
+
 no_qualifiers_class_option = [              # pylint: disable=invalid-name
     click.option('--nq', '--no-qualifiers', 'no_qualifiers', is_flag=True,
                  default=True,
@@ -46,14 +51,14 @@ no_qualifiers_class_option = [              # pylint: disable=invalid-name
                       'Default: Include qualifiers.')]
 
 deep_inheritance_class_option = [              # pylint: disable=invalid-name
-    click.option('-d', '--deep-inheritance', is_flag=True,
+    click.option('--di', '--deep-inheritance', 'deep_inheritance', is_flag=True,
                  default=False,
                  help='Include the complete subclass hierarchy of the '
                       'requested classes in the result set. '
                       'Default: Do not include subclasses.')]
 
 local_only_class_option = [              # pylint: disable=invalid-name
-    click.option('-l', '--local-only', is_flag=True,
+    click.option('--lo', '--local-only', 'local_only', is_flag=True,
                  default=False,
                  help='Do not include superclass properties and methods in '
                       'the returned class(es). '
@@ -110,8 +115,7 @@ def class_get(context, classname, **options):
 
 @class_group.command('delete', options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True,)
-@click.option('-f', '--force', is_flag=True,
-              default=False,
+@click.option('-f', '--force', is_flag=True, default=False,
               help='Delete any instances of the class as well. '
                    'Some servers may still reject the class deletion. '
                    'Default: Reject command if the class has any instances.')
@@ -276,8 +280,7 @@ def class_references(context, classname, **options):
               help='Filter the result set by association class name. '
                    'Subclasses of the specified class also match.')
 @click.option('--rc', '--result-class', 'result_class', type=str,
-              required=False,
-              metavar='CLASSNAME',
+              required=False, metavar='CLASSNAME',
               help='Filter the result set by result class name. '
                    'Subclasses of the specified class also match.')
 @click.option('-r', '--role', type=str, required=False,
@@ -365,8 +368,7 @@ def class_find(context, classname_glob, **options):
 
 @class_group.command('tree', options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME', required=False)
-@click.option('-s', '--superclasses', is_flag=True,
-              default=False,
+@click.option('-s', '--superclasses', is_flag=True, default=False,
               help='Show the superclass hierarchy. '
                    'Default: Show the subclass hierarchy.')
 @add_options(namespace_option)

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -226,10 +226,11 @@ def class_enumerate(context, classname, **options):
 
 @class_group.command('references', options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True)
-@click.option('-R', '--result-class', type=str, required=False,
-              metavar='CLASSNAME',
-              help='Filter the result set by result class name. '
-                   'Subclasses of the specified class also match.')
+@click.option('--rc', '--result-class', type=str, required=False,
+              metavar='<class name>',
+              help='Filter by the classname provided. Each returned '
+                   'class (or classname) should be this class or its '
+                   'subclasses. Optional.')
 @click.option('-r', '--role', type=str, required=False,
               metavar='PROPERTYNAME',
               help='Filter the result set by source end role name.')
@@ -271,22 +272,32 @@ def class_references(context, classname, **options):
 
 @class_group.command('associators', options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True)
-@click.option('-a', '--assoc-class', type=str, required=False,
-              metavar='CLASSNAME',
-              help='Filter the result set by association class name. '
-                   'Subclasses of the specified class also match.')
-@click.option('-C', '--result-class', type=str, required=False,
-              metavar='CLASSNAME',
-              help='Filter the result set by result class name. '
-                   'Subclasses of the specified class also match.')
+@click.option('--ac', '--assoc-class', type=str, required=False,
+              metavar='<class name>',
+              help='Filter by the association class name provided. Each '
+                   'returned class (or class name) should be associated to the '
+                   'source class through this class or its subclasses. '
+                   'Optional.')
+@click.option('--rc', '--result-class', type=str, required=False,
+              metavar='<class name>',
+              help='Filter the returned objects by the class name provided. '
+                   'Each returned class (or class name) should be this class '
+                   'or one of its subclasses. Optional')
 @click.option('-r', '--role', type=str, required=False,
-              metavar='PROPERTYNAME',
-              help='Filter the result set by source end role name.')
-@click.option('-R', '--result-role', type=str, required=False,
-              metavar='PROPERTYNAME',
-              help='Filter the result set by far end role name.')
-@add_options(no_qualifiers_class_option)
-@add_options(include_classorigin_class_option)
+              metavar='<role name>',
+              help='Filter by the role name provided. Each returned class '
+              '(or class name)should be associated with the source class '
+              '(CLASSNAME) through an association with this role (property '
+              'name in the association that matches this parameter). Optional.')
+@click.option('--rr', '--result-role', type=str, required=False,
+              metavar='<role name>',
+              help='Filter by the result role name provided. Each returned '
+              'class (or class name)should be associated with the source class '
+              '(CLASSNAME) through an association with returned object having '
+              'this role (property name in the association that matches this '
+              'parameter). Optional.')
+@add_options(includeclassqualifiers_option)
+@add_options(includeclassorigin_option)
 @add_options(propertylist_option)
 @add_options(names_only_option)
 @add_options(namespace_option)

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -36,6 +36,11 @@ from .config import DEFAULT_QUERY_LANGUAGE
 #   Common option definitions for instance group
 #
 
+# NOTE: A number of the options use double-dash as the short form.  In those
+# cases, a third definition of the options without the double-dash defines
+# the corresponding option name, ex. 'include_qualifiers'. It should be
+# defined with underscore and not dash
+
 
 # This is instance-only because the default is False for include-qualifiers
 # on instances but True on classes
@@ -58,20 +63,23 @@ include_qualifiers_list_option = [              # pylint: disable=invalid-name
 # specific to instance because DeepInheritance differs between class and
 # instance operations.
 deep_inheritance_enum_option = [              # pylint: disable=invalid-name
-    click.option('-d', '--deep-inheritance', is_flag=True, required=False,
+    click.option('--di', '--deep-inheritance', 'deep_inheritance',
+                 is_flag=True, required=False,
                  help='Include subclass properties in the returned '
                       'instances. '
                       'Default: Do not include subclass properties.')]
 
 local_only_get_option = [              # pylint: disable=invalid-name
-    click.option('-l', '--local-only', is_flag=True, required=False,
+    click.option('--lo', '--local-only', 'local_only', is_flag=True,
+                 required=False,
                  help='Do not include superclass properties in the returned '
                       'instance. '
                       'Some servers may ignore this option. '
                       'Default: Include superclass properties.')]
 
 local_only_list_option = [              # pylint: disable=invalid-name
-    click.option('-l', '--local-only', is_flag=True, required=False,
+    click.option('--lo', '--local-only', 'local_only', is_flag=True,
+                 required=False,
                  help='When traditional operations are used, do not include '
                       'superclass properties in the returned instances. '
                       'Some servers may ignore this option. '
@@ -85,7 +93,7 @@ interactive_option = [              # pylint: disable=invalid-name
                       'name, and the instances of that class are presented.')]
 
 property_create_option = [              # pylint: disable=invalid-name
-    click.option('-P', '--property', type=str, metavar='PROPERTYNAME=VALUE',
+    click.option('-p', '--property', type=str, metavar='PROPERTYNAME=VALUE',
                  required=False, multiple=True,
                  help='Initial property value for the new instance. '
                       'May be specified multiple times. '
@@ -95,7 +103,7 @@ property_create_option = [              # pylint: disable=invalid-name
                       'Default: No initial properties provided.')]
 
 property_modify_option = [              # pylint: disable=invalid-name
-    click.option('-P', '--property', type=str, metavar='PROPERTYNAME=VALUE',
+    click.option('-p', '--property', type=str, metavar='PROPERTYNAME=VALUE',
                  required=False, multiple=True,
                  help='Property to be modified, with its new value. '
                       'May be specified once for each property to be '
@@ -106,16 +114,15 @@ property_modify_option = [              # pylint: disable=invalid-name
                       'Default: No properties modified.')]
 
 filter_query_language_option = [              # pylint: disable=invalid-name
-    click.option('--filter-query-language', type=str,
-                 metavar='QUERY-LANGUAGE',
-                 default=None,
+    click.option('--fql', '--filter-query-language', 'filter_query_language',
+                 type=str, metavar='QUERY-LANGUAGE', default=None,
                  help='The filter query language to be used with '
                       '--filter-query. '
                       'Default: DMTF:FQL.')]
 
 filter_query_option = [              # pylint: disable=invalid-name
-    click.option('-f', '--filter-query', type=str, metavar='QUERY-STRING',
-                 default=None,
+    click.option('--fq', '--filter-query', 'filter_query', type=str,
+                 metavar='QUERY-STRING', default=None,
                  help='When pull operations are used, filter the instances in '
                       'the result via a filter query. '
                       'By default, and when traditional operations are used, '
@@ -244,7 +251,7 @@ def instance_create(context, classname, **options):
 @click.argument('instancename', type=str, metavar='INSTANCENAME', required=True)
 @add_options(property_modify_option)
 @click.option('--pl', '--propertylist', 'propertylist', multiple=True, type=str,
-              default=None, metavar='PROPERTYLIST',
+              default=None, required=False, metavar='PROPERTYLIST',
               help='Reduce the properties to be modified (as per '
               '--property) to a specific property list. '
               'Multiple properties may be specified with either a '
@@ -390,8 +397,7 @@ def instance_enumerate(context, classname, **options):
               required=False, metavar='CLASSNAME',
               help='Filter the result set by result class name. '
                    'Subclasses of the specified class also match.')
-@click.option('-r', '--role', type=str, required=False,
-              metavar='PROPERTYNAME',
+@click.option('-r', '--role', type=str, required=False, metavar='PROPERTYNAME',
               help='Filter the result set by source end role name.')
 @add_options(include_qualifiers_list_option)
 @add_options(include_classorigin_instance_option)
@@ -510,8 +516,7 @@ def instance_associators(context, instancename, **options):
 @instance_group.command('query', options_metavar=CMD_OPTS_TXT)
 @click.argument('query', type=str, required=True, metavar='QUERY-STRING')
 @click.option('--ql', '--query-language', 'query_language', type=str,
-              metavar='QUERY-LANGUAGE',
-              default=DEFAULT_QUERY_LANGUAGE,
+              metavar='QUERY-LANGUAGE', default=DEFAULT_QUERY_LANGUAGE,
               help='The query language to be used with --query. '
               'Default: {default}.'.
               format(default=DEFAULT_QUERY_LANGUAGE))

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -39,19 +39,21 @@ from .config import DEFAULT_QUERY_LANGUAGE
 
 # This is instance-only because the default is False for include-qualifiers
 # on instances but True on classes
-include_qualifiers_get_option = [              # pylint: disable=invalid-name
-    click.option('-q', '--include-qualifiers', is_flag=True, required=False,
-                 help='Include qualifiers in the returned instance. '
-                      'Not all servers return qualifiers on instances. '
-                      'Default: Do not include qualifiers.')]
+includequalifiers_option = [              # pylint: disable=invalid-name
+    click.option('--iq', '--include-qualifiers', is_flag=True, required=False,
+                 help='If set, requests server to include qualifiers in the '
+                 'returned instances. Not all servers return qualifiers on '
+                 'instances')]
 
-include_qualifiers_list_option = [              # pylint: disable=invalid-name
-    click.option('-q', '--include-qualifiers', is_flag=True, required=False,
-                 help='When traditional operations are used, include '
-                      'qualifiers in the returned instances. '
-                      'Some servers may ignore this option. '
-                      'By default, and when pull operations are used, '
-                      'qualifiers will never be included.')]
+includequalifiersenum_option = [              # pylint: disable=invalid-name
+    click.option('--iq', '--include-qualifiers', is_flag=True, required=False,
+                 help='If set, requests server to include qualifiers in the '
+                 'returned instances. This command may use either pull '
+                 'or traditional operations depending on the server '
+                 'and the "--use-pull" general option. If pull operations '
+                 'are used, qualifiers will not be included, even if this '
+                 'option is specified. If traditional operations are used, '
+                 'inclusion of qualifiers depends on the server.')]
 
 # specific to instance because DeepInheritance differs between class and
 # instance operations.
@@ -78,6 +80,7 @@ local_only_list_option = [              # pylint: disable=invalid-name
 
 interactive_option = [              # pylint: disable=invalid-name
     click.option('-i', '--interactive', is_flag=True, required=False,
+<<<<<<< HEAD
                  help='Prompt for selecting an instance from a list. '
                       'If used, the INSTANCENAME argument must be a class '
                       'name, and the instances of that class are presented.')]
@@ -105,13 +108,32 @@ property_modify_option = [              # pylint: disable=invalid-name
 
 filter_query_language_option = [              # pylint: disable=invalid-name
     click.option('--filter-query-language', type=str, metavar='QUERY-LANGUAGE',
+=======
+                 help='If set, `INSTANCENAME` argument must be a class rather '
+                      'than an instance and user is presented with a list of '
+                      'instances of the class from which the instance to '
+                      'process is selected.')]
+
+instance_property_option = [              # pylint: disable=invalid-name
+    click.option('-P', '--property', type=str, metavar='name=value',
+                 required=False,
+                 multiple=True,
+                 help='Optional property names of the form name=value. '
+                 'Multiple definitions allowed, one for each property to be '
+                 'included in the createdinstance. Array property values '
+                 'defined by comma-separated-values. EmbeddedInstance not '
+                 'allowed.')]
+
+filterquerylanguage_option = [              # pylint: disable=invalid-name
+    click.option('--fql', '--filter-query-language', type=str, required=False,
+>>>>>>> WIP
                  default=None,
                  help='The filter query language to be used with '
                       '--filter-query. '
                       'Default: DMTF:FQL.')]
 
-filter_query_option = [              # pylint: disable=invalid-name
-    click.option('-f', '--filter-query', type=str, metavar='QUERY-STRING',
+filterquery_option = [              # pylint: disable=invalid-name
+    click.option('-fq', '--filter-query', type=str, required=False,
                  default=None,
                  help='When pull operations are used, filter the instances in '
                       'the result via a filter query. '
@@ -239,16 +261,17 @@ def instance_create(context, classname, **options):
 
 @instance_group.command('modify', options_metavar=CMD_OPTS_TXT)
 @click.argument('instancename', type=str, metavar='INSTANCENAME', required=True)
-@add_options(property_modify_option)
-@click.option('-p', '--propertylist', multiple=True, type=str,
-              default=None, metavar='PROPERTYLIST',
-              help='Reduce the properties to be modified (as per '
-              '--property) to a specific property list. '
-              'Multiple properties may be specified with either a '
-              'comma-separated list or by using the option multiple '
-              'times. The empty string will cause no properties to '
-              'be modified. '
-              'Default: Do not reduce the properties to be modified.')
+@add_options(instance_property_option)
+@click.option('-pl', '--propertylist', multiple=True, type=str,
+              default=None, metavar='<property name>',
+              help='Define a propertylist for the request. If option '
+                   'not specified a Null property list is created. Multiple '
+                   'properties may be defined with either a comma '
+                   'separated list defining the option multiple times. '
+                   '(ex: -p pn1 -p pn22 or -p pn1,pn2). If defined as '
+                   'empty string an empty propertylist is created. The '
+                   'server uses the propertylist to limit changes made to '
+                   'the instance to properties in the propertylist.')
 @add_options(interactive_option)
 @add_options(verify_option)
 @add_options(namespace_option)
@@ -289,7 +312,7 @@ def instance_modify(context, instancename, **options):
 @instance_group.command('invokemethod', options_metavar=CMD_OPTS_TXT)
 @click.argument('instancename', type=str, metavar='INSTANCENAME', required=True)
 @click.argument('methodname', type=str, metavar='METHODNAME', required=True)
-@click.option('-p', '--parameter', type=str, metavar='PARAMETERNAME=VALUE',
+@click.option('--pa', '--parameter', type=str, metavar='name=value',
               required=False, multiple=True,
               help='Specify a method input parameter with its value. '
                    'May be specified multiple times. '
@@ -383,10 +406,11 @@ def instance_enumerate(context, classname, **options):
 
 @instance_group.command('references', options_metavar=CMD_OPTS_TXT)
 @click.argument('instancename', type=str, metavar='INSTANCENAME', required=True)
-@click.option('-R', '--result-class', type=str, required=False,
-              metavar='CLASSNAME',
-              help='Filter the result set by result class name. '
-                   'Subclasses of the specified class also match.')
+@click.option('--rc', '--resultclass', type=str, required=False,
+              metavar='<class name>',
+              help='Filter by the result class name provided. Each returned '
+                   'instance (or instance name) should be a member of this '
+                   'class or its subclasses. Optional')
 @click.option('-r', '--role', type=str, required=False,
               metavar='PROPERTYNAME',
               help='Filter the result set by source end role name.')
@@ -441,22 +465,32 @@ def instance_references(context, instancename, **options):
 
 @instance_group.command('associators', options_metavar=CMD_OPTS_TXT)
 @click.argument('instancename', type=str, metavar='INSTANCENAME', required=True)
-@click.option('-a', '--assoc-class', type=str, required=False,
-              metavar='CLASSNAME',
-              help='Filter the result set by association class name. '
-                   'Subclasses of the specified class also match.')
-@click.option('-C', '--result-class', type=str, required=False,
-              metavar='CLASSNAME',
-              help='Filter the result set by result class name. '
-                   'Subclasses of the specified class also match.')
+@click.option('--ac', '--assoc-class', type=str, required=False,
+              metavar='<class name>',
+              help='Filter by the association class name provided.Each '
+                   'returned instance (or instance name) should be associated '
+                   'to the source instance through this class or its '
+                   'subclasses. Optional.')
+@click.option('--rc', '--result-class', type=str, required=False,
+              metavar='<class name>',
+              help='Filter by the result class name provided. Each '
+                   'returned instance (or instance name) should be a member '
+                   'of this class or one of its subclasses. Optional')
 @click.option('-r', '--role', type=str, required=False,
-              metavar='PROPERTYNAME',
-              help='Filter the result set by source end role name.')
-@click.option('-R', '--result-role', type=str, required=False,
-              metavar='PROPERTYNAME',
-              help='Filter the result set by far end role name.')
-@add_options(include_qualifiers_list_option)
-@add_options(include_classorigin_instance_option)
+              metavar='<role name>',
+              help='Filter by the role name provided. Each returned instance '
+              '(or instance name)should be associated with the source instance '
+              '(INSTANCENAME) through an association with this role (property '
+              'name in the association that matches this parameter). Optional.')
+@click.option('--rr', '--result-role', type=str, required=False,
+              metavar='<role name>',
+              help='Filter by the result role name provided. Each returned '
+              'instance (or instance name)should be associated with the source '
+              ' instance name (`INSTANCENAME`) through an association with '
+              'returned object having this role (property name in the '
+              'association that matches this parameter). Optional.')
+@add_options(includequalifiersenum_option)
+@add_options(includeclassorigin_option)
 @add_options(propertylist_option)
 @add_options(names_only_option)
 @add_options(namespace_option)
@@ -505,12 +539,11 @@ def instance_associators(context, instancename, **options):
 
 
 @instance_group.command('query', options_metavar=CMD_OPTS_TXT)
-@click.argument('query', type=str, required=True, metavar='QUERY-STRING')
-@click.option('-l', '--query-language', type=str, metavar='QUERY-LANGUAGE',
-              default=DEFAULT_QUERY_LANGUAGE,
-              help='The query language to be used with --query. '
-              'Default: {default}.'.
-              format(default=DEFAULT_QUERY_LANGUAGE))
+@click.argument('query', type=str, required=True, metavar='QUERY_STRING')
+@click.option('--ql', '--query-language', type=str, required=False,
+              metavar='QUERY LANGUAGE', default=DEFAULT_QUERY_LANGUAGE,
+              help='Use the query language defined. '
+                   '(Default: {of}.'.format(of=DEFAULT_QUERY_LANGUAGE))
 @add_options(namespace_option)
 @add_options(summary_option)
 @click.pass_obj

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -26,6 +26,11 @@ from pywbem import ValueMapping, Error
 from .pywbemcli import cli
 from ._common import CMD_OPTS_TXT, format_table
 
+# NOTE: A number of the options use double-dash as the short form.  In those
+# cases, a third definition of the options without the double-dash defines
+# the corresponding option name, ex. 'include_qualifiers'. It should be
+# defined with underscore and not dash
+
 
 @cli.group('server', options_metavar=CMD_OPTS_TXT)
 def server_group():
@@ -122,19 +127,19 @@ def server_profiles(context, **options):
 @click.option('-p', '--profile', type=str, metavar='PROFILE-NAME',
               required=False,
               help='Filter by the profile name. (ex. -p Array')
-@click.option('-c', '--central-class', type=str, metavar='CLASSNAME',
-              required=False,
+@click.option('--cc', '--central-class', 'central_class', type=str,
+              metavar='CLASSNAME', required=False,
               help='Optional. Required only if profiles supports only '
               'scopig methodology')
-@click.option('-s', '--scoping-class', type=str, metavar='CLASSNAME',
-              required=False,
+@click.option('--sc', '--scoping-class', 'scoping_class', type=str,
+              metavar='CLASSNAME', required=False,
               help='Optional. Required only if profiles supports only '
               'scopig methodology')
-@click.option('-S', '--scoping-path', type=str, metavar='CLASSLIST',
-              required=False, multiple=True,
+@click.option('--sp', '--scoping-path', 'scoping_path', type=str,
+              metavar='CLASSLIST', required=False, multiple=True,
               help='Optional. Required only if profiles supports only '
               'scopig methodology. Multiples allowed')
-@click.option('-r', '--reference-direction',
+@click.option('--rd', '--reference-direction', 'reference_direction',
               type=click.Choice(['snia', 'dmtf']),
               default='dmtf',
               show_default=True,

--- a/pywbemtools/pywbemcli/_common_options.py
+++ b/pywbemtools/pywbemcli/_common_options.py
@@ -27,28 +27,36 @@ import click
 # multiple places in the command structure.
 #
 propertylist_option = [                      # pylint: disable=invalid-name
-    click.option('--pl', '--propertylist', multiple=True, type=str,
-                 default=None, metavar='<property name>',
-                 help='Define a propertylist for the request. If option '
-                      'not specified a Null property list is created and the '
-                      'server returns all properties. Multiple properties may '
-                      'be defined with either a comma separated list or by '
-                      'using the option multiple times. '
-                      '(ex: -p pn1 -p pn22 or -p pn1,pn2). '
-                      'If defined as empty string the server should return no '
-                      'properties.')]
+    click.option('--pl', '--propertylist', 'propertylist', multiple=True,
+                 type=str,
+                 default=None, metavar='PROPERTYLIST',
+                 help='Filter the properties included in the returned '
+                      'object(s). '
+                      'Multiple properties may be specified with either a '
+                      'comma-separated list or by using the option multiple '
+                      'times. Properties specified in this option that are '
+                      'not in the object(s) will be ignored. '
+                      'The empty string will include no properties. '
+                      'Default: Do not filter properties.')]
 
 names_only_option = [                      # pylint: disable=invalid-name
-    click.option('--no', '--names-only', is_flag=True, required=False,
-                 help='Retrieve only the returned object names.')]
-
-sort_option = [                            # pylint: disable=invalid-name
-    click.option('--so', '--sort', is_flag=True, required=False,
-                 help='Sort into alphabetical order by classname.')]
-
-includeclassorigin_option = [            # pylint: disable=invalid-name
-    click.option('--ico', '--include-classorigin', is_flag=True,
+    click.option('--no', '--names-only', 'names_only', is_flag=True,
                  required=False,
+                 help='Retrieve only the object paths (names). '
+                      'Default: Retrieve the complete objects including '
+                      'object paths.')]
+
+include_classorigin_instance_option = [         # pylint: disable=invalid-name
+    click.option('--ico', '--include-classorigin', 'include_classorigin',
+                 is_flag=True, required=False,
+                 help='Include class origin information in the returned '
+                      'instance(s). '
+                      'Some servers may ignore this option. '
+                      'Default: Do not include class origin information.')]
+
+include_classorigin_class_option = [            # pylint: disable=invalid-name
+    click.option('--ico', '--include-classorigin', 'include_classorigin',
+                 is_flag=True, required=False,
                  help='Include class origin information in the returned '
                       'class(es). '
                       'Default: Do not include class origin information.')]
@@ -59,9 +67,9 @@ namespace_option = [                     # pylint: disable=invalid-name
                  help='Namespace to use for this command, instead of the '
                       'default namespace of the connection.')]
 
-summary_objects_option = [              # pylint: disable=invalid-name
+summary_option = [              # pylint: disable=invalid-name
     click.option('-s', '--summary', is_flag=True, required=False,
-                 help='Return only summary of objects (count).')]
+                 help='Show only a summary (count) of the objects.')]
 
 verify_option = [              # pylint: disable=invalid-name
     click.option('-V', '--verify', is_flag=True, required=False,

--- a/pywbemtools/pywbemcli/_common_options.py
+++ b/pywbemtools/pywbemcli/_common_options.py
@@ -27,33 +27,27 @@ import click
 # multiple places in the command structure.
 #
 propertylist_option = [                      # pylint: disable=invalid-name
-    click.option('-p', '--propertylist', multiple=True, type=str,
-                 default=None, metavar='PROPERTYLIST',
-                 help='Filter the properties included in the returned '
-                      'object(s). '
-                      'Multiple properties may be specified with either a '
-                      'comma-separated list or by using the option multiple '
-                      'times. Properties specified in this option that are '
-                      'not in the object(s) will be ignored. '
-                      'The empty string will include no properties. '
-                      'Default: Do not filter properties.')]
+    click.option('--pl', '--propertylist', multiple=True, type=str,
+                 default=None, metavar='<property name>',
+                 help='Define a propertylist for the request. If option '
+                      'not specified a Null property list is created and the '
+                      'server returns all properties. Multiple properties may '
+                      'be defined with either a comma separated list or by '
+                      'using the option multiple times. '
+                      '(ex: -p pn1 -p pn22 or -p pn1,pn2). '
+                      'If defined as empty string the server should return no '
+                      'properties.')]
 
 names_only_option = [                      # pylint: disable=invalid-name
-    click.option('-o', '--names-only', is_flag=True, required=False,
-                 help='Retrieve only the object paths (names). '
-                      'Default: Retrieve the complete objects including '
-                      'object paths.')]
+    click.option('--no', '--names-only', is_flag=True, required=False,
+                 help='Retrieve only the returned object names.')]
 
-include_classorigin_instance_option = [         # pylint: disable=invalid-name
-    click.option('-c', '--include-classorigin', is_flag=True,
-                 required=False,
-                 help='Include class origin information in the returned '
-                      'instance(s). '
-                      'Some servers may ignore this option. '
-                      'Default: Do not include class origin information.')]
+sort_option = [                            # pylint: disable=invalid-name
+    click.option('--so', '--sort', is_flag=True, required=False,
+                 help='Sort into alphabetical order by classname.')]
 
-include_classorigin_class_option = [            # pylint: disable=invalid-name
-    click.option('-c', '--include-classorigin', is_flag=True,
+includeclassorigin_option = [            # pylint: disable=invalid-name
+    click.option('--ico', '--include-classorigin', is_flag=True,
                  required=False,
                  help='Include class origin information in the returned '
                       'class(es). '
@@ -65,9 +59,9 @@ namespace_option = [                     # pylint: disable=invalid-name
                  help='Namespace to use for this command, instead of the '
                       'default namespace of the connection.')]
 
-summary_option = [              # pylint: disable=invalid-name
-    click.option('-S', '--summary', is_flag=True, required=False,
-                 help='Show only a summary (count) of the objects.')]
+summary_objects_option = [              # pylint: disable=invalid-name
+    click.option('-s', '--summary', is_flag=True, required=False,
+                 help='Return only summary of objects (count).')]
 
 verify_option = [              # pylint: disable=invalid-name
     click.option('-V', '--verify', is_flag=True, required=False,

--- a/tests/unit/common_options_help_lines.py
+++ b/tests/unit/common_options_help_lines.py
@@ -33,10 +33,10 @@ CMD_OPTION_NAMESPACE_HELP_LINE = \
     '-n, --namespace NAMESPACE Namespace to use for this command'
 
 CMD_OPTION_NAMES_ONLY_HELP_LINE = \
-    '-o, --names-only Retrieve only the object paths (names).'
+    '--no, --names-only Retrieve only the object paths (names).'
 
 CMD_OPTION_SUMMARY_HELP_LINE = \
-    '-S, --summary Show only a summary (count) of the objects.'
+    '-s, --summary Show only a summary (count) of the objects.'
 
 CMD_OPTION_LOCAL_ONLY_CLASS_HELP_LINE = \
     '-l, --local-only Do not include superclass properties and methods in ' \
@@ -50,7 +50,7 @@ CMD_OPTION_LOCAL_ONLY_INSTANCE_LIST_HELP_LINE = \
     'superclass properties'
 
 CMD_OPTION_PROPERTYLIST_HELP_LINE = \
-    '-p, --propertylist PROPERTYLIST Filter the properties included in'
+    '--pl, --propertylist PROPERTYLIST Filter the properties included in'
 
 CMD_OPTION_FILTER_QUERY_LINE = \
     '-f, --filter-query QUERY-STRING When pull operations are used, filter ' \
@@ -61,15 +61,15 @@ CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE = \
     'used'
 
 CMD_OPTION_NO_QUALIFIERS_HELP_LINE = \
-    '--no-qualifiers Do not include qualifiers in the returned'
+    '--nq, --no-qualifiers Do not include qualifiers in the returned'
 
 CMD_OPTION_INCLUDE_QUALIFIERS_GET_HELP_LINE = \
-    '-q, --include-qualifiers Include qualifiers in the returned'
+    '--iq, --include-qualifiers Include qualifiers in the returned'
 
 CMD_OPTION_INCLUDE_QUALIFIERS_LIST_HELP_LINE = \
-    '-q, --include-qualifiers When traditional operations are used, ' \
+    '--iq, --include-qualifiers When traditional operations are used, ' \
     'include qualifiers in the returned'
 
 CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE = \
-    '-c, --include-classorigin Include class origin information in the ' \
+    '--ico, --include-classorigin Include class origin information in the ' \
     'returned'

--- a/tests/unit/common_options_help_lines.py
+++ b/tests/unit/common_options_help_lines.py
@@ -20,6 +20,11 @@ The expected help text strings are used with the 'innows' test, which is a
 whitespace-tolerant test for whether the expected text is in the actual text.
 """
 
+# NOTE: A number of the options use double-dash as the short form.  In those
+# cases, a third definition of the options without the double-dash defines
+# the corresponding option name, ex. 'include_qualifiers'. It should be
+# defined with underscore and not dash
+
 CMD_OPTION_HELP_HELP_LINE = \
     '-h, --help Show this message and exit.'
 
@@ -39,21 +44,21 @@ CMD_OPTION_SUMMARY_HELP_LINE = \
     '-s, --summary Show only a summary (count) of the objects.'
 
 CMD_OPTION_LOCAL_ONLY_CLASS_HELP_LINE = \
-    '-l, --local-only Do not include superclass properties and methods in ' \
+    '--lo, --local-only Do not include superclass properties and methods in ' \
     'the returned'
 
 CMD_OPTION_LOCAL_ONLY_INSTANCE_GET_HELP_LINE = \
-    '-l, --local-only Do not include superclass properties in the returned'
+    '--lo, --local-only Do not include superclass properties in the returned'
 
 CMD_OPTION_LOCAL_ONLY_INSTANCE_LIST_HELP_LINE = \
-    '-l, --local-only When traditional operations are used, do not include ' \
+    '--lo, --local-only When traditional operations are used, do not include ' \
     'superclass properties'
 
 CMD_OPTION_PROPERTYLIST_HELP_LINE = \
     '--pl, --propertylist PROPERTYLIST Filter the properties included in'
 
 CMD_OPTION_FILTER_QUERY_LINE = \
-    '-f, --filter-query QUERY-STRING When pull operations are used, filter ' \
+    '--fq, --filter-query QUERY-STRING When pull operations are used, filter ' \
     'the instances in the result'
 
 CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE = \

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -85,7 +85,7 @@ CLASS_DELETE_HELP_LINES = [
 CLASS_ENUMERATE_HELP_LINES = [
     'Usage: pywbemcli class enumerate [COMMAND-OPTIONS] CLASSNAME',
     'List top classes or subclasses of a class in a namespace.',
-    '-d, --deep-inheritance Include the complete subclass hierarchy',
+    '--di, --deep-inheritance Include the complete subclass hierarchy',
     CMD_OPTION_LOCAL_ONLY_CLASS_HELP_LINE,
     CMD_OPTION_NO_QUALIFIERS_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
@@ -344,8 +344,15 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo local only',
-     ['enumerate', 'CIM_Foo', '-l'],
+    ['Verify class subcommand enumerate CIM_Foo --lo',
+     ['enumerate', 'CIM_Foo', '--lo'],
+     {'stdout':
+      '   [Description ( "Subclass of CIM_Foo" )]',
+      'test': 'startswith'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify class subcommand enumerate CIM_Foo --lo',
+     ['enumerate', 'CIM_Foo', '--local-only'],
      {'stdout':
       '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
@@ -370,8 +377,8 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo -d',
-     ['enumerate', 'CIM_Foo', '-d'],
+    ['Verify class subcommand enumerate CIM_Foo --di',
+     ['enumerate', 'CIM_Foo', '--di'],
      {'stdout':
       '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
@@ -469,8 +476,15 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo names and -d --no',
-     ['enumerate', 'CIM_Foo', '-d', '--no'],
+    ['Verify class subcommand enumerate CIM_Foo names and --di --no',
+     ['enumerate', 'CIM_Foo', '--di', '--no'],
+     {'stdout': ['CIM_Foo_sub', 'CIM_Foo_sub2', 'CIM_Foo_sub_sub'],
+      'test': 'in'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify class subcommand enumerate CIM_Foo names and --deep-inheritance '
+      '--names-only',
+     ['enumerate', 'CIM_Foo', '--names-only', '--deep-inheritance'],
      {'stdout': ['CIM_Foo_sub', 'CIM_Foo_sub2', 'CIM_Foo_sub_sub'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
@@ -541,8 +555,8 @@ TEST_CASES = [
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand get local-only(-l)).',
-     ['get', 'CIM_Foo_sub2', '-l'],
+    ['Verify class subcommand get local-only(--lo)).',
+     ['get', 'CIM_Foo_sub2', '--lo'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
                  '',
                  '   string cimfoo_sub2;',
@@ -562,6 +576,29 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     # includequalifiers. Test the flag that excludes qualifiers
+    ['Verify class subcommand get without qualifiers. Tests whole response',
+     ['get', 'CIM_Foo_sub2', '--nq'],
+     {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
+                 '',
+                 '   string cimfoo_sub2;',
+                 '',
+                 '   string InstanceID;',
+                 '',
+                 '   uint32 IntegerProp;',
+                 '',
+                 '   uint32 Fuzzy(',
+                 '      string TestInOutParameter,',
+                 '      CIM_Foo REF TestRef,',
+                 '      string OutputParam,',
+                 '      uint32 OutputRtnValue);',
+                 '',
+                 '   uint32 DeleteNothing();',
+                 '',
+                 '};',
+                 '', ],
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
     ['Verify class subcommand get without qualifiers. Tests whole response',
      ['get', 'CIM_Foo_sub2', '--no-qualifiers'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -61,10 +61,10 @@ CLASS_HELP_LINES = [
 CLASS_ASSOCIATORS_HELP_LINES = [
     'Usage: pywbemcli class associators [COMMAND-OPTIONS] CLASSNAME',
     'List the classes associated with a class.',
-    '-a, --assoc-class CLASSNAME Filter the result set by association class',
-    '-C, --result-class CLASSNAME Filter the result set by result class',
+    '--ac, --assoc-class CLASSNAME Filter the result set by association class',
+    '--rc, --result-class CLASSNAME Filter the result set by result class',
     '-r, --role PROPERTYNAME Filter the result set by source end role',
-    '-R, --result-role PROPERTYNAME Filter the result set by far end role',
+    '--rr, --result-role PROPERTYNAME Filter the result set by far end role',
     CMD_OPTION_NO_QUALIFIERS_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
@@ -125,7 +125,7 @@ CLASS_INVOKEMETHOD_HELP_LINES = [
 CLASS_REFERENCES_HELP_LINES = [
     'Usage: pywbemcli class references [COMMAND-OPTIONS] CLASSNAME',
     'List the classes referencing a class.',
-    '-R, --result-class CLASSNAME Filter the result set by result class',
+    '--rc, --result-class CLASSNAME Filter the result set by result class',
     '-r, --role PROPERTYNAME Filter the result set by source end role',
     CMD_OPTION_NO_QUALIFIERS_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
@@ -384,8 +384,8 @@ TEST_CASES = [
       'test': 'startswith'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo -c',
-     ['enumerate', 'CIM_Foo', '-c'],
+    ['Verify class subcommand enumerate CIM_Foo --ico',
+     ['enumerate', 'CIM_Foo', '--ico'],
      {'stdout':
       '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
@@ -398,14 +398,20 @@ TEST_CASES = [
       'test': 'startswith'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo -o names only',
-     ['enumerate', 'CIM_Foo', '-o'],
+    ['Verify class subcommand enumerate CIM_Foo --no names only',
+     ['enumerate', 'CIM_Foo', '--no'],
      {'stdout': ['CIM_Foo', 'CIM_Foo_sub', 'CIM_Foo_sub2'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate -o names only - table',
-     {'args': ['enumerate', '-o'],
+    ['Verify class subcommand enumerate CIM_Foo --names only',
+     ['enumerate', 'CIM_Foo', '--names-only'],
+     {'stdout': ['CIM_Foo', 'CIM_Foo_sub', 'CIM_Foo_sub2'],
+      'test': 'in'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify class subcommand enumerate --no names only - table',
+     {'args': ['enumerate', '--no'],
       'global': ['--output-format', 'table']},
      {'stdout': """Classnames:
 +--------------+
@@ -417,8 +423,8 @@ TEST_CASES = [
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo -o names only - table',
-     {'args': ['enumerate', 'CIM_Foo', '-o'],
+    ['Verify class subcommand enumerate CIM_Foo --no names only - table',
+     {'args': ['enumerate', 'CIM_Foo', '--no'],
       'global': ['--output-format', 'table']},
      {'stdout': """Classnames:
 +--------------+
@@ -439,7 +445,7 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify class subcommand enumerate CIM_Foo summary',
-     ['enumerate', 'CIM_Foo', '-S'],
+     ['enumerate', 'CIM_Foo', '-s'],
      {'stdout': ['2 CIMClass(s) returned'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
@@ -463,8 +469,8 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo names and -d -o',
-     ['enumerate', 'CIM_Foo', '-do'],
+    ['Verify class subcommand enumerate CIM_Foo names and -d --no',
+     ['enumerate', 'CIM_Foo', '-d', '--no'],
      {'stdout': ['CIM_Foo_sub', 'CIM_Foo_sub2', 'CIM_Foo_sub_sub'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
@@ -581,7 +587,7 @@ TEST_CASES = [
 
     # pylint: disable=line-too-long
     ['Verify class subcommand get with propertylist. Tests whole response',
-     ['get', 'CIM_Foo_sub2', '-p', 'InstanceID'],
+     ['get', 'CIM_Foo_sub2', '--pl', 'InstanceID'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {', '',
                  '      [Key ( true ),',
                  '       Description ( "This is key property." )]', ''
@@ -615,7 +621,7 @@ TEST_CASES = [
 
     ['Verify class subcommand get with empty propertylist. Tests whole '
      'response',
-     ['get', 'CIM_Foo_sub2', '-p', '""'],
+     ['get', 'CIM_Foo_sub2', '--pl', '""'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {', '',
                  '      [Description ( "Method with in and out parameters" )'
                  ']',
@@ -674,7 +680,7 @@ TEST_CASES = [
     # pylint: enable=line-too-long
     # TODO include class origin. TODO not returning class origin correctly.
     ['Verify class subcommand get with propertylist and classorigin,',
-     ['get', 'CIM_Foo_sub2', '-p', 'InstanceID', '-c'],
+     ['get', 'CIM_Foo_sub2', '--pl', 'InstanceID', '-c'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {', '',
                  '      [Key ( true ),',
                  '       Description ( "This is key property." )]', ''
@@ -981,7 +987,7 @@ TEST_CASES = [
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
     ['Verify class subcommand associators simple request, one parameter',
-     ['associators', 'TST_Person', '-a', 'TST_MemberOfFamilyCollection'],
+     ['associators', 'TST_Person', '--ac', 'TST_MemberOfFamilyCollection'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Person',
                  'class TST_Person {',
                  '',
@@ -1018,10 +1024,10 @@ TEST_CASES = [
 
     ['Verify class subcommand associators request, all filters short',
      ['associators', 'TST_Person',
-      '-a', 'TST_MemberOfFamilyCollection',
+      '--ac', 'TST_MemberOfFamilyCollection',
       '-r', 'member',
-      '-R', 'family',
-      '-C', 'TST_Person'],
+      '--rr', 'family',
+      '--rc', 'TST_Person'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Person',
                  'class TST_Person {',
                  '',
@@ -1039,10 +1045,10 @@ TEST_CASES = [
     ['Verify class subcommand associators request, all filters short,  -a '
      'does not pass test',
      ['associators', 'TST_Person',
-      '-a', 'TST_MemberOfFamilyCollectionx',
+      '--ac', 'TST_MemberOfFamilyCollectionx',
       '-r', 'member',
-      '-R', 'family',
-      '-C', 'TST_Person'],
+      '--rr', 'family',
+      '--rc', 'TST_Person'],
      {'stdout': [],
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
@@ -1050,32 +1056,43 @@ TEST_CASES = [
     ['Verify class subcommand associators request, all filters short,  -r '
      'does not pass test',
      ['associators', 'TST_Person',
-      '-a', 'TST_MemberOfFamilyCollection',
+      '--ac', 'TST_MemberOfFamilyCollection',
       '-r', 'memberx',
-      '-R', 'family',
-      '-C', 'TST_Person'],
+      '--rr', 'family',
+      '--rc', 'TST_Person'],
      {'stdout': [],
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand associators request, all filters short,  -R '
+    ['Verify class subcommand associators request, all filters short,  -rr '
      'does not pass test',
      ['associators', 'TST_Person',
-      '-a', 'TST_MemberOfFamilyCollection',
+      '--ac', 'TST_MemberOfFamilyCollection',
       '-r', 'member',
-      '-R', 'familyx',
-      '-C', 'TST_Person'],
+      '--rr', 'familyx',
+      '--rc', 'TST_Person'],
      {'stdout': [],
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand associators request, all filters short,  -C '
+    ['Verify class subcommand associators request, all filters short,  --rc '
      'does not pass test',
      ['associators', 'TST_Person',
-      '-a', 'TST_MemberOfFamilyCollection',
+      '--ac', 'TST_MemberOfFamilyCollection',
       '-r', 'member',
-      '-R', 'family',
-      '-C', 'TST_Personx'],
+      '--rr', 'family',
+      '--rc', 'TST_Personx'],
+     {'stdout': [],
+      'test': 'lines'},
+     SIMPLE_ASSOC_MOCK_FILE, OK],
+
+    ['Verify class subcommand associators request, all filters long '
+     'does not pass test',
+     ['associators', 'TST_Person',
+      '--assoc-class', 'TST_MemberOfFamilyCollection',
+      '--role', 'member',
+      '--result-role', 'family',
+      '--result-class', 'TST_Personx'],
      {'stdout': [],
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
@@ -1125,7 +1142,7 @@ TEST_CASES = [
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
     ['Verify class subcommand references simple request -o',
-     ['references', 'TST_Person', '-o'],
+     ['references', 'TST_Person', '--no'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Lineage',
                  '//FakedUrl/root/cimv2:TST_MemberOfFamilyCollection'],
       'test': 'linesnows'},
@@ -1135,6 +1152,15 @@ TEST_CASES = [
      ['references', 'TST_Person',
       '--role', 'member',
       '--result-class', 'TST_MemberOfFamilyCollection'],
+     {'stdout': REFERENCES_CLASS_RTN_QUALS2,
+      'test': 'linesnows'},
+     SIMPLE_ASSOC_MOCK_FILE, OK],
+
+
+    ['Verify class subcommand references request, filters short',
+     ['references', 'TST_Person',
+      '-r', 'member',
+      '--rc', 'TST_MemberOfFamilyCollection'],
      {'stdout': REFERENCES_CLASS_RTN_QUALS2,
       'test': 'linesnows'},
      SIMPLE_ASSOC_MOCK_FILE, OK],

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -72,10 +72,10 @@ INSTANCE_HELP_LINES = [
 INSTANCE_ASSOCIATORS_HELP_LINES = [
     'Usage: pywbemcli instance associators [COMMAND-OPTIONS] INSTANCENAME',
     'List the instances associated with an instance.',
-    '-a, --assoc-class CLASSNAME Filter the result set by association clas',
-    '-C, --result-class CLASSNAME Filter the result set by result class',
+    '--ac, --assoc-class CLASSNAME Filter the result set by association clas',
+    '--rc, --result-class CLASSNAME Filter the result set by result class',
     '-r, --role PROPERTYNAME Filter the result set by source end role',
-    '-R, --result-role PROPERTYNAME Filter the result set by far end role',
+    '--rr, --result-role PROPERTYNAME Filter the result set by far end role',
     CMD_OPTION_INCLUDE_QUALIFIERS_LIST_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
@@ -155,7 +155,7 @@ INSTANCE_MODIFY_HELP_LINES = [
     'Usage: pywbemcli instance modify [COMMAND-OPTIONS] INSTANCENAME',
     'Modify properties of an instance.',
     '-P, --property PROPERTYNAME=VALUE Property to be modified',
-    '-p, --propertylist PROPERTYLIST Reduce the properties to be modified',
+    '--pl, --propertylist PROPERTYLIST Reduce the properties to be modified',
     CMD_OPTION_INTERACTIVE_HELP_LINE,
     CMD_OPTION_VERIFY_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
@@ -174,7 +174,7 @@ INSTANCE_QUERY_HELP_LINES = [
 INSTANCE_REFERENCES_HELP_LINES = [
     'Usage: pywbemcli instance references [COMMAND-OPTIONS] INSTANCENAME',
     'List the instances referencing an instance.',
-    '-R, --result-class CLASSNAME Filter the result set by result class',
+    '--rc, --result-class CLASSNAME Filter the result set by result class',
     '-r, --role PROPERTYNAME Filter the result set by source end role',
     CMD_OPTION_INCLUDE_QUALIFIERS_LIST_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
@@ -342,22 +342,22 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate names CIM_Foo -o',
-     ['enumerate', 'CIM_Foo', '-o'],
+    ['Verify instance subcommand enumerate names CIM_Foo --no',
+     ['enumerate', 'CIM_Foo', '--no'],
      {'stdout': ['', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
                  '', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"',
                  '', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo3"', ],
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate names CIM_Foo -o -s',
-     ['enumerate', 'CIM_Foo', '-o', '--summary'],
+    ['Verify instance subcommand enumerate names CIM_Foo --no -s',
+     ['enumerate', 'CIM_Foo', '--no', '--summary'],
      {'stdout': ['3 CIMInstanceName(s) returned'],
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate names CIM_Foo -o --namespace',
-     ['enumerate', 'CIM_Foo', '-o', '--namespace', 'root/cimv2'],
+    ['Verify instance subcommand enumerate names CIM_Foo --no --namespace',
+     ['enumerate', 'CIM_Foo', '--no', '--namespace', 'root/cimv2'],
      {'stdout': ['', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
                  '', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"',
                  '', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo3"', ],
@@ -423,7 +423,7 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance subcommand -o grid enumerate di CIM_Foo -d -o',
-     {'args': ['enumerate', 'CIM_Foo', '-d', '-o'],
+     {'args': ['enumerate', 'CIM_Foo', '-d', '--no'],
       'global': ['--output-format', 'grid']},
      {'stdout': """InstanceNames: CIM_Foo
 +--------+-------------+---------+-----------------------+
@@ -440,7 +440,7 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance subcommand -o grid enumerate di CIM_Foo -d -o',
-     {'args': ['enumerate', 'CIM_Foo', '-d', '-o'],
+     {'args': ['enumerate', 'CIM_Foo', '-d', '--no'],
       'global': ['--output-format', 'txt']},
      {'stdout': ['root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
                  'root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"',
@@ -469,7 +469,7 @@ TEST_CASES = [
 
     ['Verify instance subcommand -o grid enumerate di alltypes, datetime',
      {'args': ['enumerate', 'Pywbem_Alltypes', '-d',
-               '--propertylist', 'scalDateTime', '-p', 'scalTimeDelta'],
+               '--propertylist', 'scalDateTime', '--pl', 'scalTimeDelta'],
       'global': ['--output-format', 'grid']},
      {'stdout': ["""Instances: PyWBEM_AllTypes
 +-----------------------------+
@@ -702,7 +702,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand get with instancename prop list -p returns '
      ' one property',
-     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '-p', 'InstanceID'],
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--pl', 'InstanceID'],
      {'stdout': ['instance of CIM_Foo {',
                  '   InstanceID = "CIM_Foo1";',
                  '};',
@@ -724,7 +724,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand get with instancename prop list -p  '
      ' InstanceID,IntegerProp returns 2 properties',
-     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '-p', 'InstanceID,IntegerProp'],
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--pl', 'InstanceID,IntegerProp'],
      {'stdout': ['instance of CIM_Foo {',
                  '   InstanceID = "CIM_Foo1";',
                  '   IntegerProp = 1;',
@@ -736,8 +736,8 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand get with instancename prop list -p '
      ' multiple instances of option returns 2 properties',
-     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '-p', 'InstanceID',
-      '-p', 'IntegerProp'],
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--pl', 'InstanceID',
+      '--pl', 'IntegerProp'],
      {'stdout': ['instance of CIM_Foo {',
                  '   InstanceID = "CIM_Foo1";',
                  '   IntegerProp = 1;',
@@ -749,7 +749,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand get with instancename empty  prop list '
      'returns  empty instance',
-     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '-p', '""'],
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--pl', '""'],
      {'stdout': ['instance of CIM_Foo {',
                  '};',
                  ''],
@@ -1254,8 +1254,8 @@ Instances: PyWBEM_AllTypes
       'test': 'lineswons'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references -o, returns paths',
-     ['references', 'TST_Person.name="Mike"', '-o'],
+    ['Verify instance subcommand references --no, returns paths',
+     ['references', 'TST_Person.name="Mike"', '--no'],
      {'stdout': ['"root/cimv2:TST_FamilyCollection.name=\\"Family2\\"",member',
                  '=\"root/cimv2:TST_Person.name=\\"Mike\\""',
                  '//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeSofi"',
@@ -1265,9 +1265,9 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references -o, returns paths with result '
+    ['Verify instance subcommand references --no, returns paths with result '
      'class valid returns paths',
-     ['references', 'TST_Person.name="Mike"', '-o',
+     ['references', 'TST_Person.name="Mike"', '--no',
       '--result-class', 'TST_Lineage'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeSofi"',
                  '//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeGabi"', ],
@@ -1303,7 +1303,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand references -o, returns paths with result '
      'class valid returns paths sorted',
-     ['references', 'TST_Person.name="Mike"', '-o',
+     ['references', 'TST_Person.name="Mike"', '--no',
       '--result-class', 'TST_Lineage'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeGabi"',
                  '//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeSofi"', ],
@@ -1313,28 +1313,28 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand references -o, returns paths with result '
      'class short form valid returns paths',
-     ['references', 'TST_Person.name="Mike"', '-o',
-      '-R', 'TST_Lineage'],
+     ['references', 'TST_Person.name="Mike"', '--no',
+      '--rc', 'TST_Lineage'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeSofi"',
                  '//FakedUrl/root/cimv2:TST_Lineage.InstanceID="MikeGabi"', ],
       'rc': 0,
       'test': 'in'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references -o, returns paths with result '
+    ['Verify instance subcommand references --no, returns paths with result '
      'class short form valid returns paths',
-     ['references', 'TST_Person.name="Mike"', '-o', '--summary',
-      '-R', 'TST_Lineage'],
+     ['references', 'TST_Person.name="Mike"', '--no', '--summary',
+      '--rc', 'TST_Lineage'],
      {'stdout': ['2 CIMInstanceName(s) returned'],
       'rc': 0,
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
 
-    ['Verify instance subcommand references -o, returns paths with result '
+    ['Verify instance subcommand references --no, returns paths with result '
      'class short form valid returns paths',
-     {'args': ['references', 'TST_Person.name="Mike"', '-o', '--summary',
-               '-R', 'TST_Lineage'],
+     {'args': ['references', 'TST_Person.name="Mike"', '--no', '--summary',
+               '--rc', 'TST_Lineage'],
       'global': ['--output-format', 'table']},
      {'stdout': ["""Summary of CIMInstanceName returned
 +---------+-----------------+
@@ -1347,10 +1347,10 @@ Instances: PyWBEM_AllTypes
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references -S, returns paths with result '
+    ['Verify instance subcommand references -s, returns paths with result '
      'class short form valid returns paths',
-     ['references', 'TST_Person.name="Mike"', '-S',
-      '-R', 'TST_Lineage'],
+     ['references', 'TST_Person.name="Mike"', '-s',
+      '--rc', 'TST_Lineage'],
      {'stdout': ['2 CIMInstance(s) returned'],
       'rc': 0,
       'test': 'lines'},
@@ -1373,7 +1373,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand references -o, returns paths with result '
      'class not a real ref returns no paths',
-     ['references', 'TST_Person.name="Mike"', '-o',
+     ['references', 'TST_Person.name="Mike"', '--no',
       '--result-class', 'TST_Lineagex'],
      {'stdout': [],
       'rc': 0,
@@ -1476,7 +1476,7 @@ Instances: PyWBEM_AllTypes
      ASSOC_MOCK_FILE, OK],
 
     ['Verify instance subcommand associators -o, returns data',
-     ['associators', 'TST_Person.name="Mike"', '-o'],
+     ['associators', 'TST_Person.name="Mike"', '--no'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_FamilyCollection.name="Family2"'
                  '//FakedUrl/root/cimv2:TST_Person.name="Gabi"',
                  '//FakedUrl/root/cimv2:TST_Person.name="Sofi"'],

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -99,7 +99,7 @@ INSTANCE_COUNT_HELP_LINES = [
 INSTANCE_CREATE_HELP_LINES = [
     'Usage: pywbemcli instance create [COMMAND-OPTIONS] CLASSNAME',
     'Create an instance of a class in a namespace.',
-    '-P, --property PROPERTYNAME=VALUE Initial property value',
+    '-p, --property PROPERTYNAME=VALUE Initial property value',
     CMD_OPTION_VERIFY_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
@@ -117,7 +117,7 @@ INSTANCE_ENUMERATE_HELP_LINES = [
     'Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME',
     'List the instances of a class.',
     CMD_OPTION_LOCAL_ONLY_INSTANCE_LIST_HELP_LINE,
-    '-d, --deep-inheritance Include subclass properties in the returned',
+    '--di, --deep-inheritance Include subclass properties in the returned',
     CMD_OPTION_INCLUDE_QUALIFIERS_LIST_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
@@ -154,7 +154,7 @@ INSTANCE_INVOKEMETHOD_HELP_LINES = [
 INSTANCE_MODIFY_HELP_LINES = [
     'Usage: pywbemcli instance modify [COMMAND-OPTIONS] INSTANCENAME',
     'Modify properties of an instance.',
-    '-P, --property PROPERTYNAME=VALUE Property to be modified',
+    '-p, --property PROPERTYNAME=VALUE Property to be modified',
     '--pl, --propertylist PROPERTYLIST Reduce the properties to be modified',
     CMD_OPTION_INTERACTIVE_HELP_LINE,
     CMD_OPTION_VERIFY_HELP_LINE,
@@ -402,8 +402,8 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate deep-inheritance CIM_Foo -d',
-     ['enumerate', 'CIM_Foo', '-d'],
+    ['Verify instance subcommand enumerate deep-inheritance CIM_Foo --di',
+     ['enumerate', 'CIM_Foo', '--di'],
      {'stdout': ENUM_INSTANCE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
@@ -415,15 +415,16 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand -o grid enumerate deep-inheritance CIM_Foo -d',
-     {'args': ['enumerate', 'CIM_Foo', '-d'],
+    ['Verify instance subcommand -o grid enumerate deep-inheritance CIM_Foo '
+     '--di',
+     {'args': ['enumerate', 'CIM_Foo', '--di'],
       'global': ['--output-format', 'grid']},
      {'stdout': ENUM_INSTANCE_TABLE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand -o grid enumerate di CIM_Foo -d -o',
-     {'args': ['enumerate', 'CIM_Foo', '-d', '--no'],
+    ['Verify instance subcommand -o grid enumerate di CIM_Foo --di -o',
+     {'args': ['enumerate', 'CIM_Foo', '--di', '--no'],
       'global': ['--output-format', 'grid']},
      {'stdout': """InstanceNames: CIM_Foo
 +--------+-------------+---------+-----------------------+
@@ -439,8 +440,8 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand -o grid enumerate di CIM_Foo -d -o',
-     {'args': ['enumerate', 'CIM_Foo', '-d', '--no'],
+    ['Verify instance subcommand -o grid enumerate di CIM_Foo --di --no',
+     {'args': ['enumerate', 'CIM_Foo', '--di', '--no'],
       'global': ['--output-format', 'txt']},
      {'stdout': ['root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
                  'root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"',
@@ -468,7 +469,7 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance subcommand -o grid enumerate di alltypes, datetime',
-     {'args': ['enumerate', 'Pywbem_Alltypes', '-d',
+     {'args': ['enumerate', 'Pywbem_Alltypes', '--di',
                '--propertylist', 'scalDateTime', '--pl', 'scalTimeDelta'],
       'global': ['--output-format', 'grid']},
      {'stdout': ["""Instances: PyWBEM_AllTypes
@@ -653,7 +654,7 @@ Instances: PyWBEM_AllTypes
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance subcommand get with instancename local_only returns data',
-     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '-l'],
+     ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--lo'],
      {'stdout': ['instance of CIM_Foo {',
                  '   InstanceID = "CIM_Foo1";',
                  '   IntegerProp = 1;',
@@ -689,7 +690,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand get with instancename --include-qualifiers '
      'and general --use-pull returns data',
-     {'args': ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--include-qualifiers'],
+     {'args': ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--iq'],
       'global': ['--use-pull', 'no']},
      {'stdout': ['instance of CIM_Foo {',
                  '   InstanceID = "CIM_Foo1";',
@@ -839,7 +840,7 @@ Instances: PyWBEM_AllTypes
      None, OK],
 
     ['Verify instance subcommand create, new instance of CIM_Foo one property',
-     ['create', 'CIM_Foo', '-P', 'InstanceID=blah'],
+     ['create', 'CIM_Foo', '-p', 'InstanceID=blah'],
      {'stdout': 'root/cimv2:CIM_Foo.InstanceID="blah"',
       'rc': 0,
       'test': 'lines'},
@@ -847,7 +848,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand create, new instance of CIM_Foo one '
      'property and verify yes',
-     ['create', 'CIM_Foo', '-P', 'InstanceID=blah', '--verify'],
+     ['create', 'CIM_Foo', '-p', 'InstanceID=blah', '--verify'],
      {'stdout': ['instance of CIM_Foo {',
                  'InstanceID = "blah";',
                  'root/cimv2:CIM_Foo.InstanceID="blah"',
@@ -858,7 +859,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand create, new instance of CIM_Foo one '
      'property and verify no',
-     ['create', 'CIM_Foo', '-P', 'InstanceID=blah', '--verify'],
+     ['create', 'CIM_Foo', '-p', 'InstanceID=blah', '--verify'],
      {'stdout': ['instance of CIM_Foo {',
                  'InstanceID = "blah";',
                  'root/cimv2:CIM_Foo.InstanceID="blah"',
@@ -870,7 +871,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand create, new instance of CIM_Foo, '
      'one property, explicit namespace definition',
-     ['create', 'CIM_Foo', '-P', 'InstanceID=blah', '-n', 'root/cimv2'],
+     ['create', 'CIM_Foo', '-p', 'InstanceID=blah', '-n', 'root/cimv2'],
      {'stdout': "",
       'rc': 0,
       'test': 'regex'},
@@ -889,14 +890,14 @@ Instances: PyWBEM_AllTypes
     ['Verify instance subcommand create, new instance of all_types '
      'with scalar types',
      ['create', 'PyWBEM_AllTypes',
-      '-P', 'InstanceID=BunchOfValues',
-      '-P', 'scalBool=true', '-P', 'scalUint8=1',
-      '-P', 'scalUint16=9', '-P', 'scalSint16=-9',
-      '-P', 'scalUint32=999', '-P', 'scalSint32=-999',
-      '-P', 'scalSint64=-9999',
-      '-P', 'scalUint64=9999',
-      '-P', 'scalString="test\"embedded\"quote"',
-      '-P', 'scalDateTime=19991224120000.000000+360'],
+      '-p', 'InstanceID=BunchOfValues',
+      '-p', 'scalBool=true', '-p', 'scalUint8=1',
+      '-p', 'scalUint16=9', '-p', 'scalSint16=-9',
+      '-p', 'scalUint32=999', '-p', 'scalSint32=-999',
+      '-p', 'scalSint64=-9999',
+      '-p', 'scalUint64=9999',
+      '-p', 'scalString="test\"embedded\"quote"',
+      '-p', 'scalDateTime=19991224120000.000000+360'],
      {'stdout': 'root/cimv2:PyWBEM_AllTypes.InstanceId="BunchOfValues"',
       'rc': 0,
       'test': 'lines'},
@@ -905,14 +906,14 @@ Instances: PyWBEM_AllTypes
     ['Verify instance subcommand create, new instance of all_types '
      "with array values",
      ['create', 'PyWBEM_AllTypes',
-      '-P', 'InstanceID=blah',
-      '-P', 'arrayBool=true,false',
-      '-P', 'arrayUint8=1,2,3',
-      '-P', 'arraySint8=-1,-2,-3',
-      '-P', 'arrayUint16=9,19',
-      '-P', 'arrayUint32=0,99,999', '-P', 'arraySint32=0,-999,-999',
-      '-P', 'arrayUint64=0,999,9999', '-P', 'arraySint64=-9999,0,9999',
-      '-P', 'scalString="abc", "def", "jhijk"'],
+      '-p', 'InstanceID=blah',
+      '-p', 'arrayBool=true,false',
+      '-p', 'arrayUint8=1,2,3',
+      '-p', 'arraySint8=-1,-2,-3',
+      '-p', 'arrayUint16=9,19',
+      '-p', 'arrayUint32=0,99,999', '-p', 'arraySint32=0,-999,-999',
+      '-p', 'arrayUint64=0,999,9999', '-p', 'arraySint64=-9999,0,9999',
+      '-p', 'scalString="abc", "def", "jhijk"'],
      {'stdout': 'root/cimv2:PyWBEM_AllTypes.InstanceId="blah"',
       'rc': 0,
       'test': 'lines'},
@@ -920,14 +921,14 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand create, new instance Error in Property Type'
      " with array values",
-     ['create', 'PyWBEM_AllTypes', '-P', 'InstanceID=blah',
-      '-P', 'arrayBool=8,9',
-      '-P', 'arrayUint8=1,2,3',
-      '-P', 'arraySint8=-1,-2,-3',
-      '-P', 'arrayUint16=9,19',
-      '-P', 'arrayUint32=0,99,999', '-P', 'arraySint32=0,-999,-999',
-      '-P', 'arrayUint64=0,999,9999', '-P', 'arraySint64=-9999,0,9999',
-      '-P', 'scalString="abc", "def", "jhijk"'],
+     ['create', 'PyWBEM_AllTypes', '-p', 'InstanceID=blah',
+      '-p', 'arrayBool=8,9',
+      '-p', 'arrayUint8=1,2,3',
+      '-p', 'arraySint8=-1,-2,-3',
+      '-p', 'arrayUint16=9,19',
+      '-p', 'arrayUint32=0,99,999', '-p', 'arraySint32=0,-999,-999',
+      '-p', 'arrayUint64=0,999,9999', '-p', 'arraySint64=-9999,0,9999',
+      '-p', 'scalString="abc", "def", "jhijk"'],
      {'stderr': "Error: Type mismatch property 'arrayBool' between expected "
                 "type='boolean', array=True and input value='8,9'. "
                 'Exception: Invalid boolean value: "8"',
@@ -936,7 +937,7 @@ Instances: PyWBEM_AllTypes
      ALLTYPES_MOCK_FILE, OK],
 
     ['Verify instance subcommand create, new instance already exists',
-     ['create', 'PyWBEM_AllTypes', '-P', 'InstanceID=test_instance'],
+     ['create', 'PyWBEM_AllTypes', '-p', 'InstanceID=test_instance'],
      {'stderr': ['Error: CIMClass: "PyWBEM_AllTypes" does not exist in ',
                  'namespace "root/cimv2" in WEB server: FakedWBEMConnection'],
       'rc': 1,
@@ -944,7 +945,7 @@ Instances: PyWBEM_AllTypes
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance subcommand create, new instance invalid ns',
-     ['create', 'PyWBEM_AllTypes', '-P', 'InstanceID=test_instance', '-n',
+     ['create', 'PyWBEM_AllTypes', '-p', 'InstanceID=test_instance', '-n',
       'blah'],
      {'stderr': ["Error: Exception 3", "CIM_ERR_INVALID_NAMESPACE"],
       'rc': 1,
@@ -953,7 +954,7 @@ Instances: PyWBEM_AllTypes
 
 
     ['Verify instance subcommand create, new instance invalid class',
-     ['create', 'CIM_blah', '-P', 'InstanceID=test_instance'],
+     ['create', 'CIM_blah', '-p', 'InstanceID=test_instance'],
      {'stderr': ["Error:", "CIMClass"],
       'rc': 1,
       'test': 'in'},
@@ -981,7 +982,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand modify, single good change',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
-      '-P', 'scalBool=False'],
+      '-p', 'scalBool=False'],
      {'stdout': "",
       'rc': 0,
       'test': 'linesnows'},
@@ -989,7 +990,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand modify, single good change with verify yes',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
-      '-P', 'scalBool=False', '--verify'],
+      '-p', 'scalBool=False', '--verify'],
      {'stdout': ['instance of PyWBEM_AllTypes {',
                  'scalBool = false;',
                  '};',
@@ -1000,7 +1001,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand modify, single good change with verify no',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
-      '-P', 'scalBool=False', '--verify'],
+      '-p', 'scalBool=False', '--verify'],
      {'stdout': ['instance of PyWBEM_AllTypes {',
                  'scalBool = false;',
                  'Execute ModifyInstance',
@@ -1012,7 +1013,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand modify, single good change, explicit ns',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"', '-n',
-      'root/cimv2', '-P', 'scalBool=False'],
+      'root/cimv2', '-p', 'scalBool=False'],
      {'stdout': "",
       'rc': 0,
       'test': 'lines'},
@@ -1028,11 +1029,11 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand modify, multiple good change',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
-      '-P', 'scalBool=False',
-      '-P', 'arrayBool=true,false,true',
-      '-P', 'arrayUint32=0,99,999, 3', '-P', 'arraySint32=0,-999,-999,9',
-      '-P', 'arrayUint64=0,999,9999,3000', '-P', 'arraySint64=-9999,0,9999,4',
-      '-P', 'scalString="abc", "def", "jhijk"'],
+      '-p', 'scalBool=False',
+      '-p', 'arrayBool=true,false,true',
+      '-p', 'arrayUint32=0,99,999, 3', '-p', 'arraySint32=0,-999,-999,9',
+      '-p', 'arrayUint64=0,999,9999,3000', '-p', 'arraySint64=-9999,0,9999,4',
+      '-p', 'scalString="abc", "def", "jhijk"'],
      {'stdout': "",
       'rc': 0,
       'test': 'lines'},
@@ -1043,7 +1044,7 @@ Instances: PyWBEM_AllTypes
     #
     ['Verify instance subcommand modify, invalid class',
      ['modify', 'PyWBEM_AllTypesxxx.InstanceID="test_instance"',
-      '-P', 'scalBool=9'],
+      '-p', 'scalBool=9'],
      {'stderr': ["CIMClass:", "PyWBEM_AllTypesxxx",
                  "does not exist in WEB server",
                  "FakedUrl"],
@@ -1053,7 +1054,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand modify, single property, Type Error bool',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
-      '-P', 'scalBool=9'],
+      '-p', 'scalBool=9'],
      {'stderr': "Error: Type mismatch property 'scalBool' between expected "
                 "type='boolean', array=False and input value='9'. "
                 'Exception: Invalid boolean value: "9"',
@@ -1063,7 +1064,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand modify, single property, Fail modifies key',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
-      '-P', 'InstanceID=9'],
+      '-p', 'InstanceID=9'],
      {'stderr': 'Error: Server Error modifying instance. Exception: CIMError:'
                 " 4 (CIM_ERR_INVALID_PARAMETER): Property 'InstanceID' in "
                 "ModifiedInstance not in class 'PyWBEM_AllTypes'",
@@ -1074,7 +1075,7 @@ Instances: PyWBEM_AllTypes
     ['Verify instance subcommand modify, single property, Type Error uint32. '
      'Uses regex because Exception msg different between python 2 and 3',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
-      '-P', 'scalUint32=Fred'],
+      '-p', 'scalUint32=Fred'],
      {'stderr': ["Error: Type mismatch property 'scalUint32' between expected ",
                  "type='uint32', array=False and input value='Fred'. ",
                  "Exception: invalid literal for", "with base 10: 'Fred'"],
@@ -1084,7 +1085,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand modify, single Property arrayness error',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
-      '-P', 'scalBool=False,True'],
+      '-p', 'scalBool=False,True'],
      {'stderr': "Error: Type mismatch property 'scalBool' between expected "
                 "type='boolean', array=False and input value='False,True'. "
                 'Exception: Invalid boolean value: "False,True"',
@@ -1094,7 +1095,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand modify, Error value types mismatch with array',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
-      '-P', 'arrayBool=9,8'],
+      '-p', 'arrayBool=9,8'],
      {'stderr': "Error: Type mismatch property 'arrayBool' between expected "
                 "type='boolean', array=True and input value='9,8'. "
                 'Exception: Invalid boolean value: "9"',
@@ -1104,7 +1105,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand modify, Error different value types',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
-      '-P', 'arrayBool=true,8'],
+      '-p', 'arrayBool=true,8'],
      {'stderr': "Error: Type mismatch property 'arrayBool' between expected "
                 "type='boolean', array=True and input value='true,8'. "
                 'Exception: Invalid boolean value: "8"',
@@ -1114,7 +1115,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand modify, Error integer out of range',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
-      '-P', 'arrayUint32=99999999999999999999999'],
+      '-p', 'arrayUint32=99999999999999999999999'],
      {'stderr': "Error: Type mismatch property 'arrayUint32' between expected "
                 "type='uint32', array=True and input "
                 "value='99999999999999999999999'. "
@@ -1126,7 +1127,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance subcommand modify, Error property not in class',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
-      '-P', 'blah=9'],
+      '-p', 'blah=9'],
      {'stderr': 'Error: Property name "blah" not in class "PyWBEM_AllTypes".',
       'rc': 1,
       'test': 'lines'},

--- a/tests/unit/test_server_subcmd.py
+++ b/tests/unit/test_server_subcmd.py
@@ -67,10 +67,10 @@ SERVER_GETCENTRALINSTS_HELP_LINES = [
     'List central instances of mgmt profiles on the server.',
     '-o, --organization ORG-NAME Filter by the defined organization',
     '-p, --profile PROFILE-NAME Filter by the profile name',
-    '-c, --central-class CLASSNAME Optional. Required only if profiles',
-    '-s, --scoping-class CLASSNAME Optional. Required only if profiles',
-    '-S, --scoping-path CLASSLIST Optional. Required only if profiles',
-    '-r, --reference-direction [snia|dmtf] Navigation direction',
+    '--cc, --central-class CLASSNAME Optional. Required only if profiles',
+    '--sc, --scoping-class CLASSNAME Optional. Required only if profiles',
+    '--sp, --scoping-path CLASSLIST Optional. Required only if profiles',
+    '--rd, --reference-direction [snia|dmtf] Navigation direction',
     CMD_OPTION_HELP_HELP_LINE,
 ]
 


### PR DESCRIPTION
Changed a number of single character short option names to multicharacter shorter names. Changed the corresponding tests and added tests to be sure that the new short names are covered.

The list of options changes:

1. -p to  --pl for property list
2. --nq   --no-qualifiers for class
3. -R to  --rc result-class
4. -a to  --ac assoc-class
5. -C to  --rc result-class
6. -R to  --rr result-role
7. -q to  --iq include-qualifiers
8. -p to  --pl propertylis
9. -o to  --no for names-only
10. -c to --ico include-class-origin
11. -S to -s summary

The only issues I found in early testing is that it is easy to drop the first - and the one case where this causes problems is --no which becomes -n but fails because there is no namespace to not really a major issue.