### PR TITLE
Fixes issue #375 - resetting mock repo between interactive commands

### DIFF
--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -140,7 +140,7 @@ Help text for ``pywbemcli``:
                                       [file|stderr], default: file; DETAIL:
                                       [all|paths|summary], default: all. Default:
                                       EnvVar PYWBEMCLI_LOG, or all.
-      -v, --verbose / --no-verbose    Display extra information about the
+      -v, --verbose                   Display extra information about the
                                       processing.
       --version                       Show the version of this command and the
                                       pywbem package and exit.

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -140,7 +140,7 @@ Help text for ``pywbemcli``:
                                       [file|stderr], default: file; DETAIL:
                                       [all|paths|summary], default: all. Default:
                                       EnvVar PYWBEMCLI_LOG, or all.
-      -v, --verbose                   Display extra information about the
+      -v, --verbose / --no-verbose    Display extra information about the
                                       processing.
       --version                       Show the version of this command and the
                                       pywbem package and exit.

--- a/tests/unit/mock_prompt_pick_response_3.py
+++ b/tests/unit/mock_prompt_pick_response_3.py
@@ -1,0 +1,46 @@
+# !PROCESS!AT!STARTUP!
+# The previous statement is used by pywbemcli to force this script to be
+# run at pywbemcli startup and not included in the list of --mock-server
+# files that are used to build the repository.  This is a development
+# test aid.
+# (C) Copyright 2019 IBM Corp.
+# (C) Copyright 2019 Inova Development Inc.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+    Python code to mock pywbemcli._common.pywbemcli_prompt. Returns the
+    value defined in RETURN_VALUE
+
+    This file was defined to mock the return from pywbemcli instance
+    get/delete/... with the simple_assoc_mock_model and return "0" to represent
+    the first entry in the displayed output.
+
+    Add this file to the set of mock options and the prompt for picking
+    the instance will be output but the prompt for a response from the
+    user will be bypassed and the value defined in RETURN_VALUE returned.
+"""
+from mock import Mock
+
+import pywbemtools
+RETURN_VALUE = "3"
+
+
+def mock_prompt(msg):
+    """Mock function to replace pywbemcli_prompt and return a value"""
+    print('MOCK_CLICK_PROMPT %s' % msg)
+    return RETURN_VALUE
+
+
+# pylint: disable=protected-access
+pywbemtools.pywbemcli.click.prompt = Mock(side_effect=mock_prompt)

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -865,7 +865,27 @@ TEST_CASES = [
     #
     #  Test verbose option
     #
-    ['Verify --verbose on by doing a create with --verbose',
+    ['Verify --verbose on by doing a connection show with --verbose',
+     {'general': ['--name', 't1', '--verbose'],
+      'args': 'show',
+      'cmdgrp': 'connection'},
+     {'stdout': ['t1',
+                 'server : http://blahblah',
+                 'default-namespace', 'root/john',
+                 'user', 'Fred',
+                 'password', 'abcd',
+                 'timeout', '90',
+                 'verify', 'True',
+                 'certfile', 'c1.pem',
+                 'keyfile', 'k1.pem',
+                 'COMMAND', 'show',
+                 "params={'name': None}"
+                 ],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify --verbose on by doing a connection show with -v',
      {'general': ['--name', 't1', '--verbose'],
       'args': 'show',
       'cmdgrp': 'connection'},


### PR DESCRIPTION
Fix issue in pywbemcli.py where we were dropping information in setup of interactive commands so that each command reinitialized the mock
repository.

This also enables a test of multiple instance commands through stdin
with that verifies fixing the reinitialization problem.

Finally, we added a display in verbose mode of each command and it
params before the execution of the command is started. This is a
diagnostic.