### PR TITLE
Fixes #313: Modify command descriptions to use sections

### DIFF
--- a/docs/pywbemclicommands.rst
+++ b/docs/pywbemclicommands.rst
@@ -260,6 +260,7 @@ Specifying CIM property and parameter values
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 TODO: Change to reference the commands
+
 TODO: Rewrite this to more completely define the value in terms of CIM types.
 
 The ``instance create``, ``instance modify``, ``class invokemethod``, and
@@ -351,71 +352,107 @@ Example:
 Class command group
 -------------------
 
-The **class** group defines commands that act on CIM classes. see
+The **class** command group defines commands that act on CIM classes. see
 :ref:`pywbemcli class --help`. This group includes the following commands:
 
-* **associators** to retrieve the class associators classes or classnames if the
-  (``-o/--names-only``) option is set for a class defined by the CLASSNAME
-  argument in the namespace with this command or the default
-  namespace and displayed in the defined format. If successful it displays the
-  classes/classnames in the :term:`CIM object output formats` (see
-  :ref:`Output formats`). If unsuccesful it an exception. This command
-  returns the class associators, not the instance associators. The
-  :ref:`Instance command group` includes the corresponding associators
-  operation for instances:
+This group consists of the following commands:
 
-  .. code-block:: text
+* :ref:`Class associators command`
+* :ref:`Class references command`
+* :ref:`Class delete command`
+* :ref:`Class enumerate command`
+* :ref:`Class find command`
+* :ref:`Class get command`
+* :ref:`Class invokemethod command`
+* :ref:`Class tree command`
 
-      $ pywbemcli --name mockassoc class associators TST_Person --names-only
-        //FakedUrl/root/cimv2:TST_Person
-      $
 
-  See :ref:`pywbemcli class associators --help` for details.
-* **references** to get the class level reference classes or classnames for a
-  class defined by the CLASSNAME argument in the default namespace or the
-  namespace defined with this command displayed in the defined format. If
-  successful it displays the classes/classnames in the
-  :term:`CIM object output formats` (see :ref:`Output formats`).
-  If unsuccesful it an exception.. This
-  returns the class level references,not the instance references. The
-  :ref:`Instance command group` includes a corresponding instance references
-  operation:
+.. _`Class associators command`:
 
-  .. code-block:: text
+Class associators command
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``class associators`` command retrieves associated classes or class names if the
+(``-o``/``--names-only``) option is set for a class defined by the CLASSNAME
+argument in the namespace with this command or the default
+namespace and displayed in the defined format. If successful it displays the
+classes/classnames in the :term:`CIM object output formats` (see
+:ref:`Output formats`). If unsuccesful it an exception. This command
+returns the class associators, not the instance associators. The
+:ref:`Instance command group` includes the corresponding associators
+operation for instances:
+
+.. code-block:: text
+
+  $ pywbemcli --name mockassoc class associators TST_Person --names_only
+    //FakedUrl/root/cimv2:TST_Person
+  $
+
+See :ref:`pywbemcli class associators --help` for details.
+
+
+.. _`Class references command`:
+
+Class references command
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``class references`` command retrieves association classes or class names for a
+class defined by the CLASSNAME argument in the default namespace or the
+namespace defined with this command displayed in the defined format. If
+successful it displays the classes/classnames in the
+:term:`CIM object output formats` (see :ref:`Output formats`).
+If unsuccesful it returns an  exception. This command
+returns the class level references,not the instance references. The
+:ref:`Instance command group` includes a corresponding instance references
+operation:
+
+.. code-block:: text
 
     $pywbemcli --mock-server mockassoc class references TST_Person --names-only
 
     //FakedUrl/root/cimv2:TST_Lineage
     //FakedUrl/root/cimv2:TST_MemberOfFamilyCollection
 
-  See :ref:`pywbemcli class associators --help` for details.
-* **delete** to delete the class defined by the ``CLASSNAME`` argument. Note that
-  many WBEM servers may not allow this operation or may severely limit the
-  conditions under which a class can be deleted from the server.  If successful
-  it returns nothing, otherwise it displays an exception.
+See :ref:`pywbemcli class associators --help` for details.
 
-  To delete the class ``CIM_Blah``:
+.. _`Class delete command`:
 
-  .. code-block:: text
+Class delete command
+^^^^^^^^^^^^^^^^^^^^
+The ``class delete`` command deletes the class defined by the ``CLASSNAME``
+argument from the WBEM server. Note that many WBEM servers may not allow this
+operation or may severely limit the conditions under which a class can be
+deleted from the server.  If successful it returns nothing, otherwise it
+displays an exception.
+
+To delete the class ``CIM_Blah``:
+
+.. code-block:: text
 
     $ pywbemcli class delete CIM_blah
     $
 
-  Pywbemcli will not delete a class that has subclasses.
-  See :ref:`pywbemcli class delete --help` for details.
-* **enumerate** to enumerate classes or their classnames in the default
-  namespace or the namespace defined with this command. If the CLASSNAME
-  input property the enumeration starts at the subclasses of CLASSNAME. Otherwise
-  it starts at the top of the class hierarchy if the
-  ``--deep-inheritance/-di`` option is set it shows all the classes in the
-  hierarchy, not just the next level of the hierarchy. Otherwise it only
-  enumerates one level of the class hierarchy.  It can display the
-  classes/classnames in the :term:`CIM object output formats` (see
-  :ref:`Output formats`). The following example enumerates
-  the class names starting at the root of the class hiearchy for a simple
-  mocked CIM schema definition:
+Pywbemcli will not delete a class that has subclasses.
 
-  .. code-block:: text
+See :ref:`pywbemcli class delete --help` for details.
+
+.. _`Class enumerate command`:
+
+Class enumerate command
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``class enumerate`` command lists the classes or their class names in the
+default namespace or the namespace defined with this command. If the CLASSNAME
+input property exists, the enumeration starts at the subclasses of CLASSNAME. Otherwise
+it starts at the top of the class hierarchy if the ``--DeepInheritance``/``-d``
+option is set it shows all the classes in the hierarchy, not just the next
+level of the hierarchy. Otherwise it only enumerates one level of the class
+hierarchy.  This command can display the classes/classnames in the :term:`CIM object
+output formats` (see :ref:`Output formats`). The following example enumerates
+the class names starting at the root of the class hiearchy for a simple mocked
+CIM schema definition:
+
+.. code-block:: text
 
     $ pywbemcli --mock-server mockassoc class enumerate --names-only
     TST_Person
