### PR TITLE
Fix issue # 394 - Aborts session in interactive mode

### DIFF
--- a/pywbemtools/pywbemcli/_pywbem_server.py
+++ b/pywbemtools/pywbemcli/_pywbem_server.py
@@ -433,8 +433,8 @@ class PywbemServer(object):
                                           self._wbem_server,
                                           self._mock_server,
                                           verbose)
-        # All errors in building mock repository cause abort
-        # Errors where information display handled by build_repository
+                # All errors in building mock repository cause abort
+                # Errors where information display handled by build_repository
                 except MOFParseError as pe:
                     click.echo('Mock repository build exception:\n'
                                '{0}'.format(pe), err=True)

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -996,12 +996,12 @@ TEST_CASES = [
       'test': 'not-innows'},
      None, OK],
 
-    ['Delete fred.',
+    ['Delete fred. This one will fail if previous does not abort',
      {'args': ['delete', 'fred'],
       'cmdgrp': 'connection', },
      {'stdout': "",
       'test': 'innows'},
-     None, OK],
+     None, FAIL],
 
 ]
 
@@ -1030,4 +1030,4 @@ class TestGeneralOptions(CLITestsBase):
         cmd_grp = inputs['cmdgrp'] if 'cmdgrp' in inputs else ''
 
         self.command_test(desc, cmd_grp, inputs, exp_response,
-                          mock, condition, verbose=False)
+                          mock, condition, verbose=True)


### PR DESCRIPTION
We agreed that we limit the issues that cause abort of the session to
just errors in creating mof or py entities in the repository.

Removed the aborts on all errors except mock-server MOF or python script
errors in the files themselves. Even nonexistent or misnamed files do
not cause an abort.

Adds tests for both the Abort from interactive and the cmds that do not
abort in interactive mode.