### PR TITLE
Fixes issue # 358 Fix instance count command

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -212,9 +212,9 @@ The following defines the help output for the `pywbemcli class associators --hel
       List the classes associated with a class.
 
       List the CIM classes that are associated with the specified class
-      (CLASSNAME argument) or subclasses thereof in the specified CIM namespace
-      (--namespace option). If no namespace was specified, the default namespace
-      of the connection is used.
+      (CLASSNAME argument) in the specified CIM namespace (--namespace option).
+      If no namespace was specified, the default namespace of the connection is
+      used.
 
       The classes to be retrieved can be filtered by the --role, --result-role,
       --assoc-class, and --result-class options.
@@ -292,10 +292,11 @@ The following defines the help output for the `pywbemcli class delete --help` co
       option was specified, in which case the instances are also deleted.
 
       WARNING: Deleting classes can cause damage to the server: It can impact
-      instance providers and other components in the server. Use this with
-      command with caution.
+      instance providers and other components in the server. Use this command
+      with caution.
 
-      Some servers may reject the command altogether.
+      Many WBEM servers may not allow this operation or may severely limit the
+      conditions under which a class can be deleted from the server.
 
       Example:
 
@@ -413,6 +414,9 @@ The following defines the help output for the `pywbemcli class find --help` comm
         pywbemcli -n myconn class find *Foo*
 
     Options:
+      -n, --namespace NAMESPACE  Add a namespace to the search scope. May be
+                                 specified multiple times. Default: Search in all
+                                 namespaces of the server.
       -n, --namespace NAMESPACE  Add a namespace to the search scope. May be
                                  specified multiple times. Default: Search in all
                                  namespaces of the server.
@@ -538,9 +542,9 @@ The following defines the help output for the `pywbemcli class references --help
       List the classes referencing a class.
 
       List the CIM (association) classes that reference the specified class
-      (CLASSNAME argument) or subclasses thereof in the specified CIM namespace
-      (--namespace option). If no namespace was specified, the default namespace
-      of the connection is used.
+      (CLASSNAME argument) in the specified CIM namespace (--namespace option).
+      If no namespace was specified, the default namespace of the connection is
+      used.
 
       The classes to be retrieved can be filtered by the --role and --result-
       class options.
@@ -1085,29 +1089,35 @@ The following defines the help output for the `pywbemcli instance count --help` 
 
       Count the instances of each class with matching class name.
 
-      Display the count of the instances of each CIM class whose class name
-      matches the specified wildcard expression (CLASSNAME-GLOB) in all CIM
-      namespaces of the WBEM server, or in the specified namespace (--namespace
-      option).
+      Displays the count of instances of each CIM class whose class name matches
+      the specified wildcard expression (CLASSNAME-GLOB) in all CIM namespaces
+      of the WBEM server, or in the specified namespaces (--namespace option).
+      This differs from instance enumerate, etc. in that it counts the instances
+      specifically for the classname of each instance returned, not including
+      subclasses.
 
       The CLASSNAME-GLOB argument is a wildcard expression that is matched on
       the class names case insensitively. The special characters known from file
-      nme wildcarding are supported: `*` to match zero or more characters, and
+      name wildcarding are supported: `*` to match zero or more characters, and
       `?` to match a single character. In order to not have the shell expand the
       wildcards, the CLASSNAME-GLOB argument should be put in quotes.
 
-      For example, `pywbem_*` returns classes whose name begins with `PyWBEM_`,
-      `pywbem_`, etc. '*system*' returns classes whose names include the case
-      insensitive string `system`.
+      If CLASSNAME-GLOB is not specified, the all classes in the specified
+      namespaces are counted (GLOB "*").
+
+      For example, `pywbem_*` returns instances of classes whose name begins
+      with `PyWBEM_`, `pywbem_`, etc. '*system*' returns classes whose names
+      include the case insensitive string `system`.
 
       This command can take a long time to execute since it potentially
-      enumerates all instance names in all namespaces.
+      enumerates all instance names for all classes in all namespaces.
 
     Options:
       -s, --sort                 Sort by instance count. Otherwise sorted by class
                                  name
-      -n, --namespace NAMESPACE  Namespace to use for this command, instead of the
-                                 default namespace of the connection.
+      -n, --namespace NAMESPACE  Add a namespace to the search scope. May be
+                                 specified multiple times. Default: Search in all
+                                 namespaces of the server.
       -h, --help                 Show this message and exit.
 
 
@@ -1760,7 +1770,6 @@ The following defines the help output for the `pywbemcli server --help` command
 
     Commands:
       brand             Get the brand of the server.