@@ -424,13 +461,25 @@ The **class** group defines commands that act on CIM classes. see
     TST_FamilyCollection
     $
 
-  See :ref:`pywbemcli class enumerate --help` for details.
-* **find** to find classes in the target WBEM server across multiple namespaces.
-  The input argument is a GLOB expression which is used to search the server
-  CIM namespaces for matching class names.  This command uses a :term:`GLOB`
-  Unix style pathname pattern expansion on the classname to attempt to filter
-  the names and namespaces of all of the classes in the WBEM server (or the
-  namespaces defined with the ``--namespace/-n`` option):
+See :ref:`pywbemcli class enumerate --help` for details.
+
+
+.. _`Class find command`:
+
+Class find command
+^^^^^^^^^^^^^^^^^^
+
+The ``class find`` command gets classes filtered by the CLASSNAME-GLOB argument (a
+Unix style pathname pattern expansion) in the target WBEM server across
+multiple namespaces. It displays the results as a simple list or a table
+of the namespaces and class names in each namespace.
+
+If successful it displays a list of the namespaces and classnames. If the
+WBEM server returns unsupported or other errors, the command fails with an
+exception.
+
+It searches all of the namespaces  in the WBEM server or the namespaces defined
+with the ``--namespaces``/``-n`` option):
 
   .. code-block:: text
 
@@ -453,79 +502,117 @@ The **class** group defines commands that act on CIM classes. see
       root/PG_Internal:PG_WBEMSLPTemplate
       $
 
+    pywbemcli> -o table class find CIM_SystemComponent*
+    Find class CIM_SystemComponent*
+    +-------------------------------+---------------------+
+    | Namespace                     | Classname           |
+    |-------------------------------+---------------------|
+    | root/PG_InterOp               | CIM_SystemComponent |
+    | test/WsmTest                  | CIM_SystemComponent |
+    | test/cimv2                    | CIM_SystemComponent |
+    | test/CimsubTestNS0            | CIM_SystemComponent |
+    | test/TestProvider             | CIM_SystemComponent |
+    | test/EmbeddedInstance/Dynamic | CIM_SystemComponent |
+    | root/SampleProvider           | CIM_SystemComponent |
+    | test/CimsubTestNS1            | CIM_SystemComponent |
+    | test/static                   | CIM_SystemComponent |
+    | test/CimsubTestNS2            | CIM_SystemComponent |
+    | test/TestINdSrcNS2            | CIM_SystemComponent |
+    | test/EmbeddedInstance/Static  | CIM_SystemComponent |
+    | test/CimsubTestNS3            | CIM_SystemComponent |
+    | test/TestIndSrcNS1            | CIM_SystemComponent |
+    | root/cimv2                    | CIM_SystemComponent |
+    | root/benchmark                | CIM_SystemComponent |
+    +-------------------------------+---------------------+
+
+
   See :ref:`pywbemcli class find --help` for details.
-* **get** to get a single class defined by the required CLASSNAME argument in the
-  default namespace or the namespace defined with this command displayed in
-  the format defined by the ``--output-format/-o`` general option. If
-  successul it displays the returned class, otherwise it displays the exception
-  generated.  It can display the classes/classnames in the
-  :term:`CIM object output formats` (see :ref:`Output formats`).
 
-  The following example shows getting the MOF representation of the class
-  ``CIM_Foo`` from a mock repository that is named mock1 in the
-  :term:`connections file`:
 
-  .. code-block:: text
+.. _`Class get command`:
 
-      $ pywbemcli> --name mock1 class get CIM_Foo
+Class get command
+^^^^^^^^^^^^^^^^^
 
-           [Description ( "Simple CIM Class" )]
-        class CIM_Foo {
+The ``class get`` command gets a single class defined by the required CLASSNAME
+argument in the default namespace or the namespace defined with this command
+and displays the returned object. If successul it displays the returned class,
+otherwise it displays the exception generated.  It can display the class using
+the :term:`CIM object output formats` (see :ref:`Output formats`). This command
+does not have a table based format.
 
-              [Key ( true ),
-               Description ( "This is key property." )]
-           string InstanceID;
+The following example shows getting the MOF representation of the class
+``CIM_Foo`` from a mock repository that is named mock1 in the
+:term:`connections file`:
 
-              [Description ( "This is Uint32 property." )]
-           uint32 IntegerProp;
+.. code-block:: text
 
-              [Description ( "Method with in and out parameters" )]
-           uint32 Fuzzy(
-                 [IN ( true ),
-                  OUT ( true ),
-                  Description ( "Define data to be returned in output parameter" )]
-              string TestInOutParameter,
-                 [IN ( true ),
-                  OUT ( true ),
-                  Description ( "Test of ref in/out parameter" )]
-              CIM_Foo REF TestRef,
-                 [IN ( false ),
-                  OUT ( true ),
-                  Description ( "Rtns method name if exists on input" )]
-              string OutputParam,
-                 [IN ( true ),
-                  Description ( "Defines return value if provided." )]
-              uint32 OutputRtnValue);
+  $ pywbemcli> --name mock1 class get CIM_Foo
 
-              [Description ( "Method with no Parameters" )]
-           uint32 DeleteNothing();
+       [Description ( "Simple CIM Class" )]
+    class CIM_Foo {
 
-        };
-      $
+          [Key ( true ),
+           Description ( "This is key property." )]
+       string InstanceID;
 
-  See :ref:`pywbemcli class get --help` for details.
-* **invokemethod** to invoke a method defined for the CLASSNAME argument. This
-  command executes the invokemethod with a class name, not an instance name
-  and any input parameters for the InvokeMethod defined with the
-  ``--parameter`` \ ``-p`` option.
+          [Description ( "This is Uint32 property." )]
+       uint32 IntegerProp;
 
-  The ``invokemethod`` command requires CLASSNAME and METHODNAME arguments to
-  define the class and method to be invoked and optionally a``--parameter``
-  option for each parameter that is to be attached to the request to be sent to
-  the WBEM server.
+          [Description ( "Method with in and out parameters" )]
+       uint32 Fuzzy(
+             [IN ( true ),
+              OUT ( true ),
+              Description ( "Define data to be returned in output parameter" )]
+          string TestInOutParameter,
+             [IN ( true ),
+              OUT ( true ),
+              Description ( "Test of ref in/out parameter" )]
+          CIM_Foo REF TestRef,
+             [IN ( false ),
+              OUT ( true ),
+              Description ( "Rtns method name if exists on input" )]
+          string OutputParam,
+             [IN ( true ),
+              Description ( "Defines return value if provided." )]
+          uint32 OutputRtnValue);
 
-  The syntax of the ``--parameter`` option is defined in :ref:`Specifying CIM
-  property and parameter values`.
+          [Description ( "Method with no Parameters" )]
+       uint32 DeleteNothing();
 
-  If successful it returns the method return value and output parameters
-  received from the server. If unsuccessful it displays the exception
-  generated. It displays the return value as an integer and any returned CIM
-  parameters in the :term:`CIM object output formats` (see :ref:`Output
-  formats`).
-  See :ref:`pywbemcli class invokemethod --help` for details.
-* **tree** to display the class hierarchy as a tree.  This command
-  outputs a tree format in ASCII defining the either the subclass or superclass
-  hierarchy of the class name input parameter as a tree:
+    };
+  $
+
+See :ref:`pywbemcli class get --help` for details.
+
+
+.. _`Class invokemethod command`:
+
+Class invokemethod command
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``class invokemethod`` command invokes a CIM method defined for the CLASSNAME argument. This
+command executes the invokemethod with a class name, not an instance name
+and any input parameters for the InvokeMethod defined with the
+``--parameter`` \ ``-p`` option. If successful it returns the method return
+value and output parameters received from the server. If unsuccessful it
+displays the exception generated. It displays the return value as an integer and
+any returned CIM parameters in the
+:term:`CIM object output formats` (see :ref:`Output formats`).
+
+
+See :ref:`pywbemcli class invokemethod --help` for details.
+
+
+.. _`Class tree command`:
+
+Class tree command
+^^^^^^^^^^^^^^^^^^
+
+The ``class tree`` command display the class hierarchy as a tree for the namespace
+defined by ``-n / --namespace`` or the default namespace.  This command
+always outputs a tree format in ASCII defining the either the subclass or superclass
+hierarchy (``--superclasses`` option) of the class name input parameter as a tree:
 
   .. code-block:: text
 
