### PR TITLE
0.5: Reduced Appveyor runs to just 2.7 native + 3.6 cygwin

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,9 +33,9 @@ environment:
 #      UNIX_PATH: none
 #      PYTHON_CMD: python
 
-    - TOX_ENV: win64_py36_64
-      UNIX_PATH: none
-      PYTHON_CMD: python
+#    - TOX_ENV: win64_py36_64
+#      UNIX_PATH: none
+#      PYTHON_CMD: python
 
 #    - TOX_ENV: win64_py37_32
 #      UNIX_PATH: none


### PR DESCRIPTION
No review needed.