### PR TITLE
Fixes issue #443, ordering of lists of commands in help

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,12 @@ Released: not yet
 
 **Enhancements:**
 
+* Add capability to reorder commands in the help for each group.  The commands
+  in all groups except for the top group (pywbemcli -h) are ordered in the
+  help list by their order in their source file. The display of commands in
+  the top level group is alphabetical except that connection, help, and repl
+  are reordered to the bottom of the list. (See issue #466)
+
 **Cleanup:**
 
 * Test: Enabled Python warning suppression for PendingDeprecationWarning

--- a/docs/pywbemclicmdshelp.rst
+++ b/docs/pywbemclicmdshelp.rst
@@ -148,12 +148,12 @@ Help text for ``pywbemcli``:
 
     Commands:
       class       Command group for CIM classes.
-      connection  Command group for WBEM connection definitions.
-      help        Show help message for interactive mode.
       instance    Command group for CIM instances.
       qualifier   Command group for CIM qualifier declarations.
-      repl        Enter interactive mode (default).
       server      Command group for WBEM servers.
+      connection  Command group for WBEM connection definitions.
+      help        Show help message for interactive mode.
+      repl        Enter interactive mode (default).
 
 
 .. _`pywbemcli class --help`:
@@ -185,13 +185,13 @@ Help text for ``pywbemcli class`` (see :ref:`class command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      associators   List the classes associated with a class.
-      delete        Delete a class.
       enumerate     List top classes or subclasses of a class in a namespace.
-      find          List the classes with matching class names on the server.
       get           Get a class.
+      delete        Delete a class.
       invokemethod  Invoke a method on a class.
       references    List the classes referencing a class.
+      associators   List the classes associated with a class.
+      find          List the classes with matching class names on the server.
       tree          Show the subclass or superclass hierarchy for a class.
 
 
@@ -669,13 +669,13 @@ Help text for ``pywbemcli connection`` (see :ref:`connection command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      delete  Delete a WBEM connection definition.
       export  Export the current connection.
-      list    List the WBEM connection definitions.
-      save    Save the current connection to a new WBEM connection definition.
-      select  Select a WBEM connection definition as current or default.
       show    Show a WBEM connection definition or the current connection.
+      delete  Delete a WBEM connection definition.
+      select  Select a WBEM connection definition as current or default.
       test    Test the current connection with a predefined WBEM request.
+      save    Save the current connection to a new WBEM connection definition.
+      list    List the WBEM connection definitions.
 
 
 .. _`pywbemcli connection delete --help`:
@@ -975,16 +975,16 @@ Help text for ``pywbemcli instance`` (see :ref:`instance command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      associators   List the instances associated with an instance.
-      count         Count the instances of each class with matching class name.
-      create        Create an instance of a class in a namespace.
-      delete        Delete an instance of a class.
       enumerate     List the instances of a class.
       get           Get an instance of a class.
-      invokemethod  Invoke a method on an instance.
+      delete        Delete an instance of a class.
+      create        Create an instance of a class in a namespace.
       modify        Modify properties of an instance.
-      query         Execute a query on instances in a namespace.
+      associators   List the instances associated with an instance.
       references    List the instances referencing an instance.
+      invokemethod  Invoke a method on an instance.
+      query         Execute a query on instances in a namespace.
+      count         Count the instances of each class with matching class name.
 
 
 .. _`pywbemcli instance associators --help`:
@@ -1643,8 +1643,8 @@ Help text for ``pywbemcli qualifier`` (see :ref:`qualifier command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      enumerate  List the qualifier declarations in a namespace.
       get        Get a qualifier declaration.
+      enumerate  List the qualifier declarations in a namespace.
 
 
 .. _`pywbemcli qualifier enumerate --help`:
@@ -1763,12 +1763,12 @@ Help text for ``pywbemcli server`` (see :ref:`server command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      brand         Get the brand of the server.
-      centralinsts  List central instances of mgmt profiles on the server.
-      info          Get information about the server.
-      interop       Get the Interop namespace of the server.
       namespaces    List the namespaces of the server.
+      interop       Get the Interop namespace of the server.
+      brand         Get the brand of the server.
+      info          Get information about the server.
       profiles      List management profiles advertized by the server.
+      centralinsts  List central instances of mgmt profiles on the server.
 
 
 .. _`pywbemcli server brand --help`:

--- a/pywbemtools/pywbemcli/__init__.py
+++ b/pywbemtools/pywbemcli/__init__.py
@@ -36,6 +36,7 @@ from ._connection_repository import *   # noqa: F403,F401
 from .pywbemcli import *       # noqa: F403,F401
 from .config import *  # noqa: F403,F401
 from ._pywbemcli_operations import *  # noqa: F403,F401
+from ._click_extensions import *  # noqa: F403,F401
 
 from ._version import __version__  # noqa: F401
 

--- a/pywbemtools/pywbemcli/_click_extensions.py
+++ b/pywbemtools/pywbemcli/_click_extensions.py
@@ -1,0 +1,70 @@
+"""
+This file contains extensions to Click
+"""
+
+from collections import OrderedDict
+import click
+
+
+class PywbemcliGroup(click.Group):
+    """
+    Extend Click Group class to:
+    1.  Order the display of commands within the help.
+        The commands are ordered in the order that their definitions
+        appears in the source code for each command group.
+    This extension has a general name because it may be used for more than
+    one extension to the Click.Group class.
+    """
+
+    # Use ordered dictionary to sort commands by their order defined in the
+    # _cmd_... source file.
+    def __init__(self, name=None, commands=None, **attrs):
+        """
+        Use OrderedDict to keep order commands inserted into command dict
+        """
+        if commands is None:
+            commands = OrderedDict()
+        elif not isinstance(commands, OrderedDict):
+            commands = OrderedDict(commands)
+        click.Group.__init__(self, name=name,
+                             commands=commands,
+                             **attrs)
+
+    def list_commands(self, ctx):
+        """
+        Replace list_commands to eliminate the sorting
+        """
+        return self.commands.keys()
+
+
+class PywbemcliTopGroup(click.Group):
+    """
+    Extensions to be used with the top level help (pywbemcli --help)
+
+    Extend Click Group class to:
+    1.  Order the display of the commands and command groups in the top level
+        help output to sort and then put names defined in the predefined_list
+        at the end of the list of commands/groups. Since ordering of the top
+        level cannot be tied to order commands are inserted in list, we elected
+        to just move the generic ones to the end of the list.
+
+    This extension has a general name because it may be used for more than
+    one extension to the Click.Group class..
+    """
+
+    def list_commands(self, ctx):
+        """
+        Order commands by sorting and then moving any commands defined in
+        move_to_end list to the end of the list.
+        """
+        # tuple of commands to move to bottom after sort
+        move_to_end = ('connection', 'help', 'repl')
+
+        cmd_list = sorted(self.commands.keys())
+        pop_count = 0
+        # reorder list so the move_to_end list commands are at bottom
+        for i in range(len(cmd_list)):
+            if cmd_list[i - pop_count] in move_to_end:
+                cmd_list.append(cmd_list.pop(i - pop_count))
+                pop_count += 1
+        return cmd_list

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -16,7 +16,9 @@
 """
 Click Command definition for the class command group which includes
 commands for get, enumerate, associators, references, find, etc. of the objects
-CIMClass on a WBEM server
+CIMClass on a WBEM server.
+
+NOTE: Commands are ordered in help display by their order in this file.
 """
 
 from __future__ import absolute_import, print_function
@@ -33,6 +35,7 @@ from ._common_options import add_options, propertylist_option, \
     names_only_option, include_classorigin_class_option, namespace_option,  \
     summary_option, multiple_namespaces_option
 from ._displaytree import display_class_tree
+from ._click_extensions import PywbemcliGroup
 
 
 #
@@ -65,7 +68,7 @@ local_only_class_option = [              # pylint: disable=invalid-name
                       'Default: Include superclass properties and methods.')]
 
 
-@cli.group('class', options_metavar=CMD_OPTS_TXT)
+@cli.group('class', cls=PywbemcliGroup, options_metavar=CMD_OPTS_TXT)
 def class_group():
     """
     Command group for CIM classes.
@@ -80,6 +83,47 @@ def class_group():
     'class' keyword.
     """
     pass  # pylint: disable=unnecessary-pass
+
+
+@class_group.command('enumerate', options_metavar=CMD_OPTS_TXT)
+@click.argument('classname', type=str, metavar='CLASSNAME', required=False)
+@add_options(deep_inheritance_class_option)
+@add_options(local_only_class_option)
+@add_options(no_qualifiers_class_option)
+@add_options(include_classorigin_class_option)
+@add_options(names_only_option)
+@add_options(namespace_option)
+@add_options(summary_option)
+@click.pass_obj
+def class_enumerate(context, classname, **options):
+    """
+    List top classes or subclasses of a class in a namespace.
+
+    Enumerate CIM classes starting either at the top of the class hierarchy
+    in the specified CIM namespace (--namespace option), or at the specified
+    class (CLASSNAME argument) in the specified namespace. If no namespace was
+    specified, the default namespace of the connection is used.
+
+    The --local-only, --include-classorigin, and --no-qualifiers options
+    determine which parts are included in each retrieved class.
+
+    The --deep-inheritance option defines whether or not the complete subclass
+    hierarchy of the classes is retrieved.
+
+    The --names-only option can be used to show only the class paths.
+
+    In the output, the classes and class paths will be formatted as defined
+    by the --output-format general option. Table formats on classes will be
+    replaced with MOF format.
+
+    Examples:
+
+      pywbemcli -n myconn class enumerate -n interop
+
+      pywbemcli -n myconn class enumerate CIM_Foo -n interop
+    """
+    context.execute_cmd(lambda: cmd_class_enumerate(context, classname,
+                                                    options))
 
 
 @class_group.command('get', options_metavar=CMD_OPTS_TXT)
@@ -185,47 +229,6 @@ def class_invokemethod(context, classname, methodname, **options):
                                                        classname,
                                                        methodname,
                                                        options))
-
-
-@class_group.command('enumerate', options_metavar=CMD_OPTS_TXT)
-@click.argument('classname', type=str, metavar='CLASSNAME', required=False)
-@add_options(deep_inheritance_class_option)
-@add_options(local_only_class_option)
-@add_options(no_qualifiers_class_option)
-@add_options(include_classorigin_class_option)
-@add_options(names_only_option)
-@add_options(namespace_option)
-@add_options(summary_option)
-@click.pass_obj
-def class_enumerate(context, classname, **options):
-    """
-    List top classes or subclasses of a class in a namespace.
-
-    Enumerate CIM classes starting either at the top of the class hierarchy
-    in the specified CIM namespace (--namespace option), or at the specified
-    class (CLASSNAME argument) in the specified namespace. If no namespace was
-    specified, the default namespace of the connection is used.
-
-    The --local-only, --include-classorigin, and --no-qualifiers options
-    determine which parts are included in each retrieved class.
-
-    The --deep-inheritance option defines whether or not the complete subclass
-    hierarchy of the classes is retrieved.
-
-    The --names-only option can be used to show only the class paths.
-
-    In the output, the classes and class paths will be formatted as defined
-    by the --output-format general option. Table formats on classes will be
-    replaced with MOF format.
-
-    Examples:
-
-      pywbemcli -n myconn class enumerate -n interop
-
-      pywbemcli -n myconn class enumerate CIM_Foo -n interop
-    """
-    context.execute_cmd(lambda: cmd_class_enumerate(context, classname,
-                                                    options))
 
 
 @class_group.command('references', options_metavar=CMD_OPTS_TXT)

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -18,6 +18,8 @@ Click Command definition for the connection command group which includes
 cmds to list add, delete, show, and test server definitions in the
 connection information.  This also maintains a definition of servers on
 disk which is kept in sync with changes made with the add/delete commands.
+
+NOTE: Commands are ordered in help display by their order in this file.
 """
 
 from __future__ import absolute_import, print_function
@@ -34,9 +36,10 @@ from ._common import CMD_OPTS_TXT, pick_one_from_list, format_table, \
 from ._pywbem_server import PywbemServer
 from ._connection_repository import ConnectionRepository
 from ._context_obj import ContextObj
+from ._click_extensions import PywbemcliGroup
 
 
-@cli.group('connection', options_metavar=CMD_OPTS_TXT)
+@cli.group('connection', cls=PywbemcliGroup, options_metavar=CMD_OPTS_TXT)
 def connection_group():
     """
     Command group for WBEM connection definitions.

--- a/pywbemtools/pywbemcli/_cmd_qualifier.py
+++ b/pywbemtools/pywbemcli/_cmd_qualifier.py
@@ -16,6 +16,8 @@
 """
 Click Command definition for the qualifer command group which includes
 cmds for get and enumerate for CIM qualifier types.
+
+NOTE: Commands are ordered in help display by their order in this file.
 """
 
 from __future__ import absolute_import, print_function
@@ -28,9 +30,10 @@ from .pywbemcli import cli
 from ._common import display_cim_objects, CMD_OPTS_TXT, \
     output_format_is_table, sort_cimobjects, raise_pywbem_error_exception
 from ._common_options import add_options, namespace_option, summary_option
+from ._click_extensions import PywbemcliGroup
 
 
-@cli.group('qualifier', options_metavar=CMD_OPTS_TXT)
+@cli.group('qualifier', cls=PywbemcliGroup, options_metavar=CMD_OPTS_TXT)
 def qualifier_group():
     """
     Command group for CIM qualifier declarations.

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -18,6 +18,8 @@ Click command definition for the server command group which includes
 cmds for inspection and management of the objects defined by the pywbem
 server class including namespaces, WBEMServer information, and profile
 information.
+
+NOTE: Commands are ordered in help display by their order in this file.
 """
 
 from __future__ import absolute_import, print_function
@@ -28,7 +30,7 @@ from pywbem import ValueMapping, Error
 
 from .pywbemcli import cli
 from ._common import CMD_OPTS_TXT, format_table, raise_pywbem_error_exception
-
+from ._click_extensions import PywbemcliGroup
 
 # NOTE: A number of the options use double-dash as the short form.  In those
 # cases, a third definition of the options without the double-dash defines
@@ -36,7 +38,7 @@ from ._common import CMD_OPTS_TXT, format_table, raise_pywbem_error_exception
 # defined with underscore and not dash
 
 
-@cli.group('server', options_metavar=CMD_OPTS_TXT)
+@cli.group('server', cls=PywbemcliGroup, options_metavar=CMD_OPTS_TXT)
 def server_group():
     """
     Command group for WBEM servers.

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -42,6 +42,7 @@ from .config import DEFAULT_OUTPUT_FORMAT, DEFAULT_NAMESPACE, \
     DEFAULT_CONNECTION_TIMEOUT, MAX_TIMEOUT
 
 from ._connection_repository import ConnectionRepository
+from ._click_extensions import PywbemcliTopGroup
 
 __all__ = ['cli']
 
@@ -58,7 +59,8 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
 # pylint: disable=bad-continuation
-@click.group(invoke_without_command=True,
+# PywbemcliTopGroup sets order commands listed in help output
+@click.group(invoke_without_command=True, cls=PywbemcliTopGroup,
              context_settings=CONTEXT_SETTINGS,
              options_metavar=GENERAL_OPTIONS_METAVAR)
 @click.option('-n', '--name', 'svr_name', type=str, metavar='NAME',

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -172,13 +172,12 @@ Options:
 
 Commands:
   class       Command group for CIM classes.
-  connection  Command group for WBEM connection definitions.
-  help        Show help message for interactive mode.
   instance    Command group for CIM instances.
   qualifier   Command group for CIM qualifier declarations.
-  repl        Enter interactive mode (default).
   server      Command group for WBEM servers.
-
+  connection  Command group for WBEM connection definitions.
+  help        Show help message for interactive mode.
+  repl        Enter interactive mode (default).
 """
 
 REPL_HELP = """Usage: pywbemcli repl [OPTIONS]


### PR DESCRIPTION
Changes the ordering of the lists of commands in help output from the
alphabetic to the order that the commands in each group were defined for all levels except top level.

Top level commands are ordered in the help display  to put connection, help, repl at bottom
