### PR TITLE
Add autosuggest prompt toolkit extension

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -47,6 +47,12 @@ Released: not yet
   original form using, WBEMURI is error prone with quote marks.
   (see issue #390)
 
+* Add prompt-toolkit auto-suggest.  This extends the command completion 
+  capability in the repl mode (interactive mode) to make suggestions on
+  command line input based on the history file.  Usually auto-suggest completion 
+  will be shown as gray text behind the current input. Auto-suggest is not
+  available in command line mode.
+
 **Cleanup:**
 
 * Test: Enabled Python warning suppression for PendingDeprecationWarning

--- a/docs/pywbemcli/cmdlineinterface.rst
+++ b/docs/pywbemcli/cmdlineinterface.rst
@@ -56,6 +56,15 @@ gets class ``CIM_ManagedElement`` in namespace ``interop`` and displays it in
 the MOF output format. The option ``--output-format`` is a general option
 and ``--namespace`` is a command option.
 
+.. index::
+   single: tab-completion
+   single: auto-completion
+   single: auto-suggestion
+
+Pywbemcli supports several modes of tab-completion, auto-completion suggestions 
+and depending on whether it is in command or interactive mode. This is detailed 
+in the following sections.
+
 
 .. _`Modes of operation`:
 
@@ -93,6 +102,10 @@ WBEM server on ``localhost``:
     Enter password: <password>
     . . .
     <Returns MOF for the enumerated classes>
+
+.. index::
+   single: tab-completion
+   single: auto-completion
 
 In command mode, tab completion is also supported for some command shells, but
 must be enabled specifically for each shell.
@@ -251,8 +264,13 @@ example:
       associators   List the classes associated with a class.
       . . .
 
+.. index::
+   single: tab-completion
+   single: auto-completion
+   single: auto-suggestion
+
 The pywbemcli shell in the interactive mode supports popup help text
-while typing, where the valid choices are shown based upon what was typed so
+while for commands, arguments, and options typing, where the valid choices are shown based upon what was typed so
 far, and where an item from the popup list can be picked with <TAB> or with the
 cursor keys. It can be used to select from the list of general options. In the
 following examples, an underscore ``_`` is shown as the cursor:
@@ -268,9 +286,22 @@ following examples, an underscore ``_`` is shown as the cursor:
     pywbemcli> cl_
                   class
 
+.. index::
+   single: command history
+
 The pywbemcli shell supports history across multiple invocations of the shell
 using <UP-ARROW>, <DOWN-ARROW>.
 The pywbemcli history is stored in ``~/.pywbemcli_history``.
+
+.. index::
+   single: auto-suggestion
+
+The pywbemcli interactive mode also supports automated parameter suggestions based on
+the pywbemcli history file which works with the auto completion described
+above. The input is compared to the history and when there is another entry
+starting with the given text, the completion will be shown as gray text behind
+the current input. Pressing the right arrow → or c-e will insert this
+suggestion.
 
 
 .. _`Error handling`:

--- a/pywbemtools/pywbemcli/config.py
+++ b/pywbemtools/pywbemcli/config.py
@@ -99,3 +99,10 @@ USE_TERMINAL_WIDTH = True
 #: If this variable is an integer, that is the maximum width. If None, tables
 #: are output with no limit on width.
 DEFAULT_TABLE_WIDTH = 150
+
+
+#: If True, the auto-suggestion capability is enabled in the interactive
+#: mode.  This capability uses the history file to provide suggestions for
+#: the command file in addition to other auto-complete capabilities
+#: If False, auto-suggestion is disabled.
+USE_AUTOSUGGEST = True

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -27,6 +27,8 @@ from copy import deepcopy
 import click
 import click_repl
 from prompt_toolkit.history import FileHistory
+from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+
 
 import pywbem
 from pywbem import DEFAULT_CA_CERT_PATHS, LOGGER_SIMPLE_NAMES, \
@@ -39,7 +41,7 @@ from ._common import GENERAL_OPTIONS_METAVAR, TABLE_FORMATS, \
 from ._pywbem_server import PywbemServer
 from .config import DEFAULT_OUTPUT_FORMAT, DEFAULT_NAMESPACE, \
     PYWBEMCLI_PROMPT, PYWBEMCLI_HISTORY_FILE, DEFAULT_MAXPULLCNT, \
-    DEFAULT_CONNECTION_TIMEOUT, MAX_TIMEOUT
+    DEFAULT_CONNECTION_TIMEOUT, MAX_TIMEOUT, USE_AUTOSUGGEST
 
 from ._connection_repository import ConnectionRepository
 from ._click_extensions import PywbemcliTopGroup
@@ -607,4 +609,8 @@ def repl(ctx):
         'message': PYWBEMCLI_PROMPT,
         'history': FileHistory(history_file),
     }
+
+    if USE_AUTOSUGGEST:
+        prompt_kwargs['auto_suggest'] = AutoSuggestFromHistory()
+
     click_repl.repl(ctx, prompt_kwargs=prompt_kwargs)


### PR DESCRIPTION
Depends on pr #457, Fix tests for pywbem 0.15.0

This adds a component of prompt-toolkit, the auto-suggest module.
This module gathers information from the file history to augment the
suggestions for parameters in the repl mode.

I have found it useful in completion of the data parts of options when the same classnames, etc. are used repeatedly.  However, I am not sure how it will interact with any other auto-complete we add.

Note that it is really only about a 3 line change, attaching the auto_suggest part of prompt to the repl.

TODO: If we think it is useful I need to add it to the doc.

