### PR TITLE
Allow turning off --verbose in interactive mode 

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -140,7 +140,7 @@ The following defines the help output for the `pywbemcli  --help` command
                                       [file|stderr], default: file; DETAIL:
                                       [all|paths|summary], default: all. Default:
                                       EnvVar PYWBEMCLI_LOG, or all.
-      -v, --verbose                   Display extra information about the
+      -v, --verbose / --no-verbose    Display extra information about the
                                       processing.
       --version                       Show the version of this command and the
                                       pywbem package and exit.

--- a/pywbemtools/pywbemcli/_context_obj.py
+++ b/pywbemtools/pywbemcli/_context_obj.py
@@ -191,6 +191,12 @@ class ContextObj(object):  # pylint: disable=useless-object-inheritance
 
         context.execute_cmd(lambda: cmd_instance_query(context, query, options))
         """
+        # Verbose displays the click interpetation of the command and
+        # parameters from click context
+        if self.verbose:
+            ctx = click.get_current_context()
+            click.echo('COMMAND="%s", params=%r' % (ctx.info_name, ctx.params))
+
         self.spinner.start()
         try:
             cmd()
@@ -321,7 +327,7 @@ class ContextObj(object):  # pylint: disable=useless-object-inheritance
 #
 #   Debug tools to help understandingthe click context.
 #
-def display_click_context(ctx, msg=None, display_only_obj=True):
+def display_click_context(ctx, msg=None, display_attrs=True):
     """
     Debug function displays attributes of click context
     """
@@ -329,21 +335,24 @@ def display_click_context(ctx, msg=None, display_only_obj=True):
     attrs = vars(ctx)
     if not msg:
         msg = "CLICK_CONTEXT"
-    if display_only_obj:
+    if not display_attrs:
         click.echo(ctx.obj)
     else:
         click.echo('%s %s, attrs: %s' % (
             msg, ctx,
-            '. '.join("%s: %s" % item for item in attrs.items())))
+            '\n    '.join("%s: %s" % item for item in attrs.items())))
 
 
-def display_click_context_parents(ctx):
+def display_click_context_parents(ctx, display_attrs=False):
     """
     Display the current click context and its all of its parents
     """
 
     display_click_context(ctx)
     parent_ctx = ctx.parent
+    level = 0
     while parent_ctx is not None:
-        display_click_context(parent_ctx)
+        display_click_context(parent_ctx, msg='level %s' % level,
+                              display_attrs=display_attrs)
+        level += -1
         parent_ctx = parent_ctx.parent

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -211,8 +211,8 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                           detail_default=DEFAULT_LOG_DETAIL_LEVEL,
                           ev=PywbemServer.log_envvar,
                           default='all'))
-@click.option('-v', '--verbose', is_flag=True,
-              default=False,
+@click.option('-v', '--verbose/--no-verbose',
+              default=None,
               help='Display extra information about the processing.')
 @click.version_option(
     message='%(prog)s, version %(version)s\n' + PYWBEM_VERSION,
@@ -220,7 +220,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.pass_context
 def cli(ctx, server, name, default_namespace, user, password, timeout,
         verify, certfile, keyfile, ca_certs, output_format, use_pull,
-        pull_max_cnt, verbose, mock_server, timestats=None, log=None):
+        pull_max_cnt, mock_server, verbose=None, timestats=None, log=None):
     """
     Pywbemcli is a command line WBEM client that uses the DMTF CIM-XML protocol
     to communicate with WBEM servers. Pywbemcli can:

--- a/tests/unit/cli_test_extensions.py
+++ b/tests/unit/cli_test_extensions.py
@@ -308,6 +308,14 @@ class CLITestsBase(object):
                         assert remove_ws(test_str) in remove_ws(rtn_value), \
                             "Desc: {}\nString: {}\nNot in (ws ignored):\n" \
                             "{!r}".format(desc, test_str, rtn_value)
