### PR TITLE
Fixes #553: Fixed invalid test validation; minor test cleanup

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -83,6 +83,9 @@ Released: not yet
   by increasing the minimum version of the coverage package to 4.5.2.
   (See issue #547)
 
+* Test: Fixed bug with detection of invalid test validation values, and fixed
+  testcases in turn (See issue #553).
+
 **Enhancements:**
 
 * Promoted development status of pywbemtools from Alpha to Beta.

--- a/tests/unit/cli_test_extensions.py
+++ b/tests/unit/cli_test_extensions.py
@@ -368,7 +368,9 @@ class CLITestsBase(object):
                             "------------\n". \
                             format(rtn_type, desc, test_str, rtn_value)
                 else:
-                    assert 'Test {} is invalid. Skipped'.format(test_definition)
+                    raise AssertionError(
+                        "Test validation {!r} is invalid in test:\n"
+                        "{}\n".format(test_definition, desc))
 
 
 def remove_ws(inputs, join=False):

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -347,7 +347,6 @@ TEST_CASES = [
       'test': 'regex'},
      None, OK],
 
-
     ['Verify class command -h response',
      ['-h'],
      {'stdout': CLASS_HELP_LINES,
@@ -475,7 +474,6 @@ TEST_CASES = [
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-
     ['Verify class command enumerate CIM_Foo --names-only',
      ['enumerate', 'CIM_Foo', '--names-only'],
      {'stdout': ['CIM_Foo', 'CIM_Foo_sub', 'CIM_Foo_sub2'],
@@ -491,7 +489,7 @@ TEST_CASES = [
     ['Verify class command enumerate CIM_Foo summary, table',
      ['enumerate', 'CIM_Foo', '--summary'],
      {'stdout': ['2 CIMClass(s) returned'],
-      'test': 'insnows'},
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify class command enumerate CIM_Foo summary table output',
@@ -846,7 +844,6 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-
     ['Verify class command get with repr output format).',
      {'args': ['get', 'CIM_Foo'],
       'general': ['--output-format', 'txt']},
@@ -910,7 +907,6 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-
     ['Verify class command enumerate table output fails).',
      {'args': ['get', 'CIM_Foo'],
       'general': ['--output-format', 'table']},
@@ -958,7 +954,6 @@ TEST_CASES = [
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-
     ['Verify class command find simple name in all namespaces wo case',
      ['find', '*sub_su?*'],
      {'stdout': ["  root/cimv2:CIM_Foo_sub_sub"],
@@ -973,7 +968,6 @@ TEST_CASES = [
                  "  root/cimv2:CIM_Foo_sub_sub"],
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
-
 
     ['Verify class command find name in known namespace -o grid',
      {'general': ['-o', 'grid'],
@@ -1157,7 +1151,6 @@ TEST_CASES = [
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
-
     ['Verify class command tree bottom up. --superclasses',
      ['tree', '--superclasses', 'CIM_Foo_sub_sub'],
      {'stdout': """root
@@ -1215,7 +1208,6 @@ TEST_CASES = [
                  ''],
       'test': 'lines'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
-
 
     ['Verify class command associators simple request names only,',
      ['associators', 'TST_Person', '--names-only'],
@@ -1354,7 +1346,6 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
 
-
     #
     # references command tests
     #
@@ -1390,7 +1381,6 @@ TEST_CASES = [
      {'stdout': REFERENCES_CLASS_RTN_QUALS2,
       'test': 'linesnows'},
      SIMPLE_ASSOC_MOCK_FILE, OK],
-
 
     ['Verify class command references request, filters short',
      ['references', 'TST_Person',

--- a/tests/unit/test_connection_cmds.py
+++ b/tests/unit/test_connection_cmds.py
@@ -34,8 +34,7 @@ SCRIPT_DIR = os.path.dirname(__file__)
 # but not tied to the DMTF classes.
 SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
 INVOKE_METHOD_MOCK_FILE = 'simple_mock_invokemethod.py'
-MOCK_PROMPT0_FILE = "mock_prompt_0.py"
-MOCK_CONFIRMY_FILE = "mock_confirm_y.py"
+MOCK_PROMPT_0_FILE = "mock_prompt_0.py"
 
 TEST_DIR = os.path.dirname(__file__)
 
@@ -43,7 +42,6 @@ TEST_DIR = os.path.dirname(__file__)
 # test was run from the pywbemtools directory
 TEST_DIR_REL = os.path.relpath(TEST_DIR)
 MOCK_FILE_PATH = os.path.join(TEST_DIR_REL, SIMPLE_MOCK_FILE)
-CONFIRM_FILE_PATH = os.path.join(TEST_DIR_REL, MOCK_CONFIRMY_FILE)
 
 CONNECTION_HELP_LINES = [
     'Usage: pywbemcli connection [COMMAND-OPTIONS] COMMAND [ARGS]...',
@@ -73,28 +71,27 @@ CONNECTION_EXPORT_HELP_LINES = [
 CONNECTION_LIST_HELP_LINES = [
     'Usage: pywbemcli connection list [COMMAND-OPTIONS]',
     'List the WBEM connection definitions.',
-    CMD_OPTION_HELP_HELP_LINE
+    CMD_OPTION_HELP_HELP_LINE,
 ]
 
 CONNECTION_SAVE_HELP_LINES = [
     'Usage: pywbemcli connection save [COMMAND-OPTIONS] NAME',
     'Save the current connection to a new WBEM connection definition.',
-    CMD_OPTION_HELP_HELP_LINE
+    CMD_OPTION_HELP_HELP_LINE,
 ]
 
 CONNECTION_SELECT_HELP_LINES = [
     'Usage: pywbemcli connection select [COMMAND-OPTIONS] NAME',
     'Select a WBEM connection definition as current or default.',
     '-d, --default  If set, the connection is set to be the default ',
-
-    CMD_OPTION_HELP_HELP_LINE
+    CMD_OPTION_HELP_HELP_LINE,
 ]
 
 CONNECTION_SHOW_HELP_LINES = [
     'Usage: pywbemcli connection show [COMMAND-OPTIONS] NAME',
     'Show a WBEM connection definition or the current connection.',
     '--show-password  If set, show existing password in results.',
-    CMD_OPTION_HELP_HELP_LINE
+    CMD_OPTION_HELP_HELP_LINE,
 ]
 
 CONNECTION_TEST_HELP_LINES = [
@@ -106,6 +103,11 @@ CONNECTION_TEST_HELP_LINES = [
 OK = True     # mark tests OK when they execute correctly
 RUN = True    # Mark OK = False and current test case being created RUN
 FAIL = False  # Any test currently FAILING or not tested yet
+
+# Note: Some test cases are sequences, where each test case depends on the
+# previous test case and what was in the repository when each test is executed.
+# The sequences always start and end with an empty repository, and are marked
+# with "Begin of sequence" and "End of sequence".
 
 
 TEST_CASES = [
@@ -242,9 +244,11 @@ TEST_CASES = [
      None, OK],
 
     #
-    # The following tests are a sequence. Each depends on the previous
-    # and what was in the repository when each test is executed.
+    #  Sequence for simple connection save, show, list, select, delete
     #
+
+    # Begin of sequence - repository is empty.
+
     ['Verify connection command save creates file.',
      {'general': ['--server', 'http://blah'],
       'args': ['save', 'test1']},
@@ -288,7 +292,7 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection command show  test2 with --show-password',
+    ['Verify connection command show test2 with --show-password',
      ['show', 'test2', '--show-password'],
      {'stdout': ['name: test2',
                  'server: http://blahblah',
@@ -303,7 +307,7 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection command show  test2, masked password',
+    ['Verify connection command show test2, masked password',
      ['show', 'test2'],
      {'stdout': ['name: test2',
                  'server: http://blahblah',
@@ -354,16 +358,15 @@ TEST_CASES = [
      None, OK],
 
     ['Verify connection command list with 2 servers defined, not sel after '
-     ' next pywbemcli call',
+     'next pywbemcli call',
      {'general': ['--output-format', 'plain'],
       'args': ['list']},
      {'stdout': ['WBEM server connections:',
                  '(#: default, *: current)',
-                 'name    server namespace user timeout verify log',
-                 'test1   http://blah      root/cimv2        30  True',
-                 '*#test2   http://blahblah  root/cimv2   fred 18  False'
-                 'api=file,all'],
-      'test': 'insnows'},
+                 'name    server          namespace  user timeout verify',
+                 'test1   http://blah     root/cimv2           30   True',
+                 '*#test2 http://blahblah root/cimv2 fred      18  False', ],
+      'test': 'innows'},
      None, OK],
 
     ['Verify connection command delete test1',
@@ -393,13 +396,16 @@ TEST_CASES = [
          "WBEM server connections:", ""],
       'test': 'innows',
       'file': {'before': 'none', 'after': 'none'}},
-
      None, OK],
 
+    # End of sequence - repository is empty.
+
     #
-    # The following tests are a new sequence and depends on empty repo.
-    # It creates, shows and deletes a single server definition.
+    #  Sequence that creates, shows and deletes a single server definition
     #
+
+    # Begin of sequence - repository is empty.
+
     ['Verify connection command add with all arguments.',
      {'general': ['--server', 'http://blahblah',
                   '--default-namespace', 'root/blahblah',
@@ -496,10 +502,15 @@ TEST_CASES = [
       'file': {'before': 'none', 'after': 'none'}},
      None, OK],
 
+    # End of sequence - repository is empty.
+
     #
-    #  Test command line parameter errors, select, show, and delete with
-    #  no repository
+    #  Sequence that tests command line parameter errors, select, show, and
+    #  delete with no repository
     #
+
+    # Begin of sequence - repository is empty.
+
     ['Verify connection command show with name not in empty repo',
      ['show', 'Blah'],
      {'stderr': ['Name "Blah" not current and no connections file'],
@@ -539,7 +550,6 @@ TEST_CASES = [
       'file': {'before': 'none', 'after': 'none'}},
      None, OK],
 
-
     ['Verify connection command delete, empty repo fails',
      ['delete', 'blah'],
      {'stderr': ["Connection repository", "empty"],
@@ -548,11 +558,13 @@ TEST_CASES = [
       'file': {'before': 'none', 'after': 'none'}},
      None, OK],
 
-    #  The following is a sequence that starts with an empty repo
-    #  Verify create and save mock connection sequence. Starts with empty
-    #  server adds a mock server, shows it, tests if valid, and deletes
-    #  the connection
+    # End of sequence - repository is empty.
+
     #
+    #  Sequence that verifies create and save mock connection
+    #
+
+    # Begin of sequence - repository is empty.
 
     ['Verify mock connection exists.',
      {'general': ['--mock-server', MOCK_FILE_PATH],
@@ -581,7 +593,7 @@ TEST_CASES = [
      {'args': ['test'],
       'general': ['--name', 'mocktest']},
      {'stdout': "Connection successful",
-      'test': 'linnows',
+      'test': 'innows',
       'file': {'before': 'exists', 'after': 'exists'}},
      None, OK],
 
@@ -590,22 +602,21 @@ TEST_CASES = [
      {'stdout': "",
       'test': 'in',
       'file': {'before': 'exists', 'after': 'exists'}},
-     MOCK_PROMPT0_FILE, OK],
-
+     MOCK_PROMPT_0_FILE, OK],
 
     ['Verify connection command show with prompt',
      ['show', '?'],
      {'stdout': ['name: mocktest'],
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'exists'}},
-     MOCK_PROMPT0_FILE, OK],
+     MOCK_PROMPT_0_FILE, OK],
 
-    ['Verify connection command delete last one that  deletes w/o prompt',
+    ['Verify connection command delete last one that deletes w/o prompt',
      ['delete', ],
-     {'stdout': ['Deleted  connection "mocktest'],
+     {'stdout': ['Deleted connection "mocktest"'],
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'none'}},
-     MOCK_PROMPT0_FILE, OK],
+     MOCK_PROMPT_0_FILE, OK],
 
     ['Verify Add mock server to empty connections file.',
      {'general': ['--mock-server', MOCK_FILE_PATH],
@@ -615,20 +626,22 @@ TEST_CASES = [
       'file': {'before': 'none', 'after': 'exists'}},
      None, OK],
 
-    ['Verify connection command delete'
-     'verify',
+    ['Verify connection command delete, empty repository',
      ['delete', 'mocktest'],
-     {'stdout': ['name: mocktest', 'Execute delete'],
-      'test': 'onnows',
+     {'stdout': ['Deleted connection "mocktest"'],
+      'test': 'innows',
       'file': {'before': 'exists', 'after': 'none'}},
-     MOCK_CONFIRMY_FILE, OK],
+     None, OK],
+
+    # End of sequence - repository is empty.
 
     #
-    #  Verify Create from mock with cmd line params, save, show, delete works
-    #  The following is a sequence of tests that must be run in order
-    #  The following test is artifical in that the first create actually
-    #  uses the mock but not to really create a server
+    #  Sequence that verifies create from mock with cmd line params, save,
+    #  show, delete works
     #
+
+    # Begin of sequence - repository is empty.
+
     ['Verify save server with cmd line params to empty connections file.',
      {'args': ['save', 'svrtest2'],
       'general': ['--server', 'http://blah',
@@ -643,7 +656,7 @@ TEST_CASES = [
      {'stdout': "",
       'test': 'innows',
       'file': {'before': 'none', 'after': 'exists'}},
-     MOCK_CONFIRMY_FILE, OK],
+     None, OK],
 
     ['Verify save mock server with cmd line params to empty connections file.',
      {'args': ['save', 'mocktest2'],
@@ -707,9 +720,13 @@ TEST_CASES = [
       'file': {'before': 'exists', 'after': 'none'}},
      None, OK],
 
+    # End of sequence - repository is empty.
+
     #
-    #  Test select variations
+    #  Sequence that tests select variations
     #
+
+    # Begin of sequence - repository is empty.
 
     ['Verify connection show with just current server defined by --server',
      {'args': ['show'],
@@ -728,9 +745,13 @@ TEST_CASES = [
       'file': {'before': 'none', 'after': 'none'}},
      None, OK],
 
+    # End of sequence - repository is empty.
+
     #
     #  Sequence to test
     #
+
+    # Begin of sequence - repository is empty.
 
     ['Verify Create new connection names svrtest works.',
      {'general': ['--server', 'http://blah'],
@@ -788,11 +809,16 @@ WBEM server connections: (#: default, *: current)
       'file': {'before': 'exists', 'after': 'none'}},
      None, OK],
 
+    # End of sequence - repository is empty.
+
     #
-    #   Test creating a server and saving it from stdin all in single
-    #   interactive sequence
+    #  Sequence that tests creating a server and saving it from stdin all in
+    #  single interactive sequence
     #
-    ['Verify Create new connection in interactive mode and delete.',
+
+    # Begin of sequence - repository is empty.
+
+    ['Verify Create new connection in interactive mode and delete - single',
      {'general': [],
       'stdin': ['--server http://blah --user fred --password fred '
                 '--certfile cert1.pem --keyfile keys1.pem',
@@ -814,10 +840,15 @@ WBEM server connections: (#: default, *: current)
       'file': {'before': 'none', 'after': 'none'}},
      None, OK],
 
+    # End of sequence - repository is empty.
+
     #
-    # The following is a sequence to assure that the interactive creation
-    # of a server actually puts the server in the repository
+    #  Sequence to assure that the interactive creation of a server actually
+    #  puts the server in the repository
     #
+
+    # Begin of sequence - repository is empty.
+
     ['Verify Create new connection in interactive mode and delete.',
      {'general': [],
       'stdin': ['--server http://blah --user fred --password fred '
@@ -846,9 +877,14 @@ WBEM server connections: (#: default, *: current)
       'file': {'before': 'exists', 'after': 'none'}},
      None, OK],
 
+    # End of sequence - repository is empty.
+
     #
-    #   The following is a sequence. Confirm fix to issue #396
+    #  Sequence to confirm fix to issue #396
     #
+
+    # Begin of sequence - repository is empty.
+
     ['Create mock server defintion.',
      {'args': ['save', 'mocktest3'],
       'general': ['--mock-server', MOCK_FILE_PATH]},
@@ -880,6 +916,8 @@ WBEM server connections: (#: default, *: current)
       'test': 'innows',
       'file': {'before': 'None', 'after': 'None'}},
      None, OK],
+
+    # End of sequence - repository is empty.
 
 ]
 

--- a/tests/unit/test_instance_cmds.py
+++ b/tests/unit/test_instance_cmds.py
@@ -96,8 +96,8 @@ INSTANCE_ASSOCIATORS_HELP_LINES = [
     CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_FILTER_QUERY_LINE,
     CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE,
-    CMD_OPTION_HELP_HELP_LINE,
     CMD_OPTION_KEYS_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
 ]
 
 INSTANCE_COUNT_HELP_LINES = [
@@ -105,10 +105,10 @@ INSTANCE_COUNT_HELP_LINES = [
     'Count the instances of each class with matching class name.',
     '-s, --sort Sort by instance count.',
     CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE,
-    CMD_OPTION_HELP_HELP_LINE,
     CMD_OPTION_ASSOCIATION_FILTER_HELP_LINE,
     CMD_OPTION_INDICATION_FILTER_HELP_LINE,
-    CMD_OPTION_EXPERIMENTAL_FILTER_HELP_LINE
+    CMD_OPTION_EXPERIMENTAL_FILTER_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
 ]
 
 INSTANCE_CREATE_HELP_LINES = [
@@ -124,8 +124,8 @@ INSTANCE_DELETE_HELP_LINES = [
     'Usage: pywbemcli instance delete [COMMAND-OPTIONS] INSTANCENAME',
     'Delete an instance of a class.',
     CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_OPTION_HELP_HELP_LINE,
     CMD_OPTION_KEYS_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
 ]
 
 INSTANCE_ENUMERATE_HELP_LINES = [
@@ -152,8 +152,8 @@ INSTANCE_GET_HELP_LINES = [
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_OPTION_HELP_HELP_LINE,
     CMD_OPTION_KEYS_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
 ]
 
 INSTANCE_INVOKEMETHOD_HELP_LINES = [
@@ -162,8 +162,8 @@ INSTANCE_INVOKEMETHOD_HELP_LINES = [
     'Invoke a method on an instance.',
     '-p, --parameter PARAMETERNAME=VALUE Specify a method input parameter',
     CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_OPTION_HELP_HELP_LINE,
     CMD_OPTION_KEYS_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
 ]
 
 INSTANCE_MODIFY_HELP_LINES = [
@@ -173,18 +173,17 @@ INSTANCE_MODIFY_HELP_LINES = [
     '--pl, --propertylist PROPERTYLIST Reduce the properties to be modified',
     CMD_OPTION_VERIFY_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
-    CMD_OPTION_HELP_HELP_LINE,
     CMD_OPTION_KEYS_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
 ]
 
 INSTANCE_QUERY_HELP_LINES = [
-    'Usage: pywbemcli instance query [COMMAND-OPTIONS] INSTANCENAME',
+    'Usage: pywbemcli instance query [COMMAND-OPTIONS] QUERY-STRING',
     'Execute a query on instances in a namespace.',
-    '-l, --query-language QUERY-LANGUAGE The query language to be used',
+    '-ql, --query-language QUERY-LANGUAGE The query language to be used',
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
-    CMD_OPTION_KEYS_HELP_LINE,
 ]
 
 INSTANCE_REFERENCES_HELP_LINES = [
@@ -200,8 +199,8 @@ INSTANCE_REFERENCES_HELP_LINES = [
     CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_FILTER_QUERY_LINE,
     CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE,
-    CMD_OPTION_HELP_HELP_LINE,
     CMD_OPTION_KEYS_HELP_LINE,
+    CMD_OPTION_HELP_HELP_LINE,
 ]
 
 INSTANCE_SHRUB_HELP_LINES = [
@@ -486,15 +485,14 @@ TEST_CASES = [
     ['Verify instance command --help response',
      '--help',
      {'stdout': INSTANCE_HELP_LINES,
-      'test': 'insnows'},
+      'test': 'innows'},
      None, OK],
 
     ['Verify instance command -h response',
      '-h',
      {'stdout': INSTANCE_HELP_LINES,
-      'test': 'insnows'},
+      'test': 'innows'},
      None, OK],
-
 
     ['Verify instance command --help command order',
      ['--help'],
@@ -728,7 +726,6 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-
     ['Verify instance command -o txt enumerate CIM_Foo',
      {'args': ['enumerate', 'CIM_Foo'],
       'general': ['--output-format', 'txt']},
@@ -813,7 +810,6 @@ TEST_CASES = [
       'rc': 1,
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
-
 
     ['Verify command enumerate with CIM_Foo inst name table output',
      {'args': ['enumerate', 'CIM_Foo', '--names-only'],
@@ -989,7 +985,6 @@ Instances: PyWBEM_AllTypes
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
-
     ['Verify instance command get with instancename, --key, namespace returns '
      'data',
      ['get', 'CIM_Foo', '--namespace', 'root/cimv2', '--key',
@@ -1002,7 +997,6 @@ Instances: PyWBEM_AllTypes
       'rc': 0,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
-
 
     ['Verify instance command get with instancename with ":", --key, namespace '
      'returns data',
@@ -1230,10 +1224,11 @@ Instances: PyWBEM_AllTypes
      ['create', 'CIM_Foo', '-p', 'InstanceID=blah', '--verify'],
      {'stdout': ['instance of CIM_Foo {',
                  'InstanceID = "blah";',
-                 'root/cimv2:CIM_Foo.InstanceID="blah"',
-                 'Execute CreateInstance'],
+                 '};',
+                 'Execute CreateInstance',
+                 'root/cimv2:CIM_Foo.InstanceID="blah"'],
       'rc': 0,
-      'test': 'in '},
+      'test': 'in'},
      [SIMPLE_MOCK_FILE, MOCK_CONFIRM_Y_FILE], OK],
 
     ['Verify instance command create, new instance of CIM_Foo one '
@@ -1241,11 +1236,11 @@ Instances: PyWBEM_AllTypes
      ['create', 'CIM_Foo', '-p', 'InstanceID=blah', '--verify'],
      {'stdout': ['instance of CIM_Foo {',
                  'InstanceID = "blah";',
-                 'root/cimv2:CIM_Foo.InstanceID="blah"',
-                 'Execute CreateInstance'
+                 '};',
+                 'Execute CreateInstance',
                  'Request aborted'],
       'rc': 0,
-      'test': 'in '},
+      'test': 'in'},
      [SIMPLE_MOCK_FILE, MOCK_CONFIRM_N_FILE], OK],
 
     ['Verify instance command create, new instance of CIM_Foo, '
@@ -1273,7 +1268,6 @@ Instances: PyWBEM_AllTypes
       'rc': 0,
       'test': 'innows'},
      [SIMPLE_MOCK_FILE], OK],
-
 
     # TODO: For some reason the required quote marks on the instance IDs in
     # INSTANCENAME do not make it through stdin. What click presents is the
@@ -1366,7 +1360,6 @@ Instances: PyWBEM_AllTypes
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
-
     ['Verify instance command create, new instance invalid class',
      ['create', 'CIM_blah', '-p', 'InstanceID=test_instance'],
      {'stderr': ["CIMClass"],
@@ -1435,12 +1428,12 @@ Instances: PyWBEM_AllTypes
       '-p', 'scalBool=False', '--verify'],
      {'stdout': ['instance of PyWBEM_AllTypes {',
                  'scalBool = false;',
+                 '};',
                  'Execute ModifyInstance',
                  'Request aborted'],
       'rc': 0,
       'test': 'regex'},
      [ALLTYPES_MOCK_FILE, MOCK_CONFIRM_N_FILE], OK],
-
 
     ['Verify instance command modify, single good change, explicit --n',
      ['modify', 'PyWBEM_AllTypes.InstanceID="test_instance"', '-n',
@@ -1685,21 +1678,21 @@ Instances: PyWBEM_AllTypes
      ['references', 'TST_Person.name="Mike"'],
      {'stdout': REF_INSTS,
       'rc': 0,
-      'test': 'lineswons'},
+      'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
     ['Verify instance command references with --key, returns instances',
      ['references', 'TST_Person', '--key', 'name=Mike'],
      {'stdout': REF_INSTS,
       'rc': 0,
-      'test': 'lineswons'},
+      'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
     ['Verify instance command references, returns instances, explicit ns',
      ['references', 'TST_Person.name="Mike"', '-n', 'root/cimv2'],
      {'stdout': REF_INSTS,
       'rc': 0,
-      'test': 'lineswons'},
+      'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
     ['Verify instance command references --no, returns paths',
@@ -1778,7 +1771,6 @@ Instances: PyWBEM_AllTypes
       'test': 'lines'},
      ASSOC_MOCK_FILE, OK],
 
-
     ['Verify instance command references --no, returns paths with result '
      'class short form valid returns paths',
      {'args': ['references', 'TST_Person.name="Mike"', '--no', '--summary',
@@ -1823,9 +1815,10 @@ Instances: PyWBEM_AllTypes
      'class not a real ref returns no paths',
      ['references', 'TST_Person.name="Mike"', '--no',
       '--result-class', 'TST_Lineagex'],
-     {'stderr': [''],
+     {'stderr': ["CIMError: 4 (CIM_ERR_INVALID_PARAMETER):",
+                 "Class 'TST_Lineagex'"],
       'rc': 1,
-      'test': 'linnows'},
+      'test': 'innows'},
      ASSOC_MOCK_FILE, OK],
 
     ['Verify instance command references, no instance name',
@@ -2014,23 +2007,8 @@ Instances: PyWBEM_AllTypes
      None, OK],
 
     # The following use interop ns to avoid warning about namespaces.
-    ['Verify instance command count CIM_* simple model, Rtn tbl of instances',
-     {'args': ['count', 'CIM_*'],
-      'general': ['--output-format', 'table',
-                  '--default-namespace', 'interop']},
-     {'stdout': ['Count of instances per class',
-                 '+-------------+-----------------+---------+',
-                 '| Namespace   | Class           |   count |',
-                 '|-------------+-----------------+---------|',
-                 '| interop     | CIM_Foo         |       5 |',
-                 '| interop     | CIM_Foo_sub     |       4 |',
-                 '| interop     | CIM_Foo_sub_sub |       3 |',
-                 '+-------------+-----------------+---------+'],
-      'rc': 0,
-      'test': 'innows'},
-     SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance command count CIM_*  sorted, Rtn table of inst counts',
+    ['Verify instance command count CIM_* sorted, simple model, format table',
      {'args': ['count', 'CIM_*', '--sort'],
       'general': ['--output-format', 'table',
                   '--default-namespace', 'interop']},
@@ -2044,10 +2022,10 @@ Instances: PyWBEM_AllTypes
 +-------------+-----------------+---------+
 """,
       'rc': 0,
-      'test': 'innows'},
+      'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance command count CIM_*. Rtn table of inst counts',
+    ['Verify instance command count CIM_*, simple model, format table',
      {'args': ['count', 'CIM_*'],
       'general': ['--output-format', 'table',
                   '--default-namespace', 'interop']},
@@ -2061,47 +2039,36 @@ Instances: PyWBEM_AllTypes
 +-------------+-----------------+---------+
 """,
       'rc': 0,
-      'test': 'innows'},
+      'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance command count mock assoc. Return table of instances',
+    ['Verify instance command count *, assoc model, format plain',
      {'args': ['count', '*'],
       'general': ['--default-namespace', 'interop', '--output-format',
                   'plain']},
-     {'stdout': [
-         'Count of instances per class',
-         'Namespace    Class                           count',
-         'interop      TST_FamilyCollection                2',
-         'interop      TST_Lineage                         3',
-         'interop      TST_MemberOfFamilyCollection        3',
-         'interop      TST_Person                          4',
-         'interop      TST_Personsub                       4', ],
+     {'stdout': """Count of instances per class
+Namespace    Class                           count
+interop      TST_FamilyCollection                2
+interop      TST_Lineage                         3
+interop      TST_MemberOfFamilyCollection        3
+interop      TST_Person                          4
+interop      TST_Personsub                       4
+""",
       'rc': 0,
-      'test': 'innows'},
+      'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance command count *Person* . Return table of instances',
+    ['Verify instance command count *Person*, assoc model, default format',
      {'args': ['count', '*Person*'],
       'general': ['--default-namespace', 'interop']},
      {'stdout': """Count of instances per class
 Namespace    Class            count
+-----------  -------------  -------
 interop      TST_Person           4
 interop      TST_Personsub        4
 """,
       'rc': 0,
-      'test': 'linenows'},
-     ASSOC_MOCK_FILE, OK],
-
-    ['Verify instance command count *Person* . Return table of instances',
-     {'args': ['count', '*Person*'],
-      'general': ['--default-namespace', 'interop']},
-     {'stdout': """Count of instances per class
-Namespace    Class            count
-interop      TST_Person           4
-interop      TST_Personsub        4
-""",
-      'rc': 0,
-      'test': 'linennows'},
+      'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
     ['Verify instance command count *Person* with --association',
@@ -2114,7 +2081,7 @@ interop      TST_Lineage          3
 interop      TST_MemberOfFamilyCollection  3
 """,
       'rc': 0,
-      'test': 'innows'},
+      'test': 'linesnows'},
      QUALIFIER_FILTER_MODEL, OK],
 
     ['Verify instance command count *Person* with --experimental',
@@ -2126,7 +2093,7 @@ Namespace    Class            count
 interop      TST_Personsub        4
 """,
       'rc': 0,
-      'test': 'innows'},
+      'test': 'linesnows'},
      QUALIFIER_FILTER_MODEL, OK],
 
     ['Verify instance command count *Person* with --indication',
@@ -2139,7 +2106,7 @@ interop      TST_Lineage          3
 interop      TST_MemberOfFamilyCollection  3
 """,
       'rc': 0,
-      'test': 'innows'},
+      'test': 'linesnows'},
      QUALIFIER_FILTER_MODEL, OK],
 
     #
@@ -2183,7 +2150,6 @@ interop      TST_MemberOfFamilyCollection  3
       'test': 'innows'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
-
     ['Verify instance command invokemethod with all_types method',
      ['invokemethod', 'Pywbem_alltypes.InstanceID="test_instance"',
       'AllTypesMethod',
@@ -2226,7 +2192,6 @@ interop      TST_MemberOfFamilyCollection  3
     # in classnametests
     # TODO: Create new method that has all param types and options
 
-
     #
     #  instance query command. We have not implemented this command
     #
@@ -2234,14 +2199,14 @@ interop      TST_MemberOfFamilyCollection  3
      ['query', '--help'],
      {'stdout': INSTANCE_QUERY_HELP_LINES,
       'rc': 0,
-      'test': 'linnows'},
+      'test': 'innows'},
      None, OK],
 
     ['Verify instance command query -h response',
      ['query', '-h'],
      {'stdout': INSTANCE_QUERY_HELP_LINES,
       'rc': 0,
-      'test': 'linnows'},
+      'test': 'innows'},
      None, OK],
 
     ['Verify instance command query execution. Returns error becasue '
@@ -2343,7 +2308,6 @@ interop      TST_MemberOfFamilyCollection  3
       'rc': 0,
       'test': 'innows'},
      ASSOC_MOCK_FILE, RUN],
-
 
     ['Verify instance command shrub, simple tree with --assoc-class option2',
      ['shrub', 'TST_Person.name="Mike"', '--result-class', 'tst_person'],

--- a/tests/unit/test_qualdecl_cmds.py
+++ b/tests/unit/test_qualdecl_cmds.py
@@ -218,7 +218,6 @@ TEST_CASES = [
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-
     ['Verify qualifier command enumerate summary returns qual decls table',
      {'args': ['enumerate', '--summary'],
       'general': ['--output-format', 'table']},
@@ -260,7 +259,6 @@ TEST_CASES = [
       'rc': 0,
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
-
 
     ['Verify qualifier command -o grid get Abstract table out',
      {'args': ['get', 'abstract'],


### PR DESCRIPTION
See commit message.
This issue was detected while wondering why the tests did not fail when the expected help text for the "instance query" command included the --key option.