### PR TITLE
Correct an issue found in invokemethod with array parameters.

### DIFF
--- a/docs/pywbemclicommands.rst
+++ b/docs/pywbemclicommands.rst
@@ -562,7 +562,21 @@ See :ref:`pywbemcli instance get --help` for details.
 Instance invokemethod command
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The invokemethod command  invokes a method defined for the INSTANCENAME argument.
+The invokemethod command  invokes a method defined for the INSTANCENAME  and
+METHOD arguments using any CIM parameters defined with the --parameter arguments.
+If successful, it returns a ReturnValue and and CIM parameters included in
+the response. This command only formats in a simple text format.
+
+As as example:
+
+.. code-block:: text
+
+    $ pywbemcli -m tests/unit/all_types.mof -m tests/unit/all_types_method.py
+    pywbemcli> instance invokemethod PyWBEM_AllTypes.InstanceId=\"test_instance\" AllTypesMethod -p arrBool=True,False
+
+    ReturnValue=0
+    arrBool=true, false
+
 
 See :ref:`pywbemcli instance invokemethod --help` for details.
 

--- a/tests/unit/all_types.mof
+++ b/tests/unit/all_types.mof
@@ -6,8 +6,16 @@ Qualifier Description : string = null,
     Scope(any),
     Flavor(EnableOverride, ToSubclass, Translatable);
 
+Qualifier In : boolean = true,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
 Qualifier Key : boolean = false,
     Scope(property, reference),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Out : boolean = false,
+    Scope(parameter),
     Flavor(DisableOverride, ToSubclass);
 
 // This class defines all of the primitive CIM data types to be used both
@@ -85,6 +93,37 @@ class PyWBEM_AllTypes {
    Real64  arrayReal64[];
    String  arrayString[];
    Datetime arrayDateTime[];
+
+        [Description ("Contains params with different cim types")]
+    uint32 AllTypesMethod(
+        [IN, OUT, Description("BooleanScalar")]
+      Boolean scalBool,
+        [IN, OUT, Description("Uint32Scalar")]
+      Uint32 scalUint32,
+        [IN, OUT, Description("Sint32Scalar")]
+      Sint32 scalSint32,
+        [IN, OUT, Description("Real32Scalar")]
+      Real32 scalReal32[],
+        [IN, OUT, Description("StringScalar")]
+      String scalString[],
+        [IN, OUT, Description("DatetimeScalar")]
+      Datetime scalDatetime[],
+        [IN, OUT, Description("RefScalar")]
+      PyWBEM_AllTypes REF scalRef,
+        [IN, OUT, Description("BooleanArray")]
+      Boolean arrBool[],
+        [IN, OUT, Description("Uint32Array")]
+      uint32 arrUint32[],
+        [IN, OUT, Description("Sint32Array")]
+      uint32 arrSint32[],
+        [IN, OUT, Description("Real32Array")]
+      Real32 arrReal32[],
+        [IN, OUT, Description("StringArray")]
+      String arrString[],
+        [IN, OUT, Description("DatetimeArray")]
+      Datetime arrDatetime[],
+        [IN, OUT, Description("RefArray")]
+      PyWBEM_AllTypes REF arrRef[]);
 };
 
 // Single instance defined for this class.  This instance is used in tests

--- a/tests/unit/all_types_method_mock.py
+++ b/tests/unit/all_types_method_mock.py
@@ -1,0 +1,32 @@
+"""
+mock_pywbem test script that installs a method callback to be executed. This is
+based on the CIM_Foo class in the simple_mock_model.mof test file
+
+"""
+# test that GLOBALS exist
+assert "CONN" in globals()
+assert 'SERVER' in globals()
+assert 'VERBOSE'in globals()
+
+
+def alltypes_callback(conn, object_name, methodname, **params):
+    # pylint: disable=attribute-defined-outside-init, unused-argument
+    # pylint: disable=invalid-name
+    """
+    InvokeMethod callback defined in accord with pywbem
+    method_callback_interface which defines the input parameters and returns
+    all parameters received.
+    """
+    return_params = [params[p] for p in params]
+    return_value = 0
+
+    return (return_value, return_params)
+
+
+# Add the the callback to the mock repository
+global CONN  # pylint: disable=global-at-module-level
+# This method expected to use the global namespace
+# pylint: disable=undefined-variable
+
+CONN.add_method_callback('PyWBEM_AllTypes', 'AllTypesMethod',    # noqa: F821
+                         alltypes_callback)  # noqa: F821

