### PR TITLE
Travis: Changed coveralls to run on py38 and for both push and pr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -254,6 +254,6 @@ after_success:
 # Note: In case of error 422 (Couldn't find a repository matching this job),
 #       log on to https://coveralls.io to refresh the OAuth token, and
 #       make sure this project is enabled there.
-  - if [[ "$TRAVIS_EVENT_TYPE" == "push" && "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PYTHON_VERSION" == "3.4" && "$PACKAGE_LEVEL" == "latest" && -z $_MANUAL_CI_RUN ]]; then
+  - if [[ "$TRAVIS_OS_NAME" == "linux" && "$TRAVIS_PYTHON_VERSION" == "3.8" && "$PACKAGE_LEVEL" == "latest" && -z $_MANUAL_CI_RUN ]]; then
       coveralls;
     fi


### PR DESCRIPTION
This is an attempt to check whether we get the coveralls comment again when running it on python 3.8 (it ran on python 3.4 so far).
No review needed.