### PR TITLE
Fixes #354: Command-specific default output format and improved output format validation

### DIFF
--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -146,12 +146,13 @@ Help text for ``pywbemcli``:
                                       PYWBEMCLI_DEFAULT_NAMESPACE, or root/cimv2.
 
       -o, --output-format FORMAT      Output format for the command result. The
-                                      specified format may be overriden since not
-                                      all formats apply to all result data types.
-                                      FORMAT is a table format
+                                      default and allowed output formats are
+                                      command specific. The default output_format
+                                      is None so that each command selects its own
+                                      default format. FORMAT is either a table
+                                      format:
                                       [table|plain|simple|grid|psql|rst|html] or
-                                      object format [mof|xml|repr|txt]. Default:
-                                      simple.
+                                      CIM object format: [mof|xml|repr|txt].
 
       -l, --log COMP[=DEST[:DETAIL]],...
                                       Enable logging of the WBEM operations,

--- a/docs/pywbemcli/generaloptions.rst
+++ b/docs/pywbemcli/generaloptions.rst
@@ -803,8 +803,9 @@ pull operations are not supported in the WBEM server:
 Output formats
 ^^^^^^^^^^^^^^
 
-Pywbemcli supports various output formats for the command result. The output
-format can be selected with the ``--output-format``/``-o`` option.
+Pywbemcli supports multiple output formats to present command results. The output
+format can be selected with the ``--output-format``/``-o`` option. The allowed
+output formats are different for the various command groups and commands.
 
 The output formats fall into three groups:
 
@@ -828,13 +829,103 @@ The output formats fall into three groups:
 * **ASCII tree format** - The :ref:`ASCII tree format` formats the result
   as a tree, using ASCII characters to represent the tree. The only command
   supporting the ASCII tree format is ``class tree``, and it supports only
-  that one output format.
+  that one output format.  The tree format is not supported by any other
+  command today.
 
 When an unsupported output format is specified for a command response, it is
-ignored and a default output format is used instead.  For example, the command
-``class enumerate`` only supports the CIM object formats and always outputs
-in those formats.
+rejected with an exception.  For example, the command
+``class enumerate`` only supports the CIM object formats and will generate an
+exception if the command ``pywbemcli -o table class enumerate`` is entered.
 
+
+.. _`Output formats for groups and commands`:
+
+Output formats for groups and commands
+""""""""""""""""""""""""""""""""""""""
+
+Each of the commands may allow only a subset of the possible ouput formats. Thus,
+the `server brand` only outputs data in a table format so there is no defined
+default format for the `--output-format` general option.
+
+The following shows the default format for each command the the alternate
+format groups where the groups are:
+
+objects = xml|repr|txt
+
+table = table|plain|simple|grid|psql|rst|html
+
++----------+---------------+----------+----------------+--------------------------------------------+
+|Group     |Command        | Default  | Alternates     | Comments                                   |
++==========+===============+==========+================+============================================+
+| class    | associators   | 'mof'    | objects        | See Note 1 below.                          |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          | delete        | None     | None           | Nothing returned                           |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          | enumerate     | 'mof'    | objects        |  See Note 1 below.                         |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          | find          | 'simple' | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          | get           | 'mof'    | objects        |  See Note 1 below.                         |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          | invokemethod  | 'mof'    | objects        |  See Note 1 below.                         |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          | references    | 'mof'    | objects        |  See Note 1 below.                         |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          | tree          | None     | None           | Only outputs as ascii tree                 |
++----------+---------------+----------+----------------+--------------------------------------------+
+|instance  | associators   | 'mof'    | objects, table | output as cim object or table of properties|
++----------+---------------+----------+----------------+--------------------------------------------+
+|          | count         | 'simple' | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          | create        | None     |                | Nothing returned                           |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          | delete        | None     |                | Nothing returned                           |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  enumerate    | 'mof'    | objects, table |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  get          | 'mof'    | objects, table |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          | invokemethod  | 'mof'    | objexts, table |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  modify       | None     | None           |  Nothing returned                          |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  references   | 'mof'    | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|qualifier |  enumerate    | 'mof'    | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  get          | 'mof'    | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|server    |  brand        | 'simple' | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |centralinsts   | 'simple' | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  info         | 'simple' | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  interop      | 'simple' | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  namespaces   | 'simple' | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  profiles     | 'simple' | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|connection|  delete       | None     | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  export       | None     | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  list         | 'simple' | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  save         |  None    | table          |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  select       |  None    | None           |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  show         |  None    |                | Currently ignores output format            |
++----------+---------------+----------+----------------+--------------------------------------------+
+|          |  test         |  None    | None           |                                            |
++----------+---------------+----------+----------------+--------------------------------------------+
+
+NOTES:
+
+1. While the display of classes allows only CIM object display format (`mof`, etc.) the display with
+   the --names-only or --summary formats allows table output also.
 
 .. _`Table formats`:
 

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -32,7 +32,7 @@ from pywbem import Error
 
 from .pywbemcli import cli
 from ._common import CMD_OPTS_TXT, pick_one_from_list, format_table, \
