### PR TITLE
Fixes #489: Use of pywbem internal functions

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -70,6 +70,10 @@ Released: not yet
 
 * Fixed several badges on the README page.
 
+* Remove use of pywbem internal functions from pywbemcli. This removes use of
+  NocaseDict, _to_unicode, _ensure_unicode, _format from pywbemcli. (See
+  issue #489)
+
 **Enhancements:**
 
 * Promoted development status of pywbemtools from Alpha to Beta.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -92,6 +92,7 @@ tabulate==0.8.2
 prompt-toolkit==1.0.15; python_version == '2.7'
 prompt-toolkit==2.0.1; python_version >= '3.4'
 PyYAML==5.1
+pydicti=1.1.3
 
 # Indirect dependencies for install (not in requirements.txt)
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -92,7 +92,7 @@ tabulate==0.8.2
 prompt-toolkit==1.0.15; python_version == '2.7'
 prompt-toolkit==2.0.1; python_version >= '3.4'
 PyYAML==5.1
-pydicti=1.1.3
+pydicti==1.1.3
 
 # Indirect dependencies for install (not in requirements.txt)
 

--- a/pywbemtools/pywbemcli/__init__.py
+++ b/pywbemtools/pywbemcli/__init__.py
@@ -22,19 +22,20 @@ and Python 3.
 
 from __future__ import absolute_import, print_function
 
-from ._cmd_class import *       # noqa: F403,F401
-from ._cmd_instance import *       # noqa: F403,F401
+from ._cmd_class import *           # noqa: F403,F401
+from ._cmd_instance import *        # noqa: F403,F401
 from ._cmd_qualifier import *       # noqa: F403,F401
-from ._cmd_server import *       # noqa: F403,F401
-from ._cmd_connection import *   # noqa: F403,F401
-from ._common import *   # noqa: F403,F401
-from ._pywbem_server import *   # noqa: F403,F401
-from ._context_obj import *   # noqa: F403,F401
+from ._cmd_server import *          # noqa: F403,F401
+from ._cmd_connection import *      # noqa: F403,F401
+from ._common import *              # noqa: F403,F401
+from ._pywbem_server import *       # noqa: F403,F401
+from ._context_obj import *         # noqa: F403,F401
 from ._connection_repository import *   # noqa: F403,F401
-from .pywbemcli import *       # noqa: F403,F401
-from .config import *  # noqa: F403,F401
+from .pywbemcli import *            # noqa: F403,F401
+from .config import *               # noqa: F403,F401
 from ._pywbemcli_operations import *  # noqa: F403,F401
-from ._click_extensions import *  # noqa: F403,F401
-from ._association_shrub import *  # noqa: F403,F401
+from ._click_extensions import *    # noqa: F403,F401
+from ._association_shrub import *   # noqa: F403,F401
+from ._utils import *               # noqa: F403,F401
 
 from .._version import __version__  # noqa: F401

--- a/pywbemtools/pywbemcli/_association_shrub.py
+++ b/pywbemtools/pywbemcli/_association_shrub.py
@@ -49,7 +49,7 @@ from pywbem import CIMInstanceName, CIMClassName, \
     CIMFloat, CIMInt, CIMError, CIMDateTime
 from pywbem._utils import _to_unicode, _ensure_unicode, _format
 
-from pywbem._nocasedict import NocaseDict
+from pydicti import dicti
 
 from ._common import output_format_is_table, format_table, shorten_path_str, \
     warning_msg
@@ -411,8 +411,8 @@ class AssociationShrub(object):
         assoctree = OrderedDict()
         # Create dictionary of standard instance keys to potentially hide.
         # For now we always hide the following independent of key value
-        replacements = NocaseDict((("SystemCreationClassName", None),
-                                   ("SystemName", None)))
+        replacements = dicti((("SystemCreationClassName", None),
+                              ("SystemName", None)))
         for role, ref_clns in six.iteritems(self.instance_shrub):
             elementstree = OrderedDict()
             for ref_cln in ref_clns:
@@ -681,8 +681,8 @@ class AssociationShrub(object):
           ref_cln (:term:`string`):
              Classname of the reference class.
 
-          replacements (:class:`NocaseDict`_)
-            NocaseDict containing the name of each key to be considered
+          replacements (:class:`dicti`)
+            No-case dictionary containing the name of each key to be considered
             for replacement with either the value None or a defined value
             for the key.  If the value is None the key will be replaced with
             '~' independent of its value.  If the value is not None, the
@@ -700,7 +700,7 @@ class AssociationShrub(object):
         assert isinstance(inst_names_tuple, list)
         assert isinstance(inst_names_tuple[0], tuple)
         assert len(inst_names_tuple[0]) == 2
-        assert isinstance(replacements, NocaseDict)
+        assert isinstance(replacements, dicti)
 
         # If path shortening specified, determine which keys can be shortened
         # based on keys with the same value in all instance names

--- a/pywbemtools/pywbemcli/_association_shrub.py
+++ b/pywbemtools/pywbemcli/_association_shrub.py
@@ -47,12 +47,14 @@ from asciitree import LeftAligned
 
 from pywbem import CIMInstanceName, CIMClassName, \
     CIMFloat, CIMInt, CIMError, CIMDateTime
-from pywbem._utils import _to_unicode, _ensure_unicode, _format
+from ._utils import _to_unicode, _ensure_unicode
 
 from pydicti import dicti
 
 from ._common import output_format_is_table, format_table, shorten_path_str, \
     warning_msg
+
+from ._utils import _ensure_unicode, _to_unicode
 
 # Same as in pwbem.cimtypes.py
 if six.PY2:
@@ -575,8 +577,7 @@ class AssociationShrub(object):
             return keys
 
         if format not in ('standard', 'canonical', 'cimobject', 'historical'):
-            raise ValueError(
-                _format("Invalid format argument: {0}", format))
+            raise ValueError('Invalid format argument: {0}'.format(format))
 
         if path.host is not None and format != 'cimobject':
             # The CIMObject format assumes there is no host component
@@ -642,8 +643,8 @@ class AssociationShrub(object):
                 ret.append('"')
             else:
                 raise TypeError(
-                    _format("Invalid type {0} in keybinding value: {1!A}={2!A}",
-                            type(value), key, value))
+                    "Invalid type {0} in keybinding value: {1}={2}"
+                    .format(type(value), key, value))
             ret.append(',\n')
 
         del ret[-1]

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -820,29 +820,35 @@ def cmd_class_tree(context, classname, options):
             # Get the superclasses into a list
             class_ = context.conn.GetClass(classname,
                                            namespace=options['namespace'])