-      connection        Get connection info used by this server.
       get-centralinsts  List central instances of mgmt profiles on the server.
       info              Get information about the server.
       interop           Get the Interop namespace of the server.
@@ -1787,31 +1796,6 @@ The following defines the help output for the `pywbemcli server brand --help` co
       Brand information is defined by the server implementor and may or may not
       be available. Pywbem attempts to collect the brand information from
       multiple sources.
-
-    Options:
-      -h, --help  Show this message and exit.
-
-
-.. _`pywbemcli server connection --help`:
-
-pywbemcli server connection --help
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-
-
-The following defines the help output for the `pywbemcli server connection --help` command
-
-
-::
-
-    Usage: pywbemcli server connection [COMMAND-OPTIONS]
-
-      Get connection info used by this server.
-
-      Display the information about the connection used to connect to the WBEM
-      server.
-
-      This is equivalent to the 'connection show' command.
 
     Options:
       -h, --help  Show this message and exit.

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -1097,12 +1097,13 @@ The following defines the help output for the `pywbemcli instance count --help` 
       subclasses.
 
       The CLASSNAME-GLOB argument is a wildcard expression that is matched on
-      the class names case insensitively. The special characters known from file
-      name wildcarding are supported: `*` to match zero or more characters, and
-      `?` to match a single character. In order to not have the shell expand the
-      wildcards, the CLASSNAME-GLOB argument should be put in quotes.
+      class names case insensitively. The special characters from file name
+      wildcarding are supported (`*` to match zero or more characters, and `?`
+      to match a single character) and character ranges expressed with []. To
+      avoid shell expansion of wildcards, the CLASSNAME-GLOB argument should be
+      put in quotes.
 
-      If CLASSNAME-GLOB is not specified, the all classes in the specified
+      If CLASSNAME-GLOB is not specified, then all classes in the specified
       namespaces are counted (GLOB "*").
 
       For example, `pywbem_*` returns instances of classes whose name begins

--- a/docs/pywbemclicommands.rst
+++ b/docs/pywbemclicommands.rst
@@ -439,15 +439,25 @@ Instance count command
 ^^^^^^^^^^^^^^^^^^^^^^
 
 The ``instance count`` command counts the CIM instances of some or all classes
-in the namespace specified with the ``-namespace``/``-n`` command option, or
-otherwise in the default namespace of the connection.
+in the namespaces specified with the ``-namespace``/``-n`` command option, or
+all namespaces in the server.
 
-The count of instances is displayed for each class name.
-**TBD: Does it include instances of subclasses?**
+This command displays the count of instances of each CIM class whose class name
+matches the specified wildcard expression (CLASSNAME-GLOB) in all CIM
+namespaces of the WBEM server, or in the specified namespaces (--namespace
+option).  This differs from instance enumerate, etc. in that it counts the
+instances specifically for the classname of each instance returned (the
+creation classname), not including subclasses.
 
-If the ``CLASSNAME-GLOB`` argument is specified, only the classes are counted
-that match the specified :term:`Unix-style path name pattern`.
-Otherwise, all classes are counted.
+If the ``CLASSNAME-GLOB`` argument is specified, only instances of classes that
+match the specified :term:`Unix-style path name pattern` are counted. If the
+``CLASSNAME-GLOB`` argument is not specified all instances of all classes in
+the target namespaces are counted.
+
+Results for class that have no instances are not displayed.
+
+This command can take a long time to execute since it potentially enumerates
+all instance names for all classes in all namespaces.
 
 Valid output formats are :term:`Table output formats`.
 
@@ -457,14 +467,16 @@ Example:
 
     $ pywbemcli --name mymock instance count
     Count of instances per class
-    +------------------------------+---------+
-    | Class                        |   count |
-    |------------------------------+---------|
-    | TST_FamilyCollection         |       2 |
-    | TST_Lineage                  |       3 |
-    | TST_MemberOfFamilyCollection |       3 |
-    | TST_Person                   |       4 |
-    +------------------------------+---------+
+    +-------------+------------------------------+---------+
+    | Namespace   | Class                        |   count |
+    |-------------+------------------------------+---------|
+    | root/cimv2  | TST_FamilyCollection         |       2 |
+    | root/cimv2  | TST_Lineage                  |       3 |
+    | root/cimv2  | TST_MemberOfFamilyCollection |       3 |
+    | root/cimv2  | TST_Person                   |       4 |
+    | root/cimv2  | TST_Personsub                |       4 |
+    +-------------+------------------------------+---------+
+
 
 Count is useful to determine which classes in the environment are actually
 implemented. However this command can take a long time to execute because