-    hide_empty_columns, raise_pywbem_error_exception
+    hide_empty_columns, raise_pywbem_error_exception, validate_output_format
 from ._pywbem_server import PywbemServer
 from ._connection_repository import ConnectionRepository
 from ._context_obj import ContextObj
@@ -563,6 +563,8 @@ def cmd_connection_list(context):
     """
     connections = ConnectionRepository()
 
+    output_format = validate_output_format(context.output_format, 'TABLE')
+
     # build the table structure
     rows = []
     cur_sym = '*'  # single char representing current connection
@@ -601,4 +603,4 @@ def cmd_connection_list(context):
         headers,
         title='WBEM server connections: ({}: default, {}: current)'.format(
             dflt_sym, cur_sym),
-        table_format=context.output_format))
+        table_format=output_format))

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -32,7 +32,7 @@ from ._common import display_cim_objects, parse_wbemuri_str, \
     pick_instance, resolve_propertylist, create_ciminstance, \
     filter_namelist, CMD_OPTS_TXT, format_table, verify_operation, \
     process_invokemethod, raise_pywbem_error_exception, \
-    create_ciminstancename, warning_msg
+    create_ciminstancename, warning_msg, validate_output_format
 
 from ._common_options import add_options, propertylist_option, \
     names_only_option, include_classorigin_instance_option, namespace_option, \
@@ -810,6 +810,9 @@ def cmd_instance_get(context, instancename, options):
     instances to the console from which one can be picked to get from the
     server and display.
     """
+
+    output_fmt = validate_output_format(context.output_format, ['CIM', 'TABLE'])
+
     instancepath = get_instancename(context, instancename, options)
     if instancepath is None:
         return
@@ -822,7 +825,7 @@ def cmd_instance_get(context, instancename, options):
             IncludeClassOrigin=options['include_classorigin'],
             PropertyList=resolve_propertylist(options['propertylist']))
 
-        display_cim_objects(context, instance, context.output_format)
+        display_cim_objects(context, instance, output_fmt)
 
     except Error as er:
         raise_pywbem_error_exception(er)
@@ -986,6 +989,8 @@ def cmd_instance_enumerate(context, classname, options):
     Enumerate CIM instances or CIM instance names
 
     """
+    output_fmt = validate_output_format(context.output_format, ['CIM', 'TABLE'])
+
     try:
         if options['names_only']:
             results = context.conn.PyWbemcliEnumerateInstancePaths(
@@ -1007,7 +1012,7 @@ def cmd_instance_enumerate(context, classname, options):
                 MaxObjectCount=context.pull_max_cnt,
                 PropertyList=resolve_propertylist(options['propertylist']))
 
-        display_cim_objects(context, results, context.output_format,
+        display_cim_objects(context, results, output_fmt,
                             summary=options['summary'], sort=True)
 
     except Error as er:
@@ -1029,6 +1034,8 @@ def cmd_instance_references(context, instancename, options):
        If the interactive option is selected, the instancename MUST BE
        a classname.
     """
+    output_fmt = validate_output_format(context.output_format, ['CIM', 'TABLE'])
+
     instancepath = get_instancename(context, instancename, options)
     if instancepath is None:
         return
@@ -1054,7 +1061,7 @@ def cmd_instance_references(context, instancename, options):
                 MaxObjectCount=context.pull_max_cnt,
                 PropertyList=resolve_propertylist(options['propertylist']))
 
