### PR TITLE
Pinned dparse to <0.5.0 on py27 due to an issue

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -27,6 +27,10 @@ pytest-cov>=2.7.0
 
 # Safety CI by pyup.io
 safety>=1.8.4
+# dparse 0.5.0 has an infinite recursion issue on Python 2.7,
+#   see https://github.com/pyupio/dparse/issues/46
+dparse>=0.4.1,<0.5.0; python_version == '2.7'
+dparse>=0.4.1; python_version >= '3.4'
 
 # Sphinx (no imports, invoked via sphinx-build script):
 Sphinx>=1.7.6

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -77,6 +77,8 @@ Released: not yet
 * Corrected issue with use-pull general option that causes issues with using
   the 'either' option with servers that do not have pull. (See issue #530)
 
+* Pinned dparse to <0.5.0 on Python 2.7 due to an issue.
+
 **Enhancements:**
 
 * Promoted development status of pywbemtools from Alpha to Beta.


### PR DESCRIPTION
See commit message.
No review needed.