### PR TITLE
Fixes #123: cmd return consistency for commands that return nothing

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -71,6 +71,12 @@ Released: not yet
   any ongoing activities, by setting the env var PYWBEM_SPINNER to 'false',
   '0', or the empty string. This is useful when debugging.  See issue #465.
 
+* Modified the response handling on commands that may return nothing with
+  successful response to display a message if the general option --verbose
+  is defined and display nothing if --verbose not set.  This includes
+  class/instance delete, instance modify and the commands that display
+  cim objects. (See issue #123)
+
 **Cleanup:**
 
 * Test: Enabled Python warning suppression for PendingDeprecationWarning

--- a/docs/pywbemcli/generaloptions.rst
+++ b/docs/pywbemcli/generaloptions.rst
@@ -191,7 +191,9 @@ Other miscellaneous general options
 """""""""""""""""""""""""""""""""""
 
 The :ref:`--verbose general option` displays extra information about the pywbemcli
-internal processing, the :ref:`--version general option` displays pywbemcli version
+internal processing.
+
+The :ref:`--version general option` displays pywbemcli version
 information and the :ref:`--help general option` provides top level help
 
 
@@ -553,8 +555,9 @@ For details, see :ref:`Output formats`.
 --log general option
 """"""""""""""""""""
 
-The argument value of the  ``--log``/``-l`` general option defines the destination and
-parameters of logging of the requests and responses to the WBEM server.
+The argument value of the  ``--log``/``-l`` general option defines the
+destination and parameters of logging of the requests and responses to the WBEM
+server.
 
 For details, see :ref:`Pywbemcli defined logging`.
 
@@ -567,14 +570,10 @@ For details, see :ref:`Pywbemcli defined logging`.
 The ``--verbose``/``-v`` general option is a boolean option that enables the
 display of extra information about the processing.
 
-
-.. _`--version general option`:
-
---version general option
-""""""""""""""""""""""""
-
-The ``--version``/``-V`` general option displays the version of this command
-and of the pywbem package it uses, and then exits.
+In particular it outputs text for a number of commands that
+normally return nothing upon successful execution(ex. instance delete,
+instance enumerate that returns no CIM objects) to indicate the successful
+command completion.
 
 
 .. _`--help general option`:

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -824,6 +824,7 @@ def cmd_class_delete(context, classname, options):
 
     try:
         context.conn.DeleteClass(classname)
-        click.echo('{} delete successful'.format(classname))
+        if context.verbose:
+            click.echo('Deleted class {}.'.format(classname))
     except Error as er:
         raise_pywbem_error_exception(er)

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -773,7 +773,7 @@ def cmd_instance_delete(context, instancename, options):
         context.conn.DeleteInstance(instancepath)
 
         if context.verbose:
-            click.echo('Deleted {}'.format(instancepath))
+            click.echo('Deleted instance {}'.format(instancepath))
 
     except Error as er:
         raise_pywbem_error_exception(er)
@@ -868,6 +868,8 @@ def cmd_instance_modify(context, instancename, options):
     try:
         context.conn.ModifyInstance(modified_inst,
                                     PropertyList=property_list)
+        if context.verbose:
+            click.echo('Modified instance {}'.format(instancepath))
     except Error as er:
         raise click.ClickException("Server Error modifying instance. "
                                    'Exception: {}: {}'.format

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -874,6 +874,10 @@ def display_cim_objects(context, cim_objects, output_format=None, summary=False,
         display_cim_objects_summary(context, cim_objects)
         return
 
+    if not cim_objects and context.verbose:
+        click.echo("No objects returned")
+        return
+
     if sort:
         cim_objects = sort_cimobjects(cim_objects)
 

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -640,6 +640,12 @@ TEST_CASES = [
       'test': 'innows'},
      QUALIFIER_FILTER_MODEL, OK],
 
+    ['Verify instance command enumerate CIM_Foo_sub2, w --verbose rtns msg.',
+     {'args': ['enumerate', 'CIM_Foo_sub2'],
+      'general': ['--verbose']},
+     {'stdout': 'No objects returned',
+      'test': 'linesnows'},
+     SIMPLE_MOCK_FILE, OK],
 
     #
     # Enumerate errors
@@ -1010,8 +1016,16 @@ TEST_CASES = [
     # Class delete successful
     ['Verify class command delete successful with no subclasses, --force',
      ['delete', 'CIM_Foo_sub_sub', '--force'],
-     {'stdout': 'CIM_Foo_sub_sub delete successful',
+     {'stdout': '',
       'test': 'in'},
+     [SIMPLE_MOCK_FILE], OK],
+
+    # Class delete successful
+    ['Verify class command delete successful with no subclasses, --verbose',
+     {'args': ['delete', 'CIM_Foo_sub_sub', '--force'],
+      'general': ['--verbose']},
+     {'stdout': ['Deleted class', 'CIM_Foo_sub_sub'],
+      'test': 'innows'},
      [SIMPLE_MOCK_FILE], OK],
 
     ['Verify class command delete fail instances exist',

--- a/tests/unit/test_instance_cmds.py
+++ b/tests/unit/test_instance_cmds.py
@@ -440,6 +440,20 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
+    ['Verify instance command enumerate CIM_Foo_sub2, rtns nothing,',
+     {'args': ['enumerate', 'CIM_Foo_sub2'],
+      'general': []},
+     {'stdout': "",
+      'test': 'linesnows'},
+     SIMPLE_MOCK_FILE, RUN],
+
+    ['Verify instance command enumerate CIM_Foo_sub2, w --verbose rtns msg.',
+     {'args': ['enumerate', 'CIM_Foo_sub2'],
+      'general': ['--verbose']},
+     {'stdout': 'No objects returned',
+      'test': 'linesnows'},
+     SIMPLE_MOCK_FILE, RUN],
+
     ['Verify instance command enumerate CIM_Foo with --use-pull yes and '
      '--pull-max-cnt=2',
      {'args': ['enumerate', 'CIM_Foo', '--include-qualifiers'],
@@ -1240,6 +1254,15 @@ Instances: PyWBEM_AllTypes
       'test': 'linesnows'},
      ALLTYPES_MOCK_FILE, OK],
 
+    ['Verify instance modify, --verbose',
+     {'args': ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"',
+      '-p', 'scalBool=False'],
+      'general': ['--verbose']},
+     {'stdout': ['Modified'],
+      'rc': 0,
+      'test': 'innows'},
+     ALLTYPES_MOCK_FILE, OK],
+
     ['Verify instance command modify with --key, single good change',
      ['modify', 'PyWBEM_AllTypes', '--key', 'InstanceID=test_instance',
       '-p', 'scalBool=False'],
@@ -1426,6 +1449,14 @@ Instances: PyWBEM_AllTypes
      {'stdout': '',
       'rc': 0,
       'test': 'lines'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance command delete with --key, valid delete, --verbose',
+     {'args': ['delete', 'CIM_Foo', '--key', 'InstanceID=CIM_Foo1'],
+      'general': ['--verbose']},
+     {'stdout': ['Deleted'],
+      'rc': 0,
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance command delete, valid delete, explicit ns',


### PR DESCRIPTION
Per the issue, this modifies those commands the return nothing on successful completion to return a message indicating success when --verbose general option is define but return nothing when --verbose is not defined. These return a message with the action (Deleted/Modified, class/instance, and the name of the object.

This applies to class/instance delete, instance modify and the class/instance enumerate, associators, references commands.  These return the fixed message "Return empty' when there are no object returned and --verbose is set