-        display_cim_objects(context, results, context.output_format,
+        display_cim_objects(context, results, output_fmt,
                             summary=options['summary'], sort=True)
 
     except Error as er:
@@ -1073,6 +1080,8 @@ def cmd_instance_associators(context, instancename, options):
     Execute the references request operation to get references for
     the classname defined
     """
+    output_fmt = validate_output_format(context.output_format, ['CIM', 'TABLE'])
+
     instancepath = get_instancename(context, instancename, options)
     if instancepath is None:
         return
@@ -1102,7 +1111,7 @@ def cmd_instance_associators(context, instancename, options):
                 MaxObjectCount=context.pull_max_cnt,
                 PropertyList=resolve_propertylist(options['propertylist']))
 
-        display_cim_objects(context, results, context.output_format,
+        display_cim_objects(context, results, output_fmt,
                             summary=options['summary'], sort=True)
 
     except Error as er:
@@ -1121,6 +1130,7 @@ def cmd_instance_count(context, classname, options):
     """
     Get the number of instances of each class in the namespace
     """
+    output_fmt = validate_output_format(context.output_format, 'TABLE')
 
     # Differs from class find because it classname is optional.
     # If None, select all
@@ -1192,11 +1202,12 @@ def cmd_instance_count(context, classname, options):
     context.spinner_stop()
     click.echo(format_table(rows, headers,
                             title='Count of instances per class',
-                            table_format=context.output_format))
+                            table_format=output_fmt))
 
 
 def cmd_instance_query(context, query, options):
     """Execute the query defined by the inputs"""
+    output_fmt = validate_output_format(context.output_format, ['CIM', 'TABLE'])
 
     try:
         results = context.conn.PyWbemcliQueryInstances(
@@ -1205,7 +1216,7 @@ def cmd_instance_query(context, query, options):
             namespace=options['namespace'],
             MaxObjectCount=context.pull_max_cnt)
 
-        display_cim_objects(context, results, context.output_format,
+        display_cim_objects(context, results, output_fmt,
                             summary=options['summary'], sort=True)
 
     except Error as er:

--- a/pywbemtools/pywbemcli/_cmd_qualifier.py
+++ b/pywbemtools/pywbemcli/_cmd_qualifier.py
@@ -27,8 +27,8 @@ import click
 from pywbem import Error
 
 from .pywbemcli import cli
-from ._common import display_cim_objects, CMD_OPTS_TXT, \
-    output_format_is_table, sort_cimobjects, raise_pywbem_error_exception
+from ._common import display_cim_objects, CMD_OPTS_TXT, sort_cimobjects, \
+    raise_pywbem_error_exception, validate_output_format
 from ._common_options import add_options, namespace_option, summary_option
 from ._click_extensions import PywbemcliGroup
 
@@ -94,22 +94,18 @@ def qualifier_enumerate(context, **options):
 #####################################################################
 
 
-def qual_outputformat(output_format):
-    """ If output format is table type, force to mof"""
-
-    return 'mof' if output_format_is_table(output_format) else output_format
-
-
 def cmd_qualifier_get(context, qualifiername, options):
     """
     Execute the command for get qualifier and display result
     """
+    output_format = validate_output_format(context.output_format, ['CIM',
+                                                                   'TABLE'])
+
     try:
         qual_decl = context.conn.GetQualifier(qualifiername,
                                               namespace=options['namespace'])
 
-        display_cim_objects(context, qual_decl,
-                            qual_outputformat(context.output_format))
+        display_cim_objects(context, qual_decl, output_format)
 
     except Error as er:
         raise_pywbem_error_exception(er)
@@ -119,11 +115,14 @@ def cmd_qualifier_enumerate(context, options):
     """
     Execute the command for enumerate qualifiers and desplay the result.
     """
+    output_format = validate_output_format(context.output_format, ['CIM',
+                                                                   'TABLE'])
+
     try:
         qual_decls = sort_cimobjects(context.conn.EnumerateQualifiers(
             namespace=options['namespace']))
 
-        display_cim_objects(context, qual_decls, context.output_format,
+        display_cim_objects(context, qual_decls, output_format,
                             summary=options['summary'])
 
     except Error as er:

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -29,7 +29,8 @@ import click
 from pywbem import ValueMapping, Error
 
 from .pywbemcli import cli
-from ._common import CMD_OPTS_TXT, format_table, raise_pywbem_error_exception
+from ._common import CMD_OPTS_TXT, format_table, raise_pywbem_error_exception, \
+    validate_output_format
 from ._click_extensions import PywbemcliGroup
 
 # NOTE: A number of the options use double-dash as the short form.  In those
@@ -210,6 +211,8 @@ def cmd_server_namespaces(context, options):
     """
     Display namespaces in the current WBEM server
     """
+    output_format = validate_output_format(context.output_format, 'TABLE')
+
     try:
         namespaces = context.wbem_server.namespaces
         namespaces.sort()
@@ -220,7 +223,7 @@ def cmd_server_namespaces(context, options):
 
         click.echo(format_table(rows, ['Namespace Name'],
                                 title='Server Namespaces:',
-                                table_format=context.output_format))
+                                table_format=output_format))
 
     except Error as er:
         raise click.ClickException('{}: {}'.format(er.__class__.__name__, er))
@@ -230,6 +233,8 @@ def cmd_server_interop(context):
     """
     Display interop namespace in the current WBEM server
     """
+    output_format = validate_output_format(context.output_format, 'TABLE')
+
     try:
         interop_ns = context.wbem_server.interop_ns
         context.spinner_stop()
@@ -238,7 +243,7 @@ def cmd_server_interop(context):
 
         click.echo(format_table(rows, ['Namespace Name'],
                                 title='Server Interop Namespace:',
-                                table_format=context.output_format))
+                                table_format=output_format))
     except Error as er:
         raise_pywbem_error_exception(er)
 
@@ -247,6 +252,8 @@ def cmd_server_brand(context):
     """
     Display product and version info of the current WBEM server
     """
+    output_format = validate_output_format(context.output_format, 'TABLE')
+
     try:
         brand = context.wbem_server.brand
         context.spinner_stop()
@@ -254,7 +261,7 @@ def cmd_server_brand(context):
         rows = [[brand]]
         click.echo(format_table(rows, ['WBEM server brand'],
                                 title='Server brand:',
-                                table_format=context.output_format))
+                                table_format=output_format))
     except Error as er:
         raise_pywbem_error_exception(er)
 
@@ -263,6 +270,8 @@ def cmd_server_info(context):
     """
     Display general overview of info from current WBEM server
     """
+    output_format = validate_output_format(context.output_format, 'TABLE')
+
     try:
         # execute the namespaces to force contact with server before
         # turning off the spinner.
@@ -283,7 +292,7 @@ def cmd_server_info(context):
                      namespaces])
         click.echo(format_table(rows, headers,
                                 title='Server General Information',
-                                table_format=context.output_format))
+                                table_format=output_format))
 
     except Error as er:
         raise_pywbem_error_exception(er)
@@ -322,6 +331,8 @@ def cmd_server_profiles(context, options):
     """
     Display general overview of info from current WBEM server
     """
+    output_format = validate_output_format(context.output_format, 'TABLE')
+
     server = context.wbem_server
     try:
         found_server_profiles = server.get_selected_profiles(
@@ -341,7 +352,7 @@ def cmd_server_profiles(context, options):
 
         click.echo(format_table(rows, headers,
                                 title='Advertised management profiles:',
-                                table_format=context.output_format))
+                                table_format=output_format))
 
     except Error as er:
         raise_pywbem_error_exception(er)
@@ -352,6 +363,9 @@ def cmd_server_centralinsts(context, options):
     Display general information on the central instances of one or more
     profiles.
     """
+    output_format = validate_output_format(context.output_format, ['CIM',
+                                                                   'TABLE'])
+
     server = context.wbem_server
     try:
         found_server_profiles = server.get_selected_profiles(
@@ -387,6 +401,6 @@ def cmd_server_centralinsts(context, options):
         click.echo(format_table(rows,
                                 headers,
                                 title='Advertised Central Instances:',
-                                table_format=context.output_format))
+                                table_format=output_format))
     except Error as er:
         raise_pywbem_error_exception(er)

