### PR TITLE
Modify code to use exclusively the python 3 formatter

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -42,6 +42,9 @@ Released: not yet
   it fixed an issue that surfaced with pywbem minimum package levels
   on Python 3.7.
 
+* Code: refactor code to use only the .format formatter and remove all use
+  of the % formatter.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -417,9 +417,6 @@ Help text for ``pywbemcli class find`` (see :ref:`class find command`):
       -n, --namespace NAMESPACE  Add a namespace to the search scope. May be
                                  specified multiple times. Default: Search in all
                                  namespaces of the server.
-      -n, --namespace NAMESPACE  Add a namespace to the search scope. May be
-                                 specified multiple times. Default: Search in all
-                                 namespaces of the server.
       -s, --sort                 Sort by namespace. Default is to sort by
                                  classname
       -h, --help                 Show this message and exit.
@@ -1124,11 +1121,11 @@ Help text for ``pywbemcli instance count`` (see :ref:`instance count command`):
       enumerates all instance names for all classes in all namespaces.
 
     Options:
-      -s, --sort                 Sort by instance count. Otherwise sorted by class
-                                 name.
       -n, --namespace NAMESPACE  Add a namespace to the search scope. May be
                                  specified multiple times. Default: Search in all
                                  namespaces of the server.
+      -s, --sort                 Sort by instance count. Otherwise sorted by class
+                                 name.
       -h, --help                 Show this message and exit.
 
 

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -28,7 +28,7 @@ from pywbem import Error, CIMClassName, CIMError, CIM_ERR_NOT_FOUND
 from .pywbemcli import cli
 from ._common import display_cim_objects, filter_namelist, \
     resolve_propertylist, CMD_OPTS_TXT, TABLE_FORMATS, \
-    format_table, process_invokemethod
+    format_table, process_invokemethod, raise_pywbem_error_exception
 from ._common_options import add_options, propertylist_option, \
     names_only_option, include_classorigin_class_option, namespace_option,  \
     summary_option, multiple_namespaces_option
@@ -433,7 +433,7 @@ def cmd_class_get(context, classname, options):
         display_cim_objects(context, result_class,
                             output_format=context.output_format)
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise_pywbem_error_exception(er)
 
 
 def cmd_class_invokemethod(context, classname, methodname, options):
@@ -442,8 +442,8 @@ def cmd_class_invokemethod(context, classname, methodname, options):
     """
     try:
         process_invokemethod(context, classname, methodname, options)
-    except Exception as ex:
-        raise click.ClickException("%s: %s" % (ex.__class__.__name__, ex))
+    except Error as er:
+        raise_pywbem_error_exception(er)
 
 
 def cmd_class_enumerate(context, classname, options):
@@ -470,7 +470,7 @@ def cmd_class_enumerate(context, classname, options):
                             summary=options['summary'], sort=True)
 
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise_pywbem_error_exception(er)
 
 
 def cmd_class_references(context, classname, options):
@@ -500,7 +500,7 @@ def cmd_class_references(context, classname, options):
                             summary=options['summary'], sort=True)
 
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise_pywbem_error_exception(er)
 
 
 def cmd_class_associators(context, classname, options):
@@ -534,7 +534,7 @@ def cmd_class_associators(context, classname, options):
                             summary=options['summary'], sort=True)
 
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise_pywbem_error_exception(er)
 
 
 def cmd_class_find(context, classname_glob, options):
@@ -552,7 +552,7 @@ def cmd_class_find(context, classname_glob, options):
         except CIMError as ce:
             # allow processing to continue if no interop namespace
             if ce.status_code == CIM_ERR_NOT_FOUND:
-                click.echo('WARNING: %s' % ce)
+                click.echo('WARNING: {}'.format(ce))
                 ns_names = [context.conn.default_namespace]
 
     try:
@@ -573,18 +573,19 @@ def cmd_class_find(context, classname_glob, options):
         context.spinner.stop()
         if context.output_format in TABLE_FORMATS:
             headers = ['Namespace', 'Classname']
-            click.echo(format_table(rows, headers,
-                                    title='Find class %s' % classname_glob,
-                                    table_format=context.output_format))
+            click.echo(
+                format_table(rows, headers,
+                             title='Find class {}'.format(classname_glob),
+                             table_format=context.output_format))
         else:
             # Display function to display classnames returned with
             # their namespaces in the form <namespace>:<classname>
             context.spinner.stop()
             for row in rows:
-                click.echo('  %s:%s' % (row[0], row[1]))
+                click.echo('  {}:{}'.format(row[0], row[1]))
 
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise_pywbem_error_exception(er)
 
 
 def cmd_class_tree(context, classname, options):
@@ -620,7 +621,7 @@ def cmd_class_tree(context, classname, options):
                 namespace=options['namespace'],
                 DeepInheritance=True)
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise_pywbem_error_exception(er)
 
     # display the list of classes as a tree. The classname is the top
     # of the tree.
@@ -653,6 +654,6 @@ def cmd_class_delete(context, classname, options):
 
     try:
         context.conn.DeleteClass(classname)
-        click.echo('%s delete successful' % classname)
+        click.echo('{} delete successful'.format(classname))
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise_pywbem_error_exception(er)

--- a/pywbemtools/pywbemcli/_cmd_qualifier.py
+++ b/pywbemtools/pywbemcli/_cmd_qualifier.py
@@ -26,7 +26,7 @@ from pywbem import Error
 
 from .pywbemcli import cli
 from ._common import display_cim_objects, CMD_OPTS_TXT, \
-    output_format_is_table, sort_cimobjects
+    output_format_is_table, sort_cimobjects, raise_pywbem_error_exception
 from ._common_options import add_options, namespace_option, summary_option
 
 
@@ -109,7 +109,7 @@ def cmd_qualifier_get(context, qualifiername, options):
                             qual_outputformat(context.output_format))
 
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise_pywbem_error_exception(er)
 
 
 def cmd_qualifier_enumerate(context, options):
@@ -124,4 +124,4 @@ def cmd_qualifier_enumerate(context, options):
                             summary=options['summary'])
 
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise_pywbem_error_exception(er)

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -27,7 +27,8 @@ import click
 from pywbem import ValueMapping, Error
 
 from .pywbemcli import cli
-from ._common import CMD_OPTS_TXT, format_table
+from ._common import CMD_OPTS_TXT, format_table, raise_pywbem_error_exception
+
 
 # NOTE: A number of the options use double-dash as the short form.  In those
 # cases, a third definition of the options without the double-dash defines
@@ -220,7 +221,7 @@ def cmd_server_namespaces(context, options):
                                 table_format=context.output_format))
 
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise click.ClickException('{}: {}'.format(er.__class__.__name__, er))
 
 
 def cmd_server_interop(context):
@@ -237,7 +238,7 @@ def cmd_server_interop(context):
                                 title='Server Interop Namespace:',
                                 table_format=context.output_format))
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise_pywbem_error_exception(er)
 
 
 def cmd_server_brand(context):
@@ -253,7 +254,7 @@ def cmd_server_brand(context):
                                 title='Server brand:',
                                 table_format=context.output_format))
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise_pywbem_error_exception(er)
 
 
 def cmd_server_info(context):
@@ -283,7 +284,7 @@ def cmd_server_info(context):
                                 table_format=context.output_format))
 
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise_pywbem_error_exception(er)
 
 
 def get_profile_info(org_vm, inst):
@@ -324,7 +325,7 @@ def cmd_server_profiles(context, options):
                                 table_format=context.output_format))
 
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise_pywbem_error_exception(er)
 
 
 def cmd_server_centralinsts(context, options):
@@ -356,7 +357,7 @@ def cmd_server_centralinsts(context, options):
                 row.append("\n".join([str(p) for p in ci]))
             # mark current inst as failed and continue
             except Exception as ex:  # pylint: disable=broad-except
-                click.echo('Exception: %s %s' % (row, ex))
+                click.echo('Exception: {} {}'.format(row, ex))
                 row.append("Failed")
             rows.append(row)
 
@@ -369,4 +370,4 @@ def cmd_server_centralinsts(context, options):
                                 title='Advertised Central Instances:',
                                 table_format=context.output_format))
     except Error as er:
-        raise click.ClickException("%s: %s" % (er.__class__.__name__, er))
+        raise_pywbem_error_exception(er)

--- a/pywbemtools/pywbemcli/_connection_repository.py
+++ b/pywbemtools/pywbemcli/_connection_repository.py
@@ -100,7 +100,7 @@ class ConnectionRepository(object):
         #         for key, value in self._pywbemcli_servers.iteritems()]
         items = []
         for key, value in self._pywbemcli_servers.items():
-            items.append("%s: %s" % (key, value))
+            items.append('{}: {}'.format(key, value))
         items_str = ', '.join(items)
         return "{0.__class__.__name__}({{{1}}}, default_connection {2})]". \
             format(self, items_str, self.default_connection_name)
@@ -255,7 +255,7 @@ class ConnectionRepository(object):
 
             # Write to tmpfile and if successful create backup file and
             # move the tmpfile to be the new connections file contents.
-            tmpfile = "%s.tmp" % self._connections_file
+            tmpfile = '{}.tmp'.format(self._connections_file)
 
             with self.open_file(tmpfile, 'w') as _fp:
                 data = yaml.safe_dump(yaml_dict,
@@ -269,7 +269,7 @@ class ConnectionRepository(object):
 
         # create bak file and then rename tmp file
         if os.path.isfile(self._connections_file):
-            bakfile = "%s.bak" % self._connections_file
+            bakfile = '{}.bak'.format(self._connections_file)
             if os.path.isfile(bakfile):
                 os.remove(bakfile)
             if os.path.isfile(self._connections_file):
@@ -291,8 +291,10 @@ class ConnectionRepository(object):
             self._write_file()
 
         else:
-            raise ValueError('Connection name "%s" does not exist in set of '
-                             'connections' % connection_name)
+            # TODO should "Default failed be part of this message"?
+            raise ValueError('Connection name "{}" does not exist in '
+                             'connection repository {}'
+                             .format(connection_name, self.connections_file))
 
     def get_default_connection_name(self):
         """