+                elif test_definition == 'not-innows':
+                    if isinstance(test_value, six.string_types):
+                        test_value = [test_value]
+                    for test_str in test_value:
+                        assert remove_ws(test_str) not in \
+                            remove_ws(rtn_value), \
+                            "Desc: {}\nString: {}\nNot in (ws ignored):\n" \
+                            "{!r}".format(desc, test_str, rtn_value)
                 else:
                     assert 'test %s is invalid. Skipped' % test_definition
 

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -161,7 +161,7 @@ Options:
                                   [file|stderr], default: file; DETAIL:
                                   [all|paths|summary], default: all. Default:
                                   EnvVar PYWBEMCLI_LOG, or all.
-  -v, --verbose                   Display extra information about the
+  -v, --verbose / --no-verbose    Display extra information about the
                                   processing.
   --version                       Show the version of this command and the
                                   pywbem package and exit.
@@ -862,6 +862,76 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
+    #
+    #  Test verbose option
+    #
+    ['Verify --verbose on by doing a create with --verbose',
+     {'general': ['--name', 't1', '--verbose'],
+      'args': 'show',
+      'cmdgrp': 'connection'},
+     {'stdout': ['t1',
+                 'server : http://blahblah',
+                 'default-namespace', 'root/john',
+                 'user', 'Fred',
+                 'password', 'abcd',
+                 'timeout', '90',
+                 'verify', 'True',
+                 'certfile', 'c1.pem',
+                 'keyfile', 'k1.pem',
+                 'COMMAND', 'show',
+                 "params={'name': None}"
+                 ],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify --no-verbose',
+     {'general': ['--name', 't1', '--no-verbose'],
+      'args': 'show',
+      'cmdgrp': 'connection'},
+     {'stdout': ['t1',
+                 'server : http://blahblah',
+                 'default-namespace', 'root/john',
+                 'user', 'Fred',
+                 'password', 'abcd',
+                 'timeout', '90',
+                 'verify', 'True',
+                 'certfile', 'c1.pem',
+                 'keyfile', 'k1.pem'
+                 ],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    # Cannot really test without a test not_innows
+    ['Verify -verbose but turned off on interactive cmd',
+     {'general': ['--name', 't1', '-v'],
+      'stdin': ['--no-verbose connection show'],
+      'cmdgrp': None},
+     {'stdout': ['t1',
+                 'server : http://blahblah',
+                 'default-namespace', 'root/john',
+                 'user', 'Fred',
+                 'password', 'abcd',
+                 'timeout', '90',
+                 'verify', 'True',
+                 'certfile', 'c1.pem',
+                 'keyfile', 'k1.pem'
+                 ],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify -verbose but turned off on interactive cmd',
+     {'general': ['--name', 't1', '-v'],
+      'stdin': ['--no-verbose connection show'],
+      'cmdgrp': None},
+     {'stdout': ['COMMAND', 'params='],
+      'rc': 0,
+      'test': 'not-innows'},
+     None, OK],
+
+
     ['Delete testGeneralOpsMods.',
      {'args': ['delete', 't1'],
       'cmdgrp': 'connection', },
@@ -886,7 +956,7 @@ class TestGeneralOptions(CLITestsBase):
         """
         Execute pybemcli with the defined input and test output.
         """
-        cmd_grp = inputs['cmdgrp'] or ''
+        cmd_grp = inputs['cmdgrp'] if 'cmdgrp' in inputs else ''
 
         self.command_test(desc, cmd_grp, inputs, exp_response,
                           mock, condition, verbose=False)

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -52,7 +52,7 @@ def execute_pywbemcli(args, env=None, stdin=None, verbose=None):
         Passed to the executable as stdin.
 
       verbose: (bool)
-        If True, display args before calling cli
+        If True, display args, env, and stdin before executing the command
 
     Returns:
 


### PR DESCRIPTION
Allow turning off --verbose in interactive mode by changing thelong definition name to --verbose/--noverbose and the default for verbose to None on the cli function call.

This PR also adds a display when verbose is set that is turning
output to be worthwhile. It displays the current command and its
parameters when --verbose is set just before the command is called. Note
that this only displays that command, not the command group name