@@ -536,13 +623,10 @@ The **class** group defines commands that act on CIM classes. see
          |   +-- CIM_Foo_sub_sub
          +-- CIM_Foo_sub2
 
-  It can show either the subclasses or the superclasses of the defined class
-  using the (``--superclasses`` option).
+This command ignores the ``--output-format``\``-o' general option and
+always outputs the tree format.
 
-  This command ignores the ``--output-format``\``-o' general option and
-  always outputs the tree format.
-
-  See :ref:`pywbemcli class tree --help` for details.
+See :ref:`pywbemcli class tree --help` for details.
 
 
 .. _`Instance command group`:
@@ -550,17 +634,37 @@ The **class** group defines commands that act on CIM classes. see
 Instance command group
 ----------------------
 
-The **instance** group defines commands that act on CIM instances including:
+The **instance** command group defines commands that act on CIM instances as defined
+in the following subsections:
 
-* **associators** to get the associator instances for the instance name defined
-  as the :term:`INSTANCENAME` argument in the default namespace or the namespace defined with this
-  command displayed in the defined format. If successful it returns the
-  instances or instancenames associated with INSTANCENAME otherwise it returns any
-  exception generated by the response This command displays the returned instances
-  or instance in the :term:`CIM object output formats` or the table formats` (see
-  :ref:`Output formats`).:
+This group consists of the following commands:
 
-  .. code-block:: text
+* :ref:`Instance associators command`
+* :ref:`Instance count command`
+* :ref:`Instance create command`
+* :ref:`Instance delete command`
+* :ref:`Instance enumerate command`
+* :ref:`Instance get command`
+* :ref:`Instance invokemethod command`
+* :ref:`Instance modify command`
+* :ref:`Instance references command`
+* :ref:`Instance query command`
+
+
+.. _`Instance associators command`:
+
+Instance associators command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``instance associators`` command gets the associator instances for the argument
+as the :term:`INSTANCENAME` argument in the namespace defined with this
+command or the default namespace and displays it in the defined format. If successful it returns the
+instances or instance names associated with :term:`INSTANCENAME` otherwise it returns an
+exception generated by the response This command displays the returned instances
+or instance in the :term:`CIM object output formats` or the table formats` (see
+:ref:`Output formats`).:
+
+.. code-block:: text
 
     $ pywbemcli --name mockassoc instance references TST_Person --names-only --interactive
     Pick Instance name to process: 0
@@ -579,91 +683,134 @@ The **instance** group defines commands that act on CIM instances including:
     //FakedUrl/root/cimv2:TST_MemberOfFamilyCollection.family="root/cimv2:TST_FamilyCollection.name=\"Family2\"",member="root/cimv2:TST_Person.name=\"Mike\""
     $
 
-  See :ref:`pywbemcli instance associators --help` for details.
-* **count** count the number of CIM instances in a namespace. For example:
+See :ref:`pywbemcli instance associators --help` for details.
 
-  .. code-block:: text
 
-        $ pywbemcli --name mockassoc instance count
-        Count of instances per class
-        +------------------------------+---------+
-        | Class                        |   count |
-        |------------------------------+---------|
-        | TST_FamilyCollection         |       2 |
-        | TST_Lineage                  |       3 |
-        | TST_MemberOfFamilyCollection |       3 |
-        | TST_Person                   |       4 |
-        +------------------------------+---------+
+.. _`Instance count command`:
 
-  This counts the number of instances specific to the class shown where the
-  ``instance enumerate`` would show the instance for that class and its
-  subclasses.
+Instance count command
+^^^^^^^^^^^^^^^^^^^^^^
 