--- a/pywbemtools/pywbemcli/_context_obj.py
+++ b/pywbemtools/pywbemcli/_context_obj.py
@@ -53,11 +53,11 @@ class ContextObj(object):  # pylint: disable=useless-object-inheritance
         self._wbem_server = None
 
     def __repr__(self):
-        return 'ContextObj(at 0x%08x, pywbem_server=%r, outputformat=%s, ' \
-               'use_pull=%s, pull_max_cnt=%s, timestats=%s, verbose=%s' % \
-               (id(self), self.pywbem_server, self.output_format,
-                self.use_pull, self.pull_max_cnt, self.timestats,
-                self.verbose)
+        return 'ContextObj(at {:08x}, pywbem_server={!r}, outputformat={}, ' \
+               'use_pull={}, pull_max_cnt={}, timestats={}, verbose={}' \
+               .format(id(self), self.pywbem_server, self.output_format,
+                       self.use_pull, self.pull_max_cnt, self.timestats,
+                       self.verbose)
 
     @property
     def output_format(self):
@@ -111,9 +111,9 @@ class ContextObj(object):  # pylint: disable=useless-object-inheritance
         # The conn property is created in wbem_server and retained here.
         if self._conn:
             return self._conn
-        else:
-            self._conn = self.wbem_server.conn
-            return self._conn
+
+        self._conn = self.wbem_server.conn
+        return self._conn
 
     @property
     def wbem_server(self):
@@ -128,7 +128,7 @@ class ContextObj(object):  # pylint: disable=useless-object-inheritance
         # If no server defined, do not try to connect. This allows
         # commands like help, connection new, list to execute without
         # a target server defined.
-        if self._pywbem_server:
+        if self._pywbem_server:  # pylint: disable=no-else-return
             # If wbem_server not initialized, initialize it.
             if self._pywbem_server.wbem_server is None:
                 # get the password if it is required.  This may involve a
@@ -198,7 +198,8 @@ class ContextObj(object):  # pylint: disable=useless-object-inheritance
         # parameters from click context
         if self.verbose:
             ctx = click.get_current_context()
-            click.echo('COMMAND="%s", params=%r' % (ctx.info_name, ctx.params))
+            click.echo('COMMAND="{}", params={!r}'.format(ctx.info_name,
+                                                          ctx.params))
 
         if self.verbose:
             display_click_context_parents(display_attrs=True)
@@ -346,9 +347,9 @@ def display_click_context(ctx, msg=None, display_attrs=True):
     if not display_attrs:
         click.echo(ctx.obj)
     else:
-        click.echo('%s %s, attrs: %s' % (
+        click.echo('{} {}, attrs: {}'.format(
             msg, ctx,
-            '\n    '.join("%s: %s" % item for item in attrs.items())))
+            '\n    '.join('%s: %s' % item for item in attrs.items())))
 
 
 def display_click_context_parents(display_attrs=False):
@@ -359,7 +360,7 @@ def display_click_context_parents(display_attrs=False):
     ctx = click.get_current_context()
     disp_ctx = ctx.parent
     while disp_ctx is not None:
-        display_click_context(disp_ctx, msg='level %s' % level,
+        display_click_context(disp_ctx, msg='level {}'.format(level),
                               display_attrs=display_attrs)
         level += -1
         disp_ctx = disp_ctx.parent

--- a/pywbemtools/pywbemcli/_pywbem_server.py
+++ b/pywbemtools/pywbemcli/_pywbem_server.py
@@ -58,8 +58,8 @@ def _validate_server(server):
         url = server
 
     elif re.match(r"^[a-zA-Z0-9]+://", server) is not None:
-        raise click.ClickException('Invalid scheme on server argument. %s'
-                                   ' Use "http" or "https"' % server)
+        raise click.ClickException('Invalid scheme on server argument. {}'
+                                   ' Use "http" or "https"'.format(server))
     else:
         url = "{scheme}://{host}".format(
             scheme=DEFAULT_URL_SCHEME,
@@ -114,8 +114,8 @@ class PywbemServer(object):
 
         if server and mock_server:
             raise ValueError('Simultaneous "--server" and '
-                             '"--mock-server" not allowed. Server: %s, '
-                             'mock_server %s' % (server, mock_server))
+                             '"--mock-server" not allowed. Server: {}, '
+                             'mock_server {}'.format(server, mock_server))
         self.server = server
         self.mock_server = mock_server
         self.name = name
@@ -132,17 +132,17 @@ class PywbemServer(object):
         self._wbem_server = None
 
     def __str__(self):
-        return 'PywbemServer(url=%s name=%s)' % (self.server, self.name)
+        return 'PywbemServer(url={} name={})'.format(self.server, self.name)
 
     def __repr__(self):
-        return 'PywbemServer(server=%s name=%s ns=%s user=%s ' \
-               'password=%s timeout=%s verify=%s certfile=%s ' \
-               'keyfile=%s ca_certs=%s  ' \
-               'mock_server=%r wbem_server %r)' % \
-               (self.server, self.name, self.default_namespace,
-                self.user, self.password, self.timeout, self.verify,
-                self.certfile, self.keyfile, self.ca_certs, self.mock_server,
-                self.wbem_server)
+        return 'PywbemServer(server={} name={} ns={} user={} ' \
+               'password={} timeout={} verify={} certfile={} ' \
+               'keyfile={} ca_certs={}  ' \
+               'mock_server={!r} wbem_server {!r})' \
+               .format(self.server, self.name, self.default_namespace,
+                       self.user, self.password, self.timeout, self.verify,
+                       self.certfile, self.keyfile, self.ca_certs,
+                       self.mock_server, self.wbem_server)
 
     @property
     def server(self):
@@ -248,8 +248,8 @@ class PywbemServer(object):
         if timeout is None:   # disallow None
             ValueError('Timout of None not allowed')
         if timeout < 0 or timeout > MAX_TIMEOUT:
-            ValueError('Timeout option(%s) out of range %s to %s sec' %
-                       (timeout, 0, MAX_TIMEOUT))
+            ValueError('Timeout option({}) out of range {} to {} sec'
+                       .format(timeout, 0, MAX_TIMEOUT))
         # pylint: disable=attribute-defined-outside-init
         self._timeout = timeout
 
@@ -473,4 +473,4 @@ class PywbemServer(object):
                                               connection=conn, propagate=True)
             except ValueError as ve:
                 raise click.ClickException('Logger configuration error. input: '
-                                           '%s. Exception: %s' % (log, ve))
+                                           '{}. Exception: {}'.format(log, ve))

--- a/pywbemtools/pywbemcli/_pywbemcli_operations.py
+++ b/pywbemtools/pywbemcli/_pywbemcli_operations.py
@@ -306,7 +306,7 @@ class BuildRepositoryMixin(object):
         """
         for file_path in file_path_list:
             if not os.path.exists(file_path):
-                raise IOError("No such file: %s" % file_path)
+                raise IOError('No such file: {}'.format(file_path))
 
             ext = os.path.splitext(file_path)[1]
             if ext == '.mof':

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -283,9 +283,9 @@ def cli(ctx, server, svr_name, default_namespace, user, password, timeout,
         # test for conflicting server definitions.
         if server or resolved_mock_server:
             if svr_name:
-                click.ClickException('Option conflict: --name "%s" '
+                click.ClickException('Option conflict: --name "{}" '
                                      'conflicts with existence of --server and '
-                                     '--mock-server' % svr_name)
+                                     '--mock-server'.format(svr_name))
             svr_name = 'not-saved'
             pywbem_server = PywbemServer(server,
                                          resolved_default_namespace,
@@ -326,7 +326,8 @@ def cli(ctx, server, svr_name, default_namespace, user, password, timeout,
                         err=True)
                     raise click.Abort()
                 if verbose:
-                    click.echo('Current connection is "%s"' % local_svr_name)
+                    click.echo('Current connection: "{}"'
+                               .format(local_svr_name))
 
             # Get the named connection from the repo
             if local_svr_name:
@@ -335,8 +336,8 @@ def cli(ctx, server, svr_name, default_namespace, user, password, timeout,
                 for option in conditional_options:
                     if option[0]:
                         raise click.ClickException(
-                            '"--%s %s" option invalid when --name exists or '
-                            'default name set.' % (option[1], option[0]))
+                            '"--{} {}" option invalid when --name exists or '
+                            'default name set.'.format(option[1], option[0]))
 
             else:
                 # If no server defined, set None to allow commands that
@@ -547,8 +548,8 @@ def cli(ctx, server, svr_name, default_namespace, user, password, timeout,
                          resolved_timestats,
                          log, verbose)
     if verbose:
-        print('CONTEXT_obj FROM generals loc 547 %r' % ctx.obj)
-        print('CLICK CTX %s' % ctx)
+        print('CONTEXT_obj FROM generals loc 547 {!r}'.format(ctx.obj))
+        print('CLICK CTX {}'.format(ctx))
         display_click_context(ctx, msg="After adding Context",
                               display_attrs=True)
     # Invoke command if one exists.

--- a/tests/manual/test_pegasus.py
+++ b/tests/manual/test_pegasus.py
@@ -44,9 +44,9 @@ class TestsContainer(ClientTest):
     def execute_cmd(self, cmd_str):  # pylint: disable=no-self-use
         """Execute the command defined by cmd_str and return results."""
         if self.verbose:
-            print('cmd %s' % cmd_str)
+            print('cmd {}'.format(cmd_str))
         # Disable python warnings for pywbemcli call.See issue #42
-        command = 'export PYTHONWARNINGS="" && %s' % cmd_str
+        command = 'export PYTHONWARNINGS="" && {}'.format(cmd_str)
         proc = Popen(command, shell=True, stdout=PIPE, stderr=PIPE)
         std_out, std_err = proc.communicate()
         exitcode = proc.returncode
@@ -54,7 +54,7 @@ class TestsContainer(ClientTest):
             std_out = std_out.decode()
             std_err = std_err.decode()
         if self.verbose:
-            print('rtn %s\n%s\n%s' % (std_out, std_err, exitcode))
+            print('rtn {}\n{}\n{}'.format(std_out, std_err, exitcode))
 
         # return tuple of exitcode, stdout, stderr
         return exitcode, std_out, std_err
@@ -69,8 +69,8 @@ class TestsContainer(ClientTest):
         else:
             match = re.search(regex, test_str)
             if match:
-                self.fail('Found in error search regex %s, str %s' %
-                          (regex, test_str))
+                self.fail('Found in error search regex {}, str {}'
+                          .format(regex, test_str))
 
     def assert_found(self, regex, test_str):
         """ Test of find regex on multiline string.
