### PR TITLE
Fixes #521: Pinned Pygments to <2.4.0 and readme-renderer to <25.0 for Python 3.4

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -38,6 +38,10 @@ Sphinx>=1.7.6
 sphinx-git>=10.1.1
 GitPython>=2.1.1;
 sphinxcontrib-fulltoc>=1.2.0
+# Pygments 2.4.0 has removed support for Python 3.4
+Pygments>=2.1.3; python_version == '2.7'
+Pygments>=2.1.3,<2.4.0; python_version == '3.4'
+Pygments>=2.1.3; python_version >= '3.5'
 
 # PyLint (no imports, invoked via pylint script)
 # Pylint requires astroid
@@ -51,6 +55,10 @@ flake8>=3.2.1;
 
 # Twine (no imports, invoked via twine script):
 twine>=1.8.1
+# readme-renderer 25.0 has removed support for Python 3.4
+readme-renderer>21.0; python_version == '2.7'
+readme-renderer>21.0,<25.0; python_version == '3.4'
+readme-renderer>21.0; python_version >= '3.5'
 
 # Jupyter Notebook (no imports, invoked via jupyter script)
 # TODO Future: currently jupyter not used by pywbemtools

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -54,6 +54,9 @@ Released: not yet
 * Test: Fixed dependency to Python development packages on CygWin platform
   in Appveyor CI.
 
+* Pygments 2.4.0 and readme-renderer 25.0 have removed support for Python 3.4
+  and have therefore been pinned to below these versions on Python 3.4.
+
 **Enhancements:**
 
 * Promoted development status of pywbemtools from Alpha to Beta.


### PR DESCRIPTION
See commit message.