-            # get correct case sensitive classname
-            classname = class_.classname
-            classes = []
-            classes.append(class_)
+
+            # Include target class in display in list
+            classes = [class_]
+            # Get all superclasses to class_
             while class_.superclass:
                 class_ = context.conn.GetClass(class_.superclass,
                                                namespace=options['namespace'])
                 classes.append(class_)
+
+            # classname not used when displaying superclasses.
+            # display_class_tree sets it to root
             classname = None
 
         else:
             # Get the subclass hierarchy either complete or starting at the
-            # optional CLASSNAME
+            # optional CLASSNAME. NOTE: We do not include target_classname
+            # in lists of classes sent to display_class_tree. That function
+            # attaches it.
             classes = context.conn.EnumerateClasses(
                 ClassName=classname,
                 namespace=options['namespace'],
                 DeepInheritance=True)
 
-        # Get correct case sensitive classname for target class
-        if classname:
-            tclass = context.conn.GetClass(classname,
-                                           namespace=options['namespace'])
-            classname = tclass.classname
+            # Get correct case sensitive classname for target class if
+            # it exists. Simplifies display_class_tree
+            if classname:
+                tclass = context.conn.GetClass(classname,
+                                               namespace=options['namespace'])
+                classname = tclass.classname
     except Error as er:
         raise_pywbem_error_exception(er)
 

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -482,13 +482,13 @@ def _filter_classes_for_qualifiers(qualifier_filters, results, names_only, iq):
             # If returning instances, honor the names_only option
             if not names_only:
                 if not iq:
-                    cls.qualifiers = NocaseDict()
+                    cls.qualifiers = []
                     for p in cls.properties.values():
-                        p.qualifiers = NocaseDict()
+                        p.qualifiers = []
                     for m in cls.methods.values():
-                        m.qualifiers = NocaseDict()
+                        m.qualifiers = []
                         for p in m.parameters.values():
-                            p.qualifiers = NocaseDict()
+                            p.qualifiers = []
             filtered_results.append(cls)
     if names_only:
         filtered_results = [cls.classname for cls in filtered_results]

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -820,6 +820,8 @@ def cmd_class_tree(context, classname, options):
             # Get the superclasses into a list
             class_ = context.conn.GetClass(classname,
                                            namespace=options['namespace'])
+            # get correct case sensitive classname
+            classname = class_.classname
             classes = []
             classes.append(class_)
             while class_.superclass:
@@ -835,10 +837,16 @@ def cmd_class_tree(context, classname, options):
                 ClassName=classname,
                 namespace=options['namespace'],
                 DeepInheritance=True)
