### PR TITLE
Fixes issue #363, formatting of get_centralinstances response

### DIFF
--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -135,10 +135,11 @@ def class_delete(context, classname, **options):
     option was specified, in which case the instances are also deleted.
 
     WARNING: Deleting classes can cause damage to the server: It can impact
-    instance providers and other components in the server. Use this with
+    instance providers and other components in the server. Use this
     command with caution.
 
-    Some servers may reject the command altogether.
+    Many WBEM servers may not allow this operation or may severely limit the
+    conditions under which a class can be deleted from the server.
 
     Example:
 
@@ -249,7 +250,7 @@ def class_references(context, classname, **options):
     List the classes referencing a class.
 
     List the CIM (association) classes that reference the specified class
-    (CLASSNAME argument) or subclasses thereof in the specified CIM namespace
+    (CLASSNAME argument) in the specified CIM namespace
     (--namespace option). If no namespace was specified, the default namespace
     of the connection is used.
 
@@ -301,7 +302,7 @@ def class_associators(context, classname, **options):
     List the classes associated with a class.
 
     List the CIM classes that are associated with the specified class
-    (CLASSNAME argument) or subclasses thereof in the specified CIM namespace
+    (CLASSNAME argument) in the specified CIM namespace
     (--namespace option). If no namespace was specified, the default namespace
     of the connection is used.
 

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -375,7 +375,7 @@ def cmd_server_centralinsts(context, options):
                     scoping_class=options['scoping_class'],
                     scoping_path=options['scoping_path'],
                     reference_direction=options['reference_direction'])
-                row.append(":".join([str(p) for p in ci]))
+                row.append("\n".join([str(p) for p in ci]))
             # mark current inst as failed and continue
             except Exception as ex:  # pylint: disable=broad-except
                 click.echo('Exception: %s %s' % (row, ex))
@@ -384,7 +384,7 @@ def cmd_server_centralinsts(context, options):
 
         # sort by org
         rows.sort(key=lambda x: (x[0]))
-        headers = ['Profile', 'Central Instances']
+        headers = ['Profile', 'Central Instance paths']
 
         click.echo(format_table(rows,
                                 headers,

--- a/tests/unit/test_server_cmds.py
+++ b/tests/unit/test_server_cmds.py
@@ -332,17 +332,18 @@ TEST_CASES = [
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify server command get-centralinsts, ',
+    ['Verify server command get-centralinsts based on wbem server mock.',
      {'args': ['get-centralinsts', '-o', 'SNIA',
                '-p', 'Server'],
       'general': ['-d', 'interop', '-o', 'simple']},
      {'stdout': ['Advertised Central Instances:',
-                 r'Profile +Central Instances',
+                 'Profile',
+                 'Central Instance paths',
                  'SNIA:Server:1.1.0',
                  'SNIA:Server:1.2.0',
-                 'interop:XXX_StorageComputerSystem'],
+                 'interop:MCK_StorageComputerSystem'],
       'rc': 0,
-      'test': 'regex'},
+      'test': 'innows'},
      MOCK_SERVER_MODEL, OK],
 
 


### PR DESCRIPTION
Modified mock file and tests.

Fixed the one long line issue but this command is still way to limited.  It should have options to:

a. At least show the instances instead of the paths 

b. Probably fold the paths since the table output is a mess.

```
-Advertised Central Instances:
+---------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Profile                         | Central Instances                                                                                                                                                                 |
|---------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| DMTF:Component:1.4.0            |                                                                                                                                                                                   |
| DMTF:Indications:1.1.0          |                                                                                                                                                                                   |
| DMTF:Profile Registration:1.0.0 |                                                                                                                                                                                   |
| SNIA:Array:1.4.0                |                                                                                                                                                                                   |
| SNIA:SMI-S:1.2.0                |                                                                                                                                                                                   |
| SNIA:Server:1.1.0               | //FakedUrl/interop:CIM_ObjectManager.Name="FakeObjectManager",SystemCreationClassName="CIM_ComputerSystem",SystemName="Mock_WBEMServerTest",CreationClassName="CIM_ObjectManager" |
| SNIA:Server:1.2.0               | //FakedUrl/interop:MCK_StorageComputerSystem.Name="10.1.2.3",CreationClassName="MCK_StorageComputerSystem"                                                                        |
| SNIA:Software:1.4.0             |                                                                                                                                                                                   |
+---------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
pywbemcli>    


```



Modified the tests/unit/utils/wbemserver mock file to assure that the interop namespace
was setup.  It works for the tests, but was failing when used directly
with pywbemcli from the command line because the interop ns was not
being set up.

Modified the the name of one of the created classes. and added some conditional displays so the user could see what was created in the mock repository