### PR TITLE
Fixes #529,#534: use-pull internally only partly implemented

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -192,6 +192,11 @@ Released: not yet
 * Removed a circumvention for a pywbem bug related to colons in WBEM URIs
   that was fixed in pywbem 0.13.0. (See issue #131)
 
+* Added the general option `--use-pull` to the the PywbemServer() class so that
+  it is persisted in the connection file and to the display of connection
+  information (`connection show` and `connection list`). This means that
+  `--use-pull` can now be set for a particular server permanently.(See issues
+  #529 and #534).
 
 **Known issues:**
 

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -318,6 +318,7 @@ def show_connection_information(context, connection, separate_line=True,
     click.echo('\nname: {cn}{st}{sep}server: {sv}{sep}'
                'default-namespace: {dns}{sep}'
                'user: {usr}{sep}password: {pw}{sep}timeout: {to}{sep}'
+               'use_pull: {up}{sep}'
                'verify: {ve}{sep}certfile: {cf}{sep}keyfile: {kf}{sep}'
                'mock-server: {ms}{sep}ca-certs: {crts}{sep}'
                .format(cn=connection.name, st=state_str,
@@ -326,6 +327,7 @@ def show_connection_information(context, connection, separate_line=True,
                        usr=connection.user,
                        pw=disp_password,
                        to=connection.timeout,
+                       up=connection.use_pull,
                        ve=connection.verify,
                        cf=connection.certfile,
                        kf=connection.keyfile,
@@ -403,11 +405,12 @@ def cmd_connection_export(context):
                         svr.default_namespace)
     if_export_statement(PywbemServer.user_envvar, svr.user)
     if_export_statement(PywbemServer.password_envvar, svr.password)
-    if_export_statement(PywbemServer.timeout_envvar, svr.timeout)
     if_export_statement(PywbemServer.verify_envvar, svr.verify)
     if_export_statement(PywbemServer.certfile_envvar, svr.certfile)
     if_export_statement(PywbemServer.keyfile_envvar, svr.keyfile)
     if_export_statement(PywbemServer.ca_certs_envvar, svr.ca_certs)
+    if_export_statement(PywbemServer.timeout_envvar, svr.timeout)
+    if_export_statement(PywbemServer.use_pull_envvar, svr.use_pull)
 
 
 def cmd_connection_show(context, name, options):
@@ -574,7 +577,7 @@ def cmd_connection_list(context):
         dc = dflt_sym if is_default_connection(svr) else ''
         name = '{}{}{}'.format(cc, dc, name)
         row = [name, svr.server, svr.default_namespace, svr.user,
-               svr.timeout, svr.verify, svr.certfile,
+               svr.timeout, svr.use_pull, svr.verify, svr.certfile,
                svr.keyfile, "\n".join(svr.mock_server)]
         rows.append(row)
 
@@ -586,13 +589,13 @@ def cmd_connection_list(context):
             cname = '{}{}'.format('*', cname)
             svr = current_connection
             rows.append([cname, svr.server, svr.default_namespace, svr.user,
-                         svr.timeout, svr.verify, svr.certfile,
+                         svr.timeout, svr.use_pull, svr.verify, svr.certfile,
                          svr.keyfile, "\n".join(svr.mock_server)])
 
     # NOTE: Does not show ca_certs because that creates a very big table
     # in particular if you use the default.
     headers = ['name', 'server', 'namespace', 'user',
-               'timeout', 'verify', 'certfile', 'keyfile',
+               'timeout', 'use_pull', 'verify', 'certfile', 'keyfile',
                'mock-server']
 
     headers, rows = hide_empty_columns(headers, rows)

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -1497,8 +1497,10 @@ def hide_empty_columns(headers, rows):
         return True
 
     # Remove empty rows
+    len_hdr = len(headers)
     for row in rows:
-        assert len(row) == len(headers)
+        assert len(row) == len_hdr, "row: {}\nhdrs: {}". \
+            format(row, headers)
     for column in range(len(headers) - 1, -1, -1):
         if column_is_empty(rows, column):
             del headers[column]

--- a/pywbemtools/pywbemcli/_pywbem_server.py
+++ b/pywbemtools/pywbemcli/_pywbem_server.py
@@ -106,7 +106,7 @@ class PywbemServer(object):
 
     def __init__(self, server=None, default_namespace=DEFAULT_NAMESPACE,
                  name='default', user=None, password=None,
-                 timeout=DEFAULT_CONNECTION_TIMEOUT, verify=None,
+                 timeout=DEFAULT_CONNECTION_TIMEOUT, verify=None, use_pull=None,
                  certfile=None, keyfile=None, ca_certs=None, mock_server=None):
         """
             Create  a PywbemServer object. This contains the configuration
@@ -125,6 +125,7 @@ class PywbemServer(object):
         self.user = user
         self.password = password
         self.timeout = timeout
+        self.use_pull = use_pull
         self.verify = verify
         self.certfile = certfile
         self.keyfile = keyfile
@@ -138,12 +139,12 @@ class PywbemServer(object):
 
     def __repr__(self):
         return 'PywbemServer(server={} name={} ns={} user={} ' \
-               'password={} timeout={} verify={} certfile={} ' \
+               'password={} timeout={} use_pull={} verify={} certfile={} ' \
                'keyfile={} ca_certs={}  ' \
                'mock_server={!r} wbem_server {!r})' \
                .format(self.server, self.name, self.default_namespace,
-                       self.user, self.password, self.timeout, self.verify,
-                       self.certfile, self.keyfile, self.ca_certs,
+                       self.user, self.password, self.timeout, self.use_pull,
+                       self.verify, self.certfile, self.keyfile, self.ca_certs,
                        self.mock_server, self.wbem_server)
 
     @property
@@ -254,6 +255,23 @@ class PywbemServer(object):
                        .format(timeout, 0, MAX_TIMEOUT))
         # pylint: disable=attribute-defined-outside-init
         self._timeout = timeout
+
+    @property
+    def use_pull(self):
+        """
+        :term: `string`: Connection timeout to be used on requests in seconds
+        """
+        return self._use_pull
+
+    @use_pull.setter
+    def use_pull(self, use_pull):
+        """Setter method; for a description see the getter method."""
+
+        if use_pull is None or isinstance(use_pull, bool):
+            self._use_pull = use_pull
+        else:
+            ValueError("use_pull must be boolean, not {}.".
+                       format(type(use_pull)))
 
     @property
     def verify(self):
@@ -368,6 +386,7 @@ class PywbemServer(object):
                             "password": self.password,
                             "default-namespace": self.default_namespace,
                             "timeout": self.timeout,
+                            "use_pull": self.use_pull,
                             "verify": self.verify,
                             "certfile": self.certfile,
                             "keyfile": self.keyfile,

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -315,6 +315,7 @@ def cli(ctx, server, svr_name, default_namespace, user, password, timeout,
                                          user=user,
                                          password=password,
                                          timeout=resolved_timeout,
+                                         use_pull=resolved_use_pull,
                                          verify=resolved_verify,
                                          certfile=certfile,
                                          keyfile=keyfile,
@@ -368,7 +369,6 @@ def cli(ctx, server, svr_name, default_namespace, user, password, timeout,
                 pywbem_server = None
         return pywbem_server
 
-    #
     # Process cli options to produce resolved options, i.e. the
     # options with any defaults applied for non None options.
     # Produces new variables resolved... so that later tests can confirm that
@@ -532,6 +532,8 @@ def cli(ctx, server, svr_name, default_namespace, user, password, timeout,
                     modified_server = True
                 if timeout:
                     pywbem_server.timeout = resolved_timeout
+                if use_pull:
+                    pywbem_server.use_pull = resolved_use_pull
                 if server:
                     pywbem_server.server = server
                     modified_server = True


### PR DESCRIPTION
use-pull was never incorporated into the reports, lists, etc. and was left as a "transient" option in that it was not really attached to any particular connection.

1. Added to connection list and connection show which meant making it part of the PywbemServer class with its own property rather than just passed in the context in an interactive session.

2. made persistent and part of the persistent file per issue #534 (DISCUSSION is really what is discussed in that issue)