### PR TITLE
0.5: Fixed missing Python 3.7 in supported environments shown on Pypi

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,9 @@ Released: not yet
 * Fix issue with mixed old and new formats on click.echo statement.
   (See issue #419)
 
+* Fixed missing Python 3.7 in supported environments shown on Pypi.
+  (See issue #416)
+
 **Enhancements:**
 
 **Known issues:**
@@ -36,4 +39,3 @@ pywbemtools 0.5.0
 Released: 2019-09-29
 
 This is the initial release of pywbemtools.
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ classifier =
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
 
 [files]
 packages =
@@ -60,4 +61,3 @@ universal = 1
 warnerrors = true
 
 # flake8 config is in .flake8 file
-


### PR DESCRIPTION
Rolls back PR #427 into 0.5.1.