+
+        # Get correct case sensitive classname for target class
+        if classname:
+            tclass = context.conn.GetClass(classname,
+                                           namespace=options['namespace'])
+            classname = tclass.classname
     except Error as er:
         raise_pywbem_error_exception(er)
 
-    # display the list of classes as a tree. The classname is the top
+    # Display the list of classes as a tree. The classname is the top
     # of the tree.
     context.spinner_stop()
     display_class_tree(classes, classname)

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -26,7 +26,6 @@ from __future__ import absolute_import, print_function
 import click
 
 from pywbem import Error, CIMClassName, CIMError, CIM_ERR_NOT_FOUND, CIMClass
-from pywbem._nocasedict import NocaseDict
 
 from .pywbemcli import cli
 from ._common import display_cim_objects, filter_namelist, \
@@ -811,14 +810,14 @@ def cmd_class_tree(context, classname, options):
     subclass tree is displayed.
     """
 
-    # TODO: Sort out how we handle output format with tree output.
+    # TODO FUTURE: Sort out how we handle output format with tree output.
     try:
         if options['superclasses']:
             if classname is None:
                 raise click.ClickException('CLASSNAME argument required for '
                                            '--superclasses option')
 
-            # get the superclasses into a list
+            # Get the superclasses into a list
             class_ = context.conn.GetClass(classname,
                                            namespace=options['namespace'])
             classes = []
@@ -830,7 +829,7 @@ def cmd_class_tree(context, classname, options):
             classname = None
 
         else:
-            # get the subclass hierarchy either complete or starting at the
+            # Get the subclass hierarchy either complete or starting at the
             # optional CLASSNAME
             classes = context.conn.EnumerateClasses(
                 ClassName=classname,

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -1182,6 +1182,28 @@ class NoCaseList(object):
         else:
             self.str_list.append(strs)
 
+    def get(self, str):
+        """
+        Get the string that matches str case insensitive
+
+        Parameters:(:term:`string_types` or list, tuple of :term:`string_types`):  # noqa:E501
+          String to test against the instance of NocaseList.
+
+        Returns:
+            String in list that matches No case the input str
+
+        Raises:
+            KeyError: If no match
+
+        """
+        if not str:
+            return
+        tstr = str.lower()
+        for str in self.str_list:
+            if tstr == str.lower():
+                return str
+        raise KeyError('{} not found in list'.format(str))
+
 
 def shorten_path_str(path, replacements, fullpath):
 

--- a/pywbemtools/pywbemcli/_displaytree.py
+++ b/pywbemtools/pywbemcli/_displaytree.py
@@ -24,9 +24,8 @@ import six
 from asciitree import LeftAligned
 import click
 
-# Use an ordered Nocase dictionary for the tree. The Nocase allows
-# the input top_class to have a different case than the data from the classes
-# and the ordered keeps class order at each level on output.
+# Use an ordered Nocase dictionary for the tree. Ordered dictionary creates
+# tree output that has the same order in multiple versions of python.
 from pydicti import odicti
 
 
@@ -38,21 +37,28 @@ def build_tree(class_subclass_dict, top_class):
     Returns the dictionary structure in a form suitable for ascii tree
     display
     """
-    def _tree_node(class_subclass_dict, cn):
+    def _tree_node(class_to_subclass_dict, cln):
         """
         Build dictionary of the class/subclass relationships for class cn
-        in dictionary of class_subclass names.
+        in dictionary of class_subclass names. This maps the input dictionary
+        that is a flat class_name: [subclass_name] dictionary to a tree
+        dictionary for the hiearchy of classes.
 
         Returns dictionary of dictionaries in form suitable for asciitree
+
+        Parameters:
+          class_to_subclass_dict:
+            Dictionary with all classes to be in as keys and the corresponding
+            subclasses for each class as a list of classnames
         """
         node_dict = odicti()
         # If there is no subclass, the class will not exist in this dictionary
-        if cn in class_subclass_dict:
-            cn_list = class_subclass_dict[cn]
+        if cln in class_to_subclass_dict:
+            cln_list = class_to_subclass_dict[cln]
             # This should not be necessary if end nodes are not in the dict.
-            if cn_list:
-                for key in cn_list:
-                    node_dict[key] = _tree_node(class_subclass_dict, key)
+            if cln_list:
+                for key in cln_list:
+                    node_dict[key] = _tree_node(class_to_subclass_dict, key)
             else:
                 node_dict = odicti()
         else:
