### PR TITLE
Fixes #547: Fixed incorrect coverage reported after pytest

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,7 +20,7 @@ pluggy>=0.13.0
 
 # Coverage reporting (no imports, invoked via coveralls script):
 # coverage 5.0 has removed support for py34
-coverage>=4.5.0,<5.0
+coverage>=4.5.2,<5.0
 # python-coveralls 2.9.2 no longer has requirement coverage==4.0.3.
 python-coveralls>=2.9.2
 pytest-cov>=2.7.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -79,6 +79,10 @@ Released: not yet
 
 * Pinned dparse to <0.5.0 on Python 2.7 due to an issue.
 
+* Test: Fixed incorrect coverage reported at the end of the pytest run,
+  by increasing the minimum version of the coverage package to 4.5.2.
+  (See issue #547)
+
 **Enhancements:**
 
 * Promoted development status of pywbemtools from Alpha to Beta.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -115,7 +115,7 @@ yamlordereddictloader==0.4.0
 funcsigs==1.0.2
 
 # Coverage reporting (no imports, invoked via coveralls script):
-coverage==4.5
+coverage==4.5.2
 python-coveralls==2.9.2
 pytest-cov==2.7.0
 


### PR DESCRIPTION
See commit message.
For verifying that it works on Travis, look at the Travis run for Python 3.8 with minimum package levels, and verify that the coverage reported at the end of the pytest run is around 90%.