### PR TITLE
Fixes issue # 360 server connection vs connection show

### DIFF
--- a/docs/pywbemclicommands.rst
+++ b/docs/pywbemclicommands.rst
@@ -853,7 +853,6 @@ server of the :term:`current connection` to access information about the
 WBEM server itself:
 
 * :ref:`Server brand command` - Get the brand of the server.
-* :ref:`Server connection command` - Get connection info used by this server.
 * :ref:`Server get-centralinsts command` - List central instances of mgmt profiles on the server.
 * :ref:`Server info command` - Get information about the server.
 * :ref:`Server interop command` - Get the Interop namespace of the server.
@@ -889,31 +888,6 @@ Example:
     +---------------------+
 
 See :ref:`pywbemcli server brand --help` for details.
-
-
-.. _`Server connection command`:
-
-Server connection command
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The ``server connection`` command displays information on the
-:term:`current connection`.
-
-Note that the :ref:`connection show command` also displays such information.
-
-Example:
-
-.. code-block:: text
-
-    $ pywbemcli --name myserver server connection
-    url: http://localhost
-    creds: ('kschopmeyer', 'test8play')
-    .x509: None
-    default_namespace: root/cimv2
-    timeout: 30 sec.
-    ca_certs: None
-
-See :ref:`pywbemcli server connection --help` for details.
 
 
 .. _`Server info command`:

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -171,20 +171,6 @@ def server_centralinsts(context, **options):
     context.execute_cmd(lambda: cmd_server_centralinsts(context, options))
 
 
-@server_group.command('connection', options_metavar=CMD_OPTS_TXT)
-@click.pass_obj
-def server_connection(context):
-    """
-    Get connection info used by this server.
-
-    Display the information about the connection used to connect to the
-    WBEM server.
-
-    This is equivalent to the 'connection show' command.
-    """
-    context.execute_cmd(lambda: cmd_server_connection(context))
-
-
 # TODO: reactivate and implement this in version 0.6.0
 # @server_group.command('test_pull', options_metavar=CMD_OPTS_TXT)
 # @click.pass_obj
@@ -334,18 +320,6 @@ def cmd_server_profiles(context, options):
                                 title='Advertised management profiles:',
                                 table_format=context.output_format))
 
-    except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
-
-
-def cmd_server_connection(context):
-    """Display information on the current WBEM Connection"""
-    try:
-        conn = context.conn
-        click.echo('\nurl: %s\ncreds: %s\n.x509: %s\ndefault_namespace: %s\n'
-                   'timeout: %s sec.\nca_certs: %s' %
-                   (conn.url, conn.creds, conn.x509, conn.default_namespace,
-                    conn.timeout, conn.ca_certs))
     except Error as er:
         raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
 

--- a/tests/unit/test_server_cmds.py
+++ b/tests/unit/test_server_cmds.py
@@ -42,7 +42,6 @@ SERVER_HELP_LINES = [
     'Command group for WBEM servers.',
     CMD_OPTION_HELP_HELP_LINE,
     'brand             Get the brand of the server.',
-    'connection        Get connection info used by this server.',
     'get-centralinsts  List central instances of mgmt profiles on the server.',
     'info              Get information about the server.',
     'interop           Get the Interop namespace of the server.',
@@ -56,11 +55,6 @@ SERVER_BRAND_HELP_LINES = [
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
-SERVER_CONNECTION_HELP_LINES = [
-    'Usage: pywbemcli server connection [COMMAND-OPTIONS]',
-    'Get connection info used by this server.',
-    CMD_OPTION_HELP_HELP_LINE,
-]
 
 SERVER_GETCENTRALINSTS_HELP_LINES = [
     'Usage: pywbemcli server get-centralinsts [COMMAND-OPTIONS]',
@@ -134,18 +128,6 @@ TEST_CASES = [
     ['Verify server command brand  -h response',
      ['brand', '-h'],
      {'stdout': SERVER_BRAND_HELP_LINES,
-      'test': 'innows'},
-     None, OK],
-
-    ['Verify server command connection --help response',
-     ['connection', '--help'],
-     {'stdout': SERVER_CONNECTION_HELP_LINES,
-      'test': 'innows'},
-     None, OK],
-
-    ['Verify server command connection -h response',
-     ['connection', '-h'],
-     {'stdout': SERVER_CONNECTION_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
@@ -322,15 +304,6 @@ TEST_CASES = [
       'rc': 0,
       'test': 'lines'},
      MOCK_SERVER_MODEL, OK],
-
-    ['Verify server command connection with mock server',
-     ['connection'],
-     {'stdout': ["", 'url: http://FakedUrl', 'creds: None', '.x509: None',
-                 'default_namespace: root/cimv2', 'timeout: None sec.',
-                 'ca_certs: None'],
-      'rc': 0,
-      'test': 'lines'},
-     SIMPLE_MOCK_FILE, OK],
 
     ['Verify server command get-centralinsts based on wbem server mock.',
      {'args': ['get-centralinsts', '-o', 'SNIA',


### PR DESCRIPTION
**This is one proposal to just remove this command** since it is a duplicate
of the connection show command.

**DISCUSSION**  Should we just remove the command for this release.

This is just a proposal at this point.  Some day we will have a command
that wants to show a lot of information about the server but that will
be more than just the connection information.

Suggestions welcome