@@ -70,14 +76,18 @@ def build_tree(class_subclass_dict, top_class):
 def display_class_tree(classes, top_class=None):
     """
     Display the list of classes as a left justified tree  in ascii to the
-    click.echo output
+    click.echo output.
 
     Parameters:
         classes (list of :class:`~pywbem.CIMClass`)
+            This is the classes that will be included in the display
+            including the top_class. If the top_class is None an
+            artificial top_class named 'root' will be added by this
+            function.
 
         top_class (:term: `string`)
-            The top level class to display or None if the display is
-            from root.
+            The top level class to display or None.
+
     """
 
     # Build dictionary of classname : superclassname from list of CIM classes

--- a/pywbemtools/pywbemcli/_utils.py
+++ b/pywbemtools/pywbemcli/_utils.py
@@ -1,0 +1,69 @@
+# (C) Copyright 2017 IBM Corp.
+# (C) Copyright 2017 Inova Development Inc.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Utility Functions applicable across multiple components of pywbemcli.
+"""
+
+from __future__ import print_function, absolute_import
+
+import six
+
+
+__all__ = []
+
+
+def _ensure_unicode(obj):
+    """
+    If the input object is a string, make sure it is returned as a
+    :term:`unicode string`, as follows:
+
+    * If the input object already is a :term:`unicode string`, it is returned
+      unchanged.
+    * If the input string is a :term:`byte string`, it is decoded using UTF-8.
+    * Otherwise, the input object was not a string and is returned unchanged.
+
+    Copied from pywbem
+    """
+    if isinstance(obj, six.binary_type):
+        return obj.decode("utf-8")
+    return obj
+
+
+def _to_unicode(obj):
+    """
+    Convert the input binary string to a :term:`unicode string`.
+    The input object must be a byte string.
+    Use this if there is a previous test about the string type.
+
+    Copies from pywbem
+    """
+    return obj.decode("utf-8")
+
+
+def _eq_name(name1, name2):
+    """
+    Test two CIM names for equality.
+
+    The comparison is performed case-insensitively.
+
+    One or both of the names may be `None`; Two names that are `None` are
+    considered equal.
+    """
+    if name1 is None:
+        return name2 is None
+    if name2 is None:
+        return False
+    return name1.lower() == name2.lower()

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ tabulate>=0.8.2
 prompt-toolkit>=2.0.1; python_version >= '3.4'
 # See pywbemtools issue # 192. The repl mode fails with unexpected Exception
 prompt-toolkit>=1.0.15,<2.0.0; python_version == '2.7'
+pydicti>=1.1.3
 # PyYAML 5.3 has removed support for Python 3.4
 PyYAML>=5.1; python_version == '2.7'
 PyYAML>=5.1,<5.3; python_version == '3.4'

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -1127,28 +1127,15 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-    # Order inconsistent on output. so we just test that some of the lines are
-
-    # in the output
-    # root
-    #  +-- CIM_Foo
-    #      +-- CIM_Foo_sub2
-    #      +-- CIM_Foo_sub
-    #          +-- CIM_Foo_sub_sub
-    # or
-    # root
-    #  +-- CIM_Foo
-    #      +-- CIM_Foo_sub
-    #      |   +-- CIM_Foo_sub_sub
-    #      +-- CIM_Foo_sub2
-    ['Verify class command tree top down. Order uncertain.',
+    ['Verify class command tree top down. Uses simple mock, no argument',
      ['tree'],
-     {'stdout': [r'root',
-                 r' \+-- CIM_Foo',
-                 r'     \+-- CIM_Foo_sub2',
-                 r'     \+-- CIM_Foo_sub',
-                 r'[| ]*\+-- CIM_Foo_sub_sub'],  # account for ordering issue
-      'test': 'regex'},
+     {'stdout': """root
+ +-- CIM_Foo
+     +-- CIM_Foo_sub
+     |   +-- CIM_Foo_sub_sub
+     +-- CIM_Foo_sub2
+""",
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify class command tree top down starting at defined class ',

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -1140,29 +1140,42 @@ TEST_CASES = [
 
     ['Verify class command tree top down starting at defined class ',
      ['tree', 'CIM_Foo_sub'],
-     {'stdout': ['CIM_Foo_sub',
-                 ' +-- CIM_Foo_sub_sub'],
-      'test': 'lines'},
+     {'stdout': """CIM_Foo_sub
++-- CIM_Foo_sub_sub
+""",
+      'test': 'innows'},
+     SIMPLE_MOCK_FILE, RUN],
+
+    ['Verify class command tree bottom up. -s',
+     ['tree', '-s', 'CIM_Foo_sub_sub'],
+     {'stdout': """root
+    +-- CIM_Foo
+        +-- CIM_Foo_sub
+            +-- CIM_Foo_sub_sub
+""",
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class command tree bottom up. Ordering guaranteed here',
-     ['tree', '-s', 'CIM_Foo_sub_sub'],
-     {'stdout': ['root',
-                 ' +-- CIM_Foo',
-                 '     +-- CIM_Foo_sub',
-                 '         +-- CIM_Foo_sub_sub'],
-      'test': 'lines'},
+
+    ['Verify class command tree bottom up. --superclasses',
+     ['tree', '--superclasses', 'CIM_Foo_sub_sub'],
+     {'stdout': """root
+    +-- CIM_Foo
+        +-- CIM_Foo_sub
+            +-- CIM_Foo_sub_sub
+""",
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
     # class tree' error tests
-    ['Verify class command tree with invalid class',
+    ['Verify class command tree with invalid CLASSNAME fails',
      ['tree', '-s', 'CIM_Foo_subx'],
      {'stderr': ['CIMError:'],
       'rc': 1,
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class command tree with superclass option, no class',
+    ['Verify class command tree with superclass option, CLASSNAME fails',
      ['tree', '-s'],
      {'stderr': ['Error: CLASSNAME argument required for --superclasses '
                  'option'],

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -36,7 +36,6 @@ except ImportError:
 from pywbem import CIMClass, CIMProperty, CIMQualifier, CIMInstance, \
     CIMQualifierDeclaration, CIMInstanceName, Uint8, Uint32, Uint64, Sint32, \
     CIMDateTime, CIMClassName
-from pywbem._nocasedict import NocaseDict
 
 from tests.unit.pytest_extensions import simplified_test_function
 
@@ -253,78 +252,78 @@ TESTCASES_FORMAT_KEYBINDINGS = [
     # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
 
     ('Verify simple keybinding',
-     dict(kb=NocaseDict([('kEY1', u'Ham')]),
+     dict(kb=[('kEY1', u'Ham')],
           width=100,
           exp_rtn='kEY1="Ham"'),
      None, None, True),
 
     ('Verify multiple keys keybinding',
-     dict(kb=NocaseDict([('kEY1', u'Ham'), ('key2', 3)]),
+     dict(kb=[('kEY1', u'Ham'), ('key2', 3)],
           width=100,
           exp_rtn='kEY1="Ham",key2=3'),
      None, None, True),
 
     ('Verify multiple keys binding with spaces in keys',
-     dict(kb=NocaseDict([('kEY1', u'Ham and eggs'), ('key2', 'More eggs')]),
+     dict(kb=[('kEY1', u'Ham and eggs'), ('key2', 'More eggs')],
           width=100,
           exp_rtn='kEY1="Ham and eggs",key2="More eggs"'),
      None, None, True),
 
     ('Verify multiple keys binding multiple key types',
-     dict(kb=NocaseDict([('Name', 'Foo'),
-                         ('Number', Uint8(42)),
-                         ('Boolean', False),
-                         ('Ref', CIMInstanceName('CIM_Bar'))]),
+     dict(kb=[('Name', 'Foo'),
+              ('Number', Uint8(42)),
+              ('Boolean', False),
+              ('Ref', CIMInstanceName('CIM_Bar'))],
           width=100,
           exp_rtn='Name="Foo",Number=42,Boolean=FALSE,Ref="/:CIM_Bar"'),
      None, None, True),
 
     ('Verify mutliple keys that fold into multiple lines',
-     dict(kb=NocaseDict([('kEY1', u'Ham'), ('key2', 3)]),
+     dict(kb=[('kEY1', u'Ham'), ('key2', 3)],
           width=14,
           exp_rtn='kEY1="Ham"\nkey2=3'),
      None, None, True),
 
     ('Verify multiple keys binding with spaces in keys that fold',
-     dict(kb=NocaseDict([('kEY1', u'Ham and eggs'), ('key2', 'More eggs')]),
+     dict(kb=[('kEY1', u'Ham and eggs'), ('key2', 'More eggs')],
           width=25,
           exp_rtn='kEY1="Ham and eggs"\nkey2="More eggs"'),
      None, None, True),
 
     ('Verify multiple keys binding with many keys keys without fold',
-     dict(kb=NocaseDict([('k1', 1), ('k2', 2), ('k3', 3), ('k4', 4), ('k5', 5),
-                         ('k6', 6), ('k7', 7), ('k8', 8)]),
+     dict(kb=[('k1', 1), ('k2', 2), ('k3', 3), ('k4', 4), ('k5', 5),
+                         ('k6', 6), ('k7', 7), ('k8', 8)],
           width=100,
           exp_rtn=('k1=1,k2=2,k3=3,k4=4,k5=5,k6=6,k7=7,k8=8')),
      None, None, True),
 
     ('Verify multiple keys binding with many keys every key folds',
-     dict(kb=NocaseDict([('k1', 1), ('k2', 2), ('k3', 3), ('k4', 4), ('k5', 5),
-                         ('k6', 6), ('k7', 7), ('k8', 8)]),
+     dict(kb=[('k1', 1), ('k2', 2), ('k3', 3), ('k4', 4), ('k5', 5),
+                         ('k6', 6), ('k7', 7), ('k8', 8)],
           width=3,
           exp_rtn=('k1=1\nk2=2\nk3=3\nk4=4\nk5=5\nk6=6\nk7=7\nk8=8')),
      None, None, True),
 
 
     ('Verify multiple keys binding with many keys keys some fold',
-     dict(kb=NocaseDict([('k1', 1), ('k2', 2), ('k3', 3), ('k4', 4), ('k5', 5),
-                         ('k6', 6), ('k7', 7), ('k8', 8)]),
+     dict(kb=[('k1', 1), ('k2', 2), ('k3', 3), ('k4', 4), ('k5', 5),
+                         ('k6', 6), ('k7', 7), ('k8', 8)],
           width=8,
           exp_rtn=('k1=1,k2=2\nk3=3,k4=4\nk5=5,k6=6\nk7=7,k8=8')),
      None, None, False),
 
     ('Verify multiple keys binding with spaces in keys',
-     dict(kb=NocaseDict([('Name', 'Foo'),
-                         ('Number', Uint8(42)),
-                         ('Boolean', False),
-                         ('Ref', CIMInstanceName('CIM_Bar'))]),
+     dict(kb=[('Name', 'Foo'),
+              ('Number', Uint8(42)),
+              ('Boolean', False),
+              ('Ref', CIMInstanceName('CIM_Bar'))],
           width=4,
           exp_rtn='Name="Foo"\nNumber=42\nBoolean=FALSE\nRef="/:CIM_Bar"'),
      None, None, True),
 
     # Test no keys
     ('Verify no keys',
-     dict(kb=NocaseDict(),
+     dict(kb=[],
           width=100,
           exp_rtn=''),
      None, None, True),
@@ -363,35 +362,35 @@ TESTCASES_SHORT_PATH = [
     # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
 
     ('Verify simple keybinding replacement',
-     dict(kb=NocaseDict([('kEY1', u'Ham')]),
+     dict(kb=[('kEY1', u'Ham')],
           rpl={'kEY1': u'Ham'},
           fp=False,
           exp_rtn='/:cln.~'),
      None, None, True),
 
     ('Verify multiple keys keybinding, replace all',
-     dict(kb=NocaseDict([('kEY1', u'Ham'), ('key2', 3)]),
+     dict(kb=[('kEY1', u'Ham'), ('key2', 3)],
           rpl={'kEY1': u'Ham', 'key2': 3},
           fp=False,
           exp_rtn='/:cln.~,~'),
      None, None, True),
 
     ('Verify multiple keys keybinding, one replacement',
-     dict(kb=NocaseDict([('kEY1', u'Ham'), ('key2', 3)]),
+     dict(kb=[('kEY1', u'Ham'), ('key2', 3)],
           rpl={'kEY1': u'Ham', },
           fp=False,
           exp_rtn='/:cln.~,key2=3'),
      None, None, True),
 
     ('Verify multiple keys keybinding, no replacement because value different',
-     dict(kb=NocaseDict([('kEY1', u'Ham'), ('key2', 3)]),
+     dict(kb=[('kEY1', u'Ham'), ('key2', 3)],
           rpl={'kEY1': u'Hamxxxx', },
           fp=False,
           exp_rtn='/:cln.kEY1="Ham",key2=3'),
      None, None, True),
 
     ('Verify multiple keys keybinding, replacement because value None',
-     dict(kb=NocaseDict([('kEY1', u'Ham'), ('key2', 3)]),
+     dict(kb=[('kEY1', u'Ham'), ('key2', 3)],
           rpl={'kEY1': None, },
           fp=False,
           exp_rtn='/:cln.~,key2=3'),
@@ -399,7 +398,7 @@ TESTCASES_SHORT_PATH = [
 
     ('Verify multiple keys keybinding, replaced with tilde because values '
      'match',
-     dict(kb=NocaseDict([('kEY1', u'Ham'), ('key2', 3)]),
+     dict(kb=[('kEY1', u'Ham'), ('key2', 3)],
           rpl={'kEY1': None, 'key2': None},
           fp=False,
           exp_rtn='/:cln.~,~'),
@@ -407,31 +406,31 @@ TESTCASES_SHORT_PATH = [
 
     ('Verify multiple keys keybinding, replaced with tilde because values '
      'match',
-     dict(kb=NocaseDict([('kEY1', u'Ham'), ('key2', 3)]),
+     dict(kb=[('kEY1', u'Ham'), ('key2', 3)],
           rpl={'kEY1': u'xxx', 'key2': 3},
           fp=False,
           exp_rtn='/:cln.kEY1="Ham",~'),
      None, None, True),
 
     ('Verify multiple keys binding with spaces in keys',
-     dict(kb=NocaseDict([('kEY1', u'Ham and eggs'), ('key2', 'More eggs')]),
+     dict(kb=[('kEY1', u'Ham and eggs'), ('key2', 'More eggs')],
           rpl={'kEY1': u'Ham and eggs', 'key2': 'More eggs'},
           fp=False,
           exp_rtn='/:cln.~,~'),
      None, None, True),
 
     ('Verify multiple keys binding with spaces in keys',
-     dict(kb=NocaseDict([('kEY1', u'Ham and eggs'), ('key2', 'More eggs')]),
+     dict(kb=[('kEY1', u'Ham and eggs'), ('key2', 'More eggs')],
           rpl={'kEY1': u'Ham and eggs', 'key2': 'More eggs'},
           fp=True,
           exp_rtn='/:cln.kEY1="Ham and eggs",key2="More eggs"'),
      None, None, True),
 
     ('Verify multiple keys binding multiple key types',
-     dict(kb=NocaseDict([('Name', 'Foo'),
-                         ('Number', Uint8(42)),
-                         ('Boolean', False),
-                         ('Ref', CIMInstanceName('CIM_Bar'))]),
+     dict(kb=[('Name', 'Foo'),
+              ('Number', Uint8(42)),
+              ('Boolean', False),
+              ('Ref', CIMInstanceName('CIM_Bar'))],
           rpl={},
           fp=False,
           exp_rtn='/:cln.Name="Foo",Number=42,Boolean=FALSE,Ref="/:CIM_Bar"'),
@@ -447,7 +446,7 @@ def test_short_path(testcase, kb, rpl, fp, exp_rtn):
     """Test for resolve_propertylist function"""
     # The code to be tested
 
-    inst_name = CIMInstanceName('cln', kb)
+    inst_name = CIMInstanceName('cln', keybindings=kb)
     act_rtn = shorten_path_str(inst_name, rpl, fp)
 
     # Ensure that exceptions raised in the remainder of this function
@@ -1564,6 +1563,12 @@ class KVPairParsingTest(object):  # pylint: disable=useless-object-inheritance
         self.execute_test('prop_name=91999', 'prop_name', str(91999))
 
 
+######################################################
+#
+#  Test create_instance
+#
+######################################################
+
 # TODO; Convert this test to pytest
 class CreateCIMInstanceTest(unittest.TestCase):
     """Test the function that creates a CIMInstance from cli args"""
@@ -1877,10 +1882,11 @@ cls2 = dict(classname='CIM_Foo',
                         CIMQualifier('Key', value=True)
                     ]
                 ),
-                CIMProperty('P4', value='Cheese'),
+                CIMProperty('P4', value='Cheese',),
             ])
 
-# TODO add one with ref property
+
+# TODO: add one class with ref property as key. Is that even allowed?
 
 # Testcases for format_inst_to_table()
 
@@ -1902,12 +1908,10 @@ TESTCASES_CREATE_INSTNAME = [
             kv_args=['P1=Fred'],
             namespace=None,
             host=None,
-            exp_attrs=dict(
-                classname=u'CIM_Foo',
-                keybindings=NocaseDict(P1='Fred')
-            ),
+            exp_iname=CIMInstanceName(u'CIM_Foo',
+                                      keybindings=[('P1', 'Fred')]),
         ),
-        None, None, True, ),
+        None, None, True),
     (
         "Verify simple key creation with single string key with space",
         dict(
@@ -1915,12 +1919,22 @@ TESTCASES_CREATE_INSTNAME = [
             kv_args=['P1="Fred Fred"'],
             namespace=None,
             host=None,
-            exp_attrs=dict(
-                classname=u'CIM_Foo',
-                keybindings=NocaseDict(P1="Fred Fred")
-            ),
+            exp_iname=CIMInstanceName(u'CIM_Foo',
+                                      keybindings=[('P1', "Fred Fred")]),
         ),
-        None, None, True, ),
+        None, None, True),
+
+    (
+        "Verify simple key creation with single string key case independent",
+        dict(
+            cls_kwargs=cls1,
+            kv_args=['p1="Fred Fred"'],
+            namespace=None,
+            host=None,
+            exp_iname=CIMInstanceName(u'CIM_Foo',
+                                      keybindings=[('P1', "Fred Fred")]),
+        ),
+        None, None, True),
     (
         "Verify simple key creation with invalid key name",
         dict(
@@ -1928,12 +1942,9 @@ TESTCASES_CREATE_INSTNAME = [
             kv_args=['Px=Fred'],
             namespace=None,
             host=None,
-            exp_attrs=dict(
-                classname=u'CIM_Foo',
-                keybindings=NocaseDict(P1='Fred')
-            ),
+            exp_iname=None
         ),
-        click.exceptions.ClickException, None, True, ),
+        click.exceptions.ClickException, None, True),
     (
         "Verify simple key creation with two string keys and one int",
         dict(
@@ -1941,12 +1952,11 @@ TESTCASES_CREATE_INSTNAME = [
             kv_args=['P1=Fred', 'P2=John', 'P3=1'],
             namespace=None,
             host=None,
-            exp_attrs=dict(
-                classname=u'CIM_Foo',
-                keybindings=NocaseDict(P1='Fred', P2='John', P3=1)
-            ),
+            exp_iname=CIMInstanceName(u'CIM_Foo',
+                                      keybindings=[('P1', "Fred"),
+                                                   ('P2', 'John'), ('P3', 1)]),
         ),
-        None, None, True, ),
+        None, None, True),
     (
         "Verify simple key creation with two string keys and one big int",
         dict(
@@ -1954,10 +1964,10 @@ TESTCASES_CREATE_INSTNAME = [
             kv_args=['P1=Fred', 'P2=John', 'P3=123456'],
             namespace=None,
             host=None,
-            exp_attrs=dict(
-                classname=u'CIM_Foo',
-                keybindings=NocaseDict(P1='Fred', P2='John', P3=123456)
-            ),
+            exp_iname=CIMInstanceName(u'CIM_Foo',
+                                      keybindings=[('P1', "Fred"),
+                                                   ('P2', 'John'),
+                                                   ('P3', 123456)]),
         ),
         None, None, True, ),
     (
@@ -1967,23 +1977,19 @@ TESTCASES_CREATE_INSTNAME = [
             kv_args=[u'P1=Fred\u0344\u0352'],
             namespace=None,
             host=None,
-            exp_attrs=dict(
-                classname=u'CIM_Foo',
-                keybindings=NocaseDict(P1=u'Fred\u0344\u0352')
-            ),
+            exp_iname=CIMInstanceName(
+                u'CIM_Foo', keybindings=[('P1', u'Fred\u0344\u0352')]),
         ),
         None, None, True, ),
 ]
-
-# TODO test integer key, key with no value, key with invalid name, datetime
-# key
+# TODO key with no value, datetime key
 
 
 @pytest.mark.parametrize(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_CREATE_INSTNAME)
 @simplified_test_function
-def test_create_instancename(testcase, cls_kwargs, kv_args, exp_attrs,
+def test_create_instancename(testcase, cls_kwargs, kv_args, exp_iname,
                              namespace, host,):
     """
     Test the common function create_instancename()