--- a/docs/pywbemclicommands.rst
+++ b/docs/pywbemclicommands.rst
@@ -454,7 +454,7 @@ match the specified :term:`Unix-style path name pattern` are counted. If the
 ``CLASSNAME-GLOB`` argument is not specified all instances of all classes in
 the target namespaces are counted.
 
-Results for class that have no instances are not displayed.
+Results for classes that have no instances are not displayed.
 
 This command can take a long time to execute since it potentially enumerates
 all instance names for all classes in all namespaces.

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -30,7 +30,7 @@ from ._common import display_cim_objects, filter_namelist, \
     format_table, process_invokemethod
 from ._common_options import add_options, propertylist_option, \
     names_only_option, include_classorigin_class_option, namespace_option,  \
-    summary_option
+    summary_option, multiple_namespaces_option
 
 from ._displaytree import display_class_tree
 
@@ -334,6 +334,7 @@ def class_associators(context, classname, **options):
               help='Add a namespace to the search scope. '
                    'May be specified multiple times. '
                    'Default: Search in all namespaces of the server.')
+@add_options(multiple_namespaces_option)
 @click.option('-s', '--sort', is_flag=True, required=False,
               help='Sort by namespace. Default is to sort by classname')
 @click.pass_obj
@@ -546,6 +547,7 @@ def cmd_class_find(context, classname_glob, options):
     Execute the command for get class and display the result. The result is
     a list of classes/namespaces
     """
+
     if options['namespace']:
         ns_names = options['namespace']
     else:

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -347,10 +347,11 @@ def class_find(context, classname_glob, **options):
     WBEM server, or in the specified namespace (--namespace option).
 
     The CLASSNAME-GLOB argument is a wildcard expression that is matched on
-    the class names case insensitively. The special characters known from file
-    name wildcarding are supported: "*" to match zero or more characters, and
-    "?" to match a single character. In order to not have the shell expand
-    the wildcards, the CLASSNAME-GLOB argument should be put in quotes.
+    class names case insensitively. The special characters from file name
+    wildcarding are supported (`*` to match zero or more characters, and `?` to
+    match a single character) and character ranges expressed with []. To avoid
+    shell expansion of wildcards, the CLASSNAME-GLOB argument should be put in
+    quotes.
 
     For example, "pywbem_*" returns classes whose name begins with "PyWBEM_",
     "pywbem_", etc. "*system*" returns classes whose names include the case

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -555,14 +555,15 @@ def instance_count(context, classname, **options):
     it counts the instances specifically for the classname of each instance
     returned, not including subclasses.
 
-    The CLASSNAME-GLOB argument is a wildcard expression that is matched on the
-    class names case insensitively. The special characters known from file name
-    wildcarding are supported: `*` to match zero or more characters, and `?` to
-    match a single character. To avoid shell expansion of wildcards, the
-    CLASSNAME-GLOB argument should be put in quotes.
+    The CLASSNAME-GLOB argument is a wildcard expression that is matched on
+    class names case insensitively. The special characters from file name
+    wildcarding are supported (`*` to match zero or more characters, and `?` to
+    match a single character) and character ranges expressed with []. To avoid
+    shell expansion of wildcards, the CLASSNAME-GLOB argument should be put in
+    quotes.
 
-    If CLASSNAME-GLOB is not specified, the all classes in the specified
-    namespaces are counted (GLOB "*").
+    If CLASSNAME-GLOB is not specified, then all classes in the specified
+    namespaces are counted (same as when specifying CLASSNAME-GLOB as "*").
 
     For example, `pywbem_*` returns instances of classes whose name begins with
     `PyWBEM_`, `pywbem_`, etc. '*system*' returns classes whose names include

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -270,7 +270,7 @@ def filter_namelist(pattern, name_list, ignore_case=True):
     Filter out names in name_list that do not match glob pattern compiled
     as regex.
 
-    The regex is defines as IGNORECASE and anchored.
+    The regex is defined as IGNORECASE and anchored.
 
     Note that the regex may define a subset of the name string.  Thus,  regex:
         - CIM* matches any name that starts with CIM
@@ -294,6 +294,7 @@ def filter_namelist(pattern, name_list, ignore_case=True):
 
     flags = re.IGNORECASE if ignore_case else None
     # compile the regex since it used multiple times
+    regex = None
     try:
         # Convert the glob input to regex.
         regex = fnmatch.translate(pattern)

--- a/pywbemtools/pywbemcli/_common_options.py
+++ b/pywbemtools/pywbemcli/_common_options.py
@@ -77,6 +77,13 @@ verify_option = [              # pylint: disable=invalid-name
                       'to allow for verification of parameters. '
                       'Default: Do not prompt for confirmation.')]
 
+multiple_namespaces_option = [              # pylint: disable=invalid-name
+    click.option('-n', '--namespace', type=str, multiple=True,
+                 required=False, metavar='NAMESPACE',
+                 help='Add a namespace to the search scope. '
+                      'May be specified multiple times. '
+                      'Default: Search in all namespaces of the server.')]
+
 
 def add_options(options):
     """

--- a/tests/unit/common_options_help_lines.py
+++ b/tests/unit/common_options_help_lines.py
@@ -78,3 +78,6 @@ CMD_OPTION_INCLUDE_QUALIFIERS_LIST_HELP_LINE = \
 CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE = \
     '--ico, --include-classorigin Include class origin information in the ' \
     'returned'
+
+CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE = \
+    '-n, --namespace NAMESPACE  Add a namespace to the search scope. May be'

--- a/tests/unit/simple_assoc_mock_model.mof
+++ b/tests/unit/simple_assoc_mock_model.mof
@@ -24,6 +24,8 @@ class TST_Person{
     string extraProperty = "defaultvalue";
 };
 
+// NOTE: classname uses lower case s in sub.  Instance names use upper case
+// This is good test of case insensitivity for class names.
 class TST_Personsub : TST_Person{
     string secondProperty = "empty";
     uint32 counter;

--- a/tests/unit/simple_mock_model_ext.mof
+++ b/tests/unit/simple_mock_model_ext.mof
@@ -80,6 +80,7 @@ class CIM_Foo_sub_sub : CIM_Foo_sub {
       string OutputParam2);
 };
 
+// 5 instances of CIM_Foo class
 
 class CIM_Foo_sub2 : CIM_Foo {
     string cimfoo_sub2;
@@ -101,7 +102,8 @@ instance of CIM_Foo as $foo3 { InstanceID = "CIM_Foo30"; };
 
 instance of CIM_Foo as $foo3 { InstanceID = "CIM_Foo31"; };
 
-// Additional instances behond simple_mof_model.mof
+
+// 4 instances of CIM_Foo_sub class
 
 instance of CIM_Foo_sub as $foosub1{
     InstanceID = "CIM_Foo_sub1";
@@ -122,6 +124,8 @@ instance of CIM_Foo_sub as $foosub1{
     InstanceID = "CIM_Foo_sub3";
     IntegerProp = 7;
     };
+
+// 3 instances of CIM_Foo_sub_sub
 
 instance of CIM_Foo_sub_sub as $foosubsub1{
     InstanceID = "CIM_Foo_sub_sub1";

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -22,7 +22,8 @@ from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
     CMD_OPTION_HELP_HELP_LINE, CMD_OPTION_SUMMARY_HELP_LINE, \
     CMD_OPTION_NAMESPACE_HELP_LINE, CMD_OPTION_PROPERTYLIST_HELP_LINE, \
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE, \
-    CMD_OPTION_LOCAL_ONLY_CLASS_HELP_LINE, CMD_OPTION_NO_QUALIFIERS_HELP_LINE
+    CMD_OPTION_LOCAL_ONLY_CLASS_HELP_LINE, CMD_OPTION_NO_QUALIFIERS_HELP_LINE, \
+    CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE
 
 from .utils import execute_pywbemcli, assert_rc
 
@@ -98,8 +99,8 @@ CLASS_ENUMERATE_HELP_LINES = [
 CLASS_FIND_HELP_LINES = [
     'Usage: pywbemcli class find [COMMAND-OPTIONS] CLASSNAME-GLOB',
     'List the classes with matching class names on the server.',
-    '-n, --namespace NAMESPACE Add a namespace to the search scope',
     '-s, --sort                 Sort by namespace. Default is to sort by',
+    CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 


### PR DESCRIPTION
Modifications to instance count

1. Adds namespace to table output
2. Expanded instance count command to allow multiple namespaces. default is to search all namespaces
3. Clarify that the count is for instances of the class named in the
table, not counting subclasses.
4. Fix issue with actual count. There was a class name comparison that
was not case insensitive.  Since in the mock tested the classname uses different case in the class declaration and instance declarations, the bad test failed.

The fix extended over a number of files.

1. Make common option for multiple namespaces (class find and instance
count)
2. Add note to mock_assoc_model.mof about the case difference in class
name.  Better than fixing it as it will catch errors.
3. Change the same option in class find to use the common option.