### PR TITLE
Fixes issue # 537 Hide the text output from a number of tests.

### DIFF
--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -1250,4 +1250,4 @@ class TestGeneralOptions(CLITestsBase):
         cmd_grp = inputs['cmdgrp'] if 'cmdgrp' in inputs else ''
 
         self.command_test(desc, cmd_grp, inputs, exp_response,
-                          mock, condition, verbose=True)
+                          mock, condition, verbose=False)


### PR DESCRIPTION
Since changing the use of tools like simplified_test_function to allow
capturing text output (i.e. using the capsys fixture is signicantly
difficult, we found a simple mechanism, simply mock the click.echo so
that the output is never generated.

Changed the tests in common that output text so that the test output is
significantly cleaner now.

While this works for real unit tests, it does not work for functional tests (i.e calls to pywbemcli)