### PR TITLE
Using configparser / typing only on applicable Python versions

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -101,7 +101,7 @@ M2Crypto==0.31.0
 mock==2.0.0
 ordereddict==1.1
 ply==3.10
-typing==3.6.1  # from M2Crypto
+typing==3.6.1; python_version < '3.5'  # from M2Crypto
 
 # Direct dependencies for develop (must be consistent with dev-requirements.txt)
 
@@ -165,7 +165,7 @@ bleach==2.1.4
 certifi==2019.9.11
 chardet==3.0.2
 clint==0.5.1
-configparser==4.0.2
+configparser==4.0.2; python_version < '3.2'
 contextlib2==0.6.0
 docutils==0.13.1
 enum34==1.1.6; python_version < "3.4"


### PR DESCRIPTION
See commit message.
No review needed.