### PR TITLE
Fix issue #260 Dup instance failure on instance enumerate

### DIFF
--- a/tests/unit/simple_mock_model_ext.mof
+++ b/tests/unit/simple_mock_model_ext.mof
@@ -121,7 +121,7 @@ instance of CIM_Foo_sub as $foosub1{
     };
 
 instance of CIM_Foo_sub as $foosub1{
-    InstanceID = "CIM_Foo_sub3";
+    InstanceID = "CIM_Foo_sub4";
     IntegerProp = 7;
     };
 


### PR DESCRIPTION
The pywbem mocker compile MOF functions uses the CreateInstance from
pywbem mof_compiler.  This does not test for duplicate instances. See
pywbem issue # 1852.

However, we caused the problem because we duplicated a key in the test
file tests/unit/simple_mock_model_ext.mof

This fixes that key property duplication.

I must be going blind to miss this.

NOTE: Reopened issue # 260 to do this fix