### PR TITLE
Change 'subcmd' to 'command' and command group in tests and code

### DIFF
--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -375,7 +375,7 @@ def cmd_server_centralinsts(context, options):
                     scoping_class=options['scoping_class'],
                     scoping_path=options['scoping_path'],
                     reference_direction=options['reference_direction'])
-                row.append("/n".join([str(p) for p in ci]))
+                row.append(":".join([str(p) for p in ci]))
             # mark current inst as failed and continue
             except Exception as ex:  # pylint: disable=broad-except
                 click.echo('Exception: %s %s' % (row, ex))

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -375,7 +375,7 @@ def cmd_server_centralinsts(context, options):
                     scoping_class=options['scoping_class'],
                     scoping_path=options['scoping_path'],
                     reference_direction=options['reference_direction'])
-                row.append(":".join([str(p) for p in ci]))
+                row.append("/n".join([str(p) for p in ci]))
             # mark current inst as failed and continue
             except Exception as ex:  # pylint: disable=broad-except
                 click.echo('Exception: %s %s' % (row, ex))

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -437,7 +437,6 @@ def cli(ctx, server, name, default_namespace, user, password, timeout,
                 pywbem_server = connections[s_name]
                 # Test for invalid options with the --name option
                 # The following options are part of each PywbemServer object
-                # TODO: FUTURE should really put this into pywbemserver itself.
                 for option in conditional_options:
                     if option[0]:
                         raise click.ClickException(
@@ -445,8 +444,8 @@ def cli(ctx, server, name, default_namespace, user, password, timeout,
                             'default name set.' % (option[1], option[0]))
 
             else:
-                # If no server defined, set None. This allows subcmds that
-                # donot require a server executed without the server
+                # If no server defined, set None. This allows commands that
+                # do not require a server to be executed with no server
                 # defined.
                 pywbem_server = None
 

--- a/tests/unit/cli_test_extensions.py
+++ b/tests/unit/cli_test_extensions.py
@@ -21,12 +21,12 @@ class CLITestsBase(object):
         Defines methods to execute tests on pywbemcli.
 
     """
-    def subcmd_test(self, desc, subcmd, inputs, exp_response, mock_files,
-                    condition, verbose=None):
+    def command_test(self, desc, command_grp, inputs, exp_response, mock_files,
+                     condition, verbose=None):
         # pylint: disable=line-too-long, no-self-use
         """
         Test method to execute test on pywbemcli by calling the executable
-        pywbemcli for the command defined by subcmd with arguments defined
+        pywbemcli for the command defined by command with arguments defined
         by args. This can execute pywbemcli either with a mock environment
         by using the mock_files variable or without mock if the mock_files
         parameter is None. The method tests the results of the execution
@@ -36,9 +36,9 @@ class CLITestsBase(object):
           desc (:term:`string`):
             Description of the test
 
-          subcmd (:term:`string`):
-            pywbemcli subcommand inserted for this test.  This is the first
-            level subcommand (ex. class).
+          command_grp (:term:`string`):
+            pywbemcli command_grp definedfor this test.  This is the first
+            level of the command(the command group) (ex. class).
 
           inputs (:class:`py:dict` or :class:`py:list` of :term:`string` or :term:`string`):
 
@@ -53,11 +53,11 @@ class CLITestsBase(object):
             If inputs is a dict it can contain the following possible keys:
 
               * 'args': defines local arguments to append to the command after
-                  the subcommand name. Each single argument must be its own
+                  the command name. Each single argument must be its own
                   item in the iterable.
 
-              * 'globals': defines global arguments that will be inserted
-                  into the command line before the subcommand name. Each
+              * 'general': defines general arguments that will be inserted
+                  into the command line before the command name. Each
                   single argument must be its own item in the iterable.
 
               * 'env': Dictionary of environment variables where  key is the
@@ -74,8 +74,8 @@ class CLITestsBase(object):
                 as a separate repl line by the pybemcli executable.
                 If `stdin` is a single string it is passed  to the stdin
                 parameter for the call to pywbemcli. If `stdin` is defined, the
-                `subcmd` parameter is ignored and the full subcommand must be in
-                the `stdin` iterable.
+                parameters defining a command to be executed are ignored and
+                the full command must be in the `stdin` iterable.
 
                 If None, no stdin input is defined for the test.
 
@@ -148,7 +148,7 @@ class CLITestsBase(object):
             If it is a list, the same rules apply to each entry in the list.
 
             If None, test is executed without the --mock-server input parameter
-            and defines an artificial server name  Used to test subcommands
+            and defines an artificial server name  Used to test commands
             and options that do not communicate with a server.  It is faster
             than installing the mock repository
 
@@ -166,7 +166,7 @@ class CLITestsBase(object):
         env = None
         stdin = None
         if isinstance(inputs, dict):
-            global_args = inputs.get("global", None)
+            general_args = inputs.get("general", None)
             local_args = inputs.get("args", None)
             env = inputs.get("env", None)
             stdin = inputs.get('stdin', None)
@@ -175,10 +175,10 @@ class CLITestsBase(object):
                     stdin = '\n'.join(stdin)
         elif isinstance(inputs, six.string_types):
             local_args = inputs.split(" ")
-            global_args = None
+            general_args = None
         elif isinstance(inputs, (list, tuple)):
             local_args = inputs
-            global_args = None
+            general_args = None
         else:
             assert 'Invalid inputs param to test %r . Allowed types are ' \
                    'dict, string, list, tuple.' % inputs
@@ -186,12 +186,12 @@ class CLITestsBase(object):
         if isinstance(local_args, six.string_types):
             local_args = local_args.split(" ")
 
-        if isinstance(global_args, six.string_types):
-            global_args = global_args.split(" ")
+        if isinstance(general_args, six.string_types):
+            general_args = general_args.split(" ")
 
         cmd_line = []
-        if global_args:
-            cmd_line.extend(global_args)
+        if general_args:
+            cmd_line.extend(general_args)
 
         if mock_files:
             if isinstance(mock_files, (list, tuple)):
@@ -205,7 +205,7 @@ class CLITestsBase(object):
                 assert("CLI_TEST_EXTENSIONS mock_file %s invalid" % mock_files)
 
         if not stdin:
-            cmd_line.append(subcmd)
+            cmd_line.append(command_grp)
 
         if local_args:
             cmd_line.extend(local_args)

--- a/tests/unit/py_with_error.py
+++ b/tests/unit/py_with_error.py
@@ -1,5 +1,5 @@
 """
-    Test script to be loaded with pywbemcli --mock-server global option to test
+    Test script to be loaded with pywbemcli --mock-server general option to test
     capability to execute python code as part of startup.
     This script should generate an exception because of python syntax error.
 """

--- a/tests/unit/simple_python_mock_script.py
+++ b/tests/unit/simple_python_mock_script.py
@@ -1,5 +1,5 @@
 """
-    Test script to be loaded with pywbemcli --mock-server global option to test
+    Test script to be loaded with pywbemcli --mock-server general option to test
     capability to execute python code as part of startup.
     This script loads a single class into the repository.
     This script includes  asserts to confirm that the class is loaded into

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Tests the class subcommand
+Tests the class command
 """
 import os
 import pytest
@@ -303,124 +303,124 @@ FAIL = False  # Any test currently FAILING or not tested yet
 # pylint: enable=line-too-long
 TEST_CASES = [
     # desc - Description of test
-    # inputs - String, or list of args or dict of 'env', 'args', 'globals',
-    #          and 'stdin'. See See CLITestsBase.subcmd_test()  for
+    # inputs - String, or list of args or dict of 'env', 'args', 'general',
+    #          and 'stdin'. See See CLITestsBase.command_test()  for
     #          detailed documentation
     # exp_response - Dictionary of expected responses (stdout, stderr, rc) and
     #                test definition (test: <testname>).
-    #                See CLITestsBase.subcmd_test() for detailed documentation.
+    #                See CLITestsBase.command_test() for detailed documentation.
     # mock - None or name of files (mof or .py),
     # condition - If True, the test is executed,  Otherwise it is skipped.
 
-    ['Verify class subcommand --help response',
+    ['Verify class command --help response',
      ['--help'],
      {'stdout': CLASS_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand -h response',
+    ['Verify class command -h response',
      ['-h'],
      {'stdout': CLASS_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     #
-    # Enumerate subcommand and its options
+    # Enumerate command and its options
     #
-    ['Verify class subcommand enumerate --help response',
+    ['Verify class command enumerate --help response',
      ['enumerate', '--help'],
      {'stdout': CLASS_ENUMERATE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand enumerate -h response',
+    ['Verify class command enumerate -h response',
      ['enumerate', '-h'],
      {'stdout': CLASS_ENUMERATE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo',
+    ['Verify class command enumerate CIM_Foo',
      ['enumerate', 'CIM_Foo'],
      {'stdout': ['[Description ( "Subclass of CIM_Foo" )]', ],
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo --lo',
+    ['Verify class command enumerate CIM_Foo --lo',
      ['enumerate', 'CIM_Foo', '--lo'],
      {'stdout':
       '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo --lo',
+    ['Verify class command enumerate CIM_Foo --lo',
      ['enumerate', 'CIM_Foo', '--local-only'],
      {'stdout':
       '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo_sub',
+    ['Verify class command enumerate CIM_Foo_sub',
      ['enumerate', 'CIM_Foo_sub'],
      {'stdout': CIMFOO_SUB_SUB,
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo local-only',
+    ['Verify class command enumerate CIM_Foo local-only',
      ['enumerate', 'CIM_Foo', '--local-only'],
      {'stdout':
       '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo -no-qualifiers',
+    ['Verify class command enumerate CIM_Foo -no-qualifiers',
      ['enumerate', 'CIM_Foo_sub', '--no-qualifiers'],
      {'stdout': CIMFOO_SUB_SUB_NO_QUALS,
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo --di',
+    ['Verify class command enumerate CIM_Foo --di',
      ['enumerate', 'CIM_Foo', '--di'],
      {'stdout':
       '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo --deep-inheritance',
+    ['Verify class command enumerate CIM_Foo --deep-inheritance',
      ['enumerate', 'CIM_Foo', '--deep-inheritance'],
      {'stdout':
       '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo --ico',
+    ['Verify class command enumerate CIM_Foo --ico',
      ['enumerate', 'CIM_Foo', '--ico'],
      {'stdout':
       '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo --include-classorigin',
+    ['Verify class command enumerate CIM_Foo --include-classorigin',
      ['enumerate', 'CIM_Foo', '--include-classorigin'],
      {'stdout':
       '   [Description ( "Subclass of CIM_Foo" )]',
       'test': 'startswith'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo --no names only',
+    ['Verify class command enumerate CIM_Foo --no names only',
      ['enumerate', 'CIM_Foo', '--no'],
      {'stdout': ['CIM_Foo', 'CIM_Foo_sub', 'CIM_Foo_sub2'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo --names only',
+    ['Verify class command enumerate CIM_Foo --names only',
      ['enumerate', 'CIM_Foo', '--names-only'],
      {'stdout': ['CIM_Foo', 'CIM_Foo_sub', 'CIM_Foo_sub2'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate --no names only - table',
+    ['Verify class command enumerate --no names only - table',
      {'args': ['enumerate', '--no'],
-      'global': ['--output-format', 'table']},
+      'general': ['--output-format', 'table']},
      {'stdout': """Classnames:
 +--------------+
 | Class Name   |
@@ -431,9 +431,9 @@ TEST_CASES = [
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo --no names only - table',
+    ['Verify class command enumerate CIM_Foo --no names only - table',
      {'args': ['enumerate', 'CIM_Foo', '--no'],
-      'global': ['--output-format', 'table']},
+      'general': ['--output-format', 'table']},
      {'stdout': """Classnames:
 +--------------+
 | Class Name   |
@@ -446,27 +446,27 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
 
-    ['Verify class subcommand enumerate CIM_Foo --names-only',
+    ['Verify class command enumerate CIM_Foo --names-only',
      ['enumerate', 'CIM_Foo', '--names-only'],
      {'stdout': ['CIM_Foo', 'CIM_Foo_sub', 'CIM_Foo_sub2'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo summary',
+    ['Verify class command enumerate CIM_Foo summary',
      ['enumerate', 'CIM_Foo', '-s'],
      {'stdout': ['2 CIMClass(s) returned'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo summary',
+    ['Verify class command enumerate CIM_Foo summary',
      ['enumerate', 'CIM_Foo', '--summary'],
      {'stdout': ['2 CIMClass(s) returned'],
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo summary table output',
+    ['Verify class command enumerate CIM_Foo summary table output',
      {'args': ['enumerate', 'CIM_Foo', '--summary'],
-      'global': ['--output-format', 'table']},
+      'general': ['--output-format', 'table']},
      {'stdout': ["""Summary of CIMClass returned
 +---------+------------+
 |   Count | CIM Type   |
@@ -477,45 +477,45 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo names and --di --no',
+    ['Verify class command enumerate CIM_Foo names and --di --no',
      ['enumerate', 'CIM_Foo', '--di', '--no'],
      {'stdout': ['CIM_Foo_sub', 'CIM_Foo_sub2', 'CIM_Foo_sub_sub'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo names and --deep-inheritance '
+    ['Verify class command enumerate CIM_Foo names and --deep-inheritance '
       '--names-only',
      ['enumerate', 'CIM_Foo', '--names-only', '--deep-inheritance'],
      {'stdout': ['CIM_Foo_sub', 'CIM_Foo_sub2', 'CIM_Foo_sub_sub'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand enumerate CIM_Foo include qualifiers',
+    ['Verify class command enumerate CIM_Foo include qualifiers',
      ['enumerate', 'CIM_Foo'],
      {'stdout': ['Key ( true )', '[Description (', 'class CIM_Foo'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
 
-    ['Verify class subcommand get with xml output format).',
+    ['Verify class command get with xml output format).',
      {'args': ['enumerate'],
-      'global': ['--output-format', 'repr']},
+      'general': ['--output-format', 'repr']},
      {'stdout': [r"CIMClass\(classname='CIM_Foo', superclass=None,",
                  r"'InstanceID': CIMProperty\(name='InstanceID', value=None,"],
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand get with repr output format).',
+    ['Verify class command get with repr output format).',
      {'args': ['enumerate'],
-      'global': ['--output-format', 'txt']},
+      'general': ['--output-format', 'txt']},
      {'stdout': ["CIMClass(classname='CIM_Foo', ...)"],
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
 
-    ['Verify class subcommand get with repr output format).',
+    ['Verify class command get with repr output format).',
      {'args': ['enumerate'],
-      'global': ['--output-format', 'xml']},
+      'general': ['--output-format', 'xml']},
      {'stdout': ['<CLASS NAME="CIM_Foo">',
                  '<PROPERTY NAME="InstanceID"',
                  '<PROPERTY NAME="IntegerProp" PROPAGATED="false"',
@@ -526,7 +526,7 @@ TEST_CASES = [
     # Enumerate errors
     #
 
-    ['Verify class subcommand enumerate nonexistent class name',
+    ['Verify class command enumerate nonexistent class name',
      ['enumerate', 'CIM_FClassDoesNotExist'],
      {'stderr': ['CIMError', 'CIM_ERR_INVALID_CLASS'],
       'rc': 1,
@@ -536,27 +536,27 @@ TEST_CASES = [
     #
     # Test class get
     #
-    ['Verify class subcommand get --help response',
+    ['Verify class command get --help response',
      ['get', '--help'],
      {'stdout': CLASS_GET_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand get -h response',
+    ['Verify class command get -h response',
      ['get', '-h'],
      {'stdout': CLASS_GET_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    # subcommand get local-only option
-    ['Verify class subcommand get not local-only. Tests for property names',
+    # command get local-only option
+    ['Verify class command get not local-only. Tests for property names',
      ['get', 'CIM_Foo_sub2'],
      {'stdout': ['string cimfoo_sub2;', 'InstanceID', 'IntegerProp', 'Fuzzy',
                  'Key ( true )', 'IN ( false )'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand get local-only(--lo)).',
+    ['Verify class command get local-only(--lo)).',
      ['get', 'CIM_Foo_sub2', '--lo'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
                  '',
@@ -566,7 +566,7 @@ TEST_CASES = [
       'test': 'patterns'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand get local-only. Tests whole response',
+    ['Verify class command get local-only. Tests whole response',
      ['get', 'CIM_Foo_sub2', '--local-only'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
                  '',
@@ -577,7 +577,7 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     # includequalifiers. Test the flag that excludes qualifiers
-    ['Verify class subcommand get without qualifiers. Tests whole response',
+    ['Verify class command get without qualifiers. Tests whole response',
      ['get', 'CIM_Foo_sub2', '--nq'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
                  '',
@@ -600,7 +600,7 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand get without qualifiers. Tests whole response',
+    ['Verify class command get without qualifiers. Tests whole response',
      ['get', 'CIM_Foo_sub2', '--no-qualifiers'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
                  '',
@@ -624,7 +624,7 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     # pylint: disable=line-too-long
-    ['Verify class subcommand get with propertylist. Tests whole response',
+    ['Verify class command get with propertylist. Tests whole response',
      ['get', 'CIM_Foo_sub2', '--pl', 'InstanceID'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {', '',
                  '      [Key ( true ),',
@@ -657,7 +657,7 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand get with empty propertylist. Tests whole '
+    ['Verify class command get with empty propertylist. Tests whole '
      'response',
      ['get', 'CIM_Foo_sub2', '--pl', '""'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {', '',
@@ -688,26 +688,26 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand get with xml output format).',
+    ['Verify class command get with xml output format).',
      {'args': ['get', 'CIM_Foo'],
-      'global': ['--output-format', 'repr']},
+      'general': ['--output-format', 'repr']},
      {'stdout': [r"CIMClass\(classname='CIM_Foo', superclass=None,",
                  r"'InstanceID': CIMProperty\(name='InstanceID', value=None,"],
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
 
-    ['Verify class subcommand get with repr output format).',
+    ['Verify class command get with repr output format).',
      {'args': ['get', 'CIM_Foo'],
-      'global': ['--output-format', 'txt']},
+      'general': ['--output-format', 'txt']},
      {'stdout': ["CIMClass(classname='CIM_Foo', ...)"],
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
 
-    ['Verify class subcommand get with repr output format).',
+    ['Verify class command get with repr output format).',
      {'args': ['get', 'CIM_Foo'],
-      'global': ['--output-format', 'xml']},
+      'general': ['--output-format', 'xml']},
      {'stdout': ['<CLASS NAME="CIM_Foo">',
                  '<PROPERTY NAME="InstanceID"',
                  '<PROPERTY NAME="IntegerProp" PROPAGATED="false"',
@@ -717,7 +717,7 @@ TEST_CASES = [
 
     # pylint: enable=line-too-long
     # TODO include class origin. TODO not returning class origin correctly.
-    ['Verify class subcommand get with propertylist and classorigin,',
+    ['Verify class command get with propertylist and classorigin,',
      ['get', 'CIM_Foo_sub2', '--pl', 'InstanceID', '-c'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {', '',
                  '      [Key ( true ),',
@@ -745,16 +745,16 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, FAIL],
 
-    # get subcommand errors
+    # get command errors
 
-    ['Verify class subcommand get invalid classname',
+    ['Verify class command get invalid classname',
      ['get', 'CIM_Argh'],
      {'stderr': ['CIMError', 'CIM_ERR_NOT_FOUND', '6'],
       'rc': 1,
       'test': 'regex'},
 
      SIMPLE_MOCK_FILE, OK],
-    ['Verify class subcommand get invalid namespace',
+    ['Verify class command get invalid namespace',
      ['get', 'CIM_Foo', '--namespace', 'Argh'],
      {'stderr': ['CIMError', 'CIM_ERR_INVALID_NAMESPACE', '3'],
       'rc': 1,
@@ -762,21 +762,21 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     #
-    # find subcommand
+    # find command
     #
-    ['Verify class subcommand find --help response',
+    ['Verify class command find --help response',
      ['find', '--help'],
      {'stdout': CLASS_FIND_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand find -h response',
+    ['Verify class command find -h response',
      ['find', '-h'],
      {'stdout': CLASS_FIND_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand find simple name in all namespaces',
+    ['Verify class command find simple name in all namespaces',
      ['find', 'CIM_*'],
      {'stdout': ["  root/cimv2:CIM_Foo",
                  "  root/cimv2:CIM_Foo_sub",
@@ -785,7 +785,7 @@ TEST_CASES = [
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand find simple name in all namespaces wo case',
+    ['Verify class command find simple name in all namespaces wo case',
      ['find', 'cim_*'],
      {'stdout': ["  root/cimv2:CIM_Foo",
                  "  root/cimv2:CIM_Foo_sub",
@@ -794,20 +794,20 @@ TEST_CASES = [
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand find simple name in all namespaces lead wc',
+    ['Verify class command find simple name in all namespaces lead wc',
      ['find', '*sub_sub*'],
      {'stdout': ["  root/cimv2:CIM_Foo_sub_sub"],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
 
-    ['Verify class subcommand find simple name in all namespaces wo case',
+    ['Verify class command find simple name in all namespaces wo case',
      ['find', '*sub_su?*'],
      {'stdout': ["  root/cimv2:CIM_Foo_sub_sub"],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand find simple name in known namespace',
+    ['Verify class command find simple name in known namespace',
      ['find', 'CIM_*', '-n', 'root/cimv2'],
      {'stdout': ["  root/cimv2:CIM_Foo",
                  "  root/cimv2:CIM_Foo_sub",
@@ -817,8 +817,8 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
 
-    ['Verify class subcommand find name in known namespace -o grid',
-     {'global': ['-o', 'grid'],
+    ['Verify class command find name in known namespace -o grid',
+     {'general': ['-o', 'grid'],
       'args': ['find', 'CIM_*', '-n', 'root/cimv2']},
      {'stdout': ['Find class CIM_*',
                  '+-------------+-----------------+',
@@ -835,41 +835,41 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand verify nothing found for BLAH_ regex',
+    ['Verify class command verify nothing found for BLAH_ regex',
      ['find', 'BLAH_*', '-n', 'root/cimv2'],
      {'stdout': "",
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcmd find simple name in known namespace with wildcard',
+    ['Verify class command find simple name in known namespace with wildcard',
      ['find', '*sub2', '-n', 'root/cimv2'],
      {'stdout': "  root/cimv2:CIM_Foo_sub2",
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
     #
-    # subcommand "class delete"
+    # command "class delete"
     #
-    ['Verify class subcommand delete --help response',
+    ['Verify class command delete --help response',
      ['delete', '--help'],
      {'stdout': CLASS_DELETE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand delete -h response',
+    ['Verify class command delete -h response',
      ['delete', '-h'],
      {'stdout': CLASS_DELETE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     # Class delete successful
-    ['Verify class subcommand delete successful with no subclasses, --force',
+    ['Verify class command delete successful with no subclasses, --force',
      ['delete', 'CIM_Foo_sub_sub', '--force'],
      {'stdout': 'CIM_Foo_sub_sub delete successful',
       'test': 'in'},
      [SIMPLE_MOCK_FILE_EXT], OK],
 
-    ['Verify class subcommand delete fail instances exist',
+    ['Verify class command delete fail instances exist',
      ['delete', 'CIM_Foo_sub_sub'],
      {'stdout': 'CIM_Foo_sub_sub delete successful',
       'rc': 0,
@@ -877,7 +877,7 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     # Class delete errors
-    ['Verify class subcommand delete no classname',
+    ['Verify class command delete no classname',
      ['delete'],
      {'stderr': 'Error: Missing argument "CLASSNAME"',
       'rc': 2,
@@ -886,28 +886,28 @@ TEST_CASES = [
 
     # class delete error tests
 
-    ['Verify class subcommand delete fail subclasses exist',
+    ['Verify class command delete fail subclasses exist',
      ['delete', 'CIM_Foo', '--force'],
      {'stderr': 'Error: Delete rejected; subclasses exist',
       'rc': 1,
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand delete no classname fails',
+    ['Verify class command delete no classname fails',
      ['delete', ],
      {'stderr': 'Missing argument "CLASSNAME"',
       'rc': 2,
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand delete nonexistent classname fails',
+    ['Verify class command delete nonexistent classname fails',
      ['delete', 'Argh'],
      {'stderr': ['CIMError', 'CIM_ERR_INVALID_CLASS', '5'],
       'rc': 1,
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand delete fails, instances exist',
+    ['Verify class command delete fails, instances exist',
      ['delete', 'CIM_Foo_sub_sub'],
      {'stderr': 'Error: Delete rejected; instances exist',
       'rc': 1,
@@ -915,15 +915,15 @@ TEST_CASES = [
      [SIMPLE_MOCK_FILE_EXT], OK],
 
     #
-    # subcommand "class tree"
+    # command "class tree"
     #
-    ['Verify class subcommand tree --help response',
+    ['Verify class command tree --help response',
      ['tree', '--help'],
      {'stdout': CLASS_TREE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand tree -h response',
+    ['Verify class command tree -h response',
      ['tree', '-h'],
      {'stdout': CLASS_TREE_HELP_LINES,
       'test': 'innows'},
@@ -943,7 +943,7 @@ TEST_CASES = [
     #      +-- CIM_Foo_sub
     #      |   +-- CIM_Foo_sub_sub
     #      +-- CIM_Foo_sub2
-    ['Verify class subcommand tree top down. Order uncertain.',
+    ['Verify class command tree top down. Order uncertain.',
      ['tree'],
      {'stdout': [r'root',
                  r' \+-- CIM_Foo',
@@ -953,14 +953,14 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand tree top down starting at defined class ',
+    ['Verify class command tree top down starting at defined class ',
      ['tree', 'CIM_Foo_sub'],
      {'stdout': ['CIM_Foo_sub',
                  ' +-- CIM_Foo_sub_sub', ],
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand tree bottom up. Ordering guaranteed here',
+    ['Verify class command tree bottom up. Ordering guaranteed here',
      ['tree', '-s', 'CIM_Foo_sub_sub'],
      {'stdout': ['root',
                  ' +-- CIM_Foo',
@@ -970,14 +970,14 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     # class tree' error tests
-    ['Verify class subcommand tree with invalid class',
+    ['Verify class command tree with invalid class',
      ['tree', '-s', 'CIM_Foo_subx'],
      {'stderr': ['CIMError:'],
       'rc': 1,
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class subcommand tree with superclass option, no class',
+    ['Verify class command tree with superclass option, no class',
      ['tree', '-s'],
      {'stderr': ['Error: CLASSNAME argument required for --superclasses '
                  'option'],
@@ -986,22 +986,22 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     #
-    # associators subcommand tests
+    # associators command tests
     #
     #
-    ['Verify class subcommand associators --help response',
+    ['Verify class command associators --help response',
      ['associators', '--help'],
      {'stdout': CLASS_ASSOCIATORS_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand associators -h response',
+    ['Verify class command associators -h response',
      ['associators', '-h'],
      {'stdout': CLASS_ASSOCIATORS_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand associators simple request,',
+    ['Verify class command associators simple request,',
      ['associators', 'TST_Person', ],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Person',
                  'class TST_Person {',
@@ -1018,13 +1018,13 @@ TEST_CASES = [
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
 
-    ['Verify class subcommand associators simple request names only,',
+    ['Verify class command associators simple request names only,',
      ['associators', 'TST_Person', '--names-only'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Person'],
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand associators simple request, one parameter',
+    ['Verify class command associators simple request, one parameter',
      ['associators', 'TST_Person', '--ac', 'TST_MemberOfFamilyCollection'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Person',
                  'class TST_Person {',
@@ -1040,7 +1040,7 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand associators request, all filters long',
+    ['Verify class command associators request, all filters long',
      ['associators', 'TST_Person',
       '--assoc-class', 'TST_MemberOfFamilyCollection',
       '--role', 'member',
@@ -1060,7 +1060,7 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand associators request, all filters short',
+    ['Verify class command associators request, all filters short',
      ['associators', 'TST_Person',
       '--ac', 'TST_MemberOfFamilyCollection',
       '-r', 'member',
@@ -1080,7 +1080,7 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand associators request, all filters short,  -a '
+    ['Verify class command associators request, all filters short,  -a '
      'does not pass test',
      ['associators', 'TST_Person',
       '--ac', 'TST_MemberOfFamilyCollectionx',
@@ -1091,7 +1091,7 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand associators request, all filters short,  -r '
+    ['Verify class command associators request, all filters short,  -r '
      'does not pass test',
      ['associators', 'TST_Person',
       '--ac', 'TST_MemberOfFamilyCollection',
@@ -1102,7 +1102,7 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand associators request, all filters short,  -rr '
+    ['Verify class command associators request, all filters short,  -rr '
      'does not pass test',
      ['associators', 'TST_Person',
       '--ac', 'TST_MemberOfFamilyCollection',
@@ -1113,7 +1113,7 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand associators request, all filters short,  --rc '
+    ['Verify class command associators request, all filters short,  --rc '
      'does not pass test',
      ['associators', 'TST_Person',
       '--ac', 'TST_MemberOfFamilyCollection',
@@ -1124,7 +1124,7 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand associators request, all filters long '
+    ['Verify class command associators request, all filters long '
      'does not pass test',
      ['associators', 'TST_Person',
       '--assoc-class', 'TST_MemberOfFamilyCollection',
@@ -1137,21 +1137,21 @@ TEST_CASES = [
 
     # Associator errors
 
-    ['Verify class subcommand associators no CLASSNAME',
+    ['Verify class command associators no CLASSNAME',
      ['associators'],
      {'stderr': ['Error: Missing argument "CLASSNAME".', ],
       'rc': 2,
       'test': 'in'},
      None, OK],
 
-    ['Verify class subcommand associators non-existent CLASSNAME rtns empty',
+    ['Verify class command associators non-existent CLASSNAME rtns empty',
      ['associators', 'CIM_Nonexistentclass'],
      {'stdout': "",
       'rc': 0,
       'test': 'regex'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand associators non-existent namespace fails',
+    ['Verify class command associators non-existent namespace fails',
      ['associators', 'TST_Person', '--namespace', 'blah'],
      {'stderr': ['CIMError', 'CIM_ERR_INVALID_NAMESPACE'],
       'rc': 1,
@@ -1159,34 +1159,34 @@ TEST_CASES = [
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
     #
-    # references subcommand tests
+    # references command tests
     #
-    ['Verify class subcommand references --help response',
+    ['Verify class command references --help response',
      ['references', '--help'],
      {'stdout': CLASS_REFERENCES_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand references -h response',
+    ['Verify class command references -h response',
      ['references', '-h'],
      {'stdout': CLASS_REFERENCES_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand references simple request',
+    ['Verify class command references simple request',
      ['references', 'TST_Person'],
      {'stdout': REFERENCES_CLASS_RTN_QUALS1,
       'test': 'linesnows'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand references simple request -o',
+    ['Verify class command references simple request -o',
      ['references', 'TST_Person', '--no'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_Lineage',
                  '//FakedUrl/root/cimv2:TST_MemberOfFamilyCollection'],
       'test': 'linesnows'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand references request, all filters long',
+    ['Verify class command references request, all filters long',
      ['references', 'TST_Person',
       '--role', 'member',
       '--result-class', 'TST_MemberOfFamilyCollection'],
@@ -1195,7 +1195,7 @@ TEST_CASES = [
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
 
-    ['Verify class subcommand references request, filters short',
+    ['Verify class command references request, filters short',
      ['references', 'TST_Person',
       '-r', 'member',
       '--rc', 'TST_MemberOfFamilyCollection'],
@@ -1205,21 +1205,21 @@ TEST_CASES = [
 
     # Reference errors
 
-    ['Verify class subcommand references no CLASSNAME',
+    ['Verify class command references no CLASSNAME',
      ['references'],
      {'stderr': ['Error: Missing argument "CLASSNAME".', ],
       'rc': 2,
       'test': 'in'},
      None, OK],
 
-    ['Verify class subcommand references non-existent CLASSNAME rtns empty',
+    ['Verify class command references non-existent CLASSNAME rtns empty',
      ['references', 'CIM_Nonexistentclass'],
      {'stdout': "",
       'rc': 0,
       'test': 'regex'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-    ['Verify class subcommand references non-existent namespace fails',
+    ['Verify class command references non-existent namespace fails',
      ['references', 'TST_Person', '--namespace', 'blah'],
      {'stderr': ['CIMError', 'CIM_ERR_INVALID_NAMESPACE'],
       'rc': 1,
@@ -1227,31 +1227,31 @@ TEST_CASES = [
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
     #
-    # invokemethod subcommand tests
+    # invokemethod command tests
     #
-    ['Verify class subcommand invokemethod --help response',
+    ['Verify class command invokemethod --help response',
      ['invokemethod', '--help'],
      {'stdout': CLASS_INVOKEMETHOD_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify class subcommand invokemethod -h response',
+    ['Verify class command invokemethod -h response',
      ['invokemethod', '-h'],
      {'stdout': CLASS_INVOKEMETHOD_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     #
-    #  class invokemethod subcommand without parameters
+    #  class invokemethod command without parameters
     #
-    ['Verify class subcommand invokemethod',
+    ['Verify class command invokemethod',
      ['invokemethod', 'CIM_Foo', 'Fuzzy'],
      {'stdout': ["ReturnValue=0"],
       'rc': 0,
       'test': 'lines'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
-    ['Verify class subcommand invokemethod',
+    ['Verify class command invokemethod',
      ['invokemethod', 'CIM_Foo', 'Fuzzy', '-p', 'TestInOutParameter="blah"'],
      {'stdout': ['ReturnValue=0',
                  'TestInOutParameter=', 'blah'],
@@ -1259,14 +1259,14 @@ TEST_CASES = [
       'test': 'innows'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
-    ['Verify class subcommand invokemethod fails Invalid Class',
+    ['Verify class command invokemethod fails Invalid Class',
      ['invokemethod', 'CIM_Foox', 'Fuzzy', '-p', 'TestInOutParameter="blah"'],
      {'stderr': ["Error: CIMError: 6"],
       'rc': 1,
       'test': 'in'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
-    ['Verify class subcommand invokemethod fails Invalid Method',
+    ['Verify class command invokemethod fails Invalid Method',
      ['invokemethod', 'CIM_Foo', 'Fuzzyx', '-p', 'TestInOutParameter=blah'],
      {'stderr': ["CIMError: 17"],
       'rc': 1,
@@ -1274,7 +1274,7 @@ TEST_CASES = [
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
 
-    ['Verify class subcommand invokemethod fails Method not registered',
+    ['Verify class command invokemethod fails Method not registered',
      ['invokemethod', 'CIM_Foo', 'Fuzzy'],
      {'stderr': ["CIMError: 17"],
       'rc': 1,
@@ -1284,7 +1284,7 @@ TEST_CASES = [
     ['Verify  --timestats gets stats output. Cannot test '
      'with lines because execution time is variable.',
      {'args': ['get', 'CIM_Foo'],
-      'global': ['--timestats']},
+      'general': ['--timestats']},
      {'stdout': ['class CIM_Foo {',
                  'string InstanceID;',
                  'Count    Exc    Time    ReqLen    ReplyLen  Operation',
@@ -1294,14 +1294,14 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify single subcommand with stdin works',
+    ['Verify single command with stdin works',
      {'stdin': ['class get -h']},
      {'stdout': ['Usage: pywbemcli  class get '],
       'rc': 0,
       'test': 'regex'},
      None, OK],
 
-    ['Verify multiple subcommands with stdin work',
+    ['Verify multiple commands with stdin work',
      {'stdin': ['class get -h', 'class enumerate -h']},
      {'stdout': ['Usage: pywbemcli  class enumerate ',
                  'Usage: pywbemcli  class get '],
@@ -1310,7 +1310,7 @@ TEST_CASES = [
      None, OK],
 ]
 
-# TODO subcommand class delete. Extend this test to use stdin (delete, test)
+# TODO command class delete. Extend this test to use stdin (delete, test)
 # namespace
 # TODO: add test for  errors: class invalid, namespace invalid
 # other tests.  Test local-only on top level
@@ -1322,31 +1322,31 @@ TEST_CASES = [
 
 class TestSubcmdClass(CLITestsBase):
     """
-    Test all of the class subcommand variations.
+    Test all of the class command variations.
     """
-    subcmd = 'class'
+    command_group = 'class'
 
     @pytest.mark.parametrize(
         "desc, inputs, exp_response, mock, condition",
         TEST_CASES)
     def test_class(self, desc, inputs, exp_response, mock, condition):
         """
-        Common test method for those subcommands and options in the
-        class subcmd that can be tested.  This includes:
+        Common test method for those commands and options in the
+        class command that can be tested.  This includes:
 
           * Subcommands like help that do not require access to a server
 
           * Subcommands that can be tested with a single execution of a
             pywbemcli command.
         """
-        self.subcmd_test(desc, self.subcmd, inputs, exp_response,
-                         mock, condition, verbose=False)
+        self.command_test(desc, self.command_group, inputs, exp_response,
+                          mock, condition, verbose=False)
 
 
 class TestClassGeneral(object):
     # pylint: disable=too-few-public-methods, useless-object-inheritance
     """
-    Test class using pytest for the subcommands of the class subcommand
+    Test class using pytest for the commands of the class command
     """
     # @pytest.mark.skip(reason="Unfinished test")
     def test_class_error_no_server(self):  # pylint: disable=no-self-use
@@ -1371,7 +1371,7 @@ class TestClassGeneral(object):
 class TestClassEnumerate(object):
     # pylint: disable=too-few-public-methods, useless-object-inheritance
     """
-    Test the options of the pywbemcli class enumerate' subcommand
+    Test the options of the pywbemcli class enumerate' command
     """
     @pytest.mark.parametrize(
         "desc, tst_args, exp_result_start, exp_result_end",
@@ -1395,7 +1395,7 @@ class TestClassEnumerate(object):
                                    exp_result_end):
         # pylint: disable=no-self-use
         """
-        Test 'pywbemcli class enumerate subcommand based on a simple set of
+        Test 'pywbemcli class enumerate command based on a simple set of
         classes defined in the file simple_mock_model.mof
         """
         mock_mof_path = os.path.join(TEST_DIR, 'simple_mock_model.mof')

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -1049,7 +1049,7 @@ class SorterTest(unittest.TestCase):
     def test_sort_class_ref_rtn(self):
         """
         Test the return from the class references and class associators
-        subcommands which is a tuple of CIMCLassName and CIMClass
+        commands which is a tuple of CIMCLassName and CIMClass
         """
 
         cl1 = (CIMClass(

--- a/tests/unit/test_connection_cmds.py
+++ b/tests/unit/test_connection_cmds.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 """
-Test the connection command group and its subcommands. This test depends on
-a pywbemcliservers.json file in the test directory.  It assumes that the
+Test the connection command group and its commands. This test manipulates
+a connections file in the test directory.  It assumes that the
 test directory is the same as the current working directory where pywbemcli
-was called.
+was called.  If there is a connections file at the start of the test it is
+renamed for the test and restored at the end of the test.
 """
 
 import os
@@ -106,12 +107,12 @@ FAIL = False  # Any test currently FAILING or not tested yet
 
 TEST_CASES = [
     # desc - Description of test
-    # inputs - String, or list of args or dict of 'env', 'args', 'globals',
-    #          and 'stdin'. See See CLITestsBase.subcmd_test()  for
+    # inputs - String, or list of args or dict of 'env', 'args', 'general',
+    #          and 'stdin'. See See CLITestsBase.command_test()  for
     #          detailed documentation
     # exp_response - Dictionary of expected responses (stdout, stderr, rc) and
     #                test definition (test: <testname>).
-    #                See CLITestsBase.subcmd_test() for detailed documentation.
+    #                See CLITestsBase.command_test() for detailed documentation.
     # mock - None or name of files (mof or .py),
     # condition - If True, the test is executed,  Otherwise it is skipped.
 
@@ -121,116 +122,105 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand -h response',
+    ['Verify connection command -h response',
      '-h',
      {'stdout': CONNECTION_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand delete --help response',
+    ['Verify connection command delete --help response',
      ['delete', '--help'],
      {'stdout': CONNECTION_DELETE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand delete -h response',
+    ['Verify connection command delete -h response',
      ['delete', '-h'],
      {'stdout': CONNECTION_DELETE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand export --help response',
+    ['Verify connection command export --help response',
      ['export', '--help'],
      {'stdout': CONNECTION_EXPORT_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand export -h response',
+    ['Verify connection command export -h response',
      ['export', '-h'],
      {'stdout': CONNECTION_EXPORT_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand list --help response',
+    ['Verify connection command list --help response',
      ['list', '--help'],
      {'stdout': CONNECTION_LIST_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand list -h response',
+    ['Verify connection command list -h response',
      ['list', '-h'],
      {'stdout': CONNECTION_LIST_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand save --help response',
+    ['Verify connection command save --help response',
      ['save', '--help'],
      {'stdout': CONNECTION_SAVE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand save -h response',
+    ['Verify connection command save -h response',
      ['save', '-h'],
      {'stdout': CONNECTION_SAVE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand select  --help response',
+    ['Verify connection command select  --help response',
      ['select', '--help'],
      {'stdout': CONNECTION_SELECT_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand select  -h response',
+    ['Verify connection command select  -h response',
      ['select', '-h'],
      {'stdout': CONNECTION_SELECT_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand show --help response',
+    ['Verify connection command show --help response',
      ['show', '--help'],
      {'stdout': CONNECTION_SHOW_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand show -h response',
+    ['Verify connection command show -h response',
      ['show', '-h'],
      {'stdout': CONNECTION_SHOW_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand test --help response',
+    ['Verify connection command test --help response',
      ['test', '--help'],
      {'stdout': CONNECTION_TEST_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand test -h response',
+    ['Verify connection command test -h response',
      ['test', '-h'],
      {'stdout': CONNECTION_TEST_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    # ['Verify connection subcommand new. test with show and delete  ',
-    # # {'stdin': ['connection new test1 http://blah', 'connection show test1',
-    #            # 'connection delete test1']},
-    # # {'stdout': ["name: test1", "  WBEM Server uri: http://blah",
-    #  # "  default-namespace: root/cimv2", "  user: None", "  password: None",
-    #  # "  timeout: None", "  Noverify: False", "  certfile: None",
-    #  # "  keyfile: None", "  use-pull: None", "  mock-server:",
-    #  # "  log: None"],
-    #  # 'test': 'in'},
-    # # None, OK],
-
-    ['Verify connection subcommand list empty repository.',
-     {'global': ['-o', 'simple'],
+    ['Verify connection command list empty repository.',
+     {'general': ['-o', 'simple'],
       'args': ['list']},
      {'stdout': [
          "WBEM server connections:", ""],
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand delete, empty repo fails.',
+    ['Verify connection command delete, empty repo fails.',
      ['delete', 'blah'],
      {'stderr': ["Connection repository", "empty"],
       'rc': 1,
@@ -238,7 +228,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --mock-server and --server together fail.',
-     {'global': ['--mock-server', MOCK_FILE_PATH, '--server', 'http://blah'],
+     {'general': ['--mock-server', MOCK_FILE_PATH, '--server', 'http://blah'],
       'args': ['list']},
      {'stderr': ['Conflicting server definitions. Do not use --server and '
                  '--mock-server simultaneously'],
@@ -250,15 +240,15 @@ TEST_CASES = [
     # The following tests are a sequence. Each depends on the previous
     # and what was in the repository when each test is executed.
     #
-    ['Verify connection subcommand save creates file.',
-     {'global': ['--server', 'http://blah'],
+    ['Verify connection command save creates file.',
+     {'general': ['--server', 'http://blah'],
       'args': ['save', 'test1']},
      {'stdout': "",
       'test': 'innows',
       'file': {'before': 'none', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection subcommand show of just created test1',
+    ['Verify connection command show of just created test1',
      ['show', 'test1'],
      {'stdout': [
          "name: test1", "  server: http://blah",
@@ -271,16 +261,16 @@ TEST_CASES = [
       'file': {'before': 'exists', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection subcommand save with complex general options short',
-     {'global': ['--server', 'http://blahblah', '-u', 'fred', '-p',
-                 'argh', '-t', '18', '--no-verify', '-l', 'api=file,all'],
+    ['Verify connection command save with complex general options short',
+     {'general': ['--server', 'http://blahblah', '-u', 'fred', '-p',
+                  'argh', '-t', '18', '--no-verify', '-l', 'api=file,all'],
       'args': ['save', 'test2']},
      {'stdout': "",
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection subcommand show named connnection test1',
+    ['Verify connection command show named connnection test1',
      ['show', 'test1'],
      {'stdout': [
          "name: test1", "  server: http://blah",
@@ -292,7 +282,7 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand show  test2',
+    ['Verify connection command show  test2',
      ['show', 'test2'],
      {'stdout': ['name: test2',
                  'server: http://blahblah',
@@ -307,8 +297,8 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand list with 2 servers defined',
-     {'global': ['--output-format', 'plain'],
+    ['Verify connection command list with 2 servers defined',
+     {'general': ['--output-format', 'plain'],
       'args': ['list']},
      {'stdout': ['WBEM server connections:',
                  'name server namespace user timeout verify',
@@ -317,34 +307,34 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand select test2',
+    ['Verify connection command select test2',
      ['select', 'test2', '--default'],
      {'stdout': ['test2', 'default'],
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand show test2 includes "current"',
+    ['Verify connection command show test2 includes "current"',
      ['show', 'test2'],
      {'stdout': ['test2', 'http://blahblah', 'current'],
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand select test2 shows it is current',
+    ['Verify connection command select test2 shows it is current',
      ['select', 'test2'],
      {'stdout': ['test2', 'current'],
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand select test3 fails',
+    ['Verify connection command select test3 fails',
      ['select', 'test9'],
      {'stderr': ['Connection name "test9" does not exist'],
       'rc': 1,
       'test': 'regex'},
      None, OK],
 
-    ['Verify connection subcommand list with 2 servers defined, not sel after '
+    ['Verify connection command list with 2 servers defined, not sel after '
      ' next pywbemcli call',
-     {'global': ['--output-format', 'plain'],
+     {'general': ['--output-format', 'plain'],
       'args': ['list']},
      {'stdout': ['WBEM server connections:',
                  '(#: default, *: current)',
@@ -355,28 +345,28 @@ TEST_CASES = [
       'test': 'insnows'},
      None, OK],
 
-    ['Verify connection subcommand delete test1',
+    ['Verify connection command delete test1',
      ['delete', 'test1'],
      {'stdout': ['Deleted', 'test1'],
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection subcommand test',
+    ['Verify connection command test',
      ['test'],
      {'stdout': "Connection successful",
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify connection subcommand delete test2',
+    ['Verify connection command delete test2',
      ['delete', 'test2'],
      {'stdout': ['Deleted', 'test2', 'connection'],
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'none'}},
      None, OK],
 
-    ['Verify connection subcommand list empty repository.',
-     {'global': ['-o', 'simple'],
+    ['Verify connection command list empty repository.',
+     {'general': ['-o', 'simple'],
       'args': ['list']},
      {'stdout': [
          "WBEM server connections:", ""],
@@ -389,22 +379,22 @@ TEST_CASES = [
     #   The following is a new sequence but depends on the repo being empty
     #   It creates, shows and deletes a single server definition.
     #
-    ['Verify connection subcommand add with all arguments.',
-     {'global': ['--server', 'http://blahblah',
-                 '--default-namespace', 'root/blahblah',
-                 '--user', 'john',
-                 '--password', 'pw',
-                 '--timeout', '30',
-                 '--no-verify',
-                 '--certfile', 'mycertfile.pem',
-                 '--keyfile', 'mykeyfile.pem', ],
+    ['Verify connection command add with all arguments.',
+     {'general': ['--server', 'http://blahblah',
+                  '--default-namespace', 'root/blahblah',
+                  '--user', 'john',
+                  '--password', 'pw',
+                  '--timeout', '30',
+                  '--no-verify',
+                  '--certfile', 'mycertfile.pem',
+                  '--keyfile', 'mykeyfile.pem', ],
       'args': ['save', 'addallargs']},
      {'stdout': "",
       'test': 'lines',
       'file': {'before': 'none', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection subcommand show addallargs initial version',
+    ['Verify connection command show addallargs initial version',
      ['show', 'addallargs'],
      {'stdout': [
          'name: addallargs',
@@ -418,15 +408,15 @@ TEST_CASES = [
       'test': 'in'},
      None, OK],
 
-    ['Verify connection subcommand with that overwrites existing name works.',
-     {'global': ['--server', 'http://blah',
-                 '--default-namespace', 'root/blah',
-                 '--user', 'john',
-                 '--password', 'pw',
-                 '--timeout', '30',
-                 '--no-verify',
-                 '--certfile', 'mycertfile.pem',
-                 '--keyfile', 'mykeyfile.pem', ],
+    ['Verify connection command with that overwrites existing name works.',
+     {'general': ['--server', 'http://blah',
+                  '--default-namespace', 'root/blah',
+                  '--user', 'john',
+                  '--password', 'pw',
+                  '--timeout', '30',
+                  '--no-verify',
+                  '--certfile', 'mycertfile.pem',
+                  '--keyfile', 'mykeyfile.pem', ],
       'args': ['save', 'addallargs']},
      {'stderr': '',
       'rc': 0,
@@ -434,7 +424,7 @@ TEST_CASES = [
       'file': {'before': 'exists', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection subcommand show of name addallargs, overwrite changed',
+    ['Verify connection command show of name addallargs, overwrite changed',
      ['show', 'addallargs'],
      {'stdout': [
          'name: addallargs',
@@ -448,7 +438,7 @@ TEST_CASES = [
       'test': 'in'},
      None, OK],
 
-    ['Verify connection subcommand delete addallargs',
+    ['Verify connection command delete addallargs',
      ['delete', 'addallargs'],
      {'stdout': "Deleted",
       'test': 'innows',
@@ -457,11 +447,11 @@ TEST_CASES = [
 
     # uses regex because windows generates set and linux export in statements
     # No file verification required. Does not use file
-    ['Verify connection subcommand export current connection',
+    ['Verify connection command export current connection',
      {'args': ['export'],
-      'global': ['-s', 'http://blah', '-u', 'fred', '-p', 'arghh',
-                 '--no-verify',
-                 '-c', 'certfile.txt', '-k', 'keyfile.txt', '-t', '12']},
+      'general': ['-s', 'http://blah', '-u', 'fred', '-p', 'arghh',
+                  '--no-verify',
+                  '-c', 'certfile.txt', '-k', 'keyfile.txt', '-t', '12']},
      {'stdout': ['PYWBEMCLI_SERVER=http://blah$',
                  'PYWBEMCLI_DEFAULT_NAMESPACE=root/cimv2$',
                  'PYWBEMCLI_USER=fred$',
@@ -480,7 +470,7 @@ TEST_CASES = [
     #  Test command line parameter errors, select, show, and delete with
     #  no repository
     #
-    ['Verify connection subcommand show with name not in empty repo',
+    ['Verify connection command show with name not in empty repo',
      ['show', 'Blah'],
      {'stderr': ['Name "Blah" not current and no connections file'],
       'rc': 1,
@@ -488,14 +478,14 @@ TEST_CASES = [
       'file': {'before': 'none', 'after': 'none'}},
      None, OK],
 
-    ['Verify connection subcommand show with no name empty repo',
+    ['Verify connection command show with no name empty repo',
      ['show'],
      {'stderr': ['No current connection and no connections file'],
       'rc': 1,
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand select, empty repo fails',
+    ['Verify connection command select, empty repo fails',
      ['select'],
      {'stderr': ["Connection repository", "empty"],
       'rc': 1,
@@ -503,7 +493,7 @@ TEST_CASES = [
       'file': {'before': 'none', 'after': 'none'}},
      None, OK],
 
-    ['Verify connection subcommand select blah, empty repo fails',
+    ['Verify connection command select blah, empty repo fails',
      ['select', 'blah'],
      {'stderr': ["Connection repository", "empty"],
       'rc': 1,
@@ -511,7 +501,7 @@ TEST_CASES = [
       'file': {'before': 'none', 'after': 'none'}},
      None, OK],
 
-    ['Verify connection subcommand delete, empty repo fails',
+    ['Verify connection command delete, empty repo fails',
      ['delete'],
      {'stderr': ["Connection repository", "empty"],
       'rc': 1,
@@ -520,7 +510,7 @@ TEST_CASES = [
      None, OK],
 
 
-    ['Verify connection subcommand delete, empty repo fails',
+    ['Verify connection command delete, empty repo fails',
      ['delete', 'blah'],
      {'stderr': ["Connection repository", "empty"],
       'rc': 1,
@@ -535,14 +525,14 @@ TEST_CASES = [
     #
 
     ['Verify mock connection exists.',
-     {'global': ['--mock-server', MOCK_FILE_PATH],
+     {'general': ['--mock-server', MOCK_FILE_PATH],
       'args': ['save', 'mocktest']},
      {'stdout': "",
       'test': 'lines',
       'file': {'before': 'none', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection subcommand shows mock file ',
+    ['Verify connection command shows mock file ',
      ['show', 'mocktest'],
      {'stdout': [
          "name: mocktest",
@@ -556,14 +546,14 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection subcommand test against existing mock def',
+    ['Verify connection command test against existing mock def',
      {'args': ['test'],
-      'global': ['--name', 'mocktest']},
+      'general': ['--name', 'mocktest']},
      {'stdout': "Connection successful",
       'test': 'lines'},
      None, OK],
 
-    ['Verify connection subcommand select mocktest with prompt',
+    ['Verify connection command select mocktest with prompt',
      ['select'],
      {'stdout': "",
       'test': 'in',
@@ -571,14 +561,14 @@ TEST_CASES = [
      MOCK_PROMPT0_FILE, OK],
 
 
-    ['Verify connection subcommand show with prompt',
+    ['Verify connection command show with prompt',
      ['show', '?'],
      {'stdout': ['name: mocktest'],
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'exists'}},
      MOCK_PROMPT0_FILE, OK],
 
-    ['Verify connection subcommand delete with prompt that selects 0',
+    ['Verify connection command delete with prompt that selects 0',
      ['delete', ],
      {'stdout': ['Select a connection or Ctrl_C to abort',
                  '0: mocktest',
@@ -588,14 +578,14 @@ TEST_CASES = [
      MOCK_PROMPT0_FILE, OK],
 
     ['Verify Add mock server to empty connections file.',
-     {'global': ['--mock-server', MOCK_FILE_PATH],
+     {'general': ['--mock-server', MOCK_FILE_PATH],
       'args': ['save', 'mocktest']},
      {'stdout': "",
       'test': 'lines',
       'file': {'before': 'none', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection subcommand delete'
+    ['Verify connection command delete'
      'verify',
      ['delete', 'mocktest'],
      {'stdout': ['name: mocktest', 'Execute delete'],
@@ -611,15 +601,15 @@ TEST_CASES = [
     #
     ['Verify save server with cmd line params to empty connections file.',
      {'args': ['save', 'svrtest2'],
-      'global': ['--server', 'http://blah',
-                 '--timeout', '45',
-                 '--use-pull', 'no',
-                 '--default-namespace', 'root/blah',
-                 '--user', 'john',
-                 '--password', 'pw',
-                 '--verify',
-                 '--certfile', 'mycertfile.pem',
-                 '--keyfile', 'mykeyfile.pem']},
+      'general': ['--server', 'http://blah',
+                  '--timeout', '45',
+                  '--use-pull', 'no',
+                  '--default-namespace', 'root/blah',
+                  '--user', 'john',
+                  '--password', 'pw',
+                  '--verify',
+                  '--certfile', 'mycertfile.pem',
+                  '--keyfile', 'mykeyfile.pem']},
      {'stdout': "",
       'test': 'innows',
       'file': {'before': 'none', 'after': 'exists'}},
@@ -627,21 +617,21 @@ TEST_CASES = [
 
     ['Verify save mock server with cmd line params to empty connections file.',
      {'args': ['save', 'mocktest2'],
-      'global': ['--mock-server', MOCK_FILE_PATH,
-                 '--timeout', '45',
-                 '--use-pull', 'no',
-                 '--default-namespace', 'root/blah',
-                 '--user', 'john',
-                 '--password', 'pw',
-                 '--no-verify',
-                 '--certfile', 'mycertfile.pem',
-                 '--keyfile', 'mykeyfile.pem']},
+      'general': ['--mock-server', MOCK_FILE_PATH,
+                  '--timeout', '45',
+                  '--use-pull', 'no',
+                  '--default-namespace', 'root/blah',
+                  '--user', 'john',
+                  '--password', 'pw',
+                  '--no-verify',
+                  '--certfile', 'mycertfile.pem',
+                  '--keyfile', 'mykeyfile.pem']},
      {'stdout': "",
       'test': 'lines',
       'file': {'before': 'exists', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection subcommand shows mock file ',
+    ['Verify connection command shows mock file ',
      ['show', 'mocktest2'],
      {'stdout': [
          "name: mocktest2",
@@ -657,7 +647,7 @@ TEST_CASES = [
       'file': {'before': 'exists', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection subcommand shows svrtest2 ',
+    ['Verify connection command shows svrtest2 ',
      ['show', 'svrtest2'],
      {'stdout': [
          "name: svrtest2",
@@ -671,14 +661,14 @@ TEST_CASES = [
       'file': {'before': 'exists', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection subcommand delete works',
+    ['Verify connection command delete works',
      ['delete', 'mocktest2'],
      {'stdout': "",
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection subcommand delete works and file empty',
+    ['Verify connection command delete works and file empty',
      ['delete', 'svrtest2'],
      {'stderr': "",
       'rc': 0,
@@ -692,7 +682,7 @@ TEST_CASES = [
 
     ['Verify connection show with just current server defined by --server',
      {'args': ['show'],
-      'global': ['--server', 'http://blah']},
+      'general': ['--server', 'http://blah']},
      {'stdout': ['name', 'not-saved'],
       'test': 'innows',
       'file': {'before': 'none', 'after': 'none'}},
@@ -700,7 +690,7 @@ TEST_CASES = [
 
     ['Verify connection list with current server from general options, plain',
      {'args': ['list'],
-      'global': ['--server', 'http://blah', '--output-format', 'plain']},
+      'general': ['--server', 'http://blah', '--output-format', 'plain']},
      {'stdout': ['WBEM server connections: (#: default, *: current)',
                  '*not-saved http://blah root/cimv2  30 True'],
       'test': 'innows',
@@ -712,7 +702,7 @@ TEST_CASES = [
     #
 
     ['Verify mock connection exists.',
-     {'global': ['--server', 'http://blah'],
+     {'general': ['--server', 'http://blah'],
       'args': ['save', 'svrtest']},
      {'stdout': "",
       'test': 'lines',
@@ -722,7 +712,7 @@ TEST_CASES = [
 
     ['Verify connection list with current server from general options, grid',
      {'args': ['list'],
-      'global': ['--server', 'http://blah']},
+      'general': ['--server', 'http://blah']},
      {'stdout': """
 WBEM server connections: (#: default, *: current)
 +------------+-------------+-------------+-----------+----------+
@@ -738,7 +728,7 @@ WBEM server connections: (#: default, *: current)
 
     ['Verify connection select of svrtest',
      {'args': ['select', 'svrtest', '--default'],
-      'global': ['--server', 'http://blah']},
+      'general': ['--server', 'http://blah']},
      {'stdout': '"svrtest" default and current',
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'exists'}},
@@ -746,7 +736,7 @@ WBEM server connections: (#: default, *: current)
 
     ['Verify connection select of svrtest as default',
      {'args': ['show'],
-      'global': []},
+      'general': []},
      {'stdout': ['svrtest'],
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'exists'}},
@@ -754,7 +744,7 @@ WBEM server connections: (#: default, *: current)
 
     ['Verify current connection set with general opts overrides default',
      {'args': ['show'],
-      'global': ['--server', 'https://blahblahblah']},
+      'general': ['--server', 'https://blahblahblah']},
      {'stdout': ['not-saved', 'https://blahblahblah'],
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'exists'}},
@@ -763,7 +753,7 @@ WBEM server connections: (#: default, *: current)
 
     ['Verify connection delete svrtest',
      {'args': ['delete', 'svrtest'],
-      'global': []},
+      'general': []},
      {'stdout': "Deleted default connection",
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'none'}},
@@ -780,7 +770,7 @@ class TestSubcmdClass(CLITestsBase):
     """
     Test all of the class command variations.
     """
-    subcmd = 'connection'
+    command_group = 'connection'
 
     @pytest.mark.parametrize(
         "desc, inputs, exp_response, mock, condition",
@@ -788,8 +778,8 @@ class TestSubcmdClass(CLITestsBase):
     def test_connection(self, desc, inputs, exp_response, mock, condition,
                         repo_file_path):
         """
-        Common test method for those subcommands and options in the
-        class subcmd that can be tested.  Note the
+        Common test method for those commands and options in the
+        connection command group that can be tested.  Note the
         fixture remove_connection_file which is session, autouse so should
         hide any existing connection file at beginning of this test and
         restore it after the test.
@@ -828,8 +818,8 @@ class TestSubcmdClass(CLITestsBase):
             if 'before' in exp_response['file']:
                 test_file(exp_response['file']['before'])
 
-        self.subcmd_test(desc, self.subcmd, inputs, exp_response,
-                         mock, condition, verbose=False)
+        self.command_test(desc, self.command_group, inputs, exp_response,
+                          mock, condition, verbose=False)
 
         if 'file' in exp_response:
             if 'after' in exp_response['file']:

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -34,7 +34,7 @@ BAD_MOF_FILE_PATH = os.path.join(SCRIPT_DIR, 'mof_with_error.mof')
 BAD_PY_FILE_PATH = os.path.join(SCRIPT_DIR, 'py_with_error.py')
 
 
-GLOBAL_HELP = """
+GENERAL_HELP = """
 Usage: pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS]...
 
   Pywbemcli is a command line WBEM client that uses the DMTF CIM-XML
@@ -186,7 +186,7 @@ SKIP = False
 
 TEST_CASES = [
     # desc - Description of test
-    # inputs - String, or list of args or dict of 'env', 'args', 'globals',
+    # inputs - String, or list of args or dict of 'env', 'args', 'general',
     #          and 'stdin'. See See CLITestsBase.subcmd_test()  for
     #          detailed documentation. This test processor includes an
     #          additional key, `subcmd`
@@ -196,18 +196,27 @@ TEST_CASES = [
     # mock - None or name of files (mof or .py),
     # condition - If True, the test is executed,  Otherwise it is skipped.
 
-    ['Verify -help.',
-     {'global': ['--help'],
-      'subcmd': 'class',
+    ['Verify -help response.',
+     {'general': ['--help'],
+      'cmdgrp': 'class',
       'args': ['get', 'blah']},
-     {'stdout': GLOBAL_HELP,
+     {'stdout': GENERAL_HELP,
+      'rc': 0,
+      'test': 'linesnows'},
+     None, OK],
+
+    ['Verify -h response.',
+     {'general': ['--help'],
+      'cmdgrp': 'class',
+      'args': ['get', 'blah']},
+     {'stdout': GENERAL_HELP,
       'rc': 0,
       'test': 'linesnows'},
      None, OK],
 
     ['Verify invalid server definition.',
-     {'global': ['-s', 'httpx://blah'],
-      'subcmd': 'class',
+     {'general': ['-s', 'httpx://blah'],
+      'cmdgrp': 'class',
       'args': ['get', 'blah']},
      {'stderr': ['Error: Invalid scheme on server argument. httpx://blah Use '
                  '"http" or "https"'],
@@ -216,8 +225,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify invalid server port definition fails.',
-     {'global': ['-s', 'http://blah:abcd'],
-      'subcmd': 'class',
+     {'general': ['-s', 'http://blah:abcd'],
+      'cmdgrp': 'class',
       'args': ['get', 'blah']},
      {'stderr': ['Error:', 'ConnectionError', 'Socket error'],
       'rc': 1,
@@ -225,8 +234,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify valid --use-pull option parameter yes.',
-     {'global': ['-s', 'http://blah', '--use-pull', 'yes'],
-      'subcmd': 'connection',
+     {'general': ['-s', 'http://blah', '--use-pull', 'yes'],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stdout': ['use-pull: True'],
       'rc': 0,
@@ -234,8 +243,8 @@ TEST_CASES = [
      None, SKIP],
 
     ['Verify valid --use-pull option parameter no.',
-     {'global': ['-s', 'http://blah', '--use-pull', 'no'],
-      'subcmd': 'connection',
+     {'general': ['-s', 'http://blah', '--use-pull', 'no'],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stdout': ['use-pull: False'],
       'rc': 0,
@@ -243,8 +252,8 @@ TEST_CASES = [
      None, SKIP],
 
     ['Verify valid --use-pull option parameter.',
-     {'global': ['-s', 'http://blah', '--use-pull', 'either'],
-      'subcmd': 'connection',
+     {'general': ['-s', 'http://blah', '--use-pull', 'either'],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stdout': ['use-pull: None'],
       'rc': 0,
@@ -252,8 +261,8 @@ TEST_CASES = [
      None, SKIP],
 
     ['Verify invalid --use-pull option parameter fails.',
-     {'global': ['-s', 'http://blah', '--use-pull', 'blah'],
-      'subcmd': 'connection',
+     {'general': ['-s', 'http://blah', '--use-pull', 'blah'],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stderr': ['Invalid value for "-U" / "--use-pull": invalid choice: '
                  'blah. (choose from yes, no, either)'],
@@ -262,8 +271,8 @@ TEST_CASES = [
      None, SKIP],
 
     ['Verify valid --pull-max-cnt option parameter.',
-     {'global': ['-s', 'http://blah', '--pull-max-cnt', '2000'],
-      'subcmd': 'connection',
+     {'general': ['-s', 'http://blah', '--pull-max-cnt', '2000'],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stdout': ['pull-max-cnt: 2000'],
       'rc': 0,
@@ -271,8 +280,8 @@ TEST_CASES = [
      None, SKIP],
 
     ['Verify invalid --pull-max-cnt option parameter fails.',
-     {'global': ['-s', 'http://blah', '--pull-max-cnt', 'blah'],
-      'subcmd': 'connection',
+     {'general': ['-s', 'http://blah', '--pull-max-cnt', 'blah'],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stderr': ['Error: Invalid value for "--pull-max-cnt": blah is not a '
                  'valid integer'],
@@ -280,9 +289,9 @@ TEST_CASES = [
       'test': 'in'},
      None, SKIP],
 
-    ['Verify --version global option.',
-     {'global': ['-s', 'http://blah', '--version'],
-      'subcmd': 'connection',
+    ['Verify --version general option.',
+     {'general': ['-s', 'http://blah', '--version'],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stdout': [r'^pywbemcli, version [0-9]+\.[0-9]+\.[0-9]+',
                  r'^pywbem, version [0-9]+\.[0-9]+\.[0-9]+'],
@@ -294,35 +303,35 @@ TEST_CASES = [
     #  Test --verify and --no-verify general option using the connection show
     #
     ['Verify --verify general option.',
-     {'global': ['--server', 'http://blah', '--verify'],
+     {'general': ['--server', 'http://blah', '--verify'],
       'args': ['show'],
-      'subcmd': 'connection'},
+      'cmdgrp': 'connection'},
      {'stdout': "verify: True",
       'test': 'innows',
       'file': {'before': 'none', 'after': 'None'}},
      None, OK],
 
     ['Verify --no-verify general option.',
-     {'global': ['--server', 'http://blah', '--no-verify'],
+     {'general': ['--server', 'http://blah', '--no-verify'],
       'args': ['show'],
-      'subcmd': 'connection'},
+      'cmdgrp': 'connection'},
      {'stdout': "verify: False",
       'test': 'innows',
       'file': {'before': 'none', 'after': 'None'}},
      None, OK],
 
     ['Verify --verify general options  Default value.',
-     {'global': ['--server', 'http://blah'],
+     {'general': ['--server', 'http://blah'],
       'args': ['show'],
-      'subcmd': 'connection'},
+      'cmdgrp': 'connection'},
      {'stdout': "verify: True",
       'test': 'innows',
       'file': {'before': 'none', 'after': 'None'}},
      None, OK],
 
     ['Verify --mock option one file',
-     {'global': ['-m', SIMPLE_MOCK_FILE_PATH],
-      'subcmd': 'connection',
+     {'general': ['-m', SIMPLE_MOCK_FILE_PATH],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stdout': ['name: not-saved',
                  'server: None',
@@ -334,9 +343,9 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --mock option, multiple files',
-     {'global': ['-m', SIMPLE_MOCK_FILE_PATH,
-                 '-m', PYTHON_MOCK_FILE_PATH],
-      'subcmd': 'connection',
+     {'general': ['-m', SIMPLE_MOCK_FILE_PATH,
+                  '-m', PYTHON_MOCK_FILE_PATH],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stdout': ['name', 'default',
                  'server', 'None',
@@ -349,8 +358,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --mock option, file does not exist',
-     {'global': ['--mock-server', 'invalidfilename.mof'],
-      'subcmd': 'connection',
+     {'general': ['--mock-server', 'invalidfilename.mof'],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stderr': [r'Error: --mock-server: File:',
                  r'invalidfilename\.mof',
@@ -361,8 +370,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --mock option, file with bad extension',
-     {'global': ['--mock-server', 'invalidfilename.mofx'],
-      'subcmd': 'connection',
+     {'general': ['--mock-server', 'invalidfilename.mofx'],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stderr': [r'Error: --mock-server: File: ',
                  r'invalidfilename\.mofx',
@@ -374,8 +383,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --mock option, file with mof containing syntax error',
-     {'global': ['-m', BAD_MOF_FILE_PATH],
-      'subcmd': 'class',
+     {'general': ['-m', BAD_MOF_FILE_PATH],
+      'cmdgrp': 'class',
       'args': ['enumerate']},
      {'stderr': ['badtypedef InstanceID;',
                  'Repository build exception MOFParseError',
@@ -385,8 +394,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --mock option, file with python containing syntax error',
-     {'global': ['-m', BAD_PY_FILE_PATH],
-      'subcmd': 'class',
+     {'general': ['-m', BAD_PY_FILE_PATH],
+      'cmdgrp': 'class',
       'args': ['enumerate']},
      {'stderr': [r'Traceback \(most recent call last\)',
                  r'pywbemtools', r'_pywbemcli_operations\.py',
@@ -398,8 +407,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --name option with new name but not in repo fails',
-     {'global': ['-n', 'fred'],
-      'subcmd': 'connection',
+     {'general': ['-n', 'fred'],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stderr': 'Error: Named connection "fred" does not exist',
       'rc': 1,
@@ -407,8 +416,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --name option with new name but not in repo fails',
-     {'global': ['--name', 'fred'],
-      'subcmd': 'connection',
+     {'general': ['--name', 'fred'],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stderr': 'Error: Named connection "fred" does not exist',
       'rc': 1,
@@ -416,9 +425,9 @@ TEST_CASES = [
      None, OK],
 
     ['Verify simultaneous --mock-server and --server options fail',
-     {'global': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
-                 '--server', 'http://localhost'],
-      'subcmd': 'connection',
+     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
+                  '--server', 'http://localhost'],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stderr': ['Conflicting server definitions. Do not use --server '
                  'and --mock-server simultaneously',
@@ -428,8 +437,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --mock-server invalid name',
-     {'global': ['--mock-server', 'fred'],
-      'subcmd': 'connection',
+     {'general': ['--mock-server', 'fred'],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stderr': ['--mock-server: File:',
                  'fred',
@@ -440,8 +449,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --mock option one file and name fails',
-     {'global': ['-m', SIMPLE_MOCK_FILE_PATH, '--name', 'MyConnName'],
-      'subcmd': 'connection',
+     {'general': ['-m', SIMPLE_MOCK_FILE_PATH, '--name', 'MyConnName'],
+      'cmdgrp': 'connection',
       'args': ['show']},
      {'stderr': ['The --name "MyConnName" option',
                  'server', 'option',
@@ -451,8 +460,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --timestats',
-     {'global': ['--mock-server', SIMPLE_MOCK_FILE_PATH, '--timestats'],
-      'subcmd': 'class',
+     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH, '--timestats'],
+      'cmdgrp': 'class',
       'args': ['enumerate']},
      {'stdout': ['class CIM_Foo {',
                  '  Count    Exc    Time    ReqLen    ReplyLen  Operation',
@@ -462,8 +471,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --timestats -T',
-     {'global': ['--mock-server', SIMPLE_MOCK_FILE_PATH, '-T'],
-      'subcmd': 'class',
+     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH, '-T'],
+      'cmdgrp': 'class',
       'args': ['enumerate']},
      {'stdout': ['class CIM_Foo {',
                  '  Count    Exc    Time    ReqLen    ReplyLen  Operation',
@@ -472,12 +481,11 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-
     ['Verify uses pull Operation  with option either',
-     {'global': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
-                 '--timestats',
-                 '--use-pull', 'either'],
-      'subcmd': 'instance',
+     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
+                  '--timestats',
+                  '--use-pull', 'either'],
+      'cmdgrp': 'instance',
       'args': ['enumerate', 'CIM_Foo']},
      {'stdout': ['instance of CIM_Foo {',
                  '  Count    Exc    Time    ReqLen    ReplyLen  Operation',
@@ -487,10 +495,10 @@ TEST_CASES = [
      None, OK],
 
     ['Verify uses pull Operation with option yes',
-     {'global': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
-                 '--timestats',
-                 '--use-pull', 'yes'],
-      'subcmd': 'instance',
+     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
+                  '--timestats',
+                  '--use-pull', 'yes'],
+      'cmdgrp': 'instance',
       'args': ['enumerate', 'CIM_Foo']},
      {'stdout': ['instance of CIM_Foo {',
                  '  Count    Exc    Time    ReqLen    ReplyLen  Operation',
@@ -500,10 +508,10 @@ TEST_CASES = [
      None, OK],
 
     ['Verify uses pull Operation with option no',
-     {'global': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
-                 '--timestats',
-                 '--use-pull', 'no'],
-      'subcmd': 'instance',
+     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
+                  '--timestats',
+                  '--use-pull', 'no'],
+      'cmdgrp': 'instance',
       'args': ['enumerate', 'CIM_Foo']},
      {'stdout': ['instance of CIM_Foo {',
                  '  Count    Exc    Time    ReqLen    ReplyLen  Operation',
@@ -512,18 +520,15 @@ TEST_CASES = [
       'test': 'regex'},
      None, OK],
 
-
     ['Verify --mock-server and -server not allowed',
-     {'global': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
-                 '--server', 'http://blah'],
-      'subcmd': 'instance',
+     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
+                  '--server', 'http://blah'],
+      'cmdgrp': 'instance',
       'args': ['enumerate', 'CIM_Foo']},
      {'stderr': ['Conflicting server definitions. '],
       'rc': 1,
       'test': 'regex'},
      None, OK],
-
-
 
     #
     #   The following is a new sequence but depends on the repo being empty
@@ -532,24 +537,23 @@ TEST_CASES = [
     #
 
     ['Verify Create a connection for test.',
-     {'global': ['--server', 'http://blah',
-                 '--timeout', '45',
-                 '--default-namespace', 'root/blah',
-                 '--user', 'john',
-                 '--password', 'pw',
-                 '--no-verify',
-                 '--certfile', 'mycertfile.pem',
-                 '--keyfile', 'mykeyfile.pem'],
+     {'general': ['--server', 'http://blah',
+                  '--timeout', '45',
+                  '--default-namespace', 'root/blah',
+                  '--user', 'john',
+                  '--password', 'pw',
+                  '--no-verify',
+                  '--certfile', 'mycertfile.pem',
+                  '--keyfile', 'mykeyfile.pem'],
       'args': ['save', 'generaltest1'],
-      'subcmd': 'connection', },
+      'cmdgrp': 'connection', },
      {'stdout': "",
       'test': 'innows'},
      None, OK],
 
-
     ['Verify --name and other options fails',
-     {'global': ['--name', 'generaltest1', '--timeout', '90'],
-      'subcmd': 'connection',
+     {'general': ['--name', 'generaltest1', '--timeout', '90'],
+      'cmdgrp': 'connection',
       'args': ['delete', 'generaltest1']},
      {'stderr': ['timeout 90', 'invalid when'],
       'rc': 1,
@@ -557,7 +561,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify connection gets deleted.',
-     {'subcmd': 'connection',
+     {'cmdgrp': 'connection',
       'args': ['delete', 'generaltest1']},
      {'stdout': '',
       'rc': 0,
@@ -565,7 +569,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify connection already deleted.',
-     {'subcmd': 'connection',
+     {'cmdgrp': 'connection',
       'args': ['delete', 'generaltest1']},
      {'stderr': ['Connection repository', 'empty'],
       'rc': 1,
@@ -574,7 +578,7 @@ TEST_CASES = [
 
     ['Verify connection without server definition and command that '
      ' requires connection fails.',
-     {'subcmd': 'class',
+     {'cmdgrp': 'class',
       'args': ['enumerate']},
      {'stderr': ['No server defined for command that requires server. ',
                  'Define a server with "--server", "--mock-server", or ',
@@ -586,9 +590,9 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --keyfile allowed only if --certfile exists.',
-     {'subcmd': 'class',
+     {'cmdgrp': 'class',
       'args': ['enumerate'],
-      'global': ['--keyfile', 'mykey.pem']},
+      'general': ['--keyfile', 'mykey.pem']},
      {'stderr': ['The --keyfile option',
                  'is allowed only if the --certfile option is also used'],
       'rc': 1,
@@ -600,64 +604,62 @@ TEST_CASES = [
     #
 
     ['Verify Create a connection to test default connection.',
-     {'global': ['--server', 'http://blah'],
+     {'general': ['--server', 'http://blah'],
       'args': ['save', 'test-default'],
-      'subcmd': 'connection', },
+      'cmdgrp': 'connection', },
      {'stdout': '',
       'test': 'innows'},
      None, OK],
 
     ['Verify select of test-default.',
      {'args': ['select', 'test-default'],
-      'subcmd': 'connection', },
+      'cmdgrp': 'connection', },
      {'stdout': ['test-default', 'current'],
       'test': 'innows'},
      None, OK],
 
     ['Verify shows test-default connection.',
      {'args': ['show', 'test-default'],
-      'subcmd': 'connection', },
+      'cmdgrp': 'connection', },
      {'stdout': ['test-default'],
       'test': 'innows'},
      None, OK],
 
     ['Verify select of test-default connection.',
      {'args': ['select', 'test-default', '--default'],
-      'subcmd': 'connection', },
+      'cmdgrp': 'connection', },
      {'stdout': ['test-default', 'current'],
       'test': 'innows'},
      None, OK],
 
     ['Verify show current which is test-default',
      {'args': ['show'],
-      'subcmd': 'connection', },
+      'cmdgrp': 'connection', },
      {'stdout': ['test-default'],
       'test': 'innows'},
      None, OK],
 
-
     ['Delete test-default.',
      {'args': ['delete', 'test-default'],
-      'subcmd': 'connection', },
+      'cmdgrp': 'connection', },
      {'stdout': "",
       'test': 'innows'},
      None, OK],
 
     ['Verify delete worked by requesting again expecting failure.',
      {'args': ['delete', 'test-default'],
-      'subcmd': 'connection', },
+      'cmdgrp': 'connection', },
      {'stderr': ['Connection repository', 'empty'],
       'rc': 1,
       'test': 'innows'},
      None, OK],
-
 
     #
     # Test using environment variables as input
     #
     ['Verify setting one env var for input.',
      {'env': {'PYWBEMCLI_SERVER': 'http://blah'},
-      'subcmd': 'connection',
+      'cmdgrp': 'connection',
       'args': 'show'},
      {'stdout': ['name', 'default',
                  'server', 'http://blah',
@@ -685,7 +687,7 @@ TEST_CASES = [
               'PYWBEMCLI_USE_PULL': 'no',
               'PYWBEMCLI_PULL_MAX_CNT': '10',
               'PYWBEMCLI_LOG': 'api=all', },
-      'subcmd': 'connection',
+      'cmdgrp': 'connection',
       'args': 'show'},
      {'stdout': ['name', 'default',
                  'server', 'http://blah',
@@ -711,8 +713,8 @@ TEST_CASES = [
               'PYWBEMCLI_USE_PULL': 'no',
               'PYWBEMCLI_PULL_MAX_CNT': '10',
               'PYWBEMCLI_LOG': 'api=all', },
-      'subcmd': 'connection',
-      'global': ['--server', 'http://blah'],
+      'cmdgrp': 'connection',
+      'general': ['--server', 'http://blah'],
       'args': 'show'},
      {'stdout': ['server', 'http://blah',
                  'default-namespace', 'fred/fred',
@@ -731,13 +733,13 @@ TEST_CASES = [
     #
 
     ['Verify multiple commands in interacive mode.',
-     {'global': ['--server', 'http://blah', ],
+     {'general': ['--server', 'http://blah', ],
       # args not allowed in interactive mode
       'stdin': ['--certfile cert1.pem --keyfile keys1.pem connection show',
                 'connection show',
                 '--certfile cert2.pem --keyfile keys2.pem connection show',
                 'connection show'],             # should show None
-      'subcmd': 'connection', },
+      'cmdgrp': 'connection', },
      {'stdout': ['certfile: None',              # at startup and other times
                  'certfile: cert1.pem',         # after first change
                  'certfile: cert2.pem',         # after second change
@@ -748,14 +750,14 @@ TEST_CASES = [
      None, OK],
 
     ['Verify Change --mock-server to --server in interactive mode.',
-     {'global': ['--mock-server', SIMPLE_MOCK_FILE_PATH, ],
+     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH, ],
       # args not allowed in interactive mode
       'stdin': ['connection show',
                 '--server  http://blah connection show',
                 '--mock-server tests/unit/simple_mock_model.mof '
                 'connection show',
                 'connection show'],
-      'subcmd': None,
+      'cmdgrp': None,
       },
      {'stdout': ['server : None',
                  'server: http://blah',
@@ -769,24 +771,23 @@ TEST_CASES = [
     #   The following is a sequence
     #
     ['Verify Create a connection for test of mods through general opts.',
-     {'global': ['--server', 'http://blah',
-                 '--timeout', '45',
-                 '--default-namespace', 'root/fred',
-                 '--user', 'RonaldMcDonald',
-                 '--password', 'pw',
-                 '--no-verify',
-                 '--certfile', 'certfile.pem',
-                 '--keyfile', 'keyfile.pem'],
+     {'general': ['--server', 'http://blah',
+                  '--timeout', '45',
+                  '--default-namespace', 'root/fred',
+                  '--user', 'RonaldMcDonald',
+                  '--password', 'pw',
+                  '--no-verify',
+                  '--certfile', 'certfile.pem',
+                  '--keyfile', 'keyfile.pem'],
       'args': ['save', 'testGeneralOpsMods'],
-      'subcmd': 'connection', },
+      'cmdgrp': 'connection', },
      {'stdout': "",
       'test': 'innows'},
      None, OK],
 
-
     ['Verify show current which is testGeneralOpsMods',
      {'args': ['show', 'testGeneralOpsMods'],
-      'subcmd': 'connection', },
+      'cmdgrp': 'connection', },
      {'stdout': ['testGeneralOpsMods',
                  'server', 'http://blah',
                  'default-namespace', 'root/fred',
@@ -799,14 +800,13 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-
     ['Verify Change all server parameters and show.',
-     {'global': ['--name', 'testGeneralOpsMods'],
+     {'general': ['--name', 'testGeneralOpsMods'],
       # args not allowed in interactive mode
       'stdin': ['--server  http://blahblah --timeout 90 --user Fred '
                 '--default-namespace root/john --password  abcd '
                 ' --verify --certfile c1.pem --keyfile k1.pem connection show'],
-      'subcmd': None,
+      'cmdgrp': None,
       },
      {'stdout': ['testGeneralOpsMods',
                  'server : http://blahblah',
@@ -823,14 +823,14 @@ TEST_CASES = [
      None, OK],
 
     ['Change all parameters and save as t1.',
-     {'global': ['--name', 'testGeneralOpsMods'],
+     {'general': ['--name', 'testGeneralOpsMods'],
       # args not allowed in interactive mode
       'stdin': ['--server  http://blahblah --timeout 90 --user Fred '
                 '--default-namespace root/john --password  abcd '
                 ' --verify --certfile c1.pem --keyfile k1.pem connection '
                 'save t1',
                 'connection list'],
-      'subcmd': None,
+      'cmdgrp': None,
       },
      {'stdout': [''],
       'rc': 0,
@@ -838,9 +838,9 @@ TEST_CASES = [
      None, OK],
 
     ['Verify  load t1 and changed parameters are correct',
-     {'global': ['--name', 't1'],
+     {'general': ['--name', 't1'],
       'args': 'show',
-      'subcmd': 'connection'},
+      'cmdgrp': 'connection'},
      {'stdout': ['t1',
                  'server : http://blahblah',
                  'default-namespace', 'root/john',
@@ -855,17 +855,16 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-
     ['Delete testGeneralOpsMods.',
      {'args': ['delete', 'testGeneralOpsMods'],
-      'subcmd': 'connection', },
+      'cmdgrp': 'connection', },
      {'stdout': "",
       'test': 'innows'},
      None, OK],
 
     ['Delete testGeneralOpsMods.',
      {'args': ['delete', 't1'],
-      'subcmd': 'connection', },
+      'cmdgrp': 'connection', },
      {'stdout': "",
       'test': 'innows'},
      None, OK],
@@ -875,9 +874,9 @@ TEST_CASES = [
 # TODO add test for pull operations with pull ops max size variations
 
 
-class TestGlobalOptions(CLITestsBase):
+class TestGeneralOptions(CLITestsBase):
     """
-    Test the global options including statistics,  --server,
+    Test the general options including statistics,  --server,
     --timeout, --use-pull, --pull-max-cnt, --output-format
     """
     @pytest.mark.parametrize(
@@ -887,7 +886,7 @@ class TestGlobalOptions(CLITestsBase):
         """
         Execute pybemcli with the defined input and test output.
         """
-        subcmd = inputs['subcmd'] if inputs['subcmd'] else ''
+        cmd_grp = inputs['cmdgrp'] or ''
 
-        self.subcmd_test(desc, subcmd, inputs, exp_response,
-                         mock, condition, verbose=False)
+        self.command_test(desc, cmd_grp, inputs, exp_response,
+                          mock, condition, verbose=False)

--- a/tests/unit/test_instance_cmds.py
+++ b/tests/unit/test_instance_cmds.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Tests the class subcommand
+Tests the commands in the server command group.
 """
 from __future__ import absolute_import, print_function
 
@@ -298,52 +298,52 @@ FAIL = False  # Any test currently FAILING or not tested yet
 
 TEST_CASES = [
     # desc - Description of test
-    # inputs - String, or list of args or dict of 'env', 'args', 'globals',
-    #          and 'stdin'. See See CLITestsBase.subcmd_test()  for
+    # inputs - String, or list of args or dict of 'env', 'args', 'general',
+    #          and 'stdin'. See See CLITestsBase.command_test()  for
     #          detailed documentation
     # exp_response - Dictionary of expected responses (stdout, stderr, rc) and
     #                test definition (test: <testname>).
-    #                See CLITestsBase.subcmd_test() for detailed documentation.
+    #                See CLITestsBase.command_test() for detailed documentation.
     # mock - None or name of files (mof or .py),
     # condition - If True, the test is executed,  Otherwise it is skipped.
 
     #
     #   instance --help
     #
-    ['Verify instance subcommand --help response',
+    ['Verify instance command --help response',
      '--help',
      {'stdout': INSTANCE_HELP_LINES,
       'test': 'insnows'},
      None, OK],
 
-    ['Verify instance subcommand -h response',
+    ['Verify instance command -h response',
      '-h',
      {'stdout': INSTANCE_HELP_LINES,
       'test': 'insnows'},
      None, OK],
 
     #
-    #  Instance Enumerate subcommand good responses
+    #  Instance Enumerate command good responses
     #
-    ['Verify instance subcommand enumerate --help response',
+    ['Verify instance command enumerate --help response',
      ['enumerate', '--help'],
      {'stdout': INSTANCE_ENUMERATE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand enumerate -h response',
+    ['Verify instance command enumerate -h response',
      ['enumerate', '-h'],
      {'stdout': INSTANCE_ENUMERATE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand enumerate CIM_Foo',
+    ['Verify instance command enumerate CIM_Foo',
      ['enumerate', 'CIM_Foo'],
      {'stdout': ENUM_INSTANCE_RESP,
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate names CIM_Foo --no',
+    ['Verify instance command enumerate names CIM_Foo --no',
      ['enumerate', 'CIM_Foo', '--no'],
      {'stdout': ['', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
                  '', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"',
@@ -351,13 +351,13 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate names CIM_Foo --no -s',
+    ['Verify instance command enumerate names CIM_Foo --no -s',
      ['enumerate', 'CIM_Foo', '--no', '--summary'],
      {'stdout': ['3 CIMInstanceName(s) returned'],
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate names CIM_Foo --no --namespace',
+    ['Verify instance command enumerate names CIM_Foo --no --namespace',
      ['enumerate', 'CIM_Foo', '--no', '--namespace', 'root/cimv2'],
      {'stdout': ['', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
                  '', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"',
@@ -365,25 +365,25 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate CIM_Foo --include-qualifiers',
+    ['Verify instance command enumerate CIM_Foo --include-qualifiers',
      ['enumerate', 'CIM_Foo', '--include-qualifiers'],
      {'stdout': ENUM_INSTANCE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate CIM_Foo include-qualifiers and '
+    ['Verify instance command enumerate CIM_Foo include-qualifiers and '
      ' --use-pull no',
      {'args': ['enumerate', 'CIM_Foo', '--include-qualifiers'],
-      'global': ['--use-pull', 'no']},
+      'general': ['--use-pull', 'no']},
      {'stdout': ENUM_INSTANCE_RESP,
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate CIM_Foo with --use-pull yes and '
+    ['Verify instance command enumerate CIM_Foo with --use-pull yes and '
      '--pull-max-cnt=2',
      {'args': ['enumerate', 'CIM_Foo', '--include-qualifiers'],
-      'global': ['--use-pull', 'yes', '--pull-max-cnt', '2', '--log',
-                 'all=stderr']},
+      'general': ['--use-pull', 'yes', '--pull-max-cnt', '2', '--log',
+                  'all=stderr']},
      {'stderr': [r'PullInstancesWithPath\(pull_inst_result_tuple\(context='
                  'None, eos=True,',
                  r'PullInstancesWithPath\(MaxObjectCount=2',
@@ -391,11 +391,11 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate CIM_Foo with --use-pull yes and '
+    ['Verify instance command enumerate CIM_Foo with --use-pull yes and '
      '--pull-max-cnt=2 and --namesonly',
      {'args': ['enumerate', 'CIM_Foo', '--names-only'],
-      'global': ['--use-pull', 'yes', '--pull-max-cnt', '2', '--log',
-                 'all=stderr']},
+      'general': ['--use-pull', 'yes', '--pull-max-cnt', '2', '--log',
+                  'all=stderr']},
      {'stderr': [r'PullInstancePaths\(pull_path_result_tuple\(context='
                  'None, eos=True,',
                  r'PullInstancePaths\(MaxObjectCount=2',
@@ -403,30 +403,30 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate deep-inheritance CIM_Foo --di',
+    ['Verify instance command enumerate deep-inheritance CIM_Foo --di',
      ['enumerate', 'CIM_Foo', '--di'],
      {'stdout': ENUM_INSTANCE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate deep-inheritance CIM_Foo '
+    ['Verify instance command enumerate deep-inheritance CIM_Foo '
      '--deep-inheritance',
      ['enumerate', 'CIM_Foo', '--deep-inheritance'],
      {'stdout': ENUM_INSTANCE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand -o grid enumerate deep-inheritance CIM_Foo '
+    ['Verify instance command -o grid enumerate deep-inheritance CIM_Foo '
      '--di',
      {'args': ['enumerate', 'CIM_Foo', '--di'],
-      'global': ['--output-format', 'grid']},
+      'general': ['--output-format', 'grid']},
      {'stdout': ENUM_INSTANCE_TABLE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand -o grid enumerate di CIM_Foo --di -o',
+    ['Verify instance command -o grid enumerate di CIM_Foo --di -o',
      {'args': ['enumerate', 'CIM_Foo', '--di', '--no'],
-      'global': ['--output-format', 'grid']},
+      'general': ['--output-format', 'grid']},
      {'stdout': """InstanceNames: CIM_Foo
 +--------+-------------+---------+-----------------------+
 | host   | namespace   | class   | keysbindings          |
@@ -441,9 +441,9 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand -o grid enumerate di CIM_Foo --di --no',
+    ['Verify instance command -o grid enumerate di CIM_Foo --di --no',
      {'args': ['enumerate', 'CIM_Foo', '--di', '--no'],
-      'global': ['--output-format', 'txt']},
+      'general': ['--output-format', 'txt']},
      {'stdout': ['root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
                  'root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"',
                  'root/cimv2:CIM_Foo.InstanceID="CIM_Foo3"'],
@@ -451,9 +451,9 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
 
-    ['Verify instance subcommand -o grid enumerate di CIM_Foo -d -o',
+    ['Verify instance command -o grid enumerate di CIM_Foo -d -o',
      {'args': ['enumerate', 'CIM_Foo'],
-      'global': ['--output-format', 'txt']},
+      'general': ['--output-format', 'txt']},
      {'stdout': ["CIMInstance(classname='CIM_Foo', "
                  "path=CIMInstanceName(classname='CIM_Foo', "
                  "keybindings=NocaseDict({'InstanceID': 'CIM_Foo1'}), "
@@ -469,10 +469,10 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand -o grid enumerate di alltypes, datetime',
+    ['Verify instance command -o grid enumerate di alltypes, datetime',
      {'args': ['enumerate', 'Pywbem_Alltypes', '--di',
                '--propertylist', 'scalDateTime', '--pl', 'scalTimeDelta'],
-      'global': ['--output-format', 'grid']},
+      'general': ['--output-format', 'grid']},
      {'stdout': ["""Instances: PyWBEM_AllTypes
 +-----------------------------+
 | scalDateTime                |
@@ -485,15 +485,15 @@ TEST_CASES = [
 
     # TODO: modify this to output log and test for info in return and log
 
-    ['Verify instance subcommand enumerate with query.',
+    ['Verify instance command enumerate with query.',
      ['enumerate', 'CIM_Foo', '--filter-query', 'InstanceID = 3'],
      {'stdout': ENUM_INSTANCE_RESP,
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate with query, traditional ops fails',
+    ['Verify instance command enumerate with query, traditional ops fails',
      {'args': ['enumerate', 'CIM_Foo', '--filter-query', 'InstanceID = 3'],
-      'global': ['--use-pull', 'no']},
+      'general': ['--use-pull', 'no']},
      {'stderr': ["ValueError",
                  "EnumerateInstances does not support FilterQuery"],
       'rc': 1,
@@ -501,9 +501,9 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
 
-    ['Verify subcommand enumerate with CIM_Foo inst name table output',
+    ['Verify command enumerate with CIM_Foo inst name table output',
      {'args': ['enumerate', 'CIM_Foo', '--names-only'],
-      'global': ['--output-format', 'table']},
+      'general': ['--output-format', 'table']},
      {'stdout': """InstanceNames: CIM_Foo
 +--------+-------------+---------+-----------------------+
 | host   | namespace   | class   | keysbindings          |
@@ -518,9 +518,9 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify subcommand enumerate with CIM_Foo summary table output',
+    ['Verify command enumerate with CIM_Foo summary table output',
      {'args': ['enumerate', 'CIM_Foo', '--summary'],
-      'global': ['--output-format', 'table']},
+      'general': ['--output-format', 'table']},
      {'stdout': """Summary of CIMInstance returned
 +---------+-------------+
 |   Count | CIM Type    |
@@ -533,12 +533,12 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     # TODO the following uses deep-inheritance because of issue in pywbem_mock
-    ['Verify subcommand enumerate with PyWBEM_AllTypes table with scalar '
+    ['Verify command enumerate with PyWBEM_AllTypes table with scalar '
      'properties returns instance with all property types',
      {'args': ['enumerate', 'PyWBEM_AllTypes', '--deep-inheritance',
                '--propertylist',
                'instanceid,scalbool,scaluint32,scalsint32'],
-      'global': ['--output-format', 'grid']},
+      'general': ['--output-format', 'grid']},
      {'stdout': """
 Instances: PyWBEM_AllTypes
 +-----------------+------------+--------------+--------------+
@@ -551,12 +551,12 @@ Instances: PyWBEM_AllTypes
       'test': 'linesnows'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify subcommand enumerate with PyWBEM_AllTypes with array properties '
+    ['Verify command enumerate with PyWBEM_AllTypes with array properties '
      'returns instance with all property types',
      {'args': ['enumerate', 'PyWBEM_AllTypes', '--deep-inheritance',
                '--propertylist',
                'instanceid,arraybool,arrayuint32,arraysint32'],
-      'global': ['--output-format', 'grid']},
+      'general': ['--output-format', 'grid']},
      {'stdout': """
 Instances: PyWBEM_AllTypes
 +-----------------+-------------+---------------+---------------+
@@ -573,14 +573,14 @@ Instances: PyWBEM_AllTypes
     #
     # instance enumerate error returns
     #
-    ['Verify instance subcommand enumerate error, invalid classname fails',
+    ['Verify instance command enumerate error, invalid classname fails',
      ['enumerate', 'CIM_Foox'],
      {'stderr': ["Error: CIMError: 6"],
       'rc': 1,
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate error, no classname fails',
+    ['Verify instance command enumerate error, no classname fails',
      ['enumerate'],
      {'stderr':
       ['Usage: pywbemcli instance enumerate [COMMAND-OPTIONS] CLASSNAME', ],
@@ -588,7 +588,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate error, invalid namespace',
+    ['Verify instance command enumerate error, invalid namespace',
      ['enumerate', 'CIM_Foo', '--namespace', 'root/blah'],
      {'stderr':
       ["CIMError: 3 (CIM_ERR_INVALID_NAMESPACE): Namespace does not exist in "
@@ -597,7 +597,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate fails invalid query language',
+    ['Verify instance command enumerate fails invalid query language',
      ['enumerate', 'CIM_Foo', '--filter-query-language', 'blah',
       '--filter-query', 'InstanceID = 3'],
      {'stderr': ['CIMError', '14', 'CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED'],
@@ -605,9 +605,9 @@ Instances: PyWBEM_AllTypes
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand enumerate fails using traditional op',
+    ['Verify instance command enumerate fails using traditional op',
      {'args': ['enumerate', 'CIM_Foo', '--filter-query', 'InstanceID = 3'],
-      'global': ['--use-pull', 'no']},
+      'general': ['--use-pull', 'no']},
      {'stderr':
       ['ValueError', 'EnumerateInstances does not support FilterQuery'],
       'rc': 1,
@@ -615,24 +615,24 @@ Instances: PyWBEM_AllTypes
      SIMPLE_MOCK_FILE, OK],
 
     #
-    #  instance get subcommand
+    #  instance get command
     #
 
-    ['Verify instance subcommand get --help response',
+    ['Verify instance command get --help response',
      ['get', '--help'],
      {'stdout': INSTANCE_GET_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand get -h response',
+    ['Verify instance command get -h response',
      ['get', '-h'],
      {'stdout': INSTANCE_GET_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand get with instancename returns data',
+    ['Verify instance command get with instancename returns data',
      ['get', 'CIM_Foo.InstanceID="CIM_Foo1"'],
      {'stdout': ['instance of CIM_Foo {',
                  '   InstanceID = "CIM_Foo1";',
@@ -643,7 +643,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with instancename, namespace returns data',
+    ['Verify instance command get with instancename, namespace returns data',
      ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--namespace', 'root/cimv2'],
      {'stdout': ['instance of CIM_Foo {',
                  '   InstanceID = "CIM_Foo1";',
@@ -654,7 +654,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with instancename local_only returns data',
+    ['Verify instance command get with instancename local_only returns data',
      ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--lo'],
      {'stdout': ['instance of CIM_Foo {',
                  '   InstanceID = "CIM_Foo1";',
@@ -665,7 +665,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with instancename --local-only returns '
+    ['Verify instance command get with instancename --local-only returns '
      ' data',
      ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--local-only'],
      {'stdout': ['instance of CIM_Foo {',
@@ -677,7 +677,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with instancename --include-qualifiers '
+    ['Verify instance command get with instancename --include-qualifiers '
      'returns data',
      ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--include-qualifiers'],
      {'stdout': ['instance of CIM_Foo {',
@@ -689,10 +689,10 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with instancename --include-qualifiers '
+    ['Verify instance command get with instancename --include-qualifiers '
      'and general --use-pull returns data',
      {'args': ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--iq'],
-      'global': ['--use-pull', 'no']},
+      'general': ['--use-pull', 'no']},
      {'stdout': ['instance of CIM_Foo {',
                  '   InstanceID = "CIM_Foo1";',
                  '   IntegerProp = 1;',
@@ -702,7 +702,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with instancename prop list -p returns '
+    ['Verify instance command get with instancename prop list -p returns '
      ' one property',
      ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--pl', 'InstanceID'],
      {'stdout': ['instance of CIM_Foo {',
@@ -713,7 +713,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with instancename prop list '
+    ['Verify instance command get with instancename prop list '
      '--propertylist returns property',
      ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--propertylist', 'InstanceID'],
      {'stdout': ['instance of CIM_Foo {',
@@ -724,7 +724,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with instancename prop list -p  '
+    ['Verify instance command get with instancename prop list -p  '
      ' InstanceID,IntegerProp returns 2 properties',
      ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--pl', 'InstanceID,IntegerProp'],
      {'stdout': ['instance of CIM_Foo {',
@@ -736,7 +736,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with instancename prop list -p '
+    ['Verify instance command get with instancename prop list -p '
      ' multiple instances of option returns 2 properties',
      ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--pl', 'InstanceID',
       '--pl', 'IntegerProp'],
@@ -749,7 +749,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with instancename empty  prop list '
+    ['Verify instance command get with instancename empty  prop list '
      'returns  empty instance',
      ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--pl', '""'],
      {'stdout': ['instance of CIM_Foo {',
@@ -759,7 +759,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with instancename PyWBEM_AllTypes'
+    ['Verify instance command get with instancename PyWBEM_AllTypes'
      ' returns instance with all property types',
      ['get', 'PyWBEM_AllTypes.InstanceID="test_instance"'],
      {'stdout': GET_INSTANCE_ALL_TYPES,
@@ -767,14 +767,14 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand -o grid get CIM_Foo',
+    ['Verify instance command -o grid get CIM_Foo',
      {'args': ['get', 'CIM_Foo.InstanceID="CIM_Foo1"'],
-      'global': ['-o', 'simple']},
+      'general': ['-o', 'simple']},
      {'stdout': ENUM_INSTANCE_GET_TABLE_RESP,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with interactive option',
+    ['Verify instance command get with interactive option',
      ['get', 'TST_Person', '-i'],
      {'stdout':
       ['root/cimv2:TST_Person.name="Mike"',
@@ -783,7 +783,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
 
-    ['Verify instance subcommand get with interactive option',
+    ['Verify instance command get with interactive option',
      ['get', 'TST_Person', '--interactive'],
      {'stdout':
       ['root/cimv2:TST_Person.name="Mike"',
@@ -793,9 +793,9 @@ Instances: PyWBEM_AllTypes
      [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
 
     #
-    #  get subcommand errors
+    #  get command errors
     #
-    ['instance subcommand get error. no classname',
+    ['instance command get error. no classname',
      ['get'],
      {'stderr':
       ['Usage: pywbemcli instance get [COMMAND-OPTIONS] INSTANCENAME', ],
@@ -803,7 +803,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['instance subcommand get error. invalid namespace',
+    ['instance command get error. invalid namespace',
      ['get', 'CIM_Foo.InstanceID="CIM_Foo1"',
       '--namespace', 'root/invalidnamespace'],
      {'stderr':
@@ -813,7 +813,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand get with none existentinstancename',
+    ['Verify instance command get with none existentinstancename',
      ['get', 'CIM_Foo.InstanceID="CIM_NOTEXIST"'],
      {'stderr': ["Error: CIMError: 6 (CIM_ERR_NOT_FOUND): Instance not found "
                  "in repository namespace 'root/cimv2'. Path=CIMInstanceName("
@@ -824,30 +824,30 @@ Instances: PyWBEM_AllTypes
      SIMPLE_MOCK_FILE, OK],
 
     #
-    #  instance create subcommand
+    #  instance create command
     #
-    ['Verify instance subcommand create --help response',
+    ['Verify instance command create --help response',
      ['create', '--help'],
      {'stdout': INSTANCE_CREATE_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand create -h response',
+    ['Verify instance command create -h response',
      ['create', '-h'],
      {'stdout': INSTANCE_CREATE_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand create, new instance of CIM_Foo one property',
+    ['Verify instance command create, new instance of CIM_Foo one property',
      ['create', 'CIM_Foo', '-p', 'InstanceID=blah'],
      {'stdout': 'root/cimv2:CIM_Foo.InstanceID="blah"',
       'rc': 0,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand create, new instance of CIM_Foo one '
+    ['Verify instance command create, new instance of CIM_Foo one '
      'property and verify yes',
      ['create', 'CIM_Foo', '-p', 'InstanceID=blah', '--verify'],
      {'stdout': ['instance of CIM_Foo {',
@@ -858,7 +858,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in '},
      [SIMPLE_MOCK_FILE, MOCK_CONFIRM_Y_FILE], OK],
 
-    ['Verify instance subcommand create, new instance of CIM_Foo one '
+    ['Verify instance command create, new instance of CIM_Foo one '
      'property and verify no',
      ['create', 'CIM_Foo', '-p', 'InstanceID=blah', '--verify'],
      {'stdout': ['instance of CIM_Foo {',
@@ -870,7 +870,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in '},
      [SIMPLE_MOCK_FILE, MOCK_CONFIRM_N_FILE], OK],
 
-    ['Verify instance subcommand create, new instance of CIM_Foo, '
+    ['Verify instance command create, new instance of CIM_Foo, '
      'one property, explicit namespace definition',
      ['create', 'CIM_Foo', '-p', 'InstanceID=blah', '-n', 'root/cimv2'],
      {'stdout': "",
@@ -888,7 +888,7 @@ Instances: PyWBEM_AllTypes
       'test': 'regex'},
      None, FAIL],
 
-    ['Verify instance subcommand create, new instance of all_types '
+    ['Verify instance command create, new instance of all_types '
      'with scalar types',
      ['create', 'PyWBEM_AllTypes',
       '-p', 'InstanceID=BunchOfValues',
@@ -904,7 +904,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand create, new instance of all_types '
+    ['Verify instance command create, new instance of all_types '
      "with array values",
      ['create', 'PyWBEM_AllTypes',
       '-p', 'InstanceID=blah',
@@ -920,7 +920,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand create, new instance Error in Property Type'
+    ['Verify instance command create, new instance Error in Property Type'
      " with array values",
      ['create', 'PyWBEM_AllTypes', '-p', 'InstanceID=blah',
       '-p', 'arrayBool=8,9',
@@ -937,7 +937,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand create, new instance already exists',
+    ['Verify instance command create, new instance already exists',
      ['create', 'PyWBEM_AllTypes', '-p', 'InstanceID=test_instance'],
      {'stderr': ['Error: CIMClass: "PyWBEM_AllTypes" does not exist in ',
                  'namespace "root/cimv2" in WEB server: FakedWBEMConnection'],
@@ -945,7 +945,7 @@ Instances: PyWBEM_AllTypes
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand create, new instance invalid ns',
+    ['Verify instance command create, new instance invalid ns',
      ['create', 'PyWBEM_AllTypes', '-p', 'InstanceID=test_instance', '-n',
       'blah'],
      {'stderr': ["Error: Exception 3", "CIM_ERR_INVALID_NAMESPACE"],
@@ -954,7 +954,7 @@ Instances: PyWBEM_AllTypes
      SIMPLE_MOCK_FILE, OK],
 
 
-    ['Verify instance subcommand create, new instance invalid class',
+    ['Verify instance command create, new instance invalid class',
      ['create', 'CIM_blah', '-p', 'InstanceID=test_instance'],
      {'stderr': ["Error:", "CIMClass"],
       'rc': 1,
@@ -965,23 +965,23 @@ Instances: PyWBEM_AllTypes
     # We have not repeated a bunch of those in for the CreateInstance
 
     #
-    #  instance modify subcommand
+    #  instance modify command
     #
-    ['Verify instance subcommand modify --help response',
+    ['Verify instance command modify --help response',
      ['modify', '--help'],
      {'stdout': INSTANCE_MODIFY_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand modify -h response',
+    ['Verify instance command modify -h response',
      ['modify', '-h'],
      {'stdout': INSTANCE_MODIFY_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand modify, single good change',
+    ['Verify instance command modify, single good change',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
       '-p', 'scalBool=False'],
      {'stdout': "",
@@ -989,7 +989,7 @@ Instances: PyWBEM_AllTypes
       'test': 'linesnows'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand modify, single good change with verify yes',
+    ['Verify instance command modify, single good change with verify yes',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
       '-p', 'scalBool=False', '--verify'],
      {'stdout': ['instance of PyWBEM_AllTypes {',
@@ -1000,7 +1000,7 @@ Instances: PyWBEM_AllTypes
       'test': 'regex'},
      [ALLTYPES_MOCK_FILE, MOCK_CONFIRM_Y_FILE], OK],
 
-    ['Verify instance subcommand modify, single good change with verify no',
+    ['Verify instance command modify, single good change with verify no',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
       '-p', 'scalBool=False', '--verify'],
      {'stdout': ['instance of PyWBEM_AllTypes {',
@@ -1012,7 +1012,7 @@ Instances: PyWBEM_AllTypes
      [ALLTYPES_MOCK_FILE, MOCK_CONFIRM_N_FILE], OK],
 
 
-    ['Verify instance subcommand modify, single good change, explicit ns',
+    ['Verify instance command modify, single good change, explicit ns',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"', '-n',
       'root/cimv2', '-p', 'scalBool=False'],
      {'stdout': "",
@@ -1020,7 +1020,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand modify, single good change, explicit ns',
+    ['Verify instance command modify, single good change, explicit ns',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"', '--namespace',
       'root/cimv2', '--property', 'scalBool=False'],
      {'stdout': "",
@@ -1028,7 +1028,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand modify, multiple good change',
+    ['Verify instance command modify, multiple good change',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
       '-p', 'scalBool=False',
       '-p', 'arrayBool=true,false,true',
@@ -1043,7 +1043,7 @@ Instances: PyWBEM_AllTypes
     #
     # Instance modify errors
     #
-    ['Verify instance subcommand modify, invalid class',
+    ['Verify instance command modify, invalid class',
      ['modify', 'PyWBEM_AllTypesxxx.InstanceID="test_instance"',
       '-p', 'scalBool=9'],
      {'stderr': ["CIMClass:", "PyWBEM_AllTypesxxx",
@@ -1053,7 +1053,7 @@ Instances: PyWBEM_AllTypes
       'test': 'regex'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand modify, single property, Type Error bool',
+    ['Verify instance command modify, single property, Type Error bool',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
       '-p', 'scalBool=9'],
      {'stderr': "Error: Type mismatch property 'scalBool' between expected "
@@ -1063,7 +1063,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand modify, single property, Fail modifies key',
+    ['Verify instance command modify, single property, Fail modifies key',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
       '-p', 'InstanceID=9'],
      {'stderr': 'Error: Server Error modifying instance. Exception: CIMError:'
@@ -1073,7 +1073,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand modify, single property, Type Error uint32. '
+    ['Verify instance command modify, single property, Type Error uint32. '
      'Uses regex because Exception msg different between python 2 and 3',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
       '-p', 'scalUint32=Fred'],
@@ -1084,7 +1084,7 @@ Instances: PyWBEM_AllTypes
       'test': 'regex'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand modify, single Property arrayness error',
+    ['Verify instance command modify, single Property arrayness error',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
       '-p', 'scalBool=False,True'],
      {'stderr': "Error: Type mismatch property 'scalBool' between expected "
@@ -1094,7 +1094,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand modify, Error value types mismatch with array',
+    ['Verify instance command modify, Error value types mismatch with array',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
       '-p', 'arrayBool=9,8'],
      {'stderr': "Error: Type mismatch property 'arrayBool' between expected "
@@ -1104,7 +1104,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand modify, Error different value types',
+    ['Verify instance command modify, Error different value types',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
       '-p', 'arrayBool=true,8'],
      {'stderr': "Error: Type mismatch property 'arrayBool' between expected "
@@ -1114,7 +1114,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand modify, Error integer out of range',
+    ['Verify instance command modify, Error integer out of range',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
       '-p', 'arrayUint32=99999999999999999999999'],
      {'stderr': "Error: Type mismatch property 'arrayUint32' between expected "
@@ -1126,7 +1126,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance subcommand modify, Error property not in class',
+    ['Verify instance command modify, Error property not in class',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
       '-p', 'blah=9'],
      {'stderr': 'Error: Property name "blah" not in class "PyWBEM_AllTypes".',
@@ -1137,44 +1137,44 @@ Instances: PyWBEM_AllTypes
     # TODO additional modify error tests required
 
     #
-    #  instance delete subcommand
+    #  instance delete command
     #
-    ['Verify instance subcommand delete --help response',
+    ['Verify instance command delete --help response',
      ['delete', '--help'],
      {'stdout': INSTANCE_DELETE_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand delete -h response',
+    ['Verify instance command delete -h response',
      ['delete', '-h'],
      {'stdout': INSTANCE_DELETE_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand delete, valid delete',
+    ['Verify instance command delete, valid delete',
      ['delete', 'CIM_Foo.InstanceID="CIM_Foo1"'],
      {'stdout': '',
       'rc': 0,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand delete, valid delete, explicit ns',
+    ['Verify instance command delete, valid delete, explicit ns',
      ['delete', 'CIM_Foo.InstanceID="CIM_Foo1"', '-n', 'root/cimv2'],
      {'stdout': '',
       'rc': 0,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand delete, valid delete, explicit ns',
+    ['Verify instance command delete, valid delete, explicit ns',
      ['delete', 'CIM_Foo.InstanceID="CIM_Foo1"', '--namespace', 'root/cimv2'],
      {'stdout': '',
       'rc': 0,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand delete with interactive option',
+    ['Verify instance command delete with interactive option',
      ['delete', 'TST_Person', '-i'],
      {'stdout':
       ['root/cimv2:TST_Person.name="Mike"'],
@@ -1182,7 +1182,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
 
-    ['Verify instance subcommand delete with interactive option',
+    ['Verify instance command delete with interactive option',
      ['delete', 'TST_Person', '--interactive'],
      {'stdout':
       ['root/cimv2:TST_Person.name="Mike"'],
@@ -1191,9 +1191,9 @@ Instances: PyWBEM_AllTypes
      [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
 
     #
-    # Delete subcommand error tests
+    # Delete command error tests
     #
-    ['Verify instance subcommand delete, missing instance name',
+    ['Verify instance command delete, missing instance name',
      ['delete'],
      {'stderr':
       ['Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME', ],
@@ -1201,7 +1201,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand delete, instance name invalid',
+    ['Verify instance command delete, instance name invalid',
      ['delete', "blah"],
      {'stderr':
       ['Invalid wbem uri', ],
@@ -1209,7 +1209,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand delete, instance name not in repo',
+    ['Verify instance command delete, instance name not in repo',
      ['delete', 'CIM_Foo.InstanceID="xxxxx"', '--namespace', 'root/cimv2'],
      {'stderr':
       ["CIMError", "6", "CIM_ERR_NOT_FOUND"],
@@ -1217,7 +1217,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand delete, namespace not in repo',
+    ['Verify instance command delete, namespace not in repo',
      ['delete', 'CIM_Foo.InstanceID=1', '--namespace', 'Argh'],
      {'stderr':
       ["CIMError", "3", "CIM_ERR_INVALID_NAMESPACE"],
@@ -1226,37 +1226,37 @@ Instances: PyWBEM_AllTypes
      SIMPLE_MOCK_FILE, OK],
 
     #
-    #  instance references subcommand
+    #  instance references command
     #
-    ['Verify instance subcommand references --help response',
+    ['Verify instance command references --help response',
      ['references', '--help'],
      {'stdout': INSTANCE_REFERENCES_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand references -h response',
+    ['Verify instance command references -h response',
      ['references', '-h'],
      {'stdout': INSTANCE_REFERENCES_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand references, returns instances',
+    ['Verify instance command references, returns instances',
      ['references', 'TST_Person.name="Mike"'],
      {'stdout': REF_INSTS,
       'rc': 0,
       'test': 'lineswons'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references, returns instances, explicit ns',
+    ['Verify instance command references, returns instances, explicit ns',
      ['references', 'TST_Person.name="Mike"', '-n', 'root/cimv2'],
      {'stdout': REF_INSTS,
       'rc': 0,
       'test': 'lineswons'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references --no, returns paths',
+    ['Verify instance command references --no, returns paths',
      ['references', 'TST_Person.name="Mike"', '--no'],
      {'stdout': ['"root/cimv2:TST_FamilyCollection.name=\\"Family2\\"",member',
                  '=\"root/cimv2:TST_Person.name=\\"Mike\\""',
@@ -1267,7 +1267,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references --no, returns paths with result '
+    ['Verify instance command references --no, returns paths with result '
      'class valid returns paths',
      ['references', 'TST_Person.name="Mike"', '--no',
       '--result-class', 'TST_Lineage'],
@@ -1277,11 +1277,11 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references CIM_Foo with --use-pull yes '
+    ['Verify instance command references CIM_Foo with --use-pull yes '
      'and --pull-max-cnt=1',
      {'args': ['references', 'TST_Person.name="Mike"'],
-      'global': ['--use-pull', 'yes', '--pull-max-cnt', '1', '--log',
-                 'all=stderr']},
+      'general': ['--use-pull', 'yes', '--pull-max-cnt', '1', '--log',
+                  'all=stderr']},
      {'stderr': [r'PullInstancesWithPath\(MaxObjectCount=1',
                  r'OpenReferenceInstances\(pull_inst_result_tuple\('
                  'context=',
@@ -1290,11 +1290,11 @@ Instances: PyWBEM_AllTypes
       'test': 'regex'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand reference paths CIM_Foo with --use-pull '
+    ['Verify instance command reference paths CIM_Foo with --use-pull '
      'yes and --pull-max-cnt=1 and --names-only',
      {'args': ['references', 'TST_Person.name="Mike"', '--names-only'],
-      'global': ['--use-pull', 'yes', '--pull-max-cnt', '1', '--log',
-                 'all=stderr']},
+      'general': ['--use-pull', 'yes', '--pull-max-cnt', '1', '--log',
+                  'all=stderr']},
      {'stderr': [r'PullInstancePaths\(MaxObjectCount=1',
                  r'OpenReferenceInstancePaths\(pull_path_result_tuple\('
                  'context=',
@@ -1303,7 +1303,7 @@ Instances: PyWBEM_AllTypes
       'test': 'regex'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references -o, returns paths with result '
+    ['Verify instance command references -o, returns paths with result '
      'class valid returns paths sorted',
      ['references', 'TST_Person.name="Mike"', '--no',
       '--result-class', 'TST_Lineage'],
@@ -1313,7 +1313,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references -o, returns paths with result '
+    ['Verify instance command references -o, returns paths with result '
      'class short form valid returns paths',
      ['references', 'TST_Person.name="Mike"', '--no',
       '--rc', 'TST_Lineage'],
@@ -1323,7 +1323,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references --no, returns paths with result '
+    ['Verify instance command references --no, returns paths with result '
      'class short form valid returns paths',
      ['references', 'TST_Person.name="Mike"', '--no', '--summary',
       '--rc', 'TST_Lineage'],
@@ -1333,11 +1333,11 @@ Instances: PyWBEM_AllTypes
      ASSOC_MOCK_FILE, OK],
 
 
-    ['Verify instance subcommand references --no, returns paths with result '
+    ['Verify instance command references --no, returns paths with result '
      'class short form valid returns paths',
      {'args': ['references', 'TST_Person.name="Mike"', '--no', '--summary',
                '--rc', 'TST_Lineage'],
-      'global': ['--output-format', 'table']},
+      'general': ['--output-format', 'table']},
      {'stdout': ["""Summary of CIMInstanceName returned
 +---------+-----------------+
 |   Count | CIM Type        |
@@ -1349,7 +1349,7 @@ Instances: PyWBEM_AllTypes
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references -s, returns paths with result '
+    ['Verify instance command references -s, returns paths with result '
      'class short form valid returns paths',
      ['references', 'TST_Person.name="Mike"', '-s',
       '--rc', 'TST_Lineage'],
@@ -1358,22 +1358,22 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references --include-qualifiers',
+    ['Verify instance command references --include-qualifiers',
      ['references', 'TST_Person.name="Mike"', '--include-qualifiers'],
      {'stdout': REF_INSTS,
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references include-qualifiers and '
+    ['Verify instance command references include-qualifiers and '
      ' --use-pull no',
      {'args': ['references', 'TST_Person.name="Mike"', '--include-qualifiers'],
-      'global': ['--use-pull', 'no']},
+      'general': ['--use-pull', 'no']},
      {'stdout': REF_INSTS,
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
 
-    ['Verify instance subcommand references -o, returns paths with result '
+    ['Verify instance command references -o, returns paths with result '
      'class not a real ref returns no paths',
      ['references', 'TST_Person.name="Mike"', '--no',
       '--result-class', 'TST_Lineagex'],
@@ -1382,7 +1382,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references, no instance name',
+    ['Verify instance command references, no instance name',
      ['references'],
      {'stderr': ['Usage: pywbemcli instance references [COMMAND-OPTIONS] '
                  'INSTANCENAME', ],
@@ -1390,14 +1390,14 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references, invalid instance name',
+    ['Verify instance command references, invalid instance name',
      ['references', 'TST_Blah.blah="abc"'],
      {'stdout': "",
       'rc': 0,
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references with interactive option -i',
+    ['Verify instance command references with interactive option -i',
      ['references', 'TST_Person', '-i'],
      {'stdout':
       ['root/cimv2:TST_Person.name="Mike"',
@@ -1407,7 +1407,7 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
 
-    ['Verify instance subcommand references with interactive option '
+    ['Verify instance command references with interactive option '
      '--interactive',
      ['references', 'TST_Person', '--interactive'],
      {'stdout':
@@ -1418,17 +1418,17 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
 
-    ['Verify instance subcommand references with query.',
+    ['Verify instance command references with query.',
      ['references', 'TST_Person.name="Mike"', '--filter-query',
       'InstanceID = 3'],
      {'stdout': REF_INSTS,
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand references with query, traditional ops fails',
+    ['Verify instance command references with query, traditional ops fails',
      {'args': ['references', 'TST_Person.name="Mike"', '--filter-query',
                'InstanceID = 3'],
-      'global': ['--use-pull', 'no']},
+      'general': ['--use-pull', 'no']},
      {'stderr': ["ValueError:",
                  "References does not support FilterQuery"],
       'rc': 1,
@@ -1438,38 +1438,38 @@ Instances: PyWBEM_AllTypes
     # TODO add more invalid references tests
 
     #
-    #  instance associators subcommand
+    #  instance associators command
     #
-    ['Verify instance subcommand associators --help response',
+    ['Verify instance command associators --help response',
      ['associators', '--help'],
      {'stdout': INSTANCE_ASSOCIATORS_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand associators -h response',
+    ['Verify instance command associators -h response',
      ['associators', '-h'],
      {'stdout': INSTANCE_ASSOCIATORS_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand associators, returns instances',
+    ['Verify instance command associators, returns instances',
      ['associators', 'TST_Person.name="Mike"'],
      {'stdout': ASSOC_INSTS,
       'rc': 0,
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand associators, --include-qualifiers',
+    ['Verify instance command associators, --include-qualifiers',
      ['associators', 'TST_Person.name="Mike"', '--include-qualifiers'],
      {'stdout': ASSOC_INSTS,
       'rc': 0,
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand associators, --include-qualifiers wo pull',
-     {'global': ['--use-pull', 'no'],
+    ['Verify instance command associators, --include-qualifiers wo pull',
+     {'general': ['--use-pull', 'no'],
       'args': ['associators', 'TST_Person.name="Mike"',
                '--include-qualifiers']},
      {'stdout': ASSOC_INSTS,
@@ -1477,7 +1477,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand associators -o, returns data',
+    ['Verify instance command associators -o, returns data',
      ['associators', 'TST_Person.name="Mike"', '--no'],
      {'stdout': ['//FakedUrl/root/cimv2:TST_FamilyCollection.name="Family2"'
                  '//FakedUrl/root/cimv2:TST_Person.name="Gabi"',
@@ -1486,11 +1486,11 @@ Instances: PyWBEM_AllTypes
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand associators CIM_Foo with --use-pull yes '
+    ['Verify instance command associators CIM_Foo with --use-pull yes '
      'and --pull-max-cnt=1',
      {'args': ['associators', 'TST_Person.name="Mike"'],
-      'global': ['--use-pull', 'yes', '--pull-max-cnt', '1', '--log',
-                 'all=stderr']},
+      'general': ['--use-pull', 'yes', '--pull-max-cnt', '1', '--log',
+                  'all=stderr']},
      {'stderr': [r'PullInstancesWithPath\(MaxObjectCount=1',
                  r'OpenAssociatorInstances\(pull_inst_result_tuple\('
                  'context=',
@@ -1498,11 +1498,11 @@ Instances: PyWBEM_AllTypes
       'test': 'regex'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand associator paths CIM_Foo with --use-pull '
+    ['Verify instance command associator paths CIM_Foo with --use-pull '
      'yes and --pull-max-cnt=1 and --names-only',
      {'args': ['associators', 'TST_Person.name="Mike"', '--names-only'],
-      'global': ['--use-pull', 'yes', '--pull-max-cnt', '1', '--log',
-                 'all=stderr']},
+      'general': ['--use-pull', 'yes', '--pull-max-cnt', '1', '--log',
+                  'all=stderr']},
      {'stderr': [r'PullInstancePaths\(MaxObjectCount=1',
                  r'OpenAssociatorInstancePaths\(pull_path_result_tuple\('
                  'context=',
@@ -1512,7 +1512,7 @@ Instances: PyWBEM_AllTypes
 
     # Invalid associators tests
 
-    ['Verify instance subcommand associators, no instance name',
+    ['Verify instance command associators, no instance name',
      ['associators'],
      {'stderr': ['Usage: pywbemcli instance associators [COMMAND-OPTIONS] '
                  'INSTANCENAME', ],
@@ -1520,14 +1520,14 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand associators, invalid instance name',
+    ['Verify instance command associators, invalid instance name',
      ['associators', 'TST_Blah.blah="abc"'],
      {'stdout': '',
       'rc': 0,
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand associators with interactive option -i',
+    ['Verify instance command associators with interactive option -i',
      ['associators', 'TST_Person', '-i'],
      {'stdout':
       ['root/cimv2:TST_Person.name="Mike"',
@@ -1537,17 +1537,17 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
 
-    ['Verify instance subcommand associators with query.',
+    ['Verify instance command associators with query.',
      ['associators', 'TST_Person.name="Mike"', '--filter-query',
       'InstanceID = 3'],
      {'stdout': ASSOC_INSTS,
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance subcommand associators with query, traditional ops',
+    ['Verify instance command associators with query, traditional ops',
      {'args': ['associators', 'TST_Person.name="Mike"', '--filter-query',
                'InstanceID = 3'],
-      'global': ['--use-pull', 'no']},
+      'general': ['--use-pull', 'no']},
      {'stderr': ["ValueError:",
                  "Associators does not support FilterQuery"],
       'rc': 1,
@@ -1557,23 +1557,23 @@ Instances: PyWBEM_AllTypes
     # TODO add more associators error tests
 
     #
-    #  instance count subcommand
+    #  instance count command
     #
-    ['Verify instance subcommand count --help response',
+    ['Verify instance command count --help response',
      ['count', '--help'],
      {'stdout': INSTANCE_COUNT_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand count -h response',
+    ['Verify instance command count -h response',
      ['count', '-h'],
      {'stdout': INSTANCE_COUNT_HELP_LINES,
       'rc': 0,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand count, Return table of instances',
+    ['Verify instance command count, Return table of instances',
      ['count', 'CIM_*'],
      {'stdout': ['Count of instances per class',
                  '+---------+---------+',
@@ -1585,7 +1585,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance subcommand count sorted, Return table of instances',
+    ['Verify instance command count sorted, Return table of instances',
      ['count', 'CIM_*', '--sort'],
      {'stdout': ['Count of instances per class',
                  '+-----------------+---------+',
@@ -1599,7 +1599,7 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE_EXT, OK],
 
-    ['Verify instance subcommand count. Return table of instances',
+    ['Verify instance command count. Return table of instances',
      ['count', 'CIM_*'],
      {'stdout': ['Count of instances per class',
                  '+-----------------+---------+',
@@ -1619,26 +1619,26 @@ Instances: PyWBEM_AllTypes
     #  instance invokemethod tests
     #
 
-    ['class subcommand invokemethod --help',
+    ['class command invokemethod --help',
      ['invokemethod', '--help'],
      {'stdout': INSTANCE_INVOKEMETHOD_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['class subcommand invokemethod -h',
+    ['class command invokemethod -h',
      ['invokemethod', '-h'],
      {'stdout': INSTANCE_INVOKEMETHOD_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify instance subcommand invokemethod, returnvalue = 0',
+    ['Verify instance command invokemethod, returnvalue = 0',
      ['invokemethod', ':CIM_Foo.InstanceID="CIM_Foo1"', 'Fuzzy'],
      {'stdout': ['ReturnValue=0'],
       'rc': 0,
       'test': 'lines'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
-    ['Verify instance subcommand invokemethod with multiple scalar params',
+    ['Verify instance command invokemethod with multiple scalar params',
      ['invokemethod', ':CIM_Foo.InstanceID="CIM_Foo1"', 'Fuzzy',
       '-p', 'TestInOutParameter="blah"',
       '-p', 'TestRef=CIM_Foo.InstanceID="CIM_Foo1"'],
@@ -1650,7 +1650,7 @@ Instances: PyWBEM_AllTypes
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
 
-    ['Verify instance subcommand invokemethod with all_types method',
+    ['Verify instance command invokemethod with all_types method',
      ['invokemethod', 'Pywbem_alltypes.InstanceID="test_instance"',
       'AllTypesMethod',
       '-p', 'scalBool=true',
@@ -1672,7 +1672,7 @@ Instances: PyWBEM_AllTypes
       'test': 'innows'},
      [ALLTYPES_MOCK_FILE, ALLTYPES_INVOKEMETHOD_MOCK_FILE], OK],
 
-    ['Verify instance subcommand invokemethod fails Invalid Class',
+    ['Verify instance command invokemethod fails Invalid Class',
      ['invokemethod', ':CIM_Foox.InstanceID="CIM_Foo1"', 'Fuzzy', '-p',
       'TestInOutParameter="blah"'],
      {'stderr': ["Error: CIMError: 6"],
@@ -1680,7 +1680,7 @@ Instances: PyWBEM_AllTypes
       'test': 'regex'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
-    ['Verify instance subcommand invokemethod fails Method not registered',
+    ['Verify instance command invokemethod fails Method not registered',
      ['invokemethod', ':CIM_Foo.InstanceID="CIM_Foo1"', 'Fuzzy', '-p',
       'TestInOutParameter=blah'],
      {'stderr': ["Error: CIMError: 17"],
@@ -1694,23 +1694,23 @@ Instances: PyWBEM_AllTypes
 
 
     #
-    #  instance query subcommand. We have not implemented this command
+    #  instance query command. We have not implemented this command
     #
-    ['Verify instance subcommand query --help response',
+    ['Verify instance command query --help response',
      ['query', '--help'],
      {'stdout': INSTANCE_QUERY_HELP_LINES,
       'rc': 0,
       'test': 'linnows'},
      None, OK],
 
-    ['Verify instance subcommand query -h response',
+    ['Verify instance command query -h response',
      ['query', '-h'],
      {'stdout': INSTANCE_QUERY_HELP_LINES,
       'rc': 0,
       'test': 'linnows'},
      None, OK],
 
-    ['Verify instance subcommand query execution. Returns error becasue '
+    ['Verify instance command query execution. Returns error becasue '
      'mock does not support query',
      ['query', 'Select blah from blah'],
      {'stderr': ['Error: CIMError: 14 (CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED): ',
@@ -1723,9 +1723,9 @@ Instances: PyWBEM_AllTypes
 
 class TestSubcmd(CLITestsBase):
     """
-    Test all of the class subcommand variations.
+    Test all of the class command variations.
     """
-    subcmd = 'instance'
+    command_group = 'instance'
     # mock_mof_file = 'simple_mock_model.mof'
 
     @pytest.mark.parametrize(
@@ -1735,5 +1735,5 @@ class TestSubcmd(CLITestsBase):
         """
         Execute pybemcli with the defined input and test output.
         """
-        self.subcmd_test(desc, self.subcmd, inputs, exp_response,
-                         mock, condition, verbose=False)
+        self.command_test(desc, self.command_group, inputs, exp_response,
+                          mock, condition, verbose=False)

--- a/tests/unit/test_log_option.py
+++ b/tests/unit/test_log_option.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Tests the cglobal log option
+Tests the general log option
 """
 import os
 import pytest
@@ -29,7 +29,7 @@ FAIL = False
 
 TEST_CASES = [
     # desc - Description of test
-    # inputs - String, or list of args or dict of 'env', 'args', 'globals',
+    # inputs - String, or list of args or dict of 'env', 'args', 'general',
     #          and 'stdin'. See See CLITestsBase.subcmd_test()  for
     #          detailed documentation
     # exp_response - Dictionary of expected responses (stdout, stderr, rc) and
@@ -39,8 +39,8 @@ TEST_CASES = [
     # condition - If True, the test is executed,  Otherwise it is skipped.
 
     ['Verify log of class get blah. class get that fails',
-     {'global': ['-l', 'all=stderr'],
-      'subcmd': 'class',
+     {'general': ['-l', 'all=stderr'],
+      'cmdgrp': 'class',
       'args': ['get', 'blah']},
      {'stderr': ['-pywbem.api',
                  'FakedWBEMConnection',
@@ -50,9 +50,9 @@ TEST_CASES = [
       'rc': 1},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify log of class subcommand get local-only. Test stdoit',
-     {'global': ['-l', 'all=stderr:summary'],
-      'subcmd': 'class',
+    ['Verify log of class  get command get local-only. Test stdoit',
+     {'general': ['-l', 'all=stderr:summary'],
+      'cmdgrp': 'class',
       'args': ['get', 'CIM_Foo_sub2', '--local-only']},
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
                  '',
@@ -63,10 +63,10 @@ TEST_CASES = [
       'test': 'patterns'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify Log of class subcommand get local-only. test stderr'
+    ['Verify Log of class get command local-only. test stderr'
      'Cannot test stderr and stdout in same test.',
-     {'global': ['-l', 'all=stderr:summary'],
-      'subcmd': 'class',
+     {'general': ['-l', 'all=stderr:summary'],
+      'cmdgrp': 'class',
       'args': ['get', 'CIM_Foo_sub2', '--local-only']},
      {'stderr': [r'-pywbem.api.',
                  r'FakedWBEMConnection',
@@ -76,10 +76,10 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify log of class subcommand get local-only. Test stderr'
+    ['Verify log of class get command local-only. Test stderr'
      'Cannot test stderr and stdout in same test.',
-     {'global': ['-l', 'api=stderr:summary'],
-      'subcmd': 'class',
+     {'general': ['-l', 'api=stderr:summary'],
+      'cmdgrp': 'class',
       'args': ['get', 'CIM_Foo_sub2', '--local-only']},
      {'stderr': [r'-pywbem.api.',
                  r'FakedWBEMConnection',
@@ -89,11 +89,11 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify log http class subcommand get local-only. Should be no log '
+    ['Verify log http class get command local-only. Should be no log '
      'because mock does not use http'
      'Cannot test stderr and stdout in same test.',
-     {'global': ['-l', 'http=stderr:summary'],
-      'subcmd': 'class',
+     {'general': ['-l', 'http=stderr:summary'],
+      'cmdgrp': 'class',
       'args': ['get', 'CIM_Foo_sub2', '--local-only']},
      {'stderr': [],
       'test': 'in'},
@@ -101,8 +101,8 @@ TEST_CASES = [
 
     ['Verify log with error in definition. Cannot test stderr and stdout in '
      'same test.',
-     {'global': ['-l', 'httpx=stderr'],
-      'subcmd': 'class',
+     {'general': ['-l', 'httpx=stderr'],
+      'cmdgrp': 'class',
       'args': ['get', 'CIM_Foo_sub2', '--local-only']},
      {'stderr': ["Error: Logger configuration error. input: "],
       'rc': 1,
@@ -110,8 +110,8 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify log with error in definition. invalid type',
-     {'global': ['-l', 'allx=stderr'],
-      'subcmd': 'class',
+     {'general': ['-l', 'allx=stderr'],
+      'cmdgrp': 'class',
       'args': ['get', 'CIM_Foo_sub2', '--local-only']},
      {'stderr': ["Error: Logger configuration error. input: allx=stderr. "
                  "Exception: Invalid simple logger name:"],
@@ -120,10 +120,9 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
 
-    ['Verify invalid log parameter fails (no value) '
-     'same test.',
-     {'global': ['-l'],
-      'subcmd': 'class',
+    ['Verify invalid log parameter fails (no value) same test.',
+     {'general': ['-l'],
+      'cmdgrp': 'class',
       'args': ['get', 'CIM_Foo_sub2', '--local-only']},
      {'stderr': ["Usage: pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS]"],
       'rc': 2,
@@ -135,8 +134,8 @@ TEST_CASES = [
 
 class TestLogOption(CLITestsBase):
     """
-    Test use of the global log option. This was be tested in the
-    test_global_opts.py file because it requires execution of a subcommand
+    Test use of the general log option. This was be tested in the
+    test_general_opts.py file because it requires execution of a command
     to actually use the log and create logs.
     """
 
@@ -152,7 +151,7 @@ class TestLogOption(CLITestsBase):
           * Subcommands that can be tested with a single execution of a
             pywbemcli command.
         """
-        subcmd = inputs['subcmd'] if inputs['subcmd'] else ''
+        cmd_grp = inputs['cmdgrp'] if inputs['cmdgrp'] else ''
 
-        self.subcmd_test(desc, subcmd, inputs, exp_response,
-                         mock, condition)
+        self.command_test(desc, cmd_grp, inputs, exp_response,
+                          mock, condition)

--- a/tests/unit/test_qualdecl_cmds.py
+++ b/tests/unit/test_qualdecl_cmds.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Tests the qualifier grop of  subcommands
+Tests the commands in thequalifier command group
 """
 import os
 import pytest
@@ -156,73 +156,73 @@ FAIL = False   # flag any tests that fail
 
 TEST_CASES = [
     # desc - Description of test
-    # inputs - String, or list of args or dict of 'env', 'args', 'globals',
-    #          and 'stdin'. See See CLITestsBase.subcmd_test()  for
+    # inputs - String, or list of args or dict of 'env', 'args', 'general',
+    #          and 'stdin'. See See CLITestsBase.command_test()  for
     #          detailed documentation
     # exp_response - Dictionary of expected responses (stdout, stderr, rc) and
     #                test definition (test: <testname>).
-    #                See CLITestsBase.subcmd_test() for detailed documentation.
+    #                See CLITestsBase.command_test() for detailed documentation.
     # mock - None or name of files (mof or .py),
     # condition - If True, the test is executed,  Otherwise it is skipped.
 
-    ['Verify qualifier subcommand --help response',
+    ['Verify qualifier command --help response',
      '--help',
      {'stdout': QD_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify qualifier subcommand -h response',
+    ['Verify qualifier command -h response',
      '-h',
      {'stdout': QD_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify qualifier subcommand enumerate --help response',
+    ['Verify qualifier command enumerate --help response',
      ['enumerate', '--help'],
      {'stdout': QD_ENUMERATE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify qualifier subcommand enumerate -h response.',
+    ['Verify qualifier command enumerate -h response.',
      ['enumerate', '-h'],
      {'stdout': QD_ENUMERATE_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify qualifier subcommand get --help response.',
+    ['Verify qualifier command get --help response.',
      ['get', '--help'],
      {'stdout': QD_GET_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify qualifier subcommand get -h response.',
+    ['Verify qualifier command get -h response.',
      ['get', '-h'],
      {'stdout': QD_GET_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify qualifier subcommand enumerate returns qual decls.',
+    ['Verify qualifier command enumerate returns qual decls.',
      ['enumerate'],
      {'stdout': QD_ENUM_MOCK,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify qualifier subcommand enumerate with namespace returns qual decls.',
+    ['Verify qualifier command enumerate with namespace returns qual decls.',
      ['enumerate', '--namespace', 'root/cimv2'],
      {'stdout': QD_ENUM_MOCK,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify qualifier subcommand enumerate summary returns qual decls.',
+    ['Verify qualifier command enumerate summary returns qual decls.',
      ['enumerate', '--summary'],
      {'stdout': ['9', 'CIMQualifierDeclaration'],
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
 
-    ['Verify qualifier subcommand enumerate summary returns qual decls table',
+    ['Verify qualifier command enumerate summary returns qual decls table',
      {'args': ['enumerate', '--summary'],
-      'global': ['--output-format', 'table']},
+      'general': ['--output-format', 'table']},
      {'stdout': ["""Summary of CIMQualifierDeclaration returned
 +---------+-------------------------+
 |   Count | CIM Type                |
@@ -233,54 +233,54 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify qualifier subcommand get  Description',
+    ['Verify qualifier command get  Description',
      ['get', 'Description'],
      {'stdout': QD_GET_MOCK,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify qualifier subcommand get invalid qual decl name .',
+    ['Verify qualifier command get invalid qual decl name .',
      ['get', 'NoSuchQualDecl'],
      {'stderr': ["Error: CIMError: 6"],
       'rc': 1,
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify qualifier subcommand get  Description outputformat xml',
+    ['Verify qualifier command get  Description outputformat xml',
      {'args': ['get', 'Description'],
-      'global': ['--output-format', 'xml']},
+      'general': ['--output-format', 'xml']},
      {'stdout': QD_GET_MOCK_XML,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify qualifier subcommand -o grid enumerate produces table out',
+    ['Verify qualifier command -o grid enumerate produces table out',
      {'args': ['enumerate'],
-      'global': ['-o', 'grid']},
+      'general': ['-o', 'grid']},
      {'stdout': QD_TBL_OUT,
       'rc': 0,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
 
-    ['Verify qualifier subcommand -o grid get Abstract table out',
+    ['Verify qualifier command -o grid get Abstract table out',
      {'args': ['get', 'abstract'],
-      'global': ['-o', 'grid']},
+      'general': ['-o', 'grid']},
      {'stdout': QD_TBL_GET_OUT,
       'rc': 0,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify qualifier subcommand enumerate invalid namespace Fails',
+    ['Verify qualifier command enumerate invalid namespace Fails',
      ['enumerate', '--namespace', 'root/blah'],
      {'stderr': ["Error: CIMError: 3", "CIM_ERR_INVALID_NAMESPACE"],
       'rc': 1,
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify qualifier subcommand --timestats gets stats output. Cannot test'
+    ['Verify qualifier command --timestats gets stats output. Cannot test'
      'with lines because execution time is variable.',
      {'args': ['get', 'IN'],
-      'global': ['--timestats']},
+      'general': ['--timestats']},
      {'stdout': ['Qualifier In : boolean = true,',
                  'Scope(parameter),',
                  'Count    Exc    Time    ReqLen    ReplyLen  Operation',
@@ -290,9 +290,9 @@ TEST_CASES = [
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify qualifier subcommand -o repr get Description produces repr out',
+    ['Verify qualifier command -o repr get Description produces repr out',
      {'args': ['get', 'Description'],
-      'global': ['-o', 'repr']},
+      'general': ['-o', 'repr']},
      {'stdout': "CIMQualifierDeclaration(name='Description', value=None, "
                 "type='string', is_array=False, array_size=None, "
                 "scopes=NocaseDict({'CLASS': False, 'ASSOCIATION': False, "
@@ -306,23 +306,23 @@ TEST_CASES = [
 ]
 
 
-class TestSubcmdQualifiers(CLITestsBase):
+class TestcmdQualifiers(CLITestsBase):
     """
-    Test all of the qualifiers subcommand variations.
+    Test all of the qualifiers command variations.
     """
-    subcmd = 'qualifier'
+    command_group = 'qualifier'
 
     @pytest.mark.parametrize(
         "desc, inputs, exp_response, mock, condition", TEST_CASES)
     def test_qualdecl(self, desc, inputs, exp_response, mock, condition):
         """
-        Common test method for those subcommands and options in the
-        class subcmd that can be tested.  This includes:
+        Common test method for those commands and options in the
+        qualifier command group that can be tested.  This includes:
 
           * Subcommands like help that do not require access to a server
 
           * Subcommands that can be tested with a single execution of a
             pywbemcli command.
         """
-        self.subcmd_test(desc, self.subcmd, inputs, exp_response,
-                         mock, condition)
+        self.command_test(desc, self.command_group, inputs, exp_response,
+                          mock, condition)

--- a/tests/unit/test_server_cmds.py
+++ b/tests/unit/test_server_cmds.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Tests the class subcommand
+Tests the server command group
 """
 import os
 import pytest
@@ -106,115 +106,115 @@ FAIL = False  # Any test currently FAILING or not tested yet
 # pylint: enable=line-too-long
 TEST_CASES = [
     # desc - Description of test
-    # inputs - String, or list of args or dict of 'env', 'args', 'globals',
-    #          and 'stdin'. See See CLITestsBase.subcmd_test()  for
+    # inputs - String, or list of args or dict of 'env', 'args', 'general',
+    #          and 'stdin'. See See CLITestsBase.command_test()  for
     #          detailed documentation
     # exp_response - Dictionary of expected responses,
     # mock - None or name of files (mof or .py),
     # condition - If True, the test is executed,  Otherwise it is skipped.
 
-    ['Verify server subcommand --help response',
+    ['Verify server command --help response',
      '--help',
      {'stdout': SERVER_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand -h response',
+    ['Verify server command -h response',
      '-h',
      {'stdout': SERVER_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand brand  --help response',
+    ['Verify server command brand  --help response',
      ['brand', '--help'],
      {'stdout': SERVER_BRAND_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand brand  -h response',
+    ['Verify server command brand  -h response',
      ['brand', '-h'],
      {'stdout': SERVER_BRAND_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand connection --help response',
+    ['Verify server command connection --help response',
      ['connection', '--help'],
      {'stdout': SERVER_CONNECTION_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand connection -h response',
+    ['Verify server command connection -h response',
      ['connection', '-h'],
      {'stdout': SERVER_CONNECTION_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand get-centralinsts  --help response',
+    ['Verify server command get-centralinsts  --help response',
      ['get-centralinsts', '--help'],
      {'stdout': SERVER_GETCENTRALINSTS_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand get-centralinsts  -h response',
+    ['Verify server command get-centralinsts  -h response',
      ['get-centralinsts', '-h'],
      {'stdout': SERVER_GETCENTRALINSTS_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand info --help response',
+    ['Verify server command info --help response',
      ['info', '--help'],
      {'stdout': SERVER_INFO_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand info -h response',
+    ['Verify server command info -h response',
      ['info', '-h'],
      {'stdout': SERVER_INFO_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand interop --help response',
+    ['Verify server command interop --help response',
      ['interop', '--help'],
      {'stdout': SERVER_INTEROP_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand interop -h response',
+    ['Verify server command interop -h response',
      ['interop', '-h'],
      {'stdout': SERVER_INTEROP_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand namespaces --help response',
+    ['Verify server command namespaces --help response',
      ['namespaces', '--help'],
      {'stdout': SERVER_NAMESPACES_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand namespaces -h response',
+    ['Verify server command namespaces -h response',
      ['namespaces', '-h'],
      {'stdout': SERVER_NAMESPACES_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand profiles --help response',
+    ['Verify server command profiles --help response',
      ['profiles', '--help'],
      {'stdout': SERVER_PROFILES_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify server subcommand profiles -h response',
+    ['Verify server command profiles -h response',
      ['profiles', '-h'],
      {'stdout': SERVER_PROFILES_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     #
-    #   Verify the individual subcommands returning data
+    #   Verify the individual commands returning data
     #
-    ['Verify server subcommand interop',
+    ['Verify server command interop',
      {'args': ['interop'],
-      'global': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-d', 'interop', '-o', 'simple']},
      {'stdout': ['Server Interop Namespace:',
                  'Namespace Name',
                  '----------------',
@@ -223,9 +223,9 @@ TEST_CASES = [
       'test': 'lines'},
      MOCK_SERVER_MODEL, OK],
 
-    ['Verify server subcommand namespaces',
+    ['Verify server command namespaces',
      {'args': ['namespaces'],
-      'global': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-d', 'interop', '-o', 'simple']},
      {'stdout': ['Server Namespaces:',
                  'Namespace Name',
                  '----------------',
@@ -235,9 +235,9 @@ TEST_CASES = [
      MOCK_SERVER_MODEL, OK],
 
     # TODO: Remove this test once removal of --sort option is agreed.
-    ['Verify server subcommand namespaces with sort option',
+    ['Verify server command namespaces with sort option',
      {'args': ['namespaces', '-s'],
-      'global': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-d', 'interop', '-o', 'simple']},
      {'stdout': ['Server Namespaces:',
                  'Namespace Name',
                  '----------------',
@@ -246,9 +246,9 @@ TEST_CASES = [
       'test': 'lines'},
      MOCK_SERVER_MODEL, FAIL],
 
-    ['Verify server subcommand brand',
+    ['Verify server command brand',
      {'args': ['brand'],
-      'global': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-d', 'interop', '-o', 'simple']},
      {'stdout': ['Server brand:',
                  'WBEM server brand',
                  '-------------------',
@@ -257,9 +257,9 @@ TEST_CASES = [
       'test': 'lines'},
      MOCK_SERVER_MODEL, OK],
 
-    ['Verify server subcommand profiles',
+    ['Verify server command profiles',
      {'args': ['profiles'],
-      'global': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-d', 'interop', '-o', 'simple']},
      {'stdout': ['Advertised management profiles:',
                  'Organization    Registered Name       Version',
                  '--------------  --------------------  ---------',
@@ -275,9 +275,9 @@ TEST_CASES = [
       'test': 'lines'},
      MOCK_SERVER_MODEL, OK],
 
-    ['Verify server subcommand profiles, filtered by org',
+    ['Verify server command profiles, filtered by org',
      {'args': ['profiles', '-o', 'DMTF'],
-      'global': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-d', 'interop', '-o', 'simple']},
      {'stdout': ['Advertised management profiles:',
                  'Organization    Registered Name       Version',
                  '--------------  --------------------  ---------',
@@ -288,9 +288,9 @@ TEST_CASES = [
       'test': 'lines'},
      MOCK_SERVER_MODEL, OK],
 
-    ['Verify server subcommand profiles, filtered by org, long',
+    ['Verify server command profiles, filtered by org, long',
      {'args': ['profiles', '--organization', 'DMTF'],
-      'global': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-d', 'interop', '-o', 'simple']},
      {'stdout': ['Advertised management profiles:',
                  'Organization    Registered Name       Version',
                  '--------------  --------------------  ---------',
@@ -301,9 +301,9 @@ TEST_CASES = [
       'test': 'lines'},
      MOCK_SERVER_MODEL, OK],
 
-    ['Verify server subcommand profiles, filtered by name',
+    ['Verify server command profiles, filtered by name',
      {'args': ['profiles', '-p', 'Profile Registration'],
-      'global': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-d', 'interop', '-o', 'simple']},
      {'stdout': ['Advertised management profiles:',
                  'Organization    Registered Name       Version',
                  '--------------  --------------------  ---------',
@@ -312,9 +312,9 @@ TEST_CASES = [
       'test': 'lines'},
      MOCK_SERVER_MODEL, OK],
 
-    ['Verify server subcommand profiles, filtered by org, long',
+    ['Verify server command profiles, filtered by org, long',
      {'args': ['profiles', '--profile', 'Profile Registration'],
-      'global': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-d', 'interop', '-o', 'simple']},
      {'stdout': ['Advertised management profiles:',
                  'Organization    Registered Name       Version',
                  '--------------  --------------------  ---------',
@@ -323,7 +323,7 @@ TEST_CASES = [
       'test': 'lines'},
      MOCK_SERVER_MODEL, OK],
 
-    ['Verify server subcommand connection with mock server',
+    ['Verify server command connection with mock server',
      ['connection'],
      {'stdout': ["", 'url: http://FakedUrl', 'creds: None', '.x509: None',
                  'default_namespace: root/cimv2', 'timeout: None sec.',
@@ -332,10 +332,10 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify server subcommand get-centralinsts, ',
+    ['Verify server command get-centralinsts, ',
      {'args': ['get-centralinsts', '-o', 'SNIA',
                '-p', 'Server'],
-      'global': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-d', 'interop', '-o', 'simple']},
      {'stdout': ['Advertised Central Instances:',
                  r'Profile +Central Instances',
                  'SNIA:Server:1.1.0',
@@ -346,9 +346,9 @@ TEST_CASES = [
      MOCK_SERVER_MODEL, OK],
 
 
-    ['Verify server subcommand info with mock server',
+    ['Verify server command info with mock server',
      {'args': ['info'],
-      'global': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-d', 'interop', '-o', 'simple']},
      {'stdout':
       ['Server General Information',
        'Brand        Version    Interop Namespace    Namespaces',
@@ -368,16 +368,16 @@ TEST_CASES = [
 
 class TestSubcmdServer(CLITestsBase):
     """
-    Execute the testcases for server subcommand variations.
+    Execute the testcases for server command variations.
     """
-    subcmd = 'server'
+    command_group = 'server'
 
     @pytest.mark.parametrize(
         "desc, inputs, exp_response, mock, condition",
         TEST_CASES)
     def test_class(self, desc, inputs, exp_response, mock, condition):
         """
-        Common test method for those subcommands and options in the
+        Common test method for those commands and options in the
         class subcmd that can be tested.  This includes:
 
           * Subcommands like help that do not require access to a server
@@ -385,5 +385,5 @@ class TestSubcmdServer(CLITestsBase):
           * Subcommands that can be tested with a single execution of a
             pywbemcli command.
         """
-        self.subcmd_test(desc, self.subcmd, inputs, exp_response,
-                         mock, condition)
+        self.command_test(desc, self.command_group, inputs, exp_response,
+                          mock, condition)

--- a/tests/unit/utils/dmtf_mof_schema_def.py
+++ b/tests/unit/utils/dmtf_mof_schema_def.py
@@ -19,7 +19,7 @@ To change the schema used:
 2. Delete the TESTSUITE_SCHEMA_DIR directory.
    This eliminates the old schema.
 
-3. Execute the test tests/unit/test_server_subcmd.py. This should cause the
+3. Execute the test tests/unit/test_server_cmd.py. This should cause the
    new schema to be downloaded and expanded as part of the test.
 
 5. Add the new DMTF CIM schema zip file to git so that it is persisted for


### PR DESCRIPTION
We have decided on the names "command" and "command group" to define the
components of the pywbemcli cmd line.  However they were all named
subcmds in the tests, test methods, test definition tools. Changed all of that to command and command_group just to be consistent.

The word subcmd should not occur any more.

This just changes the text and the key names in the test dictionaries. 

It does not change code.

Also changed the test file names from test_*_subcmd.py to test_*_cmd.py