-  Count is useful to determine which classes in the environment are actually
-  implemented. However this command can take a long time to execute because
-  it must a) enumerate all the classes in the namespaces, b) enumerate the
-  instances for each class.
+The ``instance count`` command returns acount of the number of CIM instances in the
+namespace defined by ``--namespace`` or the default namespace. The list of
+classes processed is filtered by the ``CLASSNAME-GLOB`` optional argument using
+using :term:`GLOB` .
+
+For example:
+
+.. code-block:: text
+
+    $ pywbemcli --name mockassoc instance count
+    Count of instances per class
+    +------------------------------+---------+
+    | Class                        |   count |
+    |------------------------------+---------|
+    | TST_FamilyCollection         |       2 |
+    | TST_Lineage                  |       3 |
+    | TST_MemberOfFamilyCollection |       3 |
+    | TST_Person                   |       4 |
+    +------------------------------+---------+
+
+This counts the number of instances specific to the class shown where the
+``instance enumerate`` would show the instances for that class and its
+subclasses.
+
+Count is useful to determine which classes in the environment are actually
+implemented. However this command can take a long time to execute because
+it must a) enumerate all the classes in the namespaces, b) enumerate the
+instances for each class.
 
   See :ref:`pywbemcli instance count --help` for details.
-* **create** create a CIMInstance of the CLASSNAME argument in a namespace
-  defined with as an option to the command or the default namespace in the
-  WBEM server. The command build the CIMInstance from the class defined by
-  CLASSNAME and the properties defined by the ``--property``\``-p`` option The
-  properties are defined as name/value pairs, one property for each instance of
-  the ``--property`` option.
 
-  The syntax of the ``--property`` is documented in
-  :ref:`Specifying CIM property and parameter values`.
 
-  The following is an example with three properties, ``InstanceId`` a scalar
-  string property, ``IntProp`` a scalar numeric property, and ``IntArr`` an
-  array integer property. Note that the ``--property/-p`` value does not
-  determine the property type.  ``IntProp`` and ``IntArr`` could be any of the
-  numeric types (Unint32, Sint32, etc.) However, generally integers and float
-  values are used for integer and float property types.
 
-  .. code-block:: text
+.. _`Instance create command`:
+
+Instance create command
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``instance create`` command creates a new CIMInstance in the WBEM server namespace
+defined with ``--namespace`` or the default namespace. The command builds the CIMInstance from the class defined by
+CLASSNAME and the properties defined by the ``--property``\``-p`` option The
+properties are defined as name/value pairs, one property for each instance of
+the ``--property`` option. Since the WBEM server (and pywbem) requires that
+each property be typed, pywbemtools uses the CIMClass defined by CLASSNAME
+retrieved from the WBEM server to define the type required to define the
+CIMProperty.
+
+For a single property in the new instance this is simply the `--property`` option
+with the property name and value:
+
+.. code-block:: text
+
+    --property <property-name>=<property-value"
+
+    where quotes are only required if the value includes whitespace.
+
+For array properties the values are defined separated by commas:
+
+.. code-block:: text
 
     $pywbemcli instance create TST_Blah -p InstancId=blah1 -p IntProp=3 -p IntArr=3,6,9
 
     $pywbemcli instance create TST_Blah -p InstancId=\"blah 2\" -p IntProp=3 -p IntArr=3,6,9
 
-  If the create is successful, the server defined CIM Instance path is displayed.
-  If the operation fails, the exception is displayed. If there is a descrepency
-  between the defined properties and the CIMClass property characteristics
-  pywbemcli generates an exception.
+If the create is successful, the server defined CIM Instance path is displayed.
+If the operation fails, the exception is displayed. If there is a descrepency
+between the defined properties and the CIMClass property parameters
+pywbemcli generates an exception.
 
-  See :ref:`pywbemcli instance create --help` for details.
-* **delete** delete an instance defined by the :term:`INSTANCENAME` argument
-    in a namespace defined by either the ``--namespace` option or the general
-    `--default-namespace`` The form of INSTANCENAME is determined by the
-    ``--interactive`` options and must be either:
+The following example creates an instance of the class TST_Blah with one
+scalar and one array property.
 
-    * a string representation of a CIMInstanceName as defined by a :term:`WBEM URI`
-    * A class name in which case pywbemcli will get the instance names from the
-      WBEM server and present a selection list for the user to select an
-      instance name.
+.. code-block:: text
 
-  The following example deletes the instance defined by the explicit instance
-  name (Note the extra backslash required to escape the double quote on the
-  terminal):
+    $pywbemcli instance create TST_Blah InstancId="blah1", intprop=3, intarr=3,6,9
 
-  .. code-block:: text
+See :ref:`pywbemcli instance create --help` for details.
+
+.. _`Instance delete command`:
+
+Instance delete command
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``instance delete`` command deletes an instance defined by the :term:`INSTANCENAME` argument
+in a namespace defined by either the ``--namespace` option or the general
+`--default-namespace`` The form of INSTANCENAME is determined by the
+``--interactive`` options and must be either:
+
+* a string representation of a CIMInstanceName as defined by a :term:`WBEM URI`
+* A class name in which case pywbemcli will get the instance names from the
+  WBEM server and present a selection list for the user to select an
+  instance name :ref:`Displaying CIM instances/classes or their names`
+
+The following example deletes the instance defined by the explicit instance
+name (Note the extra backslash required to escape the double quote on the
+terminal): FOOTNOTE TODO
+
+.. code-block:: text
 
     $ pywbemcli --name mockassoc instance delete root/cimv2:TST_Person.name=\"Saara\"
     $
 
-  See :ref:`pywbemcli instance delete --help` for details.
-* **enumerate** to enumerate instances or their paths defined by the CLASSNAME
-  argument in the namespace defined by ``-n``\``--namespace`` or the general option
-  ``-d``\``--default-namespace`` in the defined format. This command displays the
-  returned instances or instance names in the :term:`CIM object output formats`
-  or the table formats` (see :ref:`Output formats`).
+See :ref:`pywbemcli instance delete --help` for details.
 
-  The following example returns a two instanced to an ``instance enumerate``
-  command as MOF:
 
-  .. code-block:: text
+.. _`Instance enumerate command`:
+
+Instance enumerate command
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``instance enumerate`` command enumerates instances or their paths defined by the CLASSNAME
+argument in the namespace defined by ``-o``\``--namespace`` or the general option
+``-o``\``--default-namespace`` in the defined format. This command displays the
+returned instances or instance names in the :term:`CIM object output formats`
+or the table formats` (see :ref:`Output formats`).
+
+The following example returns a two instanced to an ``instance enumerate``
+command as MOF:
+
+.. code-block:: text
 
     $ pywbemcli --name mockassoc instance enumerate TST_FamilyCollection
 
@@ -675,58 +822,75 @@ The **instance** group defines commands that act on CIM instances including:
        name = "Family2";
     };
 
-  See :ref:`pywbemcli instance enumerate --help` for details.
-* **get** to get a single CIM instance defined by the :term:`INSTANCENAME`
-    argument from the default namespace or the namespace defined with the
-    command displayed in the defined format. The form of :term:`INSTANCENAME` is
-    determined by the ``--interactive`` option. It can display the returned
-    instance in the :term:`CIM object output formats` or the table formats`
-    (see :ref:`Output formats`). Otherwise it returns the received exception.
+See :ref:`pywbemcli instance enumerate --help` for details.
 
