### PR TITLE
Add common  class NocaseList for use with ks/shrub-add-nocaselist

### DIFF
--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -1006,13 +1006,9 @@ def format_keys(obj, max_width):
 
 class NoCaseList(object):
     """
-    This class is a dervivative of lists the simplifies working with
-    some of the CIM object attributes that are case insensitive such as
-    class names, roles, etc.
-
-    # TODO: Future; Possibly optimize by setting strs to lower in constructor
-    Right now the usage is primarily for small lists to this implementation
-    does not cause excessive overhead.
+    This class simplifies working with lists of strings that are to be tested
+    case-insenstive. This simplifies working with  the CIM object attributes
+    that are case insensitive such as class names, roles, etc.
 
     NOTE: This code does not handle None either for items in the list or for
     the str parameter in __contains__
@@ -1040,7 +1036,13 @@ class NoCaseList(object):
 
     def __contains__(self, str):
         """
-        Implement 'in'
+        Implement Python 'in' functionality.
+
+        Parameters(:term:`string_types`):
+          String to test against the instance of NocaseList
+
+        Returns:
+          True if string in list (case insensitive compare)
         """
 
         assert str is not None
@@ -1048,13 +1050,14 @@ class NoCaseList(object):
 
     def add(self, strs):
         """
-        add str or list of strings to the list
+        Add string or list of strings to the list
 
-        Example:
+        Parameters:(:term:`string_types` or list, tuple of :term:`string_types`):  # noqa:E501
+          String to test against the instance of NocaseList.
 
-        classnames = NoCaseList(conn.EnumerateClassNames(...))
         """
-
+        if not strs:
+            return
         if isinstance(strs, list):
             self.str_list.extend(strs)
         else:

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -1004,6 +1004,63 @@ def format_keys(obj, max_width):
     return wbem_uri_keys
 
 
+class NoCaseList(object):
+    """
+    This class is a dervivative of lists the simplifies working with
+    some of the CIM object attributes that are case insensitive such as
+    class names, roles, etc.
+
+    # TODO: Future; Possibly optimize by setting strs to lower in constructor
+    Right now the usage is primarily for small lists to this implementation
+    does not cause excessive overhead.
+
+    NOTE: This code does not handle None either for items in the list or for
+    the str parameter in __contains__
+
+    Example:
+
+        roles = NoCaseList(roles)
+        # the following does case insensitive test
+        if role in roles:
+            do something
+    """
+
+    def __init__(self, strs):
+        """
+        Constructor requires list of strings input
+
+        Parameters:
+
+          strs(list of :term: `string`)
+            The strings that will make up the list
+        """
+
+        assert isinstance(strs, list)
+        self.str_list = strs
+
+    def __contains__(self, str):
+        """
+        Implement 'in'
+        """
+
+        assert str is not None
+        return str.lower() in (n.lower() for n in self.str_list)
+
+    def add(self, strs):
+        """
+        add str or list of strings to the list
+
+        Example:
+
+        classnames = NoCaseList(conn.EnumerateClassNames(...))
+        """
+
+        if isinstance(strs, list):
+            self.str_list.extend(strs)
+        else:
+            self.str_list.append(strs)
+
+
 def _print_paths_as_table(objects, table_width, table_format):
     # pylint: disable=unused-argument
     """

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -42,7 +42,8 @@ from pywbemtools.pywbemcli._common import parse_wbemuri_str, \
     create_ciminstance, compare_instances, resolve_propertylist, \
     _format_instances_as_rows, _print_instances_as_table, is_classname, \
     pick_one_from_list, pick_multiple_from_list, hide_empty_columns, \
-    verify_operation, split_str_w_esc, format_keys, create_ciminstancename
+    verify_operation, split_str_w_esc, format_keys, create_ciminstancename, \
+    NoCaseList
 # pylint: disable=unused-import
 from pywbemtools.pywbemcli._context_obj import ContextObj
 
@@ -447,6 +448,99 @@ TESTCASES_PICK_ONE_FROM_LIST = [
           exp_rtn=u'TWO'),
      None, None, OK),
 ]
+
+TESTCASES_NOCASE_LIST = [
+    # TESTCASES for NoCaseList
+    #
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * kwargs: Keyword arguments for the test function and response:
+    #   * input_list: string for construction of NoCaseList
+    #   * test_str: string for 'in' test
+    #   * add_strs: string or list of strings for .add test
+    #   * exp_rtn: expected list of strings returned
+    # * exp_exc_types: Expected exception type(s), or None.
+    # * exp_warn_types: Expected warning type(s), or None.
+    # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
+
+    ('Verify in test fails',
+     dict(input_list=['ABC', 'Def', 'ijK'],
+          test_str='AAA',
+          add_strs=None,
+          exp_rtn=False),
+     None, None, OK),
+
+    ('Verify in test fails, test string shorter',
+     dict(input_list=['ABC', 'Def', 'ijK'],
+          test_str='AB',
+          add_strs=None,
+          exp_rtn=False),
+     None, None, OK),
+
+    ('Verify test passes, test string ABC',
+     dict(input_list=['ABC', 'Def', 'ijK'],
+          test_str='ABC',
+          add_strs=None,
+          exp_rtn=True),
+     None, None, OK),
+
+    ('Verify test passes on first string 1',
+     dict(input_list=['Abc', 'Def', 'ijK'],
+          test_str='ABC',
+          add_strs=None,
+          exp_rtn=True),
+     None, None, OK),
+
+    ('Verify test passes on first string 2',
+     dict(input_list=['Abc', 'Def', 'ijK'],
+          test_str='aBC',
+          add_strs=None,
+          exp_rtn=True),
+     None, None, OK),
+
+    ('Verify test passes on first string 3',
+     dict(input_list=['Abc', 'Def', 'ijK'],
+          test_str='abc',
+          add_strs=None,
+          exp_rtn=True),
+     None, None, OK),
+
+    ('Verify add  test old string',
+     dict(input_list=['Abc', 'Def', 'ijK'],
+          test_str='abc',
+          add_strs='lmn',
+          exp_rtn=True),
+     None, None, OK),
+
+    ('Verify add test added string',
+     dict(input_list=['Abc', 'Def', 'ijK'],
+          test_str='lmn',
+          add_strs='LMN',
+          exp_rtn=True),
+     None, None, OK),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_NOCASE_LIST)
+@simplified_test_function
+def test_nocase_list(testcase, input_list, test_str, add_strs, exp_rtn):
+    """Test for resolve_propertylist function"""
+
+    # The code to be tested
+    test_list = NoCaseList(input_list)
+
+    if add_strs:
+        test_list.add(add_strs)
+
+    act_rslt = test_str in test_list
+
+    # Ensure that exceptions raised in the remainder of this function
+    # are not mistaken as expected exceptions
+    assert testcase.exp_exc_types is None
+
+    assert act_rslt == exp_rtn
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Required before ks/add_shrub_display pr

Adds a new common funct and it tests that allows simple tests for no case test of string in list of strings. This is primarily for use with the shrub display changes but is probably more general that that so we put it into _common.py