--- a/pywbemtools/pywbemcli/config.py
+++ b/pywbemtools/pywbemcli/config.py
@@ -39,7 +39,7 @@ However, they should be used from the ``pywbemcli`` namespace.
 # This module is meant to be safe for 'import *'.
 
 
-__all__ = ['DEFAULT_CONNECTION_TIMEOUT', 'DEFAULT_OUTPUT_FORMAT',
+__all__ = ['DEFAULT_CONNECTION_TIMEOUT',
            'DEFAULT_NAMESPACE', 'PYWBEMCLI_PROMPT', 'PYWBEMCLI_HISTORY_FILE',
            'DEFAULT_MAXPULLCNT', 'MAX_TIMEOUT', 'DEFAULT_URL_SCHEME',
            'USE_TERMINAL_WIDTH', 'DEFAULT_TABLE_WIDTH']
@@ -48,10 +48,6 @@ __all__ = ['DEFAULT_CONNECTION_TIMEOUT', 'DEFAULT_OUTPUT_FORMAT',
 #: is not set by an input parameter.
 #: Positive integer.
 DEFAULT_CONNECTION_TIMEOUT = 30
-
-#: Specifies the default output format selected if no output format is
-#: defined on the cmd line, environment variable, or a config file.
-DEFAULT_OUTPUT_FORMAT = 'simple'
 
 #: Specifies the default namespace uses if no default namespace is defined
 #: on the cmd line, environment variable, or a config file.

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -38,7 +38,7 @@ from ._context_obj import ContextObj, display_click_context
 from ._common import GENERAL_OPTIONS_METAVAR, TABLE_FORMATS, \
     CIM_OBJECT_OUTPUT_FORMATS
 from ._pywbem_server import PywbemServer
-from .config import DEFAULT_OUTPUT_FORMAT, DEFAULT_NAMESPACE, \
+from .config import DEFAULT_NAMESPACE, \
     PYWBEMCLI_PROMPT, PYWBEMCLI_HISTORY_FILE, DEFAULT_MAXPULLCNT, \
     DEFAULT_CONNECTION_TIMEOUT, MAX_TIMEOUT, USE_AUTOSUGGEST
 from ._connection_repository import ConnectionRepository
@@ -195,15 +195,15 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
                    format(ev=PywbemServer.defaultnamespace_envvar,
                           default=DEFAULT_NAMESPACE))
 @click.option('-o', '--output-format', metavar='FORMAT',
-              # defaulted in code
               help='Output format for the command result. '
-                   'The specified format may be overriden since not all '
-                   'formats apply to all result data types. '
-                   'FORMAT is a table format [{tb}] or object format [{ob}]. '
-                   'Default: {default}.'.
+                   'The default and allowed output formats are command '
+                   'specific. '
+                   'The default output_format is None so that each command '
+                   'selects its own default format. '
+                   'FORMAT is either a table format: [{tb}] or CIM object '
+                   'format: [{ob}].'.
                    format(tb='|'.join(TABLE_FORMATS),
-                          ob='|'.join(CIM_OBJECT_OUTPUT_FORMATS),
-                          default=DEFAULT_OUTPUT_FORMAT))
+                          ob='|'.join(CIM_OBJECT_OUTPUT_FORMATS)))
 @click.option('-l', '--log', type=str, metavar='COMP[=DEST[:DETAIL]],...',
               # defaulted in code
               envvar=PywbemServer.log_envvar,

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -467,16 +467,16 @@ TEST_CASES = [
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class command enumerate CIM_Foo summary',
+    ['Verify class command enumerate CIM_Foo summary table',
      ['enumerate', 'CIM_Foo', '-s'],
      {'stdout': ['2 CIMClass(s) returned'],
-      'test': 'in'},
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class command enumerate CIM_Foo summary',
+    ['Verify class command enumerate CIM_Foo summary, table',
      ['enumerate', 'CIM_Foo', '--summary'],
      {'stdout': ['2 CIMClass(s) returned'],
-      'test': 'linesnows'},
+      'test': 'insnows'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify class command enumerate CIM_Foo summary table output',
@@ -657,6 +657,14 @@ TEST_CASES = [
      {'stderr': ['CIMError', 'CIM_ERR_INVALID_CLASS'],
       'rc': 1,
       'test': 'regex'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify class command enumerate table output fails).',
+     {'args': ['enumerate'],
+      'general': ['--output-format', 'table']},
+     {'stderr': ['CIM Object formats ', 'not allowed'],
+      'rc': 1,
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
     #
@@ -884,6 +892,15 @@ TEST_CASES = [
      {'stderr': ['CIMError', 'CIM_ERR_INVALID_NAMESPACE', '3'],
       'rc': 1,
       'test': 'regex'},
+     SIMPLE_MOCK_FILE, OK],
+
+
+    ['Verify class command enumerate table output fails).',
+     {'args': ['get', 'CIM_Foo'],
+      'general': ['--output-format', 'table']},
+     {'stderr': ['CIM Object formats ', 'not allowed'],
+      'rc': 1,
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
     #
@@ -1321,6 +1338,7 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
+
     #
     # references command tests
     #
@@ -1365,6 +1383,14 @@ TEST_CASES = [
      {'stdout': REFERENCES_CLASS_RTN_QUALS2,
       'test': 'linesnows'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
+
+    ['Verify class command refereces table output fails).',
+     {'args': ['associators', 'TST_Person'],
+      'general': ['--output-format', 'table']},
+     {'stderr': ['CIM Object formats ', 'not allowed'],
+      'rc': 1,
+      'test': 'innows'},
+     SIMPLE_MOCK_FILE, OK],
 
     # Reference errors
 

--- a/tests/unit/test_connection_cmds.py
+++ b/tests/unit/test_connection_cmds.py
@@ -742,7 +742,7 @@ TEST_CASES = [
 
     ['Verify connection list with current server from general options, grid',
      {'args': ['list'],
-      'general': ['--server', 'http://blah']},
+      'general': ['--output-format', 'table', '--server', 'http://blah']},
      {'stdout': """
 WBEM server connections: (#: default, *: current)
 +------------+-------------+-------------+-----------+----------+
@@ -870,6 +870,15 @@ WBEM server connections: (#: default, *: current)
      {'stdout': ['Deleted connection "mocktest3"'],
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'None'}},
+     None, OK],
+
+    ['Verify connection list with mof output format mof fails',
+     {'args': ['list'],
+      'general': ['--output-format', 'mof', '--server', 'http://blah']},
+     {'stderr': ['not allowed'],
+      'rc': 1,
+      'test': 'innows',
+      'file': {'before': 'None', 'after': 'None'}},
      None, OK],
 
 ]

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -157,12 +157,13 @@ Options:
                                   option. Default: EnvVar
                                   PYWBEMCLI_DEFAULT_NAMESPACE, or root/cimv2.
   -o, --output-format FORMAT      Output format for the command result. The
-                                  specified format may be overriden since not
-                                  all formats apply to all result data types.
-                                  FORMAT is a table format
+                                  default and allowed output formats are
+                                  command specific. The default output_format
+                                  is None so that each command selects its own
+                                  default format. FORMAT is either a table
+                                  format:
                                   [table|plain|simple|grid|psql|rst|html] or
-                                  object format [mof|xml|repr|txt]. Default:
-                                  simple.
+                                  CIM object format: [mof|xml|repr|txt].
   -l, --log COMP[=DEST[:DETAIL]],...
                                   Enable logging of the WBEM operations,
                                   defined by a list of log configuration

--- a/tests/unit/test_instance_cmds.py
+++ b/tests/unit/test_instance_cmds.py
@@ -1998,7 +1998,8 @@ Instances: PyWBEM_AllTypes
     # The following use interop ns to avoid warning about namespaces.
     ['Verify instance command count CIM_* simple model, Rtn tbl of instances',
      {'args': ['count', 'CIM_*'],
-      'general': ['--default-namespace', 'interop']},
+      'general': ['--output-format', 'table',
+                  '--default-namespace', 'interop']},
      {'stdout': ['Count of instances per class',
                  '+-------------+-----------------+---------+',
                  '| Namespace   | Class           |   count |',
@@ -2013,7 +2014,8 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance command count CIM_*  sorted, Rtn table of inst counts',
      {'args': ['count', 'CIM_*', '--sort'],
-      'general': ['--default-namespace', 'interop']},
+      'general': ['--output-format', 'table',
+                  '--default-namespace', 'interop']},
      {'stdout': """Count of instances per class
 +-------------+-----------------+---------+
 | Namespace   | Class           |   count |
@@ -2029,7 +2031,8 @@ Instances: PyWBEM_AllTypes
 
     ['Verify instance command count CIM_*. Rtn table of inst counts',
      {'args': ['count', 'CIM_*'],
-      'general': ['--default-namespace', 'interop']},
+      'general': ['--output-format', 'table',
+                  '--default-namespace', 'interop']},
      {'stdout': """Count of instances per class
 +-------------+-----------------+---------+
 | Namespace   | Class           |   count |


### PR DESCRIPTION
Change default for output format to None and add test for each command  that uses output_format to validate that it can handle the cmd line output-format value  provided.

See commit message for details.