-    This example successfully retrieves the instance defined by the INSTANCENAME
-    ``root/cimv2:TST_Person.name=\"Saara\"``:
 
-    .. code-block:: text
+.. _`Instance get command`:
 
-        $ pywbemcli --name mockassocinstance instance get root/cimv2:TST_Person.name=\"Saara\"
+Instance get command
+^^^^^^^^^^^^^^^^^^^^
 
-        instance of TST_Person {
-           name = "Saara";
-        };
+The ``instance get`` command gets a single CIM instance defined by the :term:`INSTANCENAME`
+argument from the default namespace or the namespace defined with the
+command displayed in the defined format. The form of :term:`INSTANCENAME` is
+determined by the ``--interactive`` option. It can display the returned
+instance in the :term:`CIM object output formats` or the table formats`
+(see :ref:`Output formats`). Otherwise it returns the received exception.
 
-  See :ref:`pywbemcli instance get --help` for details.
-* **invokemethod** to invoke a method defined for the class argument.
-  The ``invokemethod`` command requires INSTANCENAME and METHODNAME arguments to
-  define the instance and method to be invoked and optionally a``--parameter\-p``
-  option for each   parameter that is to be attached to the request to be sent
-  to the WBEM server.
+This example successfully retrieves the instance defined by the INSTANCENAME
+``root/cimv2:TST_Person.name=\"Saara\"``:
 
-  The syntax of the ``--parameter`` option is defined in :ref:`Specifying CIM
-  property and parameter values`.
+.. code-block:: text
 
-  If successful it returns the method return value and output parameters
-  received from the server. If unsuccessful it displays the exception
-  generated. It displays the return value as an integer and any returned CIM
-  parameters in the :term:`CIM object output formats` (see :ref:`Output
-  formats`).
-  See :ref:`pywbemcli instance invokemethod --help` for details.
-* **modify** modify an existing instance of the class defined by the CLASSNAME argument
-  in the WBEM server  namespace defined by either the default namespace or
-  namespace option. The user provides the definition of an instance in the same
-  form as the ``add`` command but the instance must already exist in the
-  WBEM server and the instance created from the command line must include all
-  of the key properties so that it can be identified in the server.
+    $ pywbemcli --name mockassocinstance instance get root/cimv2:TST_Person.name=\"Saara\"
 
-  If successful, this command displays nothing, otherwise it displays the
-  received exception.
+    instance of TST_Person {
+       name = "Saara";
+    };
 
-  See :ref:`pywbemcli instance modify --help` for details.
-* **references** to get the reference instances or paths for a
-  instance defined as the :term:`INSTANCENAME` input argument in the default
-  namespace or the namespace defined with this command displayed in the
-  defined format. It can display any returned instances in the
-  :term:`CIM object output formats` or the table formats`
-  (see :ref:`Output formats`). Otherwise it returns the received exception.:
+See :ref:`pywbemcli instance get --help` for details.
+
+
+.. _`Instance invokemethod command`:
+
+Instance invokemethod command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The invokemethod command  invokes a method defined for the INSTANCENAME argument.
+
+See :ref:`pywbemcli instance invokemethod --help` for details.
+
+
+.. _`Instance modify command`:
+
+Instance modify command
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``instance modify`` command modifies an existing instance of the class
+defined by the CLASSNAME argument in the WBEM server  namespace defined by
+either the default namespace or namespace option. The user provides the
+definition of an instance in the same form as the ``add`` command but the
+instance must already exist in the WBEM server and the instance created from
+the command line must include all of the key properties so that it can be
+identified in the server.
+
+If successful, this command displays nothing, otherwise it displays the
+received exception.
+
+See :ref:`pywbemcli instance modify --help` for details.
+
+
+.. _`Instance references command`:
+
+Instance references command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``instance references`` command gets the reference instances or paths for a
+instance defined as the :term:`INSTANCENAME` input argument in the default
+namespace or the namespace defined with this command displayed in the
+defined format. It can display any returned instances in the
+:term:`CIM object output formats` or the table formats`
+(see :ref:`Output formats`). Otherwise it returns the received exception.:
 
   .. code-block:: text
 
@@ -737,18 +901,26 @@ The **instance** group defines commands that act on CIM instances including:
          child = "/root/cimv2:TST_Person.name=\"Sofi\"";
       };
 
-  See :ref:`pywbemcli instance references --help` for details.
-* **query** to execute an execquery with query string defined as an argument.
-  The QUERY argument must be a valid query defined for the ``--query-language``
-  option and available in the WBEM server being queried.  The default for
-  the ``--query-language`` option is DMTF:CQL but any query language and query
-  will be passed to the server.
+See :ref:`pywbemcli instance references --help` for details.
 
-  It displays any instances returned in the defined formats or any exception
-  returned.  It can display any returned instances in the
-  :term:`CIM object output formats` or the table formats
-  (see :ref:`Output formats`).
-  See :ref:`pywbemcli instance query --help` for details.
+
+.. _`Instance query command`:
+
+Instance query command
+^^^^^^^^^^^^^^^^^^^^^^
+
+The ``instance query`` command executes an ExecQuery CIM-XML operation with query string defined as an argument.
+The QUERY argument must be a valid query defined for the ``--query-language``
+option and available in the WBEM server being queried.  The default for
+the ``--query-language`` option is DMTF:CQL but any query language and query
+will be passed to the server.
+
+It displays any instances returned in the defined formats or any exception
+returned.  It can display any returned instances in the
+:term:`CIM object output formats` or the table formats
+(see :ref:`Output formats`).
+
+See :ref:`pywbemcli instance query --help` for details.
 
 .. _`qualifier command group`:
 
@@ -758,34 +930,46 @@ Qualifier command group
 The **qualifier** command group defines commands that act on
 CIMQualifierDeclaration entities in the WBEM server including:
 
-* **get** to get a single qualifier declaration defined by the ``QUALIFIERNAME``
-  argument from the namespace in the target WBEM server defined with this
-  command  or the default namespace and display in the defined output format.
-  The output formats can be either one of the :term:`CIM object output formats`
-  or the table formats` (see :ref:`Output formats`).
 
