### PR TITLE
Fixes #510: cmds order display py dependent

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -57,6 +57,9 @@ Released: not yet
 * Pygments 2.4.0 and readme-renderer 25.0 have removed support for Python 3.4
   and have therefore been pinned to below these versions on Python 3.4.
 
+* Fix bug where order of commands listed in help output was different for
+  different versions of Python. (See issue # 510)
+
 **Enhancements:**
 
 * Promoted development status of pywbemtools from Alpha to Beta.

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -214,14 +214,14 @@ Help text for ``pywbemcli class`` (see :ref:`class command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      associators   List the classes associated with a class.
-      get           Get a class.
       enumerate     List top classes or subclasses of a class in a namespace.
-      tree          Show the subclass or superclass hierarchy for a class.
-      references    List the classes referencing a class.
-      invokemethod  Invoke a method on a class.
-      find          List the classes with matching class names on the server.
+      get           Get a class.
       delete        Delete a class.
+      invokemethod  Invoke a method on a class.
+      references    List the classes referencing a class.
+      associators   List the classes associated with a class.
+      find          List the classes with matching class names on the server.
+      tree          Show the subclass or superclass hierarchy for a class.
 
 
 .. _`pywbemcli class associators --help`:
@@ -772,13 +772,13 @@ Help text for ``pywbemcli connection`` (see :ref:`connection command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      show    Show a WBEM connection definition or the current connection.
-      list    List the WBEM connection definitions.
       export  Export the current connection.
+      show    Show a WBEM connection definition or the current connection.
+      delete  Delete a WBEM connection definition.
+      select  Select a WBEM connection definition as current or default.
       test    Test the current connection with a predefined WBEM request.
       save    Save the current connection to a new WBEM connection definition.
-      select  Select a WBEM connection definition as current or default.
-      delete  Delete a WBEM connection definition.
+      list    List the WBEM connection definitions.
 
 
 .. _`pywbemcli connection delete --help`:
@@ -1080,17 +1080,17 @@ Help text for ``pywbemcli instance`` (see :ref:`instance command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      count         Count the instances of each class with matching class name.
-      associators   List the instances associated with an instance.
-      shrub         Show the association shrub for INSTANCENAME.
-      get           Get an instance of a class.
-      create        Create an instance of a class in a namespace.
-      invokemethod  Invoke a method on an instance.
-      modify        Modify properties of an instance.
-      references    List the instances referencing an instance.
       enumerate     List the instances of a class.
-      query         Execute a query on instances in a namespace.
+      get           Get an instance of a class.
       delete        Delete an instance of a class.
+      create        Create an instance of a class in a namespace.
+      modify        Modify properties of an instance.
+      associators   List the instances associated with an instance.
+      references    List the instances referencing an instance.
+      invokemethod  Invoke a method on an instance.
+      query         Execute a query on instances in a namespace.
+      count         Count the instances of each class with matching class name.
+      shrub         Show the association shrub for INSTANCENAME.
 
 
 .. _`pywbemcli instance associators --help`:
@@ -1934,8 +1934,8 @@ Help text for ``pywbemcli qualifier`` (see :ref:`qualifier command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      enumerate  List the qualifier declarations in a namespace.
       get        Get a qualifier declaration.
+      enumerate  List the qualifier declarations in a namespace.
 
 
 .. _`pywbemcli qualifier enumerate --help`:
@@ -2056,12 +2056,12 @@ Help text for ``pywbemcli server`` (see :ref:`server command group`):
       -h, --help  Show this message and exit.
 
     Commands:
-      info          Get information about the server.
-      centralinsts  List central instances of mgmt profiles on the server.
+      namespaces    List the namespaces of the server.
       interop       Get the Interop namespace of the server.
       brand         Get the brand of the server.
+      info          Get information about the server.
       profiles      List management profiles advertized by the server.
-      namespaces    List the namespaces of the server.
+      centralinsts  List central instances of mgmt profiles on the server.
 
 
 .. _`pywbemcli server brand --help`:

--- a/pywbemtools/pywbemcli/_click_extensions.py
+++ b/pywbemtools/pywbemcli/_click_extensions.py
@@ -22,13 +22,14 @@ class PywbemcliGroup(click.Group):
         """
         Use OrderedDict to keep order commands inserted into command dict
         """
+        print('PYWBEMCI_INIT %s %s' % (name, commands))
+        print('attrs %s' % attrs)
         if commands is None:
             commands = OrderedDict()
         elif not isinstance(commands, OrderedDict):
+            print('PYWBEMCLI INIT pre commands %s' % commands)
             commands = OrderedDict(commands)
-        click.Group.__init__(self, name=name,
-                             commands=commands,
-                             **attrs)
+        click.Group.__init__(self, name=name, commands=commands, **attrs)
 
     def list_commands(self, ctx):
         """
@@ -49,14 +50,15 @@ class PywbemcliTopGroup(click.Group):
         to just move the generic ones to the end of the list.
 
     This extension has a general name because it may be used for more than
-    one extension to the Click.Group class..
+    one extension to the Click.Group class.
     """
 
     def list_commands(self, ctx):
         """
-        Order commands by sorting and then moving any commands defined in
-        move_to_end list to the end of the list.
+        Order The top level commands by sorting and then moving any commands
+        defined in  move_to_end list to the end of the list.
         """
+        print("LIST_COMMANDS %s" % self.commands.keys())
         # tuple of commands to move to bottom after sort
         move_to_end = ('connection', 'help', 'repl')
 
@@ -67,4 +69,5 @@ class PywbemcliTopGroup(click.Group):
             if cmd_list[i - pop_count] in move_to_end:
                 cmd_list.append(cmd_list.pop(i - pop_count))
                 pop_count += 1
+        print('RETURNS %s' % cmd_list)
         return cmd_list

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -333,6 +333,21 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
+    ['Verify class command --help command order',
+     ['--help'],
+     {'stdout': r'Commands:'
+                '.*\n  enumerate'
+                '.*\n  get'
+                '.*\n  delete'
+                '.*\n  invokemethod'
+                '.*\n  references'
+                '.*\n  associators'
+                '.*\n  find'
+                '.*\n  tree',
+      'test': 'regex'},
+     None, OK],
+
+
     ['Verify class command -h response',
      ['-h'],
      {'stdout': CLASS_HELP_LINES,

--- a/tests/unit/test_instance_cmds.py
+++ b/tests/unit/test_instance_cmds.py
@@ -495,6 +495,24 @@ TEST_CASES = [
       'test': 'insnows'},
      None, OK],
 
+
+    ['Verify instance command --help command order',
+     ['--help'],
+     {'stdout': r'Commands:'
+                '.*\n  enumerate'
+                '.*\n  get'
+                '.*\n  delete'
+                '.*\n  create'
+                '.*\n  modify'
+                '.*\n  associators'
+                '.*\n  references'
+                '.*\n  invokemethod'
+                '.*\n  query'
+                '.*\n  count'
+                '.*\n  shrub',
+      'test': 'regex'},
+     None, OK],
+
     #
     #  Instance Enumerate command good responses
     #


### PR DESCRIPTION
Fixes the issue where the order of commands listed in the --help for command groups was different in python 2 than in python 3.

See commit for details.