@@ -2000,19 +2006,19 @@ def test_create_instancename(testcase, cls_kwargs, kv_args, exp_attrs,
 
     assert isinstance(obj, CIMInstanceName)
 
-    exp_classname = exp_attrs['classname']
+    exp_classname = exp_iname.classname
     assert obj.classname == exp_classname
     assert isinstance(obj.classname, type(exp_classname))
 
-    exp_keybindings = exp_attrs.get('keybindings', NocaseDict())
+    exp_keybindings = exp_iname.keybindings
     assert obj.keybindings == exp_keybindings
     assert isinstance(obj.keybindings, type(exp_keybindings))
 
-    exp_namespace = exp_attrs.get('namespace', None)
+    exp_namespace = exp_iname.namespace
     assert obj.namespace == exp_namespace
     assert isinstance(obj.namespace, type(exp_namespace))
 
-    exp_host = exp_attrs.get('host', None)
+    exp_host = exp_iname.host
     assert obj.host == exp_host
     assert isinstance(obj.host, type(exp_host))
 


### PR DESCRIPTION
Resolves most of Issue# 489. Removes all use of pywbem functions except mofstr.

That will be in subsequent pr.

This does fix Issue $ 135, indeterminante ordering of items in tree output that differest between pythone 2.7 and 3.x.  That was fixed by the use of an order based dict (odicti)