-  The following example gets the ``Key`` qualifier declaration from the
-  default namespace:
+.. _`Qualifier get command`:
 
-  .. code-block:: text
+Qualifier get command
+^^^^^^^^^^^^^^^^^^^^^
 
-    $ pywbemcli --name mockassocinstance.mof qualifier get Key
-    Qualifier Key : boolean = false,
-        Scope(property, reference),
-        Flavor(DisableOverride, ToSubclass);
+The ``qualifier get`` command gets a single qualifier declaration defined by the ``QUALIFIERNAME``
+argument from the namespace in the target WBEM server defined with this
+command  or the default namespace and display in the defined output format.
+The output formats can be either one of the :term:`CIM object output formats`
+or the table formats` (see :ref:`Output formats`).
 
-  See :ref:`pywbemcli qualifier get --help` for details.
+The following example gets the ``Key`` qualifier declaration from the
+default namespace:
 
-* **enumerate** to enumerate all qualifier declarations within the namespace
-  defined with this command or the default namespace in the target WBEM
-  server . The output formats can be either one  of the
-  :term:`CIM object output formats` or the table formats`
-  (see :ref:`Output formats`).
+.. code-block:: text
 
-  This example displays all of the qualifier declarations in the default
-  namespace as a simple table.
+  $ pywbemcli --name mockassocinstance.mof qualifier get Key
+  Qualifier Key : boolean = false,
+      Scope(property, reference),
+      Flavor(DisableOverride, ToSubclass);
 
