### PR TITLE
Fixes #390: Simpler expression for INSTANCENAME

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -43,6 +43,10 @@ Released: not yet
   the top level group is alphabetical except that connection, help, and repl
   are reordered to the bottom of the list. (See issue #466)
 
+* Define alternatives for creating INSTANCENAME input parameter since the
+  original form using, WBEMURI is error prone with quote marks.
+  (see issue #390)
+
 **Cleanup:**
 
 * Test: Enabled Python warning suppression for PendingDeprecationWarning

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -1066,6 +1066,11 @@ Help text for ``pywbemcli instance associators`` (see :ref:`instance associators
       --no, --names-only              Retrieve only the object paths (names).
                                       Default: Retrieve the complete objects
                                       including object paths.
+      -k, --key KEYNAME=VALUE         Value for a key in keybinding of
+                                      CIMInstanceName. May be specified multiple
+                                      times. Allows defining keys without the
+                                      issues of quotes. Default: No initial
+                                      properties provided.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
                                       of the default namespace of the connection.
       -s, --summary                   Show only a summary (count) of the objects.
@@ -1211,6 +1216,10 @@ Help text for ``pywbemcli instance delete`` (see :ref:`instance delete command`)
       namespace of the connection.
 
     Options:
+      -k, --key KEYNAME=VALUE    Value for a key in keybinding of CIMInstanceName.
+                                 May be specified multiple times. Allows defining
+                                 keys without the issues of quotes. Default: No
+                                 initial properties provided.
       -n, --namespace NAMESPACE  Namespace to use for this command, instead of the
                                  default namespace of the connection.
       -h, --help                 Show this message and exit.
@@ -1356,6 +1365,11 @@ Help text for ``pywbemcli instance get`` (see :ref:`instance get command`):
                                       not in the object(s) will be ignored. The
                                       empty string will include no properties.
                                       Default: Do not filter properties.
+      -k, --key KEYNAME=VALUE         Value for a key in keybinding of
+                                      CIMInstanceName. May be specified multiple
+                                      times. Allows defining keys without the
+                                      issues of quotes. Default: No initial
+                                      properties provided.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
                                       of the default namespace of the connection.
       -h, --help                      Show this message and exit.
@@ -1418,6 +1432,11 @@ Help text for ``pywbemcli instance invokemethod`` (see :ref:`instance invokemeth
                                       Array property values are specified as a
                                       comma-separated list; embedded instances are
                                       not supported. Default: No input parameters.
+      -k, --key KEYNAME=VALUE         Value for a key in keybinding of
+                                      CIMInstanceName. May be specified multiple
+                                      times. Allows defining keys without the
+                                      issues of quotes. Default: No initial
+                                      properties provided.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
                                       of the default namespace of the connection.
       -h, --help                      Show this message and exit.
@@ -1487,6 +1506,11 @@ Help text for ``pywbemcli instance modify`` (see :ref:`instance modify command`)
                                       change, to allow for verification of
                                       parameters. Default: Do not prompt for
                                       confirmation.
+      -k, --key KEYNAME=VALUE         Value for a key in keybinding of
+                                      CIMInstanceName. May be specified multiple
+                                      times. Allows defining keys without the
+                                      issues of quotes. Default: No initial
+                                      properties provided.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
                                       of the default namespace of the connection.
       -h, --help                      Show this message and exit.
@@ -1599,6 +1623,11 @@ Help text for ``pywbemcli instance references`` (see :ref:`instance references c
       --no, --names-only              Retrieve only the object paths (names).
                                       Default: Retrieve the complete objects
                                       including object paths.
+      -k, --key KEYNAME=VALUE         Value for a key in keybinding of
+                                      CIMInstanceName. May be specified multiple
+                                      times. Allows defining keys without the
+                                      issues of quotes. Default: No initial
+                                      properties provided.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead
                                       of the default namespace of the connection.
       -s, --summary                   Show only a summary (count) of the objects.

--- a/docs/pywbemcli/features.rst
+++ b/docs/pywbemcli/features.rst
@@ -230,6 +230,12 @@ The instance name (INSTANCENAME argument) can be specified in two ways:
   the ``-namespace``/``-n`` command option, or the default namespace of the
   connection.
 
+* By specifying the WBEM URI without keybindings and using the --key option
+  to specify the keybindings ad defined in section
+  :ref:`Defining INSTANCENAME command argument with --key option`. The
+  advantage of this technique is that it eliminates the use of the double
+  quote surrounding the key values.
+
 
 .. _`The INSTANCENAME command argument as a WBEM URI`:
 
@@ -361,3 +367,19 @@ interactive selection, as shown in the following example:
        InstanceID = "CIM_Foo1";
        IntegerProp = 1;
     };
+
+
+.. _`Defining INSTANCENAME command argument with --key option`:
+
+`Defining INSTANCENAME command argument with --key option`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The INSTANCENAME may be specified by a combination of the namespace/classname
+as an argument with the --key option to define keybindings. Each --key option
+definition defines a single keybinding in the form name=value.   In general,
+the value component does not require the double quote that is required with
+WBEM_URL unless there are space characters in a string value.
+
+  Example:
+
+    CIM_Foo --key InstanceId=inst1

--- a/tests/unit/common_options_help_lines.py
+++ b/tests/unit/common_options_help_lines.py
@@ -78,3 +78,6 @@ CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE = \
 
 CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE = \
     '-n, --namespace NAMESPACE  Add a namespace to the search scope. May be'
+
+CMD_OPTION_KEYS_HELP_LINE = \
+    '-k, --key KEYNAME=VALUE         Value for a key in keybinding of'

--- a/tests/unit/test_instance_cmds.py
+++ b/tests/unit/test_instance_cmds.py
@@ -32,7 +32,8 @@ from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
     CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE, \
     CMD_OPTION_LOCAL_ONLY_INSTANCE_LIST_HELP_LINE, \
     CMD_OPTION_LOCAL_ONLY_INSTANCE_GET_HELP_LINE, \
-    CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE
+    CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE, \
+    CMD_OPTION_KEYS_HELP_LINE
 
 TEST_DIR = os.path.dirname(__file__)
 
@@ -91,6 +92,7 @@ INSTANCE_ASSOCIATORS_HELP_LINES = [
     CMD_OPTION_FILTER_QUERY_LINE,
     CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE,
     CMD_OPTION_HELP_HELP_LINE,
+    CMD_OPTION_KEYS_HELP_LINE,
 ]
 
 INSTANCE_COUNT_HELP_LINES = [
@@ -115,6 +117,7 @@ INSTANCE_DELETE_HELP_LINES = [
     'Delete an instance of a class.',
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
+    CMD_OPTION_KEYS_HELP_LINE,
 ]
 
 INSTANCE_ENUMERATE_HELP_LINES = [
@@ -142,6 +145,7 @@ INSTANCE_GET_HELP_LINES = [
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
+    CMD_OPTION_KEYS_HELP_LINE,
 ]
 
 INSTANCE_INVOKEMETHOD_HELP_LINES = [
@@ -151,6 +155,7 @@ INSTANCE_INVOKEMETHOD_HELP_LINES = [
     '-p, --parameter PARAMETERNAME=VALUE Specify a method input parameter',
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
+    CMD_OPTION_KEYS_HELP_LINE,
 ]
 
 INSTANCE_MODIFY_HELP_LINES = [
@@ -161,6 +166,7 @@ INSTANCE_MODIFY_HELP_LINES = [
     CMD_OPTION_VERIFY_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
+    CMD_OPTION_KEYS_HELP_LINE,
 ]
 
 INSTANCE_QUERY_HELP_LINES = [
@@ -170,6 +176,7 @@ INSTANCE_QUERY_HELP_LINES = [
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
+    CMD_OPTION_KEYS_HELP_LINE,
 ]
 
 INSTANCE_REFERENCES_HELP_LINES = [
@@ -186,6 +193,7 @@ INSTANCE_REFERENCES_HELP_LINES = [
     CMD_OPTION_FILTER_QUERY_LINE,
     CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE,
     CMD_OPTION_HELP_HELP_LINE,
+    CMD_OPTION_KEYS_HELP_LINE,
 ]
 
 ENUM_INSTANCE_RESP = """instance of CIM_Foo {
@@ -800,6 +808,58 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
+    ['Verify instance command get instname with path and --namespace',
+     ['get', '/root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"', '--namespace',
+      'root/cimv2'],
+     {'stdout': ['instance of CIM_Foo {',
+                 '   InstanceID = "CIM_Foo1";',
+                 '   IntegerProp = 1;',
+                 '};',
+                 ''],
+      'rc': 0,
+      'test': 'innows'},
+     SIMPLE_MOCK_FILE, OK],
+
+
+    ['Verify instance command get with instancename, --key, namespace returns '
+     'data',
+     ['get', 'CIM_Foo', '--namespace', 'root/cimv2', '--key',
+      'InstanceID=CIM_Foo1'],
+     {'stdout': ['instance of CIM_Foo {',
+                 '   InstanceID = "CIM_Foo1";',
+                 '   IntegerProp = 1;',
+                 '};',
+                 ''],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+
+    ['Verify instance command get with instancename with ":", --key, namespace '
+     'returns data',
+     ['get', ':CIM_Foo', '--namespace', 'root/cimv2', '--key',
+      'InstanceID=CIM_Foo1'],
+     {'stdout': ['instance of CIM_Foo {',
+                 '   InstanceID = "CIM_Foo1";',
+                 '   IntegerProp = 1;',
+                 '};',
+                 ''],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance command get with instancename, -k namespace returns data',
+     ['get', 'CIM_Foo', '--namespace', 'root/cimv2', '-k',
+      'InstanceID=CIM_Foo1'],
+     {'stdout': ['instance of CIM_Foo {',
+                 '   InstanceID = "CIM_Foo1";',
+                 '   IntegerProp = 1;',
+                 '};',
+                 ''],
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
     ['Verify instance command get with instancename local_only returns data',
      ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--lo'],
      {'stdout': ['instance of CIM_Foo {',
@@ -961,6 +1021,15 @@ Instances: PyWBEM_AllTypes
                  "'CIM_NOTEXIST'}), namespace='root/cimv2', host=None)"],
       'rc': 1,
       'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance command get instname with path and --namespace',
+     ['get', '/cimv2/test:CIM_Foo.InstanceID="CIM_Foo1"', '--namespace',
+      'root/cimv2'],
+     {'stderr': "Conflicting namespaces between wbemuri cimv2/test and option"
+      " root/cimv2",
+      'rc': 1,
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
     #
@@ -1164,6 +1233,14 @@ Instances: PyWBEM_AllTypes
       'test': 'linesnows'},
      ALLTYPES_MOCK_FILE, OK],
 
+    ['Verify instance command modify with --key, single good change',
+     ['modify', 'PyWBEM_AllTypes', '--key', 'InstanceID=test_instance',
+      '-p', 'scalBool=False'],
+     {'stdout': "",
+      'rc': 0,
+      'test': 'linesnows'},
+     ALLTYPES_MOCK_FILE, OK],
+
     ['Verify instance command modify, single good change with verify yes',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
       '-p', 'scalBool=False', '--verify'],
@@ -1337,6 +1414,13 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
 
+    ['Verify instance command delete with --key, valid delete',
+     ['delete', 'CIM_Foo', '--key', 'InstanceID=CIM_Foo1'],
+     {'stdout': '',
+      'rc': 0,
+      'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
     ['Verify instance command delete, valid delete, explicit ns',
      ['delete', 'CIM_Foo.InstanceID="CIM_Foo1"', '-n', 'root/cimv2'],
      {'stdout': '',
@@ -1413,6 +1497,13 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance command references, returns instances',
      ['references', 'TST_Person.name="Mike"'],
+     {'stdout': REF_INSTS,
+      'rc': 0,
+      'test': 'lineswons'},
+     ASSOC_MOCK_FILE, OK],
+
+    ['Verify instance command references with --key, returns instances',
+     ['references', 'TST_Person', '--key', 'name=Mike'],
      {'stdout': REF_INSTS,
       'rc': 0,
       'test': 'lineswons'},
@@ -1616,6 +1707,13 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance command associators, returns instances',
      ['associators', 'TST_Person.name="Mike"'],
+     {'stdout': ASSOC_INSTS,
+      'rc': 0,
+      'test': 'lines'},
+     ASSOC_MOCK_FILE, OK],
+
+    ['Verify instance command associators with --key, returns instances',
+     ['associators', 'TST_Person', '--key', 'name=Mike'],
      {'stdout': ASSOC_INSTS,
       'rc': 0,
       'test': 'lines'},
@@ -1828,8 +1926,15 @@ interop      TST_Personsub        4
       'test': 'lines'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
+    ['Verify instance command invokemethod with --key, returnvalue = 0',
+     ['invokemethod', 'CIM_Foo', 'Fuzzy', '--key', 'InstanceID=CIM_Foo1'],
+     {'stdout': ['ReturnValue=0'],
+      'rc': 0,
+      'test': 'lines'},
+     [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
+
     ['Verify instance command invokemethod with multiple scalar params',
-     ['invokemethod', ':CIM_Foo.InstanceID="CIM_Foo1"', 'Fuzzy',
+     ['invokemethod', 'CIM_Foo.InstanceID="CIM_Foo1"', 'Fuzzy',
       '-p', 'TestInOutParameter="blah"',
       '-p', 'TestRef=CIM_Foo.InstanceID="CIM_Foo1"'],
      {'stdout': ['ReturnValue=0',
@@ -1863,7 +1968,7 @@ interop      TST_Personsub        4
      [ALLTYPES_MOCK_FILE, ALLTYPES_INVOKEMETHOD_MOCK_FILE], OK],
 
     ['Verify instance command invokemethod fails Invalid Class',
-     ['invokemethod', ':CIM_Foox.InstanceID="CIM_Foo1"', 'Fuzzy', '-p',
+     ['invokemethod', 'CIM_Foox.InstanceID="CIM_Foo1"', 'Fuzzy', '-p',
       'TestInOutParameter="blah"'],
      {'stderr': ["Error: CIMError: 6"],
       'rc': 1,
@@ -1871,7 +1976,7 @@ interop      TST_Personsub        4
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
     ['Verify instance command invokemethod fails Method not registered',
-     ['invokemethod', ':CIM_Foo.InstanceID="CIM_Foo1"', 'Fuzzy', '-p',
+     ['invokemethod', 'CIM_Foo.InstanceID="CIM_Foo1"', 'Fuzzy', '-p',
       'TestInOutParameter=blah'],
      {'stderr': ["Error: CIMError: 17"],
       'rc': 1,


### PR DESCRIPTION
NOTE: This pr based on pr # 457, (fix tests as we move to pywbem 0.15.0)

Add option -k --key to allow keys of the instance name to be defined
separately and then aggragated by pywbemcli.

This allows us to handle the messy parts of creating CIMInstanceName
keybindings without having to involve the user in quote marks, etc.

Originally INSTANCENAME would have to be expressed as a WBEM_URL
complete with correctly placed double quotes.

CIM_Foo.InstanceId="blah"

This allows entering the INSTANCENAME as

CIM_Foo -k InstanceID=blah