### PR TITLE
0.5: Pinned dparse to <0.5.0 on py27 due to an issue

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,6 +23,10 @@ python-coveralls>=2.8.0;
 
 # Safety CI by pyup.io
 safety>=1.8.4
+# dparse 0.5.0 has an infinite recursion issue on Python 2.7,
+#   see https://github.com/pyupio/dparse/issues/46
+dparse>=0.4.1,<0.5.0; python_version == '2.7'
+dparse>=0.4.1; python_version >= '3.4'
 
 # TODO: Remove the pinning of the pytest-cov version again once issue
 #       https://github.com/z4r/python-coveralls/issues/66

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -50,6 +50,8 @@ Released: not yet
 * Corrected issue with use-pull general option that causes issues with using
   the 'either' option with servers that do not have pull. (See issue #530)
 
+* Pinned dparse to <0.5.0 on Python 2.7 due to an issue.
+
 **Enhancements:**
 
 * Test: Improved assertion messages in tests.


### PR DESCRIPTION
Rolls back PR #545 back into 0.5