--- a/tests/unit/simple_mock_invokemethod.py
+++ b/tests/unit/simple_mock_invokemethod.py
@@ -20,6 +20,10 @@ def fuzzy_callback(conn, object_name, methodname, **params):
     params from the TestInvokeMethod object attributes.
     """
     return_params = params.get('TestOutParameter', [])
+
+    if 'TestInOutParameter' in params:
+        return_params.append(params['TestInOutParameter'])
+
     if 'TestRef' in params:
         return_params.append(params['TestRef'])
 

--- a/tests/unit/test_class_subcmd.py
+++ b/tests/unit/test_class_subcmd.py
@@ -1252,9 +1252,10 @@ TEST_CASES = [
 
     ['Verify class subcommand invokemethod',
      ['invokemethod', 'CIM_Foo', 'Fuzzy', '-p', 'TestInOutParameter="blah"'],
-     {'stdout': ["ReturnValue=0"],
+     {'stdout': ['ReturnValue=0',
+                 'TestInOutParameter=', 'blah'],
       'rc': 0,
-      'test': 'lines'},
+      'test': 'innows'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
     ['Verify class subcommand invokemethod fails Invalid Class',
@@ -1266,17 +1267,17 @@ TEST_CASES = [
 
     ['Verify class subcommand invokemethod fails Invalid Method',
      ['invokemethod', 'CIM_Foo', 'Fuzzyx', '-p', 'TestInOutParameter=blah'],
-     {'stderr': ["Error: CIMError: 17"],
+     {'stderr': ["CIMError: 17"],
       'rc': 1,
-      'test': 'in'},
+      'test': 'innows'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
 
     ['Verify class subcommand invokemethod fails Method not registered',
      ['invokemethod', 'CIM_Foo', 'Fuzzy'],
-     {'stderr': ["Error: CIMError: 17"],
+     {'stderr': ["CIMError: 17"],
       'rc': 1,
-      'test': 'in'},
+      'test': 'innows'},
      [SIMPLE_MOCK_FILE], OK],
 
     ['Verify  --timestats gets stats output. Cannot test '

--- a/tests/unit/test_instance_subcmd.py
+++ b/tests/unit/test_instance_subcmd.py
@@ -41,6 +41,7 @@ INVOKE_METHOD_MOCK_FILE = "simple_mock_invokemethod.py"
 MOCK_PROMPT_0_FILE = "mock_prompt_0.py"
 MOCK_CONFIRM_Y_FILE = "mock_confirm_y.py"
 MOCK_CONFIRM_N_FILE = "mock_confirm_n.py"
+ALLTYPES_INVOKEMETHOD_MOCK_FILE = 'all_types_method_mock.py'
 
 
 #
@@ -1596,7 +1597,7 @@ Instances: PyWBEM_AllTypes
                  '+-----------------+---------+'],
       'rc': 0,
       'test': 'lines'},
-     SIMPLE_MOCK_FILE_EXT, RUN],
+     SIMPLE_MOCK_FILE_EXT, OK],
 
     ['Verify instance subcommand count. Return table of instances',
      ['count', 'CIM_*'],
@@ -1610,7 +1611,7 @@ Instances: PyWBEM_AllTypes
                  '+-----------------+---------+'],
       'rc': 0,
       'test': 'lines'},
-     SIMPLE_MOCK_FILE_EXT, RUN],
+     SIMPLE_MOCK_FILE_EXT, OK],
 
     # TODO add subclass instances to the count test.
 
@@ -1630,20 +1631,46 @@ Instances: PyWBEM_AllTypes
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand invokemethod',
+    ['Verify instance subcommand invokemethod, returnvalue = 0',
      ['invokemethod', ':CIM_Foo.InstanceID="CIM_Foo1"', 'Fuzzy'],
      {'stdout': ['ReturnValue=0'],
       'rc': 0,
       'test': 'lines'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
-    ['Verify instance subcommand invokemethod with param',
+    ['Verify instance subcommand invokemethod with multiple scalar params',
      ['invokemethod', ':CIM_Foo.InstanceID="CIM_Foo1"', 'Fuzzy',
-      '-p', 'TestInOutParameter="blah"'],
-     {'stdout': ["ReturnValue=0"],
+      '-p', 'TestInOutParameter="blah"',
+      '-p', 'TestRef=CIM_Foo.InstanceID="CIM_Foo1"'],
+     {'stdout': ['ReturnValue=0',
+                 'TestInOutParameter=', 'blah',
+                 'TestRef=', 'CIM_Foo.InstanceID=', 'CIM_Foo1'],
       'rc': 0,
-      'test': 'lines'},
+      'test': 'innows'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
+
+
+    ['Verify instance subcommand invokemethod with all_types method',
+     ['invokemethod', 'Pywbem_alltypes.InstanceID="test_instance"',
+      'AllTypesMethod',
+      '-p', 'scalBool=true',
+      '-p', 'arrBool=false,true',
+      '-p', 'scalUint32=9',
+      '-p', 'arrUint32=9,3,255',
+      '-p', 'scalString=abcdefjh',
+      '-p', 'arrString="abc","def"',
+      '-p', 'scalRef=PyWBEM_AllTypes.InstanceID="1"'],
+     {'stdout': ['ReturnValue=0',
+                 'scalBool=true',
+                 'arrBool=false, true',
+                 'scalUint32=9',
+                 'arrUint32=9, 3, 255',
+                 'scalString="abcdefjh"',
+                 'arrString=', 'abc', 'def',
+                 'scalRef=', 'PyWBEM_AllTypes.InstanceID='],
+      'rc': 0,
+      'test': 'innows'},
+     [ALLTYPES_MOCK_FILE, ALLTYPES_INVOKEMETHOD_MOCK_FILE], OK],
 
     ['Verify instance subcommand invokemethod fails Invalid Class',
      ['invokemethod', ':CIM_Foox.InstanceID="CIM_Foo1"', 'Fuzzy', '-p',
@@ -1709,4 +1736,4 @@ class TestSubcmd(CLITestsBase):
         Execute pybemcli with the defined input and test output.
         """
         self.subcmd_test(desc, self.subcmd, inputs, exp_response,
-                         mock, condition)
+                         mock, condition, verbose=False)


### PR DESCRIPTION
1. pywbemcli was ignoring all but the last input  parameter.
2. The output formatting was too simplistic and ignored array
   values

Corrects the issues, extends the testing by extending  all_types mof
to add a method that has IN,OUT parameters for many CIM types
and creates a mock invokemethod for this method that returns all
parameters input.

Adds tests for the different CIM Parameter types.

Adds example of invokemethod to documentation.