### PR TITLE
Fix pywbemtools install issue on Python 3.4

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -45,6 +45,9 @@ Released: not yet
 
 * Added documentation for the --version general option.
 
+* Increased pywbem minimum version to 0.16.0 to accomodate install issues
+  on Python 3.4, and to pick up other fixes.
+
 **Enhancements:**
 
 * Add capability to reorder commands in the help for each group.  The commands

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -44,7 +44,7 @@ wheel==0.29.0
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
-pywbem==0.15.0
+pywbem==0.16.0
 
 pbr==1.10.0
 six==1.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 
 # Direct dependencies (except pip, setuptools, wheel):
 
-pywbem>=0.15.0
+pywbem>=0.16.0
 # git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
 
 pbr>=1.10.0
@@ -21,4 +21,7 @@ tabulate>=0.8.2
 prompt-toolkit>=2.0.1; python_version >= '3.4'
 # See pywbemtools issue # 192. The repl mode fails with unexpected Exception
 prompt-toolkit>=1.0.15,<2.0.0; python_version == '2.7'
-PyYAML>=5.1
+# PyYAML 5.3 has removed support for Python 3.4
+PyYAML>=5.1; python_version == '2.7'
+PyYAML>=5.1,<5.3; python_version == '3.4'
+PyYAML>=5.1; python_version > '3.4'


### PR DESCRIPTION
See commit message.
Note, this includes increasing the minimum pywbem version to 0.16.0.