### PR TITLE
Fix issue #339 Remove verify from connection save and connection delete

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -702,10 +702,7 @@ The following defines the help output for the `pywbemcli connection delete --hel
         pywbemcli connection delete blah
 
     Options:
-      -V, --verify  Prompt for confirmation before performing a change, to allow
-                    for verification of parameters. Default: Do not prompt for
-                    confirmation.
-      -h, --help    Show this message and exit.
+      -h, --help  Show this message and exit.
 
 
 .. _`pywbemcli connection export --help`:
@@ -795,10 +792,7 @@ The following defines the help output for the `pywbemcli connection save --help`
         pywbemcli --server https://srv1 connection save mysrv
 
     Options:
-      -V, --verify  Prompt for confirmation before performing a change, to allow
-                    for verification of parameters. Default: Do not prompt for
-                    confirmation.
-      -h, --help    Show this message and exit.
+      -h, --help  Show this message and exit.
 
 
 .. _`pywbemcli connection select --help`:

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -28,8 +28,7 @@ from pywbem import Error
 
 from .pywbemcli import cli
 from ._common import CMD_OPTS_TXT, pick_one_from_list, format_table, \
-    verify_operation, hide_empty_columns
-from ._common_options import add_options, verify_option
+    hide_empty_columns
 from ._pywbem_server import PywbemServer
 from ._connection_repository import ConnectionRepository
 from ._context_obj import ContextObj
@@ -107,7 +106,6 @@ def connection_show(context, name):
 
 @connection_group.command('delete', options_metavar=CMD_OPTS_TXT)
 @click.argument('name', type=str, metavar='NAME', required=False)
-@add_options(verify_option)
 @click.pass_obj
 def connection_delete(context, name, **options):
     """
@@ -182,7 +180,6 @@ def connection_test(context):
 
 @connection_group.command('save', options_metavar=CMD_OPTS_TXT)
 @click.argument('name', type=str, metavar='NAME', required=True)
-@add_options(verify_option)
 @click.pass_obj
 def connection_save(context, name, **options):
     """
@@ -481,22 +478,15 @@ def cmd_connection_delete(context, name, options):
     """
     connections = ConnectionRepository()
 
+    # Select the connection with prompt if name is None.
+    # This also stops the spinner
     name = select_connection(name, context, connections)
-
-    context.spinner.stop()
-    if options['verify']:
-        click.echo('Verify delete of %s' % name)
-        show_connection_information(context,
-                                    connections[name],
-                                    separate_line=False)
-        if not verify_operation('Execute delete', msg=True):
-            return
 
     cname = get_current_connection_name(context)
     connections.delete(name)
 
     default = 'default ' if cname and cname == name else ''
-    click.echo('Deleted %sconnection "%s".' % (default, name))
+    click.echo('Deleted %s connection "%s".' % (default, name))
 
 
 def cmd_connection_save(context, name, options):
@@ -514,12 +504,6 @@ def cmd_connection_save(context, name, options):
     connections = ConnectionRepository()
 
     context.spinner.stop()
-    if options['verify']:
-        click.echo('Verify save of %s' % current_connection.name)
-        click.echo(show_connection_information(context, current_connection,
-                                               separate_line=False))
-        if not verify_operation('Execute save', msg=True):
-            return
 
     connections.add(save_connection.name, save_connection)
 

--- a/tests/unit/test_connection_subcmd.py
+++ b/tests/unit/test_connection_subcmd.py
@@ -23,8 +23,7 @@ import os
 import pytest
 
 from .cli_test_extensions import CLITestsBase
-from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE, \
-    CMD_OPTION_VERIFY_HELP_LINE
+from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
 
 SCRIPT_DIR = os.path.dirname(__file__)
 
@@ -59,7 +58,6 @@ CONNECTION_HELP_LINES = [
 CONNECTION_DELETE_HELP_LINES = [
     'Usage: pywbemcli connection delete [COMMAND-OPTIONS] NAME',
     'Delete a WBEM connection definition.',
-    CMD_OPTION_VERIFY_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
@@ -78,7 +76,6 @@ CONNECTION_LIST_HELP_LINES = [
 CONNECTION_SAVE_HELP_LINES = [
     'Usage: pywbemcli connection save [COMMAND-OPTIONS] NAME',
     'Save the current connection to a new WBEM connection definition.',
-    CMD_OPTION_VERIFY_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE
 ]
 
@@ -598,11 +595,11 @@ TEST_CASES = [
       'file': {'before': 'none', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection subcommand delete with prompt that selects y for '
+    ['Verify connection subcommand delete'
      'verify',
-     ['delete', 'mocktest', '--verify'],
+     ['delete', 'mocktest'],
      {'stdout': ['name: mocktest', 'Execute delete'],
-      'test': 'regex',
+      'test': 'onnows',
       'file': {'before': 'exists', 'after': 'none'}},
      MOCK_CONFIRMY_FILE, OK],
 
@@ -612,9 +609,8 @@ TEST_CASES = [
     #  The following test is artifical in that the first create actually
     #  uses the mock but not to really create a server
     #
-    ['Verify save server with cmd line params to empty connections file. Using '
-     '--verify',
-     {'args': ['save', '--verify', 'svrtest2'],
+    ['Verify save server with cmd line params to empty connections file.',
+     {'args': ['save', 'svrtest2'],
       'global': ['--server', 'http://blah',
                  '--timeout', '45',
                  '--use-pull', 'no',


### PR DESCRIPTION
Removed the option completely from connection save and connection
delete commands.

Also modified the tests that test this option to just execute the save
and modified the help test for these commands.