-  .. code-block:: text
+See :ref:`pywbemcli qualifier get --help` for details.
+
+
+.. _`Qualifier enumerate command`:
+
+Qualifier enumerate command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``qualifier enumerate`` command  enumerates all qualifier declarations within the namespace
+defined with this command or the default namespace in the target WBEM
+server . The output formats can be either one  of the
+:term:`CIM object output formats` or the table formats`
+(see :ref:`Output formats`).
+
+This example displays all of the qualifier declarations in the default
+namespace as a simple table.
+
+.. code-block:: text
 
     $ pywbemcli --name mockassocinstance --output-format table qualifier enumerate
 
@@ -806,7 +990,7 @@ CIMQualifierDeclaration entities in the WBEM server including:
     |             |         |         |         |             | ToSubclass      |
     +-------------+---------+---------+---------+-------------+-----------------+
 
-  See :ref:`pywbemcli qualifier enumerate --help` for details.
+See :ref:`pywbemcli qualifier enumerate --help` for details.
 
 .. _`Server command group`:
 
@@ -818,13 +1002,28 @@ server to access information about the WBEM server itself. These commands
 are generally not namespace specific but access information about the server,
 namespaces, etc. The commands are:
 
-* **brand** to get general information on the server.  Brand information is an
-  attempt by pywbem and pywbemtools to determine the product that represents
-  the WBEM server infrastructure.  Since that was not clearly defined in the DMTF
-  specifications, this command may return strange results but it returns
-  legitimate results for most servers:
+This group consists of the following commands:
 
-  .. code-block:: text
+* :ref:`Server brand command`
+* :ref:`Server connection command`
+* :ref:`Server info command`
+* :ref:`Server interop command`
+* :ref:`Server namespaces command`
+* :ref:`Server profiles command`
+* :ref:`Server get-centralinsts command`
+
+.. _`Server brand command`:
+
+Server brand command
+^^^^^^^^^^^^^^^^^^^^
+
+The ``server brand`` command gets general information on the server.  Brand information is an
+attempt by pywbem and pywbemtools to determine the product that represents
+the WBEM server infrastructure.  Since that was not clearly defined in the DMTF
+specifications, this command may return strange results but it returns
+legitimate results for most servers:
+
+.. code-block:: text
 
     $ pywbemcli --name op server brand
     Server Brand:
@@ -834,12 +1033,19 @@ namespaces, etc. The commands are:
     | OpenPegasus         |
     +---------------------+
 
-  See :ref:`pywbemcli server brand --help` for details.
-* **connection** to display information on the connection defined for this
-  server.  This is same information as was defined when the connection was
-  saved with ``connection save`` or the cli general options:
+See :ref:`pywbemcli server brand --help` for details.
 
-  .. code-block:: text
+
+.. _`Server connection command`:
+
+Server connection command
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``server connection command`` displays information on the connection defined for this
+server.  This is same information as was defined when the connection was
+saved with ``connection save`` or the cli general options:
+
+.. code-block:: text
 
     $pywbemcli --name op server connection
 
@@ -850,10 +1056,17 @@ namespaces, etc. The commands are:
     timeout: 30 sec.
     ca_certs: None
 
-  See :ref:`pywbemcli server connection --help` for details.
-* **info** to get general information on the server.  This command returns
-  information on the brand, namespaces, and other reasonable information on the
-  WBEM server:
+See :ref:`pywbemcli server connection --help` for details.
+
+
+.. _`Server info command`:
+
+Server info command
+^^^^^^^^^^^^^^^^^^^
+
+The server info command gets general information on the server.  This command returns
+information on the brand, namespaces, and other reasonable information on the
+WBEM server:
 
   .. code-block:: text
 
@@ -882,8 +1095,15 @@ namespaces, etc. The commands are:
     |             |           |                     | test/static                   |
     +-------------+-----------+---------------------+-------------------------------+
 
-  See :ref:`pywbemcli server info --help` for details.
-* **interop** to get a the name of the interop namespace target WBEM server:
+See :ref:`pywbemcli server info --help` for details.
+
+
+.. _`Server interop command`:
+
+Server interop command
+^^^^^^^^^^^^^^^^^^^^^^
+
+The ``server interop`` command get a the name of the interop namespace target WBEM server:
 
   .. code-block:: text
 
@@ -895,8 +1115,15 @@ namespaces, etc. The commands are:
     | root/PG_InterOp  |
     +------------------+
 
-  See :ref:`pywbemcli server interop --help` for details.
-* **namespaces** to get a list of the namespaces defined in the target server:
+See :ref:`pywbemcli server interop --help` for details.
+
+
+.. _`Server namespaces command`:
+
+Server namespaces command
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``server namespaces`` command gets a list of the namespaces defined in the target server:
 
   .. code-block:: text
 
@@ -905,15 +1132,8 @@ namespaces, etc. The commands are:
     Namespace Name
     root/PG_InterOp
     root/benchmark
-    root/SampleProvider
-    test/CimsubTestNS2
-    test/CimsubTestNS3
-    test/CimsubTestNS0
-    test/CimsubTestNS1
     root/PG_Internal
     test/WsmTest
-    test/TestIndSrcNS1
-    test/TestINdSrcNS2
     test/EmbeddedInstance/Static
     test/TestProvider
     test/EmbeddedInstance/Dynamic
@@ -924,21 +1144,28 @@ namespaces, etc. The commands are:
     $
 
   See :ref:`pywbemcli server namespaces --help` for details.
-* **profiles** to get information on the WBEM management profiles
-  (see :term:`WBEM management profile`)
-  defined in the target WBEM server. WBEM management profiles are the mechanism WBEM
-  uses to provide the user a programmatic connection to defined management
-  functionality with the implementation of that functionality in a WBEM server
-  (see :term:`DSP1001` and :term:`DSP1033`).
 
-  This request returns the organization, registered name, and version of each
-  profile definition returned from the server and the options can be used to
-  filter the returned profiles by Organization and registered name.
 
-  The following example shows the CIM profiles in
-  an example WBEM server:
+.. _`Server profiles command`:
 
-  .. code-block:: text
+Server profiles command
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``server profiles`` command gets information on the WBEM management profiles
+(see :term:`WBEM management profile`)
+defined in the target WBEM server. WBEM management profiles are the mechanism WBEM
+uses to provide the user a programmatic connection to defined management
+functionality with the implementation of that functionality in a WBEM server
+(see :term:`DSP1001` and :term:`DSP1033`).
+
+This request returns the organization, registered name, and version of each
+profile definition returned from the server and the options can be used to
+filter the returned profiles by Organization and registered name.
+
+The following example shows the CIM profiles in
+an example WBEM server:
+
+.. code-block:: text
 
 
      $ pywbemcli --output-format simple  --name op server profiles
@@ -967,12 +1194,19 @@ namespaces, etc. The commands are:
     SNIA            Software                  1.2.0
 
 
-  See :ref:`pywbemcli server profiles --help` for details.
-* **get_centralinsts** to get the instance names of the central/scoping
-  instances of one or more :term:`WBEM management profile` s defined in the
-  target WBEM server:
+See :ref:`pywbemcli server profiles --help` for details.
 
-  .. code-block:: text
+
+.. _`Server get-centralinsts command`:
+
+Server get-centralinsts command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``server get-centralinsts`` command gets the instance names of the central/scoping
+instances of one or more :term:`WBEM management profile` s defined in the
+target WBEM server:
+
+.. code-block:: text
 
 
     $ pywbemcli> server centralinsts --org DMTF --profile "Computer System"
@@ -983,7 +1217,7 @@ namespaces, etc. The commands are:
     | DMTF:Computer System:1.0.0      | //leonard/test/TestProvider:Test_StorageSystem.Name="StorageSystemInstance1",CreationClassName="Test_StorageSystem"://leonard/test/TestProvider:Test_StorageSystem.Name="StorageSystemInstance2",CreationClassName="Test_StorageSystem" |
     +---------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-  See :ref:`pywbemcli server get-centralinsts --help` for details.
+See :ref:`pywbemcli server get-centralinsts --help` for details.
 
 .. _`Connection command group`:
 
@@ -1039,18 +1273,32 @@ The connection information is saved in the :term:`connections file` when the
 ``connection add`` or ``connection save`` command are executed. Multiple
 connection files may be maintained in separate directories.
 
-The commands include:
+The commands in this group are:
 
-* **add** creates a new connection using the command arguments and sets the new
-  connection as the current connection. This command saves the
-  new connection to the :term:`connections file` (see ``connection save``).
+* :ref:`Connection add command`
+* :ref:`Connection delete command`
+* :ref:`Connection export command`
+* :ref:`Connection list command`
+* :ref:`Connection save command`
+* :ref:`Connection select command`
+* :ref:`Connection show command`
+* :ref:`Connection test command`
 
-  The following example shows creating a new connection from within the
-  interactive mode of pywbemcli. The parameters for the connection are defined
-  through the input options for the command. These use the same option names
-  as the corresponding general options to define the WBEM server:
+.. _`Connection add command`:
 
-  .. code-block:: text
+Connection add command
+^^^^^^^^^^^^^^^^^^^^^^
+
+The ``connection add`` command creates a new connection using the command arguments and sets the new
+connection as the current connection. This command saves the
+new connection to the :term:`connections file` (see ``connection save``).
+
+The following example shows creating a new connection from within the
+interactive mode of pywbemcli. The parameters for the connection are defined
+through the input options for the command. These use the same option names
+as the corresponding general options to define the WBEM server:
+
+.. code-block:: text
 
     pywbemcli> connection add --name me --server http://localhost --user me --password mypw --no-verify
     pywbemcli> connection list
@@ -1069,21 +1317,27 @@ The commands include:
     +--------------+------------------+-------------+-------------+-----------+------------+----------------------------------------+
     pywbemcli>
 
-  NOTE: The ``*`` on the name indicates the current connection, the one that
-  will be used for any subsequent commands within a single interactive session.
-  This can be changed using ``connection select``
+NOTE: The ``*`` on the name indicates the current connection, the one that
+will be used for any subsequent commands within a single interactive session.
+This can be changed using ``connection select``
 
-  See :ref:`pywbemcli connection add --help` for details.
-* **delete** delete a specific connection by name or by selection. The following
-  example deletes the connection defined in the add command above:
+See :ref:`pywbemcli connection add --help` for details.
 
-  .. code-block:: text
+
+.. _`Connection delete command`:
+
+Connection delete command
+^^^^^^^^^^^^^^^^^^^^^^^^^
+The ``connection delete`` command deletes a specific connection by name or by selection. The following
+example deletes the connection defined in the add command above:
+
+.. code-block:: text
 
     $ pywbemcli connection delete me
 
   To delete by selection:
 
-  .. code-block:: text
+.. code-block:: text
 
     $ pywbemcli connection delete
     Select a connection or Ctrl_C to abort.
@@ -1095,21 +1349,47 @@ The commands include:
     $
 
 
-  See :ref:`pywbemcli connection delete --help` for details.
-* **export** export the current connection information as environment variables.
-  See :ref:`pywbemcli connection export --help` for details.
-* **list** list the connections in the :term:`connections file` as a table. This produces
-  a table output showing the connections defined in the connections file.
+See :ref:`pywbemcli connection delete --help` for details.
 
-  See :ref:`pywbemcli connection list --help` for details.
-* **save** Save the current connection information
-  to the :term:`connections file`.  If the current connection does not have a name
-  a console request asks for a name for the connection.
-  See :ref:`pywbemcli connection save --help` for details.
-* **select** select a connection from the connection table.  A connection
-  may be selected either by using the name argument or if no argument is
-  provided by selecting from a list presented on the console. The following
-  example shows changing connection from within the interactive mode of pywbemcli:
+
+.. _`Connection export command`:
+
+Connection export command
+^^^^^^^^^^^^^^^^^^^^^^^^^
+The ``connection export`` command  exports the current connection information as environment variables.
+  See :ref:`pywbemcli connection export --help` for details.
+
+
+.. _`Connection list command`:
+
+Connection list command
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``connection list`` command lists the connections in the :term:`connections file` as a table. This produces
+a table output showing the connections defined in the connections file.
+
+See :ref:`pywbemcli connection list --help` for details.
+
+
+.. _`Connection save command`:
+
+Connection save command
+^^^^^^^^^^^^^^^^^^^^^^^
+The ``connection save`` command saves the current connection information
+to the :term:`connections file`.  If the current connection does not have a name
+a console request asks for a name for the connection.
+See :ref:`pywbemcli connection save --help` for details.
+
+
+.. _`Connection select command`:
+
+Connection select command
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``connection select`` command selects a connection from the connection table.  A connection
+may be selected either by using the name argument or if no argument is
+provided by selecting from a list presented on the console. The following
+example shows changing connection from within the interactive mode of pywbemcli:
 
   .. code-block:: text
 
@@ -1121,13 +1401,13 @@ The commands include:
     Input integer between 0 and 2 or Ctrl-C to exit selection: 1
     pywbemcli> connection list
     WBEMServer Connections:
-    +------------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------+
-    | name       | server uri       | namespace   | user        | password   |   timeout | no-verify  | certfile   | keyfile   | log   |
-    |------------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------|
-    | mock1      |                  | root/cimv2  |             |            |        30 | False      |            |           |       |
-    | mockassoc* |                  | root/cimv2  |             |            |        30 | False      |            |           |       |
-    | op         | http://localhost | root/cimv2  | kschopmeyer | test8play  |        30 | True       |            |           |       |
-    +------------+------------------+-------------+-------------+------------+-----------+------------+------------+-----------+-------+
+    +------------+------------------+-------------+-------------+------------+-----------+------------+
+    | name       | server uri       | namespace   | user        | password   |   timeout | no-verify  |
+    |------------+------------------+-------------+-------------+------------+-----------+------------+
+    | mock1      |                  | root/cimv2  |             |            |        30 | False      |
+    | mockassoc* |                  | root/cimv2  |             |            |        30 | False      |
+    | op         | http://localhost | root/cimv2  | xxxxxxxxxxx | edfddfedd  |        30 | True       |
+    +------------+------------------+-------------+-------------+------------+-----------+------------+
 
     $ pywbemcli> connection show
 
@@ -1146,28 +1426,40 @@ The commands include:
       log: None
 
 
-  See :ref:`pywbemcli connection select --help` for details.
-* **show** show information in the current connection.  See the the ``select``
-  above for an example of this command.
+See :ref:`pywbemcli connection select --help` for details.
 
-  See :ref:`pywbemcli connection show --help` for details.
-* **test** execute a single predefined operation on the current connection
-  to determine if it is a WBEM server. It executes a single ``EnumerateClasses``
-  WBEM operation in the default namespace. If the server accepts the request
-  a simple text ``Connection successful`` will be returned.
 
-  See :ref:`pywbemcli connection test --help` for details.
+.. _`Connection show command`:
 
-  The following example defines the connection with ``--server``, ``--user``,
-  and ``--pasword`` and executes the test with successful result:
+Connection show command
+^^^^^^^^^^^^^^^^^^^^^^^^^
+The ``connection show`` command shows information in the current connection.  See the the ``select``
+above for an example of this command.
 
- .. code-block:: text
+See :ref:`pywbemcli connection show --help` for details.
+
+
+.. _`Connection test command`:
+
+Connection test command
+^^^^^^^^^^^^^^^^^^^^^^^
+The ``connection test`` command executes a single predefined operation on the current connection
+to determine if it is a WBEM server. It executes a single ``EnumerateClasses``
+WBEM operation in the default namespace. If the server accepts the request
+a simple text ``Connection successful`` will be returned.
+
+See :ref:`pywbemcli connection test --help` for details.
+
+The following example defines the connection with ``--server``, ``--user``,
+and ``--pasword`` and executes the test with successful result:
+
+.. code-block:: text
 
   $ pywbemcli --server http://localhost --user me --password mypw connection test
   $ Connection successful
 
-  An unsuccessful test will normally result in an exception that defines the
-  issue as follows for the server http://blah in the example below:
+An unsuccessful test will normally result in an exception that defines the
+issue as follows for the server http://blah in the example below:
 
   .. code-block:: text
 
@@ -1182,7 +1474,7 @@ Repl command
 This command sets pywbemcli into the :ref:`interactive mode`.  Pywbemcli can be
 started in the :ref:`interactive mode` either by entering:
 
-  .. code-block:: text
+.. code-block:: text
 
    $ pywbemcli repl
    Enter 'help' for help, <CTRL-D> or ':q' to exit pywbemcli.
@@ -1190,7 +1482,7 @@ started in the :ref:`interactive mode` either by entering:
 
 or by executing the script without any command or command group:
 
-  .. code-block:: text
+.. code-block:: text
 
    $ pywbemcli
    Enter 'help' for help, <CTRL-D> or ':q' to exit pywbemcli.


### PR DESCRIPTION
Waiting on other PRs for pywbemclicommands.rst

Modifies all of the command descriptions to a new level of
sections so that they can be seen in index, toc, and also
references.

Note that I changed text on some of the early ones but for most of them
I simply changed the bullets to sections so we can merge more easily
with the other changes occuring simultaneously.