### PR TITLE
Fixes #530 - Issue with use_pull general option

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -74,6 +74,9 @@ Released: not yet
   NocaseDict, _to_unicode, _ensure_unicode, _format from pywbemcli. (See
   issue #489)
 
+* Corrected issue with use-pull general option that causes issues with using
+  the 'either' option with servers that do not have pull. (See issue #530)
+
 **Enhancements:**
 
 * Promoted development status of pywbemtools from Alpha to Beta.
@@ -186,6 +189,7 @@ Released: not yet
 
 * Removed a circumvention for a pywbem bug related to colons in WBEM URIs
   that was fixed in pywbem 0.13.0. (See issue #131)
+
 
 **Known issues:**
 

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -456,8 +456,9 @@ def cli(ctx, server, svr_name, default_namespace, user, password, timeout,
             'Conflicting server definitions: mock-server: {}, name: {}'.
             format(', '.join(resolved_mock_server), svr_name))
 
-    resolved_use_pull = USE_PULL_CHOICE[use_pull] if use_pull \
-        else DEFAULT_PULL_CHOICE
+    # set pull default if necessary and create the resolved variable
+    use_pull = use_pull or DEFAULT_PULL_CHOICE
+    resolved_use_pull = USE_PULL_CHOICE[use_pull]
 
     resolved_pull_max_cnt = pull_max_cnt or DEFAULT_MAXPULLCNT
 


### PR DESCRIPTION
Corrects issue(bug) where invalid internal representation of the option was
passed internally.

Marked for rollback since it is really a bug and there is one server in the snia testbed that fails.

Note that this change currently does not have a corresponding test.  I created pywbem issue # 2125 to extend pywbem mocker and tested a subset of that code with pywbemcli to confirm fix. 