@@ -82,7 +82,8 @@ class TestsContainer(ClientTest):
         else:
             match = re.search(regex, test_str)
             if match is None:
-                self.fail('Failed search regex %s, str %s' % (regex, test_str))
+                self.fail('Failed search regex {}, str {}'
+                          .format(regex, test_str))
 
     def assertRegexp(self, regex, test_str):
         """
@@ -103,7 +104,7 @@ class ClassTests(TestsContainer):
 
     def class_cmd(self, params):
         """Adds the cmd name prefix and executes"""
-        cmd = 'pywbemcli -s %s class %s' % (self.host, params)
+        cmd = 'pywbemcli -s {} class {}'.format(self.host, params)
         exitcode, std_out_str, std_err_str = self.execute_cmd(cmd)
         return exitcode, std_out_str, std_err_str
 
@@ -112,8 +113,8 @@ class ClassTests(TestsContainer):
         exitcode, out, err = self.class_cmd('get CIM_ManagedElement')
 
         self.assertEqual(exitcode, 0)
-        self.assertEqual(err, '', 'Expect no std_err. Found %s' % err)
-        self.assert_found('CIM_ManagedElement', out)
+        self.assertEqual(err, '', 'Expect no std_err. Found {}'.format(err))
+        self.assert_found('CIM_ManagedElement ', out)
 
     def test__get_localonly(self):
         """Test class get --local-only"""
@@ -180,7 +181,7 @@ class InstanceTests(TestsContainer):
 
     def instance_cmd(self, params):
         """Adds the instance cmd name prefix and executes"""
-        cmd = 'pywbemcli -s %s instance %s' % (self.host, params)
+        cmd = 'pywbemcli -s {} instance {}'.format(self.host, params)
         exitcode, std_out_str, std_err_str = self.execute_cmd(cmd)
         return exitcode, std_out_str, std_err_str
 
@@ -263,9 +264,9 @@ class InstanceTests(TestsContainer):
             '--property scalDateTime="19991224120000.000000+360" '
             '--property scalString="A string value" ')
         self.assertEqual(exitcode, 0, 'Expected good response. Rcvd '
-                         ' code %s err %s' % (exitcode, err))
+                         ' exitcode {}, err {}'.format(exitcode, err))
         self.assertEqual(exitcode, 0, 'Create instance of Pywbem_AllTypes '
-                         'failed. exitcode %s, err %s' % (exitcode, err))
+                         'failed. exitcode {}, err {}'.format(exitcode, err))
 
         exitcode, out, err = self.instance_cmd(
             'delete PyWBEM_AllTypes.InstanceId=ScalarTest1')
@@ -279,7 +280,7 @@ class InstanceTests(TestsContainer):
         exitcode, out, err = self.instance_cmd(
             'create pywbem_alltypes --property InstanceId=ArrayBool '
             '--property BlahBool=True,False')
-        print('err %s' % err)
+        print('err {}'.format(err))
         self.assertEqual(exitcode, 1)
 
     def test_references(self):

--- a/tests/unit/cli_test_extensions.py
+++ b/tests/unit/cli_test_extensions.py
@@ -161,7 +161,7 @@ class CLITestsBase(object):
         # pylint: enable=line-too-long
 
         if not condition:
-            pytest.skip("Condition for test case %s not met" % desc)
+            pytest.skip('Condition for test case {} not met'.format(desc))
 
         env = None
         stdin = None
@@ -180,8 +180,8 @@ class CLITestsBase(object):
             local_args = inputs
             general_args = None
         else:
-            assert 'Invalid inputs param to test %r . Allowed types are ' \
-                   'dict, string, list, tuple.' % inputs
+            assert False, 'Invalid inputs param to test {!r}. Allowed types ' \
+                'are dict, string, list, tuple.'.format(inputs)
 
         if isinstance(local_args, six.string_types):
             local_args = local_args.split(" ")
@@ -202,7 +202,9 @@ class CLITestsBase(object):
                 cmd_line.extend(['--mock-server',
                                  os.path.join(TEST_DIR, mock_files)])
             else:
-                assert("CLI_TEST_EXTENSIONS mock_file %s invalid" % mock_files)
+                assert False, \
+                    'CLI_TEST_EXTENSIONS mock_file {} invalid' \
+                    .format(mock_files)
 
         if not stdin:
             cmd_line.append(command_grp)
@@ -211,10 +213,10 @@ class CLITestsBase(object):
             cmd_line.extend(local_args)
 
         if verbose:
-            print('\nCMDLINE: %s' % cmd_line)
+            print('\nCMDLINE: {}'.format(cmd_line))
 
         if verbose and env:
-            print('ENV: %s' % env)
+            print('ENV: {}'.format(env))
 
         rc, stdout, stderr = execute_pywbemcli(cmd_line, env=env, stdin=stdin,
                                                verbose=verbose)
@@ -223,7 +225,7 @@ class CLITestsBase(object):
         assert_rc(exp_rc, rc, stdout, stderr)
 
         if verbose:
-            print('RC=%s\nSTDOUT=%s\nSTDERR=%s' % (rc, stdout, stderr))
+            print('RC={}\nSTDOUT={}\nSTDERR={}'.format(rc, stdout, stderr))
 
         if exp_response['test']:
             test_definition = exp_response['test']
@@ -317,7 +319,7 @@ class CLITestsBase(object):
                             "Desc: {}\nString: {}\nNot in (ws ignored):\n" \
                             "{!r}".format(desc, test_str, rtn_value)
                 else:
-                    assert 'test %s is invalid. Skipped' % test_definition
+                    assert 'Test {} is invalid. Skipped'.format(test_definition)
 
 
 def remove_ws(inputs):

--- a/tests/unit/mock_confirm_n.py
+++ b/tests/unit/mock_confirm_n.py
@@ -32,7 +32,7 @@ RETURN_VALUE = False
 
 def mock_confirm(msg):
     """Mock function to replace pywbemcli_prompt and return a value"""
-    print('MOCK_CLICK_CONFIRM(n): %s' % msg)
+    print('MOCK_CLICK_CONFIRM(n): {}'.format(msg))
     return RETURN_VALUE
 
 

--- a/tests/unit/mock_confirm_y.py
+++ b/tests/unit/mock_confirm_y.py
@@ -32,7 +32,7 @@ RETURN_VALUE = True
 
 def mock_confirm(msg):
     """Mock function to replace pywbemcli_prompt and return a value"""
-    print('MOCK_CLICK_CONFIRM(y): %s' % msg)
+    print('MOCK_CLICK_CONFIRM(y): {}'.format(msg))
     return RETURN_VALUE
 
 

--- a/tests/unit/mock_password_prompt.py
+++ b/tests/unit/mock_password_prompt.py
@@ -26,14 +26,15 @@
 """
 from mock import Mock
 import pywbemtools
+RETURN_VALUE = "mypw"
 
 
 def mock_prompt(msg,
                 hide_input=True,
                 confirmation_prompt=False, type=str, err=True):
     """Mock function to replace pywbemcli_prompt and return a value"""
-    print('MOCK_CLICK_PROMPT %s' % msg)
-    return "mypw"
+    print('MOCK_CLICK_PROMPT {}'.format(msg))
+    return RETURN_VALUE
 
 
 # pylint: disable=protected-access

--- a/tests/unit/mock_prompt_pick_response_3.py
+++ b/tests/unit/mock_prompt_pick_response_3.py
@@ -38,7 +38,7 @@ RETURN_VALUE = "3"
 
 def mock_prompt(msg):
     """Mock function to replace pywbemcli_prompt and return a value"""
-    print('MOCK_CLICK_PROMPT %s' % msg)
+    print('MOCK_CLICK_PROMPT {}'.format(msg))
     return RETURN_VALUE
 
 

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -883,18 +883,18 @@ TEST_CASES = [
     # Class delete errors
     ['Verify class command delete no classname',
      ['delete'],
-     {'stderr': 'Error: Missing argument "CLASSNAME"',
+     {'stderr': 'Missing argument "CLASSNAME"',
       'rc': 2,
-      'test': 'in'},
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
     # class delete error tests
 
     ['Verify class command delete fail subclasses exist',
      ['delete', 'CIM_Foo', '--force'],
-     {'stderr': 'Error: Delete rejected; subclasses exist',
+     {'stderr': 'Delete rejected; subclasses exist',
       'rc': 1,
-      'test': 'in'},
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify class command delete no classname fails',
@@ -913,9 +913,9 @@ TEST_CASES = [
 
     ['Verify class command delete fails, instances exist',
      ['delete', 'CIM_Foo_sub_sub'],
-     {'stderr': 'Error: Delete rejected; instances exist',
+     {'stderr': 'Delete rejected; instances exist',
       'rc': 1,
-      'test': 'in'},
+      'test': 'innows'},
      [SIMPLE_MOCK_FILE_EXT], OK],
 
     #
@@ -1248,7 +1248,7 @@ TEST_CASES = [
     #
     #  class invokemethod command without parameters
     #
-    ['Verify class command invokemethod',
+    ['Verify class command invokemethod. Class CIM_Foo, method Fuzzy',
      ['invokemethod', 'CIM_Foo', 'Fuzzy'],
      {'stdout': ["ReturnValue=0"],
       'rc': 0,
@@ -1265,22 +1265,21 @@ TEST_CASES = [
 
     ['Verify class command invokemethod fails Invalid Class',
      ['invokemethod', 'CIM_Foox', 'Fuzzy', '-p', 'TestInOutParameter="blah"'],
-     {'stderr': ["Error: CIMError: 6"],
+     {'stderr': ['CIMError', '6'],
       'rc': 1,
-      'test': 'in'},
+      'test': 'innows'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
     ['Verify class command invokemethod fails Invalid Method',
      ['invokemethod', 'CIM_Foo', 'Fuzzyx', '-p', 'TestInOutParameter=blah'],
-     {'stderr': ["Error: ClickException: .* CIM_Foo .* Fuzzyx"],
+     {'stderr': ['Class CIM_Foo does not have a method Fuzzyx'],
       'rc': 1,
-      'test': 'regex'},
+      'test': 'innows'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
-
 
     ['Verify class command invokemethod fails Method not registered',
      ['invokemethod', 'CIM_Foo', 'Fuzzy'],
-     {'stderr': ["CIMError: 17"],
+     {'stderr': ['CIMError', '17'],
       'rc': 1,
       'test': 'innows'},
      [SIMPLE_MOCK_FILE], OK],

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -23,9 +23,9 @@ from __future__ import absolute_import, print_function
 
 from datetime import datetime
 import unittest
-import pytest
 import click
 from mock import patch
+import pytest
 
 try:
     from collections import OrderedDict
@@ -1166,9 +1166,9 @@ class SplitTestNone(object):  # pylint: disable=useless-object-inheritance
         result.
         """
         act_result = split_array_value(input_str, ',')
-        # print('split input %s result %s' % (input_str, result))
-        assert (exp_result == act_result) % \
-            'Failed split test exp %r, act %r' % (exp_result, act_result)
+        assert exp_result == act_result,  \
+            'Failed split test exp {!r}, act {!r}'.format(exp_result,
+                                                          act_result)
 
     def test_split(self):
         # pylint: disable=no-self-use
@@ -1197,10 +1197,10 @@ class KVPairParsingTest(object):  # pylint: disable=useless-object-inheritance
 
         assert (exp_name == act_name), \
             ' KVPairParsing. Expected ' \
-            ' name=%s, function returned %s' % (exp_name, act_name)
+            ' name={}, function returned {}'.format(exp_name, act_name)
         assert (exp_value == act_value), \
             ' KVPairParsing. Expected ' \
-            ' value=%s, act value=%s' % (exp_value, act_value)
+            ' value={}, act value={}'.format(exp_value, act_value)
 
     def test_scalar_int(self):
         # pylint: disable=no-self-use

--- a/tests/unit/test_connection_cmds.py
+++ b/tests/unit/test_connection_cmds.py
@@ -904,7 +904,7 @@ class TestSubcmdClass(CLITestsBase):
             if file_test == 'exists':
                 assert os.path.isfile(pywbemserversfile) and \
                     os.path.getsize(pywbemserversfile) > 0, \
-                    "Fail. File  %s should exist" % pywbemserversfile
+                    'Fail. File {} should exist'.format(pywbemserversfile)
             elif file_test.lower() == 'none':
                 if os.path.isfile(pywbemserversfile):
                     print('FILE THAT SHOULD NOT EXIST')
@@ -912,10 +912,11 @@ class TestSubcmdClass(CLITestsBase):
                         print(fin.read())
 
                 assert not os.path.isfile(pywbemserversfile), \
-                    "Fail. File %s should not exist" % pywbemserversfile
+                    'Fail. File {} should not exist'.format(pywbemserversfile)
 
             else:
-                assert False, 'File test option name %s invalid' % file_test
+                assert False, 'File test option name {} invalid' \
+                    .format(file_test)
 
         if not condition:
             pytest.skip("Condition for test case not met")

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -779,7 +779,7 @@ TEST_CASES = [
      {'general': ['--verbose'],
       'args': ['show'],
       'cmdgrp': 'connection', },
-     {'stdout': ['Current connection is "test-default"'],
+     {'stdout': ['Current connection: "test-default"'],
       'test': 'innows'},
      None, OK],
 
@@ -1144,7 +1144,7 @@ TEST_CASES = [
      {'general': [],
       'stdin': ['--server http://blah --user fred --password fred ',
                 'connection save fred',
-                '--mock-server %s class enumerate' % BAD_MOF_FILE_PATH,
+                '--mock-server {} class enumerate'.format(BAD_MOF_FILE_PATH),
                 'connection select fred',
                 'connection show',
                 'connection delete fred'],

--- a/tests/unit/test_instance_cmds.py
+++ b/tests/unit/test_instance_cmds.py
@@ -973,7 +973,7 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance command create, new instance already exists',
      ['create', 'PyWBEM_AllTypes', '-p', 'InstanceID=test_instance'],
-     {'stderr': ['Error: CIMClass: "PyWBEM_AllTypes" does not exist in ',
+     {'stderr': ['CIMClass: "PyWBEM_AllTypes" does not exist in ',
                  'namespace "root/cimv2" in WEB server: FakedWBEMConnection'],
       'rc': 1,
       'test': 'regex'},
@@ -982,15 +982,15 @@ Instances: PyWBEM_AllTypes
     ['Verify instance command create, new instance invalid ns',
      ['create', 'PyWBEM_AllTypes', '-p', 'InstanceID=test_instance', '-n',
       'blah'],
-     {'stderr': ["Error: Exception 3", "CIM_ERR_INVALID_NAMESPACE"],
+     {'stderr': ['CIMError', '3', 'CIM_ERR_INVALID_NAMESPACE'],
       'rc': 1,
-      'test': 'in'},
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
 
     ['Verify instance command create, new instance invalid class',
      ['create', 'CIM_blah', '-p', 'InstanceID=test_instance'],
-     {'stderr': ["Error:", "CIMClass"],
+     {'stderr': ["CIMClass"],
       'rc': 1,
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],

--- a/tests/unit/test_tableformat.py
+++ b/tests/unit/test_tableformat.py
@@ -92,15 +92,16 @@ class BaseTableTests(unittest.TestCase):
         actual_lines = actual.split(os.linesep)
         expected_lines = expected.split(os.linesep)
         if len(actual_lines) != len(expected_lines):
-            print('Different number of lines actual %s, expected %s' %
-                  (len(actual_lines), len(expected_lines)))
+            print('Different number of lines actual {}, expected {}'
+                  .format(len(actual_lines), len(expected_lines)))
         line = 0
         for line_a, line_e in zip(actual_lines, expected_lines):
             if line_a != line_e:
-                print('Line %s: Difference\n%s\n%s' % (line, line_a, line_e))
+                print('Line {}: Difference\n{}\n{}'.format(line, line_a,
+                                                           line_e))
                 if len(line_a) != len(line_e):
-                    print('Different lengths act %s exp %s' % (len(line_a),
-                                                               len(line_e)))
+                    print('Different lengths act {} exp {}'.format(len(line_a),
+                                                                   len(line_e)))
             line += 1
 
 
@@ -133,7 +134,8 @@ class FormatTableTests(BaseTableTests):
         self.compare_results(actual, expected)
 
         self.assertEqual(actual, expected,
-                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+                         'Actual:\n{}\nExpected:\n{}\n'.format(actual,
+                                                               expected))
 
     def test_tpsql_table_hdr(self):
         """Test a table output_format table with header"""
@@ -161,7 +163,8 @@ class FormatTableTests(BaseTableTests):
         self.compare_results(actual, expected)
 
         self.assertEqual(actual, expected,
-                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+                         'Actual:\n{}\nExpected:\n{}\n'.format(actual,
+                                                               expected))
 
     def test_html_table_hdr(self):
         """Test a table output_format table with header"""
@@ -199,7 +202,8 @@ class FormatTableTests(BaseTableTests):
         self.compare_results(actual, expected)
 
         self.assertEqual(actual, expected,
-                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+                         'Actual:\n{}\nExpected:\n{}\n'.format(actual,
+                                                               expected))
 
     def test_table_simple_hdr(self):
         """Test a simple table with header"""
@@ -225,7 +229,8 @@ class FormatTableTests(BaseTableTests):
         self.compare_results(actual, expected)
 
         self.assertEqual(actual, expected,
-                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+                         'Actual:\n{}\nExpected:\n{}\n'.format(actual,
+                                                               expected))
 
     def test_table_simple_hdr_sort1(self):
         """Test a simple table with header and the sort option"""
@@ -252,7 +257,8 @@ class FormatTableTests(BaseTableTests):
         self.compare_results(actual, expected)
 
         self.assertEqual(actual, expected,
-                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+                         'Actual:\n{}\nExpected:\n{}\n'.format(actual,
+                                                               expected))
 
     def test_table_simple_hdr_sort2(self):
         """Test a simple table with header and the sort option"""
@@ -279,7 +285,8 @@ class FormatTableTests(BaseTableTests):
         self.compare_results(actual, expected)
 
         self.assertEqual(actual, expected,
-                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+                         'Actual:\n{}\nExpected:\n{}\n'.format(actual,
+                                                               expected))
 
     def test_table_simple_hdr_sort3(self):
         """Test a simple table with header and the sort option"""
@@ -306,7 +313,8 @@ class FormatTableTests(BaseTableTests):
         self.compare_results(actual, expected)
 
         self.assertEqual(actual, expected,
-                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+                         'Actual:\n{}\nExpected:\n{}\n'.format(actual,
+                                                               expected))
 
     def test_table_simple_no_hdr(self):
         """Test print a simple table no header"""
@@ -331,7 +339,8 @@ class FormatTableTests(BaseTableTests):
         self.compare_results(actual, expected)
 
         self.assertEqual(actual, expected,
-                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+                         'Actual:\n{}\nExpected:\n{}\n'.format(actual,
+                                                               expected))
 
     def test_table_plain_hdr(self):
         """Test a none table borders with header"""
@@ -357,7 +366,8 @@ class FormatTableTests(BaseTableTests):
 
         self.compare_results(actual, expected)
         self.assertEqual(actual, expected,
-                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+                         'Actual:\n{}\nExpected:\n{}\n'.format(actual,
+                                                               expected))
 
     def test_table_grid(self):
         """Test printing a plain table with borders and header"""
@@ -389,7 +399,8 @@ class FormatTableTests(BaseTableTests):
 
         self.compare_results(actual, expected)
         self.assertEqual(actual, expected,
-                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+                         'Actual:\n{}\nExpected:\n{}\n'.format(actual,
+                                                               expected))
 
     def test_table_rst_hdr(self):
         """Test a none table borders with header"""
@@ -418,7 +429,8 @@ class FormatTableTests(BaseTableTests):
 
         self.compare_results(actual, expected)
         self.assertEqual(actual, expected,
-                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+                         'Actual:\n{}\nExpected:\n{}\n'.format(actual,
+                                                               expected))
 
     def test_folded_cell_plain(self):
         """Test building a folded cell table plain with header"""
@@ -438,7 +450,8 @@ class FormatTableTests(BaseTableTests):
 
         self.compare_results(actual, expected)
         self.assertEqual(actual, expected,
-                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+                         'Actual:\n{}\nExpected:\n{}\n'.format(actual,
+                                                               expected))
 
     def test_folded_cell_simple(self):
         """Test a folded cell table simplewith header"""
@@ -465,7 +478,8 @@ class FormatTableTests(BaseTableTests):
 
         self.compare_results(actual, expected)
         self.assertEqual(actual, expected,
-                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+                         'Actual:\n{}\nExpected:\n{}\n'.format(actual,
+                                                               expected))
 
     def test_folded_cell_grid(self):
         """Test a folded cell table with header"""
@@ -489,7 +503,8 @@ class FormatTableTests(BaseTableTests):
 
         self.compare_results(actual, expected)
         self.assertEqual(actual, expected,
-                         'Actual:\n%s\nExpected:\n%s\n' % (actual, expected))
+                         'Actual:\n{}\nExpected:\n{}\n'.format(actual,
+                                                               expected))
 
 
 if __name__ == '__main__':

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -93,7 +93,7 @@ def execute_pywbemcli(args, env=None, stdin=None, verbose=None):
     if verbose:
         display_envvars = '\n'.join(
             [var for var in os.environ if 'PYWBCLI' in var])
-        print('OS_ENVIRON %s' % display_envvars)
+        print('OS_ENVIRON {}'.format(display_envvars))
 
     assert isinstance(args, (list, tuple))
     cmd_args = [cli_cmd]
@@ -103,13 +103,13 @@ def execute_pywbemcli(args, env=None, stdin=None, verbose=None):
         cmd_args.append(arg)
 
     if verbose:
-        print("\nexecute_pywbemcli CMD_ARGS %s" % cmd_args)
+        print('\nexecute_pywbemcli CMD_ARGS {}'.format(cmd_args))
 
     if stdin and six.PY3:
         stdin = stdin.encode('utf-8')
 
     if verbose and stdin:
-        print('stdin %s' % stdin)
+        print('stdin {}'.format(stdin))
 
     # The click package on Windows writes NL at the Python level
     # as '\r\r\n' at the level of the shell under some cases. This is
@@ -134,9 +134,8 @@ def execute_pywbemcli(args, env=None, stdin=None, verbose=None):
         del os.environ[name]
 
     if verbose:
-        print('output type %s\nstdout:%r\nstderr:%r' % (type(stdout_str),
-                                                        stdout_str,
-                                                        stderr_str))
+        print('output type {}\nstdout:{!r}\nstderr:{!r}'
+              .format(type(stdout_str), stdout_str, stderr_str))
 
     if isinstance(stdout_str, six.binary_type):
         stdout_str = stdout_str.decode('utf-8')

--- a/tests/unit/utils/wbemserver_mock.py
+++ b/tests/unit/utils/wbemserver_mock.py
@@ -171,27 +171,26 @@ class WbemServerMock(object):
         self.build_mock()
 
     def __str__(self):
-        ret_str = 'object_manager_name=%r, interop_ns=%r, system_name=%r, ' \
-            'dmtf_schema_ver=%r, schema_dir=%r, wbem_server=%s' % \
-            (self.object_manager_name, self.interop_ns, self.system_name,
-             self.dmtf_schema_ver, self.schema_dir,
-             getattr(self, 'wbem_server', None))
-        return ret_str
+        return 'object_manager_name={!r}}, interop_ns={!r}}, system_name=' \
+            '{!r}}, dmtf_schema_ver={!r}}, schema_dir={!r}}, wbem_server={}' \
+            .format(self.object_manager_name, self.interop_ns, self.system_name,
+                    self.dmtf_schema_ver, self.schema_dir,
+                    getattr(self, 'wbem_server', None))
 
     def __repr__(self):
         """
         Return a representation of the class object
         with all attributes, that is suitable for debugging.
         """
-        ret_str = 'WBEMServerMock(object_manager_name=%r, interop_ns=%r, ' \
-            'system_name=%r, dmtf_schema_ver=%r, schema_dir=%r, ' \
-            'pg_schema_dir=%r, pg_schema_files=%s, wbem_server=%r, ' \
-            'registered_profiles=%r)' % \
-            (self.object_manager_name, self.interop_ns, self.system_name,
-             self.dmtf_schema_ver, self.schema_dir, self.pg_schema_dir,
-             self.pg_schema_files,
-             getattr(self, 'wbem_server', None), self.registered_profiles)
-        return ret_str
+        return 'WBEMServerMock(object_manager_name={!r}, interop_ns={!r}, ' \
+            'system_name={!r}, dmtf_schema_ver={!r}, schema_dir={!r}, ' \
+            'pg_schema_dir={!r}, pg_schema_files={}, wbem_server={!r}, ' \
+            'registered_profiles={!r})' \
+            .format(self.object_manager_name, self.interop_ns, self.system_name,
+                    self.dmtf_schema_ver, self.schema_dir, self.pg_schema_dir,
+                    self.pg_schema_files,
+                    getattr(self, 'wbem_server', None),
+                    self.registered_profiles)
 
     def build_classes(self, namespace):
         """
@@ -282,7 +281,7 @@ class WbemServerMock(object):
         rtn_ominsts = self.conn.EnumerateInstances("CIM_ObjectManager",
                                                    namespace=self.interop_ns)
         assert len(rtn_ominsts) == 1, \
-            "Expected 1 ObjetManager instance, got %r" % rtn_ominsts
+            "Expected 1 ObjetManager instance, got {!r}}".format(rtn_ominsts)
 
         return ominst
 
@@ -310,7 +309,8 @@ class WbemServerMock(object):
         rtn_namespaces = self.conn.EnumerateInstances("CIM_Namespace",
                                                       namespace=self.interop_ns)
         assert len(rtn_namespaces) == len(namespaces), \
-            "Expected namespaces: %r, got %s" % (namespaces, rtn_namespaces)
+            "Expected namespaces: {!r}, got {}".format(namespaces,
+                                                       rtn_namespaces)
 
     def build_reg_profile_insts(self, profiles):
         """
@@ -334,7 +334,7 @@ class WbemServerMock(object):
             org_vm_dict[org_vm.tovalues(value)] = value
 
         for profile in profiles:
-            instance_id = '%s+%s+%s' % (profile[0], profile[1], profile[2])
+            instance_id = '{}+{}+{}'.format(profile[0], profile[1], profile[2])
             reg_prof_dict = {'RegisteredOrganization': org_vm_dict[profile[0]],
                              'RegisteredName': profile[1],
                              'RegisteredVersion': profile[2],

--- a/tools/click_help_capture.py
+++ b/tools/click_help_capture.py
@@ -79,13 +79,13 @@ def rst_headline(title, level):
         level_char = '='
 
     # output anchor in form .. _`smicli commands`:
-    anchor = '.. _`%s`:' % title
+    anchor = '.. _`{}`:'.format(title)
     title_marker = level_char * len(title)
     if level == 0:
-        return '\n%s\n\n%s\n%s\n%s\n' % (anchor, title_marker, title,
-                                         title_marker)
+        return '\n{}\n\n{}\n{}\n{}\n'.format(anchor, title_marker, title,
+                                             title_marker)
 
-    return '\n%s\n\n%s\n%s\n' % (anchor, title, title_marker)
+    return '\n{}\n\n{}\n{}\n'.format(anchor, title, title_marker)
 
 
 def print_rst_verbatum_text(text_str):
@@ -104,7 +104,7 @@ def print_rst_verbatum_text(text_str):
             new_lines.append(indent(line, 4))
         else:
             new_lines.append(line)
-    print('%s' % '\n'.join(new_lines))
+    print('{}'.format('\n'.join(new_lines)))
 
 
 HELP_DICT = {}
@@ -127,7 +127,7 @@ def cmd_exists(cmd):
         proc = subprocess.Popen(echo_cmd, shell=True, stdout=subprocess.PIPE,
                                 stderr=subprocess.STDOUT)
         out, _ = proc.communicate()
-        print("Debug: %s: %s" % (echo_cmd, out), file=sys.stderr)
+        print("Debug: {}: {}".format(echo_cmd, out), file=sys.stderr)
 
     proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
@@ -147,12 +147,12 @@ def get_subcmd_group_names(script_cmd, script_name, cmd):
 
     returns list of command groups/commands
     """
-    command = '%s %s --help' % (script_cmd, cmd)
+    command = '{} {} --help'.format(script_cmd, cmd)
     # Disable python warnings for script call.
     if sys.platform != 'win32':
-        command = 'export PYTHONWARNINGS="" && %s' % command
+        command = 'export PYTHONWARNINGS="" && {}'.format(command)
     if VERBOSE:
-        print('command %s' % command)
+        print('command {}'.format(command))
     proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
     std_out, std_err = proc.communicate()
@@ -165,11 +165,11 @@ def get_subcmd_group_names(script_cmd, script_name, cmd):
         std_err = std_err.decode()
 
     if exitcode:
-        raise RuntimeError("Error: Shell execution of command %r failed with "
-                           "rc=%s: %s" % (command, exitcode, std_err))
+        raise RuntimeError('Error: Shell execution of command {!r} failed with '
+                           'rc={}: {}'.format(command, exitcode, std_err))
     if std_err:
-        raise RuntimeError("Error: Unexpected stderr from command %r:\n"
-                           "%s" % (command, std_err))
+        raise RuntimeError("Error: Unexpected stderr from command {!r}}:\n"
+                           "{}".format(command, std_err))
 
     # Split stdout into list of lines
     lines = std_out.split('\n')
@@ -197,7 +197,7 @@ def get_subgroup_names(group_name, script_cmd, script_name):
     subcmds_list = get_subcmd_group_names(script_cmd, script_name, group_name)
     space = ' ' if group_name else ''
 
-    return ['%s%s%s' % (group_name, space, name) for name in subcmds_list]
+    return ['{}{}{}'.format(group_name, space, name) for name in subcmds_list]
 
 
 def create_help_cmd_list(script_cmd, script_name):
@@ -220,32 +220,32 @@ def create_help_cmd_list(script_cmd, script_name):
     # sort to match order of click
     help_groups_result.sort()
     if USE_RST:
-        print(rst_headline("%s Help Command Details" % script_name, 2))
-        print('\nThis section shows the help text for each %s '
-              'command group and command.\n' % script_name)
+        print(rst_headline("{} Help Command Details".format(script_name), 2))
+        print('\nThis section shows the help text for each {} '
+              'command group and command.\n'.format(script_name))
 
     for name in help_groups_result:
-        command = '%s %s' % (script_name, name)
-        command_help = '%s %s --help' % (script_name, name)
+        command = '{} {}'.format(script_name, name)
+        command_help = '{} {} --help'.format(script_name, name)
         out = HELP_DICT[name]
         if USE_RST:
             level = len(name.split())  # 0: top, 1: group, 2: command
             if level == 0:
-                line = 'Help text for ``%s``:' % script_name
+                line = 'Help text for ``{}``:'.format(script_name)
             elif level == 1 and name not in ('repl', 'help'):
-                line = 'Help text for ``%s`` (see :ref:`%s command group`):' % \
-                    (command, name)
+                line = 'Help text for ``{}`` (see :ref:`{} command group`):' \
+                    .format(command, name)
             else:
-                line = 'Help text for ``%s`` (see :ref:`%s command`):' % \
-                    (command, name)
+                line = 'Help text for ``{}`` (see :ref:`{} command`):' \
+                    .format(command, name)
             if level > 0:
                 # Don't generate section header for top level
                 print(rst_headline(command_help, 2 + level))
-            print('\n\n%s\n\n' % line)
+            print('\n\n{}\n\n'.format(line))
             print_rst_verbatum_text(out.decode())
         else:
-            print('%s\n%s command: %s' %
-                  (('=' * 50), script_name, command_help))
+            print('{}\n{} command: {}'
+                  .format(('=' * 50), script_name, command_help))
             print(out.decode())
 
     return help_groups_result
@@ -254,10 +254,10 @@ def create_help_cmd_list(script_cmd, script_name):
 if __name__ == '__main__':
     # Verify that the script exists. Executing with --help loads click
     # script generates help and exits.
-    check_cmd = '%s --help' % SCRIPT_CMD
+    check_cmd = '{} --help'.format(SCRIPT_CMD)
     rc, msg = cmd_exists(check_cmd)
     if rc != 0:
-        print("Error: Shell execution of %r returns rc=%s: %s" %
-              (check_cmd, rc, msg), file=sys.stderr)
+        print("Error: Shell execution of {!r} returns rc={}: {}"
+              .format(check_cmd, rc, msg), file=sys.stderr)
         sys.exit(1)
     create_help_cmd_list(SCRIPT_CMD, SCRIPT_NAME)


### PR DESCRIPTION
Modify code to use exclusively the python 3 formatter both foroutputting and for internal string manipulation.  There should be NO use of the % formatter when this pr is committed in pywbemcli or the test code.

This includes changes to some tests also.

Finally, it refactors one very common exception, the default exception
that is the last resort for the functions that call the server into a single function rather than many repeated copies of the statement itself that raises the exception.

These changes to NOT change behavior.