### PR TITLE
Fixes issue #419. Mixed old an new formatters

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fix issue with mixed old and new formats on click.echo statement.
+  (See issue #419)
+
 **Enhancements:**
 
 **Known issues:**

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -22,9 +22,9 @@ from __future__ import absolute_import
 import os
 import sys
 import traceback
+from copy import deepcopy
 import click
 import click_repl
-from copy import deepcopy
 from prompt_toolkit.history import FileHistory
 
 import pywbem
@@ -406,8 +406,7 @@ def cli(ctx, server, svr_name, default_namespace, user, password, timeout,
                                                         exc_traceback)
                         raise click.ClickException(
                             "Mock Python process-at-startup script '{}' "
-                            "failed:\n{}" %
-                            (file_path, "\n".join(tb)))
+                            "failed:\n{}".format(file_path, "\n".join(tb)))
                 else:  # not processed during startup
                     resolved_mock_server.append(file_path)
 

--- a/tests/unit/py_err_processatstartup.py
+++ b/tests/unit/py_err_processatstartup.py
@@ -1,0 +1,14 @@
+# !PROCESS!AT!STARTUP!
+"""
+This is an error test of the code that processes a script at startup. This
+python code specifically includes a syntax error to be caught by pywbemcli.
+Note that this file is marked to process at startup which is really a private
+extension for the test environment.
+"""
+
+
+def mock?prompt(msg):  # noqa: E999
+    """Mock function to replace pywbemcli_prompt and return a value"""
+    # pylint: disable=undefined-variable
+    print(msg)
+    return "HaHa"

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -33,6 +33,7 @@ SIMPLE_MOCK_FILE_PATH = os.path.join(SCRIPT_DIR, 'simple_mock_model.mof')
 PYTHON_MOCK_FILE_PATH = os.path.join(SCRIPT_DIR, 'simple_python_mock_script.py')
 BAD_MOF_FILE_PATH = os.path.join(SCRIPT_DIR, 'mof_with_error.mof')
 BAD_PY_FILE_PATH = os.path.join(SCRIPT_DIR, 'py_with_error.py')
+BAD_PY_ERR_STRTUP_PATH = os.path.join(SCRIPT_DIR, 'py_err_processatstartup.py')
 
 
 GENERAL_HELP = """
@@ -402,6 +403,21 @@ TEST_CASES = [
       'rc': 1,
       'test': 'regex'},
      None, OK],
+
+    ['Verify -m option, file with python startup file containing syntax error',
+     {'general': ['-m', SIMPLE_MOCK_FILE_PATH],
+      'cmdgrp': 'class',
+      'args': ['enumerate']},
+     {'stderr': ['Mock Python process-at-startup',
+                 'Traceback (most recent call last)',
+                 'pywbemtools', 'pywbemcli.py',
+                 'line ', 'in cli',
+                 'py_err_processatstartup.py',
+                 'def mock?prompt(msg):',
+                 'SyntaxError: invalid syntax'],
+      'rc': 1,
+      'test': 'innows'},
+     BAD_PY_ERR_STRTUP_PATH, OK],
 
     ['Verify -n option with new name but not in repo fails',
      {'general': ['-n', 'fred'],


### PR DESCRIPTION
One ClickException statement mixed the old and new formatters using the
{} from the new but the % template/variable list separator from the new
formatter.

Marked for rollback but I would NOT push specal release for this since it is really  code to support our mocking of things like prompts and the script input has an error.