### PR TITLE
Fixes issue #349 consistency of prompting

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -44,12 +44,17 @@ This documentation uses a few special terms to refer to Python types:
       argument or option value of pywbemcli. Several commands of the instance
       command group use INSTANCENAME as a command line argument.
       The only supported format for INSTANCENAME is a :term:`WBEM URI`.
-      See also :ref:`Interactively selecting INSTANCENAME`.
+      See also :ref:`Specifying the INSTANCENAME command argument` for the
+      definition of how to define both a complete WBEM URL as INSTANCENAME
+      and to use a wildcard where pywbemcli presents a selection list of
+      instance names.
 
       Examples::
 
         CIM_RegisteredProfile.InstanceID="acme:1"
         CIM_System.CreationClassName="ACME_System",Name="MySystem"
+
+        CIM_System.?   # Interactive specification of instance name
 
    connection id
       A string that uniquely identifies each :class:`pywbem.WBEMConnection`

--- a/docs/pywbemclicmdlineinterface.rst
+++ b/docs/pywbemclicmdlineinterface.rst
@@ -300,7 +300,7 @@ Pywbemcli terminates with one of the following program exit codes:
     error. This will mostly be caused by CIM errors returned by the server,
     but can also be caused by the pywbemcli code itself.
 
-  * Programming errors in mock Python scripts (see `Mock support overview`_);
+  * Programming errors in mock Python scripts (see: :ref:`Mock support overview`);
     the error message includes a Python traceback of the error.
 
 * **1 - Python traceback**: In such cases, pywbemcli terminates during its

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -1005,7 +1005,7 @@ The following defines the help output for the `pywbemcli instance associators --
       specified in the --namespace option, or otherwise the default namespace of
       the connection. Any host name in the WBEM URI will be ignored.
 
-      2. By specifying the --interactive option and a CIM class name in the
+      2. By specifying a class name with the characters ".?" as the keys in the
       INSTANCENAME argument. The instances of the specified class are displayed
       and the user is prompted for an index number to select an instance. The
       CIM namespace in which the instances are looked up is the namespace
@@ -1058,10 +1058,6 @@ The following defines the help output for the `pywbemcli instance associators --
                                       including object paths.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
                                       of the default namespace of the connection.
-      -i, --interactive               Prompt for selecting an instance from a
-                                      list. If used, the INSTANCENAME argument
-                                      must be a class name, and the instances of
-                                      that class are presented.
       -s, --summary                   Show only a summary (count) of the objects.
       --fq, --filter-query QUERY-STRING
                                       When pull operations are used, filter the
@@ -1197,7 +1193,7 @@ The following defines the help output for the `pywbemcli instance delete --help`
       specified in the --namespace option, or otherwise the default namespace of
       the connection. Any host name in the WBEM URI will be ignored.
 
-      2. By specifying the --interactive option and a CIM class name in the
+      2. By specifying a class name with the characters ".?" as the keys in the
       INSTANCENAME argument. The instances of the specified class are displayed
       and the user is prompted for an index number to select an instance. The
       CIM namespace in which the instances are looked up is the namespace
@@ -1205,10 +1201,6 @@ The following defines the help output for the `pywbemcli instance delete --help`
       the connection.
 
     Options:
-      -i, --interactive          Prompt for selecting an instance from a list. If
-                                 used, the INSTANCENAME argument must be a class
-                                 name, and the instances of that class are
-                                 presented.
       -n, --namespace NAMESPACE  Namespace to use for this command, instead of the
                                  default namespace of the connection.
       -h, --help                 Show this message and exit.
@@ -1312,18 +1304,18 @@ The following defines the help output for the `pywbemcli instance get --help` co
 
       The instance can be specified in two ways:
 
-      * By specifying an untyped WBEM URI of an instance path in the
-      INSTANCENAME   argument. The namespace in which the instance is looked up
-      is the   namespace specified in the WBEM URI, or otherwise the namespace
-      specified   in the --namespace option, or otherwise the default namespace
-      of the   connection. Any host name in the WBEM URI will be ignored.
+      1. By specifying an untyped WBEM URI of an instance path in the
+      INSTANCENAME argument. The namespace in which the instance is looked up is
+      the namespace specified in the WBEM URI, or otherwise the namespace
+      specified in the --namespace option, or otherwise the default namespace of
+      the connection. Any host name in the WBEM URI will be ignored.
 
-      * By specifying the --interactive option and a class name in the
+      2. By specifying a class name with the characters ".?" as the keys in the
       INSTANCENAME argument. The instances of the specified class are displayed
-      and the user is prompted for an index number to select an instance.   The
-      namespace in which the instances are looked up is the namespace
-      specified in the --namespace option, or otherwise the default namespace
-      of the connection.
+      and the user is prompted for an index number to select an instance. The
+      namespace in which the instances are looked up is the namespace specified
+      in the --namespace option, or otherwise the default namespace of the
+      connection.
 
       In the output, the instance will formatted as defined by the --output-
       format general option.
@@ -1352,10 +1344,6 @@ The following defines the help output for the `pywbemcli instance get --help` co
                                       Default: Do not filter properties.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
                                       of the default namespace of the connection.
-      -i, --interactive               Prompt for selecting an instance from a
-                                      list. If used, the INSTANCENAME argument
-                                      must be a class name, and the instances of
-                                      that class are presented.
       -h, --help                      Show this message and exit.
 
 
@@ -1388,7 +1376,7 @@ The following defines the help output for the `pywbemcli instance invokemethod -
       specified in the --namespace option, or otherwise the default namespace of
       the connection. Any host name in the WBEM URI will be ignored.
 
-      2. By specifying the --interactive option and a CIM class name in the
+      2. By specifying a class name with the characters ".?" as the keys in the
       INSTANCENAME argument. The instances of the specified class are displayed
       and the user is prompted for an index number to select an instance. The
       CIM namespace in which the instances are looked up is the namespace
@@ -1416,10 +1404,6 @@ The following defines the help output for the `pywbemcli instance invokemethod -
                                       Array property values are specified as a
                                       comma-separated list; embedded instances are
                                       not supported. Default: No input parameters.
-      -i, --interactive               Prompt for selecting an instance from a
-                                      list. If used, the INSTANCENAME argument
-                                      must be a class name, and the instances of
-                                      that class are presented.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
                                       of the default namespace of the connection.
       -h, --help                      Show this message and exit.
@@ -1449,7 +1433,7 @@ The following defines the help output for the `pywbemcli instance modify --help`
       specified in the --namespace option, or otherwise the default namespace of
       the connection. Any host name in the WBEM URI will be ignored.
 
-      2. By specifying the --interactive option and a CIM class name in the
+      2. By specifying a class name with the characters ".?" as the keys in the
       INSTANCENAME argument. The instances of the specified class are displayed
       and the user is prompted for an index number to select an instance. The
       CIM namespace in which the instances are looked up is the namespace
@@ -1483,10 +1467,6 @@ The following defines the help output for the `pywbemcli instance modify --help`
                                       will cause no properties to be modified.
                                       Default: Do not reduce the properties to be
                                       modified.
-      -i, --interactive               Prompt for selecting an instance from a
-                                      list. If used, the INSTANCENAME argument
-                                      must be a class name, and the instances of
-                                      that class are presented.
       -V, --verify                    Prompt for confirmation before performing a
                                       change, to allow for verification of
                                       parameters. Default: Do not prompt for
@@ -1557,7 +1537,7 @@ The following defines the help output for the `pywbemcli instance references --h
       specified in the --namespace option, or otherwise the default namespace of
       the connection. Any host name in the WBEM URI will be ignored.
 
-      2. By specifying the --interactive option and a CIM class name in the
+      2. By specifying a class name with the characters ".?" as the keys in the
       INSTANCENAME argument. The instances of the specified class are displayed
       and the user is prompted for an index number to select an instance. The
       CIM namespace in which the instances are looked up is the namespace
@@ -1605,10 +1585,6 @@ The following defines the help output for the `pywbemcli instance references --h
                                       including object paths.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
                                       of the default namespace of the connection.
-      -i, --interactive               Prompt for selecting an instance from a
-                                      list. If used, the INSTANCENAME argument
-                                      must be a class name, and the instances of
-                                      that class are presented.
       -s, --summary                   Show only a summary (count) of the objects.
       --fq, --filter-query QUERY-STRING
                                       When pull operations are used, filter the

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -1005,12 +1005,12 @@ The following defines the help output for the `pywbemcli instance associators --
       specified in the --namespace option, or otherwise the default namespace of
       the connection. Any host name in the WBEM URI will be ignored.
 
-      2. By specifying a class name with the characters ".?" as the keys in the
-      INSTANCENAME argument. The instances of the specified class are displayed
-      and the user is prompted for an index number to select an instance. The
-      CIM namespace in which the instances are looked up is the namespace
-      specified in the --namespace option, or otherwise the default namespace of
-      the connection.
+      2. By specifying a class name with wildcard for the keys in the
+      INSTANCENAME argument, i.e. "CLASSNAME.?. The instances of the specified
+      class are displayed and the user is prompted for an index number to select
+      an instance. The namespace in which the instances are looked up is the
+      namespace specified in the --namespace option, or otherwise the default
+      namespace of the connection.
 
       The instances to be retrieved can be filtered by the --filter-query,
       --role, --result-role, --assoc-class, and --result-class options.
@@ -1193,12 +1193,12 @@ The following defines the help output for the `pywbemcli instance delete --help`
       specified in the --namespace option, or otherwise the default namespace of
       the connection. Any host name in the WBEM URI will be ignored.
 
-      2. By specifying a class name with the characters ".?" as the keys in the
-      INSTANCENAME argument. The instances of the specified class are displayed
-      and the user is prompted for an index number to select an instance. The
-      CIM namespace in which the instances are looked up is the namespace
-      specified in the --namespace option, or otherwise the default namespace of
-      the connection.
+      2. By specifying a class name with wildcard for the keys in the
+      INSTANCENAME argument, i.e. "CLASSNAME.?. The instances of the specified
+      class are displayed and the user is prompted for an index number to select
+      an instance. The namespace in which the instances are looked up is the
+      namespace specified in the --namespace option, or otherwise the default
+      namespace of the connection.
 
     Options:
       -n, --namespace NAMESPACE  Namespace to use for this command, instead of the
@@ -1305,17 +1305,17 @@ The following defines the help output for the `pywbemcli instance get --help` co
       The instance can be specified in two ways:
 
       1. By specifying an untyped WBEM URI of an instance path in the
-      INSTANCENAME argument. The namespace in which the instance is looked up is
-      the namespace specified in the WBEM URI, or otherwise the namespace
+      INSTANCENAME argument. The CIM namespace in which the instance is looked
+      up is the namespace specified in the WBEM URI, or otherwise the namespace
       specified in the --namespace option, or otherwise the default namespace of
       the connection. Any host name in the WBEM URI will be ignored.
 
-      2. By specifying a class name with the characters ".?" as the keys in the
-      INSTANCENAME argument. The instances of the specified class are displayed
-      and the user is prompted for an index number to select an instance. The
-      namespace in which the instances are looked up is the namespace specified
-      in the --namespace option, or otherwise the default namespace of the
-      connection.
+      2. By specifying a class name with wildcard for the keys in the
+      INSTANCENAME argument, i.e. "CLASSNAME.?. The instances of the specified
+      class are displayed and the user is prompted for an index number to select
+      an instance. The namespace in which the instances are looked up is the
+      namespace specified in the --namespace option, or otherwise the default
+      namespace of the connection.
 
       In the output, the instance will formatted as defined by the --output-
       format general option.
@@ -1376,12 +1376,12 @@ The following defines the help output for the `pywbemcli instance invokemethod -
       specified in the --namespace option, or otherwise the default namespace of
       the connection. Any host name in the WBEM URI will be ignored.
 
-      2. By specifying a class name with the characters ".?" as the keys in the
-      INSTANCENAME argument. The instances of the specified class are displayed
-      and the user is prompted for an index number to select an instance. The
-      CIM namespace in which the instances are looked up is the namespace
-      specified in the --namespace option, or otherwise the default namespace of
-      the connection.
+      2. By specifying a class name with wildcard for the keys in the
+      INSTANCENAME argument, i.e. "CLASSNAME.?. The instances of the specified
+      class are displayed and the user is prompted for an index number to select
+      an instance. The namespace in which the instances are looked up is the
+      namespace specified in the --namespace option, or otherwise the default
+      namespace of the connection.
 
       The method input parameters are specified using the --parameter option,
       which may be specified multiple times.
@@ -1433,12 +1433,12 @@ The following defines the help output for the `pywbemcli instance modify --help`
       specified in the --namespace option, or otherwise the default namespace of
       the connection. Any host name in the WBEM URI will be ignored.
 
-      2. By specifying a class name with the characters ".?" as the keys in the
-      INSTANCENAME argument. The instances of the specified class are displayed
-      and the user is prompted for an index number to select an instance. The
-      CIM namespace in which the instances are looked up is the namespace
-      specified in the --namespace option, or otherwise the default namespace of
-      the connection.
+      2. By specifying a class name with wildcard for the keys in the
+      INSTANCENAME argument, i.e. "CLASSNAME.?. The instances of the specified
+      class are displayed and the user is prompted for an index number to select
+      an instance. The namespace in which the instances are looked up is the
+      namespace specified in the --namespace option, or otherwise the default
+      namespace of the connection.
 
       The properties to be modified and their new values are specified using the
       --property option, which may be specified multiple times.
@@ -1537,12 +1537,12 @@ The following defines the help output for the `pywbemcli instance references --h
       specified in the --namespace option, or otherwise the default namespace of
       the connection. Any host name in the WBEM URI will be ignored.
 
-      2. By specifying a class name with the characters ".?" as the keys in the
-      INSTANCENAME argument. The instances of the specified class are displayed
-      and the user is prompted for an index number to select an instance. The
-      CIM namespace in which the instances are looked up is the namespace
-      specified in the --namespace option, or otherwise the default namespace of
-      the connection.
+      2. By specifying a class name with wildcard for the keys in the
+      INSTANCENAME argument, i.e. "CLASSNAME.?. The instances of the specified
+      class are displayed and the user is prompted for an index number to select
+      an instance. The namespace in which the instances are looked up is the
+      namespace specified in the --namespace option, or otherwise the default
+      namespace of the connection.
 
       The instances to be retrieved can be filtered by the --filter-query,
       --role and --result-class options.

--- a/docs/pywbemclicommands.rst
+++ b/docs/pywbemclicommands.rst
@@ -387,13 +387,8 @@ Instance associators command
 The ``instance associators`` command lists the CIM instances that are associated
 with the specified source instance.
 
-The instance name (INSTANCENAME argument) can be specified in two ways as
-defined in :ref:`Interactively selecting INSTANCENAME`:
-
-* By specifying an untyped WBEM_URI.
-
-* By specifying the WBEM_URI with the wild card "?" in place of the keys
-  component of the WBEM_URI, (i.e. <classname>.?).
+The specification of the instance name (INSTANCENAME argument) is documented
+in the section :ref:`Specifying the INSTANCENAME command argument`.
 
 If the ``--names-only``/``--no`` command option is set, only the instance paths
 are displayed. Otherwise, the instances are displayed.
@@ -517,13 +512,8 @@ Instance delete command
 
 The ``instance delete`` command deletes a CIM instance.
 
-The instance name (INSTANCENAME argument) can be specified in two ways as
-defined in :ref:`Interactively selecting INSTANCENAME`:
-
-* By specifying an untyped WBEM_URI.
-
-* By specifying the WBEM_URI with the wild card "?" in place of the keys
-  component of the WBEM_URI, (i.e. <classname>.?).
+The specification of the instance name (INSTANCENAME argument) is documented
+in the section :ref:`Specifying the INSTANCENAME command argument`.
 
 The following example deletes an instance by specifying its instance name.
 Note the extra backslash (see :term:`backslash-escaped`) that is required to
@@ -578,13 +568,8 @@ Instance get command
 
 The ``instance get`` command gets a CIM instance.
 
-The instance name (INSTANCENAME argument) can be specified in two ways as
-defined in :ref:`Interactively selecting INSTANCENAME`:
-
-* By specifying an untyped WBEM_URI.
-
-* By specifying the WBEM_URI with the wild card "?" in place of the keys
-  component of the WBEM_URI, (i.e. <classname>.?).
+The specification of the instance name (INSTANCENAME argument) is documented
+in the section :ref:`Specifying the INSTANCENAME command argument`.
 
 The command displays the instance using :term:`CIM object output formats`
 or :term:`Table output formats`.
@@ -598,7 +583,7 @@ This example gets an instance by instance name:
        name = "Saara";
     };
 
-or using the keys wild card:
+or using the keys wildcard:
 
 .. code-block:: text
 
@@ -624,13 +609,8 @@ Instance invokemethod command
 The ``instance invokemethod`` command invokes a CIM method on the specified
 instance and displays the return value and any output parameters.
 
-The instance name (INSTANCENAME argument) can be specified in two ways as
-defined in :ref:`Interactively selecting INSTANCENAME`:
-
-* By specifying an untyped WBEM_URI.
-
-* By specifying the WBEM_URI with the wild card "?" in place of the keys
-  component of the WBEM_URI, (i.e. <classname>.?).
+The specification of the instance name (INSTANCENAME argument) is documented
+in the section :ref:`Specifying the INSTANCENAME command argument`.
 
 Input parameters for the method can be specified with the ``--parameter``/``-p``
 command option, which can be specified multiple times.
@@ -649,7 +629,7 @@ Example:
     ReturnValue=0
     arrBool=true, false
 
-Or using the wild card to create a selection list for the instance names
+Or using the wildcard to create a selection list for the instance names
 
 .. code-block:: text
 
@@ -675,13 +655,8 @@ Instance modify command
 The ``instance modify`` command modifies the properties of an existing CIM
 instance.
 
-The instance name (INSTANCENAME argument) can be specified in two ways as
-defined in :ref:`Interactively selecting INSTANCENAME`:
-
-* By specifying an untyped WBEM_URI.
-
-* By specifying the WBEM_URI with the wild card "?" in place of the keys
-  component of the WBEM_URI, (i.e. <classname>.?).
+The specification of the instance name (INSTANCENAME argument) is documented
+in the section :ref:`Specifying the INSTANCENAME command argument`.
 
 The new property values are specified by possibly multiple ``--property``/``-p``
 command options.
@@ -702,13 +677,8 @@ Instance references command
 The ``instance references`` command lists the CIM instances that reference
 the specified source instance.
 
-The instance name (INSTANCENAME argument) can be specified in two ways as
-defined in :ref:`Interactively selecting INSTANCENAME`:
-
-* By specifying an untyped WBEM_URI.
-
-* By specifying the WBEM_URI with the wild card "?" in place of the keys
-  component of the WBEM_URI, (i.e. <classname>.?).
+The specification of the instance name (INSTANCENAME argument) is documented
+in the section :ref:`Specifying the INSTANCENAME command argument`.
 
 If the ``--names-only``/``--no`` command option is set, only the instance paths
 are displayed. Otherwise, the instances are displayed.

--- a/docs/pywbemclicommands.rst
+++ b/docs/pywbemclicommands.rst
@@ -387,22 +387,13 @@ Instance associators command
 The ``instance associators`` command lists the CIM instances that are associated
 with the specified source instance.
 
-The source instance can be specified in two ways:
+The instance name (INSTANCENAME argument) can be specified in two ways as
+defined in :ref:`Interactively selecting INSTANCENAME`:
 
-* By specifying an untyped WBEM URI of an instance path in the
-  ``INSTANCENAME`` argument. The namespace of the instance is the namespace
-  specified in the WBEM URI, or otherwise the namespace specified with the
-  ``-namespace``/``-n`` command option, or otherwise the default namespace
-  of the connection. Any host name in the WBEM URI will be ignored.
-  For details, see :ref:`Specifying the INSTANCENAME command argument`.
+* By specifying an untyped WBEM_URI.
 
-* By specifying the ``--interactive`` command option and a class name in the
-  ``INSTANCENAME`` argument. The instances of the specified class are displayed
-  and the user is prompted for an index number to select an instance. The
-  namespace of the instance is the namespace specified with the
-  ``-namespace``/``-n`` command option, or otherwise the default namespace
-  of the connection.
-  For details, see :ref:`Interactively selecting INSTANCENAME`.
+* By specifying the WBEM_URI with the wild card "?" in place of the keys
+  component of the WBEM_URI, (i.e. <classname>.?).
 
 If the ``--names-only``/``--no`` command option is set, only the instance paths
 are displayed. Otherwise, the instances are displayed.
@@ -414,7 +405,7 @@ Example:
 
 .. code-block:: text
 
-    $ pywbemcli --name mymock instance references TST_Person --names-only --interactive
+    $ pywbemcli --name mymock instance references TST_Person.? --names-only
     Pick Instance name to process: 0
     0: root/cimv2:TST_Person.name="Mike"
     1: root/cimv2:TST_Person.name="Saara"
@@ -526,22 +517,13 @@ Instance delete command
 
 The ``instance delete`` command deletes a CIM instance.
 
-The instance can be specified in two ways:
+The instance name (INSTANCENAME argument) can be specified in two ways as
+defined in :ref:`Interactively selecting INSTANCENAME`:
 
-* By specifying an untyped WBEM URI of an instance path in the
-  ``INSTANCENAME`` argument. The namespace of the instance is the namespace
-  specified in the WBEM URI, or otherwise the namespace specified with the
-  ``-namespace``/``-n`` command option, or otherwise the default namespace
-  of the connection. Any host name in the WBEM URI will be ignored.
-  For details, see :ref:`Specifying the INSTANCENAME command argument`.
+* By specifying an untyped WBEM_URI.
 
-* By specifying the ``--interactive`` command option and a class name in the
-  ``INSTANCENAME`` argument. The instances of the specified class are displayed
-  and the user is prompted for an index number to select an instance. The
-  namespace of the instance is the namespace specified with the
-  ``-namespace``/``-n`` command option, or otherwise the default namespace
-  of the connection.
-  For details, see :ref:`Interactively selecting INSTANCENAME`.
+* By specifying the WBEM_URI with the wild card "?" in place of the keys
+  component of the WBEM_URI, (i.e. <classname>.?).
 
 The following example deletes an instance by specifying its instance name.
 Note the extra backslash (see :term:`backslash-escaped`) that is required to
@@ -596,22 +578,13 @@ Instance get command
 
 The ``instance get`` command gets a CIM instance.
 
-The instance can be specified in two ways:
+The instance name (INSTANCENAME argument) can be specified in two ways as
+defined in :ref:`Interactively selecting INSTANCENAME`:
 
-* By specifying an untyped WBEM URI of an instance path in the
-  ``INSTANCENAME`` argument. The namespace of the instance is the namespace
-  specified in the WBEM URI, or otherwise the namespace specified with the
-  ``-namespace``/``-n`` command option, or otherwise the default namespace
-  of the connection. Any host name in the WBEM URI will be ignored.
-  For details, see :ref:`Specifying the INSTANCENAME command argument`.
+* By specifying an untyped WBEM_URI.
 
-* By specifying the ``--interactive`` command option and a class name in the
-  ``INSTANCENAME`` argument. The instances of the specified class are displayed
-  and the user is prompted for an index number to select an instance. The
-  namespace of the instance is the namespace specified with the
-  ``-namespace``/``-n`` command option, or otherwise the default namespace
-  of the connection.
-  For details, see :ref:`Interactively selecting INSTANCENAME`.
+* By specifying the WBEM_URI with the wild card "?" in place of the keys
+  component of the WBEM_URI, (i.e. <classname>.?).
 
 The command displays the instance using :term:`CIM object output formats`
 or :term:`Table output formats`.
@@ -625,6 +598,21 @@ This example gets an instance by instance name:
        name = "Saara";
     };
 
+or using the keys wild card:
+
+.. code-block:: text
+
+    $ pywbemcli --name mymock instance get root/cimv2:TST_Person.?
+    Pick Instance name to process
+    0: root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"
+    1: root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"
+    2: root/cimv2:CIM_Foo.InstanceID="CIM_Foo3"
+    Input integer between 0 and 2 or Ctrl-C to exit selection: : 0
+    instance of TST_Person {
+       name = "Saara";
+    };
+
+
 See :ref:`pywbemcli instance get --help` for details.
 
 
@@ -636,22 +624,13 @@ Instance invokemethod command
 The ``instance invokemethod`` command invokes a CIM method on the specified
 instance and displays the return value and any output parameters.
 
-The instance can be specified in two ways:
+The instance name (INSTANCENAME argument) can be specified in two ways as
+defined in :ref:`Interactively selecting INSTANCENAME`:
 
-* By specifying an untyped WBEM URI of an instance path in the
-  ``INSTANCENAME`` argument. The namespace of the instance is the namespace
-  specified in the WBEM URI, or otherwise the namespace specified with the
-  ``-namespace``/``-n`` command option, or otherwise the default namespace
-  of the connection. Any host name in the WBEM URI will be ignored.
-  For details, see :ref:`Specifying the INSTANCENAME command argument`.
+* By specifying an untyped WBEM_URI.
 
-* By specifying the ``--interactive`` command option and a class name in the
-  ``INSTANCENAME`` argument. The instances of the specified class are displayed
-  and the user is prompted for an index number to select an instance. The
-  namespace of the instance is the namespace specified with the
-  ``-namespace``/``-n`` command option, or otherwise the default namespace
-  of the connection.
-  For details, see :ref:`Interactively selecting INSTANCENAME`.
+* By specifying the WBEM_URI with the wild card "?" in place of the keys
+  component of the WBEM_URI, (i.e. <classname>.?).
 
 Input parameters for the method can be specified with the ``--parameter``/``-p``
 command option, which can be specified multiple times.
@@ -670,6 +649,21 @@ Example:
     ReturnValue=0
     arrBool=true, false
 
+Or using the wild card to create a selection list for the instance names
+
+.. code-block:: text
+
+    $ pywbemcli --mock-server tests/unit/all_types.mof --mock-server tests/unit/all_types_method_mock.py.py
+
+    pywbemcli> instance invokemethod PyWBEM_AllTypes.? --parameter arrBool=True,False
+    Pick Instance name to process
+    0: root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"
+    1: root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"
+    2: root/cimv2:CIM_Foo.InstanceID="CIM_Foo3"
+    Input integer between 0 and 2 or Ctrl-C to exit selection: : 0
+    ReturnValue=0
+    arrBool=true, false
+
 See :ref:`pywbemcli instance invokemethod --help` for details.
 
 
@@ -681,22 +675,13 @@ Instance modify command
 The ``instance modify`` command modifies the properties of an existing CIM
 instance.
 
-The instance can be specified in two ways:
+The instance name (INSTANCENAME argument) can be specified in two ways as
+defined in :ref:`Interactively selecting INSTANCENAME`:
 
-* By specifying an untyped WBEM URI of an instance path in the
-  ``INSTANCENAME`` argument. The namespace of the instance is the namespace
-  specified in the WBEM URI, or otherwise the namespace specified with the
-  ``-namespace``/``-n`` command option, or otherwise the default namespace
-  of the connection. Any host name in the WBEM URI will be ignored.
-  For details, see :ref:`Specifying the INSTANCENAME command argument`.
+* By specifying an untyped WBEM_URI.
 
-* By specifying the ``--interactive`` command option and a class name in the
-  ``INSTANCENAME`` argument. The instances of the specified class are displayed
-  and the user is prompted for an index number to select an instance. The
-  namespace of the instance is the namespace specified with the
-  ``-namespace``/``-n`` command option, or otherwise the default namespace
-  of the connection.
-  For details, see :ref:`Interactively selecting INSTANCENAME`.
+* By specifying the WBEM_URI with the wild card "?" in place of the keys
+  component of the WBEM_URI, (i.e. <classname>.?).
 
 The new property values are specified by possibly multiple ``--property``/``-p``
 command options.
@@ -717,22 +702,13 @@ Instance references command
 The ``instance references`` command lists the CIM instances that reference
 the specified source instance.
 
-The source instance can be specified in two ways:
+The instance name (INSTANCENAME argument) can be specified in two ways as
+defined in :ref:`Interactively selecting INSTANCENAME`:
 
-* By specifying an untyped WBEM URI of an instance path in the
-  ``INSTANCENAME`` argument. The namespace of the instance is the namespace
-  specified in the WBEM URI, or otherwise the namespace specified with the
-  ``-namespace``/``-n`` command option, or otherwise the default namespace
-  of the connection. Any host name in the WBEM URI will be ignored.
-  For details, see :ref:`Specifying the INSTANCENAME command argument`.
+* By specifying an untyped WBEM_URI.
 
-* By specifying the ``--interactive`` command option and a class name in the
-  ``INSTANCENAME`` argument. The instances of the specified class are displayed
-  and the user is prompted for an index number to select an instance. The
-  namespace of the instance is the namespace specified with the
-  ``-namespace``/``-n`` command option, or otherwise the default namespace
-  of the connection.
-  For details, see :ref:`Interactively selecting INSTANCENAME`.
+* By specifying the WBEM_URI with the wild card "?" in place of the keys
+  component of the WBEM_URI, (i.e. <classname>.?).
 
 If the ``--names-only``/``--no`` command option is set, only the instance paths
 are displayed. Otherwise, the instances are displayed.

--- a/docs/pywbemclifeatures.rst
+++ b/docs/pywbemclifeatures.rst
@@ -289,20 +289,44 @@ The following are examples of scalar property definitions:
 Interactively selecting INSTANCENAME
 ------------------------------------
 
-The INSTANCENAME argument has a certain complexity, particularly for
-associations and for classes with multiple keys.
+The INSTANCENAME argument can be complex, particularly for associations and
+classes with multiple keys.
 
-To simplify this, pywbemcli provides an option (``-i`` or ``--interactive``) on
-commands that have an INSTANCENAME argument, that allows the user to specify
-only the class name (as the INSTANCENAME argument value), retrieves all the
-instance names of that class from the server and presents the user with a
-select list from which an instance name can be chosen.
+To simplify using INSTANCENAME on the command line, pywbemcli provides a wild
+card character "?" that can be used with commands in place of the INSTANCENAME
+keys on commands that have an INSTANCENAME argument. This allows the user to
+specify only the class name (as the INSTANCENAME argument value) with the wild
+card for the keys. Pywbemcli retrieves all instance names of that class from
+the server and presents the user with a select list from which an instance name
+can be chosen.
+
+Thus an INSTANCENAME argument on the command line can be specified in two ways:
+
+* By specifying an untyped WBEM URI of an instance path in the
+  ``INSTANCENAME`` argument. The namespace of the instance is the namespace
+  specified in the WBEM URI, or otherwise the namespace specified with the
+  ``-namespace``/``-n`` command option, or otherwise the default namespace
+  of the connection. Any host name in the WBEM URI will be ignored.
+  For details, see :ref:`Specifying the INSTANCENAME command argument`.
+
+* By specifying the ``--interactive`` command option and a class name in the
+  ``INSTANCENAME`` argument. The instances of the specified class are displayed
+  and the user is prompted for an index number to select an instance. The
+  namespace of the instance is the namespace specified with the
+  ``-namespace``/``-n`` command option, or otherwise the default namespace
+  of the connection.
+  For details, see :ref:`Interactively selecting INSTANCENAME`.
+
+Thus, in place of the full instance name (ex.
+``CIM_Foo.InstanceID="CIM_Foo1"``) the users uses ``CIM_Foo.?`` to initiate
+pywbemcli instance name selection
+
 
 Example:
 
 .. code-block:: text
 
-    $ pywbemcli --mock-server tests/unit/simple_mock_model.mof instance get CIM_Foo --interactive
+    $ pywbemcli --mock-server tests/unit/simple_mock_model.mof instance get CIM_Foo.?
     Pick Instance name to process
     0: root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"
     1: root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -86,12 +86,6 @@ local_only_list_option = [              # pylint: disable=invalid-name
                       'By default, and when pull operations are used, '
                       'superclass properties will always be included.')]
 
-interactive_option = [              # pylint: disable=invalid-name
-    click.option('-i', '--interactive', is_flag=True, required=False,
-                 help='Prompt for selecting an instance from a list. '
-                      'If used, the INSTANCENAME argument must be a class '
-                      'name, and the instances of that class are presented.')]
-
 property_create_option = [              # pylint: disable=invalid-name
     click.option('-p', '--property', type=str, metavar='PROPERTYNAME=VALUE',
                  required=False, multiple=True,
@@ -160,7 +154,6 @@ def instance_group():
 @add_options(include_classorigin_instance_option)
 @add_options(propertylist_option)
 @add_options(namespace_option)
-@add_options(interactive_option)
 @click.pass_obj
 def instance_get(context, instancename, **options):
     """
@@ -168,18 +161,18 @@ def instance_get(context, instancename, **options):
 
     The instance can be specified in two ways:
 
-    * By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
-      argument. The namespace in which the instance is looked up is the
-      namespace specified in the WBEM URI, or otherwise the namespace specified
-      in the --namespace option, or otherwise the default namespace of the
-      connection. Any host name in the WBEM URI will be ignored.
+    1. By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
+    argument. The namespace in which the instance is looked up is the
+    namespace specified in the WBEM URI, or otherwise the namespace specified
+    in the --namespace option, or otherwise the default namespace of the
+    connection. Any host name in the WBEM URI will be ignored.
 
-    * By specifying the --interactive option and a class name in the
-      INSTANCENAME argument. The instances of the specified class are displayed
-      and the user is prompted for an index number to select an instance.
-      The namespace in which the instances are looked up is the namespace
-      specified in the --namespace option, or otherwise the default namespace
-      of the connection.
+    2. By specifying a class name with the characters ".?" as the keys in the
+    INSTANCENAME argument. The instances of the specified class are displayed
+    and the user is prompted for an index number to select an instance.
+    The namespace in which the instances are looked up is the namespace
+    specified in the --namespace option, or otherwise the default namespace
+    of the connection.
 
     In the output, the instance will formatted as defined by the
     --output-format general option.
@@ -190,7 +183,6 @@ def instance_get(context, instancename, **options):
 
 @instance_group.command('delete', options_metavar=CMD_OPTS_TXT)
 @click.argument('instancename', type=str, metavar='INSTANCENAME', required=True)
-@add_options(interactive_option)
 @add_options(namespace_option)
 @click.pass_obj
 def instance_delete(context, instancename, **options):
@@ -205,7 +197,7 @@ def instance_delete(context, instancename, **options):
     in the --namespace option, or otherwise the default namespace of the
     connection. Any host name in the WBEM URI will be ignored.
 
-    2. By specifying the --interactive option and a CIM class name in the
+    2. By specifying a class name with the characters ".?" as the keys in the
     INSTANCENAME argument. The instances of the specified class are displayed
     and the user is prompted for an index number to select an instance.
     The CIM namespace in which the instances are looked up is the namespace
@@ -259,7 +251,6 @@ def instance_create(context, classname, **options):
               'times. The empty string will cause no properties to '
               'be modified. '
               'Default: Do not reduce the properties to be modified.')
-@add_options(interactive_option)
 @add_options(verify_option)
 @add_options(namespace_option)
 @click.pass_obj
@@ -275,7 +266,7 @@ def instance_modify(context, instancename, **options):
     in the --namespace option, or otherwise the default namespace of the
     connection. Any host name in the WBEM URI will be ignored.
 
-    2. By specifying the --interactive option and a CIM class name in the
+    2. By specifying a class name with the characters ".?" as the keys in the
     INSTANCENAME argument. The instances of the specified class are displayed
     and the user is prompted for an index number to select an instance.
     The CIM namespace in which the instances are looked up is the namespace
@@ -306,7 +297,6 @@ def instance_modify(context, instancename, **options):
                    'Array property values are specified as a comma-separated '
                    'list; embedded instances are not supported. '
                    'Default: No input parameters.')
-@add_options(interactive_option)
 @add_options(namespace_option)
 @click.pass_obj
 def instance_invokemethod(context, instancename, methodname, **options):
@@ -325,7 +315,7 @@ def instance_invokemethod(context, instancename, methodname, **options):
     in the --namespace option, or otherwise the default namespace of the
     connection. Any host name in the WBEM URI will be ignored.
 
-    2. By specifying the --interactive option and a CIM class name in the
+    2. By specifying a class name with the characters ".?" as the keys in the
     INSTANCENAME argument. The instances of the specified class are displayed
     and the user is prompted for an index number to select an instance.
     The CIM namespace in which the instances are looked up is the namespace
@@ -404,7 +394,6 @@ def instance_enumerate(context, classname, **options):
 @add_options(propertylist_option)
 @add_options(names_only_option)
 @add_options(namespace_option)
-@add_options(interactive_option)
 @add_options(summary_option)
 @add_options(filter_query_option)
 @add_options(filter_query_language_option)
@@ -425,7 +414,7 @@ def instance_references(context, instancename, **options):
     in the --namespace option, or otherwise the default namespace of the
     connection. Any host name in the WBEM URI will be ignored.
 
-    2. By specifying the --interactive option and a CIM class name in the
+    2. By specifying a class name with the characters ".?" as the keys in the
     INSTANCENAME argument. The instances of the specified class are displayed
     and the user is prompted for an index number to select an instance.
     The CIM namespace in which the instances are looked up is the namespace
@@ -469,7 +458,6 @@ def instance_references(context, instancename, **options):
 @add_options(propertylist_option)
 @add_options(names_only_option)
 @add_options(namespace_option)
-@add_options(interactive_option)
 @add_options(summary_option)
 @add_options(filter_query_option)
 @add_options(filter_query_language_option)
@@ -490,7 +478,7 @@ def instance_associators(context, instancename, **options):
     in the --namespace option, or otherwise the default namespace of the
     connection. Any host name in the WBEM URI will be ignored.
 
-    2. By specifying the --interactive option and a CIM class name in the
+    2. By specifying a class name with the characters ".?" as the keys in the
     INSTANCENAME argument. The instances of the specified class are displayed
     and the user is prompted for an index number to select an instance.
     The CIM namespace in which the instances are looked up is the namespace
@@ -584,13 +572,17 @@ def instance_count(context, classname, **options):
 def get_instancename(context, instancename, options):
     """
     Common function to get the instancename from either the input or the user.
+    If the instance name replaces the keys with ".?" execute the console
+    prompt to select the instance name.
 
     Returns:
      CIMInstanceName with namespace retrieved either from the namespace option
      in options dictionary or the connection default_namespace.
     """
     try:
-        if options['interactive']:
+        # if the keys component is the character ? execute select
+        if instancename.endswith(".?"):
+            instancename = instancename[:-2]
             ns = options.get('namespace', context.conn.default_namespace)
 
             try:
@@ -603,7 +595,8 @@ def get_instancename(context, instancename, options):
                 return None
 
         else:
-            instancepath = parse_wbemuri_str(instancename, options['namespace'])
+            instancepath = parse_wbemuri_str(instancename,
+                                             options['namespace'])
         return instancepath
 
     except ValueError as ve:

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -161,18 +161,18 @@ def instance_get(context, instancename, **options):
 
     The instance can be specified in two ways:
 
-    1. By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
-    argument. The namespace in which the instance is looked up is the
-    namespace specified in the WBEM URI, or otherwise the namespace specified
-    in the --namespace option, or otherwise the default namespace of the
-    connection. Any host name in the WBEM URI will be ignored.
+    1. By specifying an untyped WBEM URI of an instance path in the
+    INSTANCENAME argument. The CIM namespace in which the instance is looked up
+    is the namespace specified in the WBEM URI, or otherwise the namespace
+    specified in the --namespace option, or otherwise the default namespace of
+    the connection. Any host name in the WBEM URI will be ignored.
 
-    2. By specifying a class name with the characters ".?" as the keys in the
-    INSTANCENAME argument. The instances of the specified class are displayed
-    and the user is prompted for an index number to select an instance.
-    The namespace in which the instances are looked up is the namespace
-    specified in the --namespace option, or otherwise the default namespace
-    of the connection.
+    2. By specifying a class name with wildcard for the keys in the
+    INSTANCENAME argument, i.e. "CLASSNAME.?. The instances of the specified
+    class are displayed and the user is prompted for an index number to select
+    an instance. The namespace in which the instances are looked up is the
+    namespace specified in the --namespace option, or otherwise the default
+    namespace of the connection.
 
     In the output, the instance will formatted as defined by the
     --output-format general option.
@@ -191,18 +191,18 @@ def instance_delete(context, instancename, **options):
 
     The CIM instance to be deleted can be specified as follows:
 
-    1. By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
-    argument. The CIM namespace in which the instance is looked up is the
-    namespace specified in the WBEM URI, or otherwise the namespace specified
-    in the --namespace option, or otherwise the default namespace of the
-    connection. Any host name in the WBEM URI will be ignored.
+    1. By specifying an untyped WBEM URI of an instance path in the
+    INSTANCENAME argument. The CIM namespace in which the instance is looked up
+    is the namespace specified in the WBEM URI, or otherwise the namespace
+    specified in the --namespace option, or otherwise the default namespace of
+    the connection. Any host name in the WBEM URI will be ignored.
 
-    2. By specifying a class name with the characters ".?" as the keys in the
-    INSTANCENAME argument. The instances of the specified class are displayed
-    and the user is prompted for an index number to select an instance.
-    The CIM namespace in which the instances are looked up is the namespace
-    specified in the --namespace option, or otherwise the default namespace
-    of the connection.
+    2. By specifying a class name with wildcard for the keys in the
+    INSTANCENAME argument, i.e. "CLASSNAME.?. The instances of the specified
+    class are displayed and the user is prompted for an index number to select
+    an instance. The namespace in which the instances are looked up is the
+    namespace specified in the --namespace option, or otherwise the default
+    namespace of the connection.
     """
     context.execute_cmd(lambda: cmd_instance_delete(context, instancename,
                                                     options))
@@ -260,18 +260,18 @@ def instance_modify(context, instancename, **options):
 
     The CIM instance to be modified can be specified in two ways:
 
-    1. By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
-    argument. The CIM namespace in which the instance is looked up is the
-    namespace specified in the WBEM URI, or otherwise the namespace specified
-    in the --namespace option, or otherwise the default namespace of the
-    connection. Any host name in the WBEM URI will be ignored.
+    1. By specifying an untyped WBEM URI of an instance path in the
+    INSTANCENAME argument. The CIM namespace in which the instance is looked up
+    is the namespace specified in the WBEM URI, or otherwise the namespace
+    specified in the --namespace option, or otherwise the default namespace of
+    the connection. Any host name in the WBEM URI will be ignored.
 
-    2. By specifying a class name with the characters ".?" as the keys in the
-    INSTANCENAME argument. The instances of the specified class are displayed
-    and the user is prompted for an index number to select an instance.
-    The CIM namespace in which the instances are looked up is the namespace
-    specified in the --namespace option, or otherwise the default namespace
-    of the connection.
+    2. By specifying a class name with wildcard for the keys in the
+    INSTANCENAME argument, i.e. "CLASSNAME.?. The instances of the specified
+    class are displayed and the user is prompted for an index number to select
+    an instance. The namespace in which the instances are looked up is the
+    namespace specified in the --namespace option, or otherwise the default
+    namespace of the connection.
 
     The properties to be modified and their new values are specified using the
     --property option, which may be specified multiple times.
@@ -309,18 +309,18 @@ def instance_invokemethod(context, instancename, methodname, **options):
 
     The CIM instance can be specified in two ways:
 
-    1. By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
-    argument. The CIM namespace in which the instance is looked up is the
-    namespace specified in the WBEM URI, or otherwise the namespace specified
-    in the --namespace option, or otherwise the default namespace of the
-    connection. Any host name in the WBEM URI will be ignored.
+    1. By specifying an untyped WBEM URI of an instance path in the
+    INSTANCENAME argument. The CIM namespace in which the instance is looked up
+    is the namespace specified in the WBEM URI, or otherwise the namespace
+    specified in the --namespace option, or otherwise the default namespace of
+    the connection. Any host name in the WBEM URI will be ignored.
 
-    2. By specifying a class name with the characters ".?" as the keys in the
-    INSTANCENAME argument. The instances of the specified class are displayed
-    and the user is prompted for an index number to select an instance.
-    The CIM namespace in which the instances are looked up is the namespace
-    specified in the --namespace option, or otherwise the default namespace
-    of the connection.
+    2. By specifying a class name with wildcard for the keys in the
+    INSTANCENAME argument, i.e. "CLASSNAME.?. The instances of the specified
+    class are displayed and the user is prompted for an index number to select
+    an instance. The namespace in which the instances are looked up is the
+    namespace specified in the --namespace option, or otherwise the default
+    namespace of the connection.
 
     The method input parameters are specified using the --parameter option,
     which may be specified multiple times.
@@ -408,18 +408,18 @@ def instance_references(context, instancename, **options):
 
     The CIM instance can be specified in two ways:
 
-    1. By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
-    argument. The CIM namespace in which the instance is looked up is the
-    namespace specified in the WBEM URI, or otherwise the namespace specified
-    in the --namespace option, or otherwise the default namespace of the
-    connection. Any host name in the WBEM URI will be ignored.
+    1. By specifying an untyped WBEM URI of an instance path in the
+    INSTANCENAME argument. The CIM namespace in which the instance is looked up
+    is the namespace specified in the WBEM URI, or otherwise the namespace
+    specified in the --namespace option, or otherwise the default namespace of
+    the connection. Any host name in the WBEM URI will be ignored.
 
-    2. By specifying a class name with the characters ".?" as the keys in the
-    INSTANCENAME argument. The instances of the specified class are displayed
-    and the user is prompted for an index number to select an instance.
-    The CIM namespace in which the instances are looked up is the namespace
-    specified in the --namespace option, or otherwise the default namespace
-    of the connection.
+    2. By specifying a class name with wildcard for the keys in the
+    INSTANCENAME argument, i.e. "CLASSNAME.?. The instances of the specified
+    class are displayed and the user is prompted for an index number to select
+    an instance. The namespace in which the instances are looked up is the
+    namespace specified in the --namespace option, or otherwise the default
+    namespace of the connection.
 
     The instances to be retrieved can be filtered by the --filter-query, --role
     and --result-class options.
@@ -472,18 +472,18 @@ def instance_associators(context, instancename, **options):
 
     The CIM instance can be specified in two ways:
 
-    1. By specifying an untyped WBEM URI of an instance path in the INSTANCENAME
-    argument. The CIM namespace in which the instance is looked up is the
-    namespace specified in the WBEM URI, or otherwise the namespace specified
-    in the --namespace option, or otherwise the default namespace of the
-    connection. Any host name in the WBEM URI will be ignored.
+    1. By specifying an untyped WBEM URI of an instance path in the
+    INSTANCENAME argument. The CIM namespace in which the instance is looked up
+    is the namespace specified in the WBEM URI, or otherwise the namespace
+    specified in the --namespace option, or otherwise the default namespace of
+    the connection. Any host name in the WBEM URI will be ignored.
 
-    2. By specifying a class name with the characters ".?" as the keys in the
-    INSTANCENAME argument. The instances of the specified class are displayed
-    and the user is prompted for an index number to select an instance.
-    The CIM namespace in which the instances are looked up is the namespace
-    specified in the --namespace option, or otherwise the default namespace
-    of the connection.
+    2. By specifying a class name with wildcard for the keys in the
+    INSTANCENAME argument, i.e. "CLASSNAME.?. The instances of the specified
+    class are displayed and the user is prompted for an index number to select
+    an instance. The namespace in which the instances are looked up is the
+    namespace specified in the --namespace option, or otherwise the default
+    namespace of the connection.
 
     The instances to be retrieved can be filtered by the --filter-query,
     --role, --result-role, --assoc-class, and --result-class options.

--- a/tests/unit/test_instance_cmds.py
+++ b/tests/unit/test_instance_cmds.py
@@ -26,7 +26,7 @@ from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE, CMD_OPTION_VERIFY_HELP_LINE, \
     CMD_OPTION_INCLUDE_QUALIFIERS_LIST_HELP_LINE, \
     CMD_OPTION_INCLUDE_QUALIFIERS_GET_HELP_LINE, \
-    CMD_OPTION_INTERACTIVE_HELP_LINE, CMD_OPTION_FILTER_QUERY_LINE, \
+    CMD_OPTION_FILTER_QUERY_LINE, \
     CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE, \
     CMD_OPTION_LOCAL_ONLY_INSTANCE_LIST_HELP_LINE, \
     CMD_OPTION_LOCAL_ONLY_INSTANCE_GET_HELP_LINE, \
@@ -83,7 +83,6 @@ INSTANCE_ASSOCIATORS_HELP_LINES = [
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
     CMD_OPTION_NAMES_ONLY_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_OPTION_INTERACTIVE_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_FILTER_QUERY_LINE,
     CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE,
@@ -110,7 +109,6 @@ INSTANCE_CREATE_HELP_LINES = [
 INSTANCE_DELETE_HELP_LINES = [
     'Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME',
     'Delete an instance of a class.',
-    CMD_OPTION_INTERACTIVE_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
@@ -139,7 +137,6 @@ INSTANCE_GET_HELP_LINES = [
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_OPTION_INTERACTIVE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
@@ -148,7 +145,6 @@ INSTANCE_INVOKEMETHOD_HELP_LINES = [
     'METHODNAME',
     'Invoke a method on an instance.',
     '-p, --parameter PARAMETERNAME=VALUE Specify a method input parameter',
-    CMD_OPTION_INTERACTIVE_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
@@ -158,7 +154,6 @@ INSTANCE_MODIFY_HELP_LINES = [
     'Modify properties of an instance.',
     '-p, --property PROPERTYNAME=VALUE Property to be modified',
     '--pl, --propertylist PROPERTYLIST Reduce the properties to be modified',
-    CMD_OPTION_INTERACTIVE_HELP_LINE,
     CMD_OPTION_VERIFY_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
@@ -183,7 +178,6 @@ INSTANCE_REFERENCES_HELP_LINES = [
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
     CMD_OPTION_NAMES_ONLY_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_OPTION_INTERACTIVE_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_FILTER_QUERY_LINE,
     CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE,
@@ -775,8 +769,8 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance command get with interactive option',
-     ['get', 'TST_Person', '-i'],
+    ['Verify instance command get with interactive wild card on classname',
+     ['get', 'TST_Person.?'],
      {'stdout':
       ['root/cimv2:TST_Person.name="Mike"',
        'instance of TST_Person {'],
@@ -784,8 +778,8 @@ Instances: PyWBEM_AllTypes
       'test': 'in'},
      [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
 
-    ['Verify instance command get with interactive option',
-     ['get', 'TST_Person', '--interactive'],
+    ['Verify instance command get with  wild card for keys',
+     ['get', 'TST_Person.?'],
      {'stdout':
       ['root/cimv2:TST_Person.name="Mike"',
        'instance of TST_Person {'],
@@ -1175,16 +1169,8 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance command delete with interactive option',
-     ['delete', 'TST_Person', '-i'],
-     {'stdout':
-      ['root/cimv2:TST_Person.name="Mike"'],
-      'rc': 0,
-      'test': 'in'},
-     [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
-
-    ['Verify instance command delete with interactive option',
-     ['delete', 'TST_Person', '--interactive'],
+    ['Verify instance command delete with interactive wild card on classname',
+     ['delete', 'TST_Person.?'],
      {'stdout':
       ['root/cimv2:TST_Person.name="Mike"'],
       'rc': 0,
@@ -1398,19 +1384,8 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance command references with interactive option -i',
-     ['references', 'TST_Person', '-i'],
-     {'stdout':
-      ['root/cimv2:TST_Person.name="Mike"',
-       'instance of TST_Lineage {',
-       'instance of TST_MemberOfFamilyCollection {'],
-      'rc': 0,
-      'test': 'in'},
-     [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
-
-    ['Verify instance command references with interactive option '
-     '--interactive',
-     ['references', 'TST_Person', '--interactive'],
+    ['Verify instance command references with selection suffix keys wild card ',
+     ['references', 'TST_Person.?'],
      {'stdout':
       ['root/cimv2:TST_Person.name="Mike"',
        'instance of TST_Lineage {',
@@ -1528,8 +1503,9 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance command associators with interactive option -i',
-     ['associators', 'TST_Person', '-i'],
+    ['Verify instance command associators with interactive wild card on '
+     'classname',
+     ['associators', 'TST_Person.?'],
      {'stdout':
       ['root/cimv2:TST_Person.name="Mike"',
        'instance of TST_Person {',


### PR DESCRIPTION
1. Modified code to use ? as a wild card for  the key component of
wbem uri to kick off the selection process.  This modifies all the
following instance commands: get, delete, modify, references, associatiors,
invokemethod.

2. Modified the instance tests and the doc on the instance get, delete,
associations, and references, etc. to reflect this new way of specifying
the INSTANCENAME.

3. I think that the connection show is correct now in that it uses
the current connection if name not provided and uses ? if the user wants
the prompted list.

4. Modified the documentaton for instance get, delete, modify,
references, associators, invokemethod.  I shortened the test in each
command in favor of pointing them to the general section on the
INSTANCENAME in features.

This turns out to be a  really good solution, much better than the
--interactive option.

NOTE: I fixed one ref definition error in pywbemclicmdline.rst