### PR TITLE
pick_from_list bypass user request if only one choice

### DIFF
--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -190,14 +190,14 @@ Help text for ``pywbemcli class`` (see :ref:`class command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      associators   List the classes associated with a class.
-      get           Get a class.
       enumerate     List top classes or subclasses of a class in a namespace.
-      tree          Show the subclass or superclass hierarchy for a class.
-      references    List the classes referencing a class.
-      invokemethod  Invoke a method on a class.
-      find          List the classes with matching class names on the server.
+      get           Get a class.
       delete        Delete a class.
+      invokemethod  Invoke a method on a class.
+      references    List the classes referencing a class.
+      associators   List the classes associated with a class.
+      find          List the classes with matching class names on the server.
+      tree          Show the subclass or superclass hierarchy for a class.
 
 
 .. _`pywbemcli class associators --help`:
@@ -708,13 +708,13 @@ Help text for ``pywbemcli connection`` (see :ref:`connection command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      show    Show a WBEM connection definition or the current connection.
-      list    List the WBEM connection definitions.
       export  Export the current connection.
+      show    Show a WBEM connection definition or the current connection.
+      delete  Delete a WBEM connection definition.
+      select  Select a WBEM connection definition as current or default.
       test    Test the current connection with a predefined WBEM request.
       save    Save the current connection to a new WBEM connection definition.
-      select  Select a WBEM connection definition as current or default.
-      delete  Delete a WBEM connection definition.
+      list    List the WBEM connection definitions.
 
 
 .. _`pywbemcli connection delete --help`:
@@ -1014,16 +1014,16 @@ Help text for ``pywbemcli instance`` (see :ref:`instance command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      count         Count the instances of each class with matching class name.
-      associators   List the instances associated with an instance.
-      get           Get an instance of a class.
-      create        Create an instance of a class in a namespace.
-      invokemethod  Invoke a method on an instance.
-      modify        Modify properties of an instance.
-      references    List the instances referencing an instance.
       enumerate     List the instances of a class.
-      query         Execute a query on instances in a namespace.
+      get           Get an instance of a class.
       delete        Delete an instance of a class.
+      create        Create an instance of a class in a namespace.
+      modify        Modify properties of an instance.
+      associators   List the instances associated with an instance.
+      references    List the instances referencing an instance.
+      invokemethod  Invoke a method on an instance.
+      query         Execute a query on instances in a namespace.
+      count         Count the instances of each class with matching class name.
 
 
 .. _`pywbemcli instance associators --help`:
@@ -1728,8 +1728,8 @@ Help text for ``pywbemcli qualifier`` (see :ref:`qualifier command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      enumerate  List the qualifier declarations in a namespace.
       get        Get a qualifier declaration.
+      enumerate  List the qualifier declarations in a namespace.
 
 
 .. _`pywbemcli qualifier enumerate --help`:
@@ -1848,12 +1848,12 @@ Help text for ``pywbemcli server`` (see :ref:`server command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      info          Get information about the server.
-      centralinsts  List central instances of mgmt profiles on the server.
+      namespaces    List the namespaces of the server.
       interop       Get the Interop namespace of the server.
       brand         Get the brand of the server.
+      info          Get information about the server.
       profiles      List management profiles advertized by the server.
-      namespaces    List the namespaces of the server.
+      centralinsts  List central instances of mgmt profiles on the server.
 
 
 .. _`pywbemcli server brand --help`:

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -1145,7 +1145,9 @@ The ``connection delete`` command deletes a connection definition from the
 
 If the ``NAME`` argument is specified, the connection definition with that name
 is deleted. Otherwise, the command displays the list of connection definitions
-and prompts the user for picking the one to be deleted.
+and prompts the user to select the one to be deleted. If there is only a
+single connection, that connection is deleted without the user selection
+request.
 
 Example that deletes a connection definition by the specified name:
 
@@ -1267,7 +1269,9 @@ The ``connection select`` command selects a connection definition from the
 
 If the ``NAME`` argument is specified, the connection definition with that name
 is selected. Otherwise, the command displays the list of connection definitions
-and prompts the user for picking the one to be selected.
+and prompts the user to pick the one to be selected. If there is only a
+single connection, that connection is selected without the user
+request.
 
 If the ``--default`` command option is set, the connection definition in
 addition becomes the default connection, by marking it accordingly in the
@@ -1322,8 +1326,9 @@ Connection show command
 
 The ``connection show`` command shows information about a connection definition:
 
-* If ``NAME`` is ``?``, pywbemcli prompts the user for picking one and shows
-  the existing current connection.
+* If ``NAME`` is ``?``, pywbemcli prompts the user to select one and shows
+  the existing current connection. If there is only a single connection the
+  user selection is bypassed.
 * If ``NAME`` is specified, show the connection definition with that name.
 * If ``NAME`` is not specified, show the existing current connection.
 

--- a/docs/pywbemcli/features.rst
+++ b/docs/pywbemcli/features.rst
@@ -228,7 +228,8 @@ The instance name (INSTANCENAME argument) can be specified in two ways:
   :ref:`Interactively selecting INSTANCENAME command argument` (i.e.
   CLASSNAME.?). The namespace of the instance is the namespace specified with
   the ``-namespace``/``-n`` command option, or the default namespace of the
-  connection.
+  connection.  If there is only a single instance, that instance is selected
+  automaticaly with without user request.
 
 * By specifying the WBEM URI without keybindings and using the --key option
   to specify the keybindings ad defined in section

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -116,6 +116,9 @@ def pick_one_from_list(context, options, title):
     Interactive component that displays a set of options (strings) and asks
     the user to select one.  Returns the item and index of the selected string.
 
+    If there is only a single item in the options, simply return that choice
+    without user intervention.
+
     Parameters:
       options:
         List of strings from which one will is to be selected
@@ -133,6 +136,12 @@ def pick_one_from_list(context, options, title):
     TODO: Possible Future This could be replaced by the python pick library
     that would use curses for the selection process.
     """
+
+    # If there is only a single choice, return that choice.
+    if len(options) == 1:
+        return options[0]
+
+    # Issue list of choices and prompt for user choice of index
     if context:
         context.spinner_stop()
 
@@ -142,8 +151,11 @@ def pick_one_from_list(context, options, title):
         index += 1
         click.echo('{}: {}'.format(index, str_))
     selection = None
-    msg = 'Input integer between 0 and {} or Ctrl-C to exit selection: ' \
+    msg = 'Input integer between 0 and {} or Ctrl-C to exit selection' \
         .format(index)
+
+    # Loop for valid user choice until valid choice made or selection aborted
+    # by user
     while True:
         try:
             selection_txt = click.prompt(msg)

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -446,6 +446,11 @@ TESTCASES_PICK_ONE_FROM_LIST = [
      dict(options=[u'ZERO', u'ONE', u'TWO'], choices=['9', '-1', 'a', '2'],
           exp_rtn=u'TWO'),
      None, None, OK),
+
+    ('Verify returns correct choice with only single choice so no usr request',
+     dict(options=[u'ZERO'], choices=None,
+          exp_rtn=u'ZERO'),
+     None, None, OK),
 ]
 
 
@@ -458,15 +463,22 @@ def test_pick_one_from_list(testcase, options, choices, exp_rtn):
     Test for pick_one_from_list function. Uses mock patch to define return
     values from the mock.
     """
-    # setup mock for this test
-    mock_function = 'pywbemtools.pywbemcli.click.prompt'
-    with patch(mock_function, side_effect=choices) as mock_prompt:
-        # The code to be tested
-        title = "Test pick_one_from_list"
+    title = "Test pick_one_from_list"
+
+    # test option with only one choice bypasses user request
+    if not choices:
         context = ContextObj(None, None, None, None, None, None, None)
         act_rtn = pick_one_from_list(context, options, title)
-        context.spinner_stop()
-        assert mock_prompt.call_count == len(choices)
+    else:
+        # setup mock for this test
+        mock_function = 'pywbemtools.pywbemcli.click.prompt'
+        with patch(mock_function, side_effect=choices) as mock_prompt:
+            # The code to be tested
+            # fake context object
+            context = ContextObj(None, None, None, None, None, None, None)
+            act_rtn = pick_one_from_list(context, options, title)
+            context.spinner_stop()
+            assert mock_prompt.call_count == len(choices)
 
     # Ensure that exceptions raised in the remainder of this function
     # are not mistaken as expected exceptions

--- a/tests/unit/test_connection_cmds.py
+++ b/tests/unit/test_connection_cmds.py
@@ -599,11 +599,9 @@ TEST_CASES = [
       'file': {'before': 'exists', 'after': 'exists'}},
      MOCK_PROMPT0_FILE, OK],
 
-    ['Verify connection command delete with prompt that selects 0',
+    ['Verify connection command delete last one that  deletes w/o prompt',
      ['delete', ],
-     {'stdout': ['Select a connection or Ctrl_C to abort',
-                 '0: mocktest',
-                 'Input integer between 0 and 0 or Ctrl-C to exit selection:'],
+     {'stdout': ['Deleted  connection "mocktest'],
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'none'}},
      MOCK_PROMPT0_FILE, OK],


### PR DESCRIPTION
Modify the pick_from_list() that normally issues a list of choices for the
user to pick one without issuing the pick list when there is only a
single choice and return that choice.  This bypasses the user having
to pick from a choice of one when there is only one choice.

Adds test for this and a change to the documentation to document this
behavior.

COMMENTS:

This is a change of behavior so not sure it is what we should do. 

 The alternatives are:

1.  Not to do this since it is unexpected unexpected behavior for the user. The fact that the user would not get a selection list in this case is a surprise that changes the normal behavior.
2.  Just do enter rather than the number if there is only one. Again, this is unexpected behavior.
3.  Put out message indicating that we picked one without issuing the list if there is only one and we pick it for them.

NOTE: Andy asked if their was a default on the pick list. No there is not.  There is no easy way to pick defaults for things like instances unless we were to do it from history (i.e. mark as default the last one picked or something like  that). In the case of the connection list, we do the default with the connection table itself by defining one connection that will be the default if the user starts pywbemcli with no connection specified.

Any suggestions are welcome.
