### PR TITLE
Extend coverage by adding tests

### DIFF
--- a/pywbemtools/pywbemcli/_pywbem_server.py
+++ b/pywbemtools/pywbemcli/_pywbem_server.py
@@ -328,19 +328,6 @@ class PywbemServer(object):
         """
         return self._wbem_server
 
-    def _validate_timeout(self):
-        """
-        Validate that timeout parameter is in proper range.
-
-        Exception: ValueError in Invalid
-        """
-        if not self.timeout:   # disallow None
-            ValueError('Timout of None not allowed')
-        if self.timeout is not None and (self.timeout < 0 or  # noqa: W504
-                                         self.timeout > MAX_TIMEOUT):
-            ValueError('Timeout option(%s) out of range %s to %s sec' %
-                       (self.timeout, 0, MAX_TIMEOUT))
-
     def password_prompt(self, ctx):
         """
         Request password from console.

--- a/tests/unit/mock_password_prompt.py
+++ b/tests/unit/mock_password_prompt.py
@@ -1,0 +1,40 @@
+# !PROCESS!AT!STARTUP!
+# The previous statement is used by pywbemcli to force this script to be
+# run at pywbemcli startup and not included in the list of --mock-server
+# files that are used to build the repository.  This is a development
+# test aid.
+# (C) Copyright 2017 IBM Corp.
+# (C) Copyright 2017 Inova Development Inc.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+    Python code to mock click.click_prompt. Returns the
+    value defined in RETURN_VALUE
+
+    Used to mock response from commmon_verify_operation
+"""
+from mock import Mock
+import pywbemtools
+
+
+def mock_prompt(msg,
+                hide_input=True,
+                confirmation_prompt=False, type=str, err=True):
+    """Mock function to replace pywbemcli_prompt and return a value"""
+    print('MOCK_CLICK_PROMPT %s' % msg)
+    return "mypw"
+
+
+# pylint: disable=protected-access
+pywbemtools.pywbemcli.click.prompt = Mock(side_effect=mock_prompt)

--- a/tests/unit/test_connection_cmds.py
+++ b/tests/unit/test_connection_cmds.py
@@ -484,6 +484,15 @@ TEST_CASES = [
       'file': {'before': 'none', 'after': 'none'}},
      None, OK],
 
+    ['Verify connection command export no current conection',
+     {'args': ['export'],
+      'general': []},
+     {'stderr': ['No server currently defined as current'],
+      'rc': 1,
+      'test': 'innows',
+      'file': {'before': 'none', 'after': 'none'}},
+     None, OK],
+
     #
     #  Test command line parameter errors, select, show, and delete with
     #  no repository


### PR DESCRIPTION
Extend coverage by adding tests for areas that are currently shown tonot have any coverage in coverage_report

Adds tests to increase coverage in

1. pywbemcli.py - Adds tests to catch a number of the documented
exceptions in pywbemcli.

2. Add tests for password prompt

3. Added tests for other exceptions I noted were not tested with the
coverage report.

NOTE: All this and I picked up about 1%. Note that in the last few weeks
we went from 200+ tests to over 400 and only picked up about 1%. The
next few percent are going to be difficult since each little piece of
code is generally a whole test

Code changes.

I made two code changes here because they are very small
and because they had a direct impact on the tests I was adding:

1. Found an error that only affects our tests where we want to compile
some mock script during startup.  We were using the cli argument
'mock_server' internally and should have been using the variable
'resolved_mock_server' so that the  script that was flagged as startup was shown as a
file that gets added to the mock_server. Now these files are compiled
during startup and not included as part of the mock_server.

2. We had left one place in the code where a script compile exception
did not cause an abort (pywbemcli.py, line 414.  I changed that.

3. pywbemcli line 435 testing choices for use_pull.  We did not need to
do this test because the option handler does it for us. That was dead code so
I just removed it.

I marked this for rollback but could go either way.