### PR TITLE
Fixes #568: Removed 'and exit' from option help text

### DIFF
--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -118,8 +118,8 @@ Help text for ``pywbemcli``:
       --pdb                           Pause execution in the built-in pdb debugger just before executing the command within
                                       pywbemcli. Default: EnvVar PYWBEMCLI_PDB, or false.
 
-      --version                       Show the version of this command and the pywbem package and exit.
-      -h, --help                      Show this message and exit.
+      --version                       Show the version of this command and the pywbem package.
+      -h, --help                      Show this help message.
 
     Commands:
       class       Command group for CIM classes.
@@ -155,7 +155,7 @@ Help text for ``pywbemcli class`` (see :ref:`class command group`):
       can also be specified before the 'class' keyword.
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
     Commands:
       enumerate     List top classes or subclasses of a class in a namespace.
@@ -226,7 +226,7 @@ Help text for ``pywbemcli class associators`` (see :ref:`class associators comma
 
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       -s, --summary                   Show only a summary (count) of the objects.
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli class delete --help`:
@@ -268,7 +268,7 @@ Help text for ``pywbemcli class delete`` (see :ref:`class delete command`):
                                  deletion. Default: Reject command if the class has any instances.
 
       -n, --namespace NAMESPACE  Namespace to use for this command, instead of the default namespace of the connection.
-      -h, --help                 Show this message and exit.
+      -h, --help                 Show this help message.
 
 
 .. _`pywbemcli class enumerate --help`:
@@ -337,7 +337,7 @@ Help text for ``pywbemcli class enumerate`` (see :ref:`class enumerate command`)
                                       classes that are not experimental (--no-iexperimental). If the option is not defined
                                       no filtering occurs
 
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli class find --help`:
@@ -395,7 +395,7 @@ Help text for ``pywbemcli class find`` (see :ref:`class find command`):
                                       classes that are not experimental (--no-iexperimental). If the option is not defined
                                       no filtering occurs
 
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli class get --help`:
@@ -442,7 +442,7 @@ Help text for ``pywbemcli class get`` (see :ref:`class get command`):
                                       empty string will include no properties. Default: Do not filter properties.
 
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli class invokemethod --help`:
@@ -482,7 +482,7 @@ Help text for ``pywbemcli class invokemethod`` (see :ref:`class invokemethod com
                                       Default: No input parameters.
 
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli class references --help`:
@@ -538,7 +538,7 @@ Help text for ``pywbemcli class references`` (see :ref:`class references command
 
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       -s, --summary                   Show only a summary (count) of the objects.
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli class tree --help`:
@@ -582,7 +582,7 @@ Help text for ``pywbemcli class tree`` (see :ref:`class tree command`):
     Command Options:
       -s, --superclasses         Show the superclass hierarchy. Default: Show the subclass hierarchy.
       -n, --namespace NAMESPACE  Namespace to use for this command, instead of the default namespace of the connection.
-      -h, --help                 Show this message and exit.
+      -h, --help                 Show this help message.
 
 
 .. _`pywbemcli connection --help`:
@@ -610,7 +610,7 @@ Help text for ``pywbemcli connection`` (see :ref:`connection command group`):
       can also be specified before the 'connection' keyword.
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
     Commands:
       export  Export the current connection.
@@ -646,7 +646,7 @@ Help text for ``pywbemcli connection delete`` (see :ref:`connection delete comma
         pywbemcli connection delete blah
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
 
 .. _`pywbemcli connection export --help`:
@@ -674,7 +674,7 @@ Help text for ``pywbemcli connection export`` (see :ref:`connection export comma
         pywbemcli --server https://srv1 --user me --password pw connection export
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
 
 .. _`pywbemcli connection list --help`:
@@ -703,7 +703,7 @@ Help text for ``pywbemcli connection list`` (see :ref:`connection list command`)
 
     Command Options:
       -f, --full  If set, display the full table. Otherwise display a brief view(name, server, mock_server columns).
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
 
 .. _`pywbemcli connection save --help`:
@@ -733,7 +733,7 @@ Help text for ``pywbemcli connection save`` (see :ref:`connection save command`)
         pywbemcli --server https://srv1 connection save mysrv
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
 
 .. _`pywbemcli connection select --help`:
@@ -781,7 +781,7 @@ Help text for ``pywbemcli connection select`` (see :ref:`connection select comma
       -d, --default  If set, the connection is set to be the default connection  in the connections file in addition to
                      setting it as the current connection.
 
-      -h, --help     Show this message and exit.
+      -h, --help     Show this help message.
 
 
 .. _`pywbemcli connection show --help`:
@@ -826,7 +826,7 @@ Help text for ``pywbemcli connection show`` (see :ref:`connection show command`)
 
     Command Options:
       --show-password  If set, show existing password in results. Otherwise, password is masked
-      -h, --help       Show this message and exit.
+      -h, --help       Show this help message.
 
 
 .. _`pywbemcli connection test --help`:
@@ -853,7 +853,7 @@ Help text for ``pywbemcli connection test`` (see :ref:`connection test command`)
         pywbemcli --name mysrv connection test
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
 
 .. _`pywbemcli help --help`:
@@ -873,7 +873,7 @@ Help text for ``pywbemcli help`` (see :ref:`help command`):
       Show help message for interactive mode.
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
 
 .. _`pywbemcli instance --help`:
@@ -901,7 +901,7 @@ Help text for ``pywbemcli instance`` (see :ref:`instance command group`):
       can also be specified before the 'instance' keyword.
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
     Commands:
       enumerate     List the instances of a class.
@@ -988,9 +988,9 @@ Help text for ``pywbemcli instance associators`` (see :ref:`instance associators
       --fql, --filter-query-language QUERY-LANGUAGE
                                       The filter query language to be used with --filter-query. Default: DMTF:FQL.
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
-                                      --namespace options and exit.
+                                      --namespace options.
 
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli instance count --help`:
@@ -1047,7 +1047,7 @@ Help text for ``pywbemcli instance count`` (see :ref:`instance count command`):
                                       no filtering occurs
 
       -s, --sort                      Sort by instance count. Otherwise sorted by class name.
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli instance create --help`:
@@ -1090,7 +1090,7 @@ Help text for ``pywbemcli instance create`` (see :ref:`instance create command`)
                                       parameters. Default: Do not prompt for confirmation.
 
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli instance delete --help`:
@@ -1118,9 +1118,9 @@ Help text for ``pywbemcli instance delete`` (see :ref:`instance delete command`)
 
       -n, --namespace NAMESPACE  Namespace to use for this command, instead of the default namespace of the connection.
       --hi, --help-instancename  Show help message for specifying INSTANCENAME including use of the --key and --namespace
-                                 options and exit.
+                                 options.
 
-      -h, --help                 Show this message and exit.
+      -h, --help                 Show this help message.
 
 
 .. _`pywbemcli instance enumerate --help`:
@@ -1185,7 +1185,7 @@ Help text for ``pywbemcli instance enumerate`` (see :ref:`instance enumerate com
 
       --fql, --filter-query-language QUERY-LANGUAGE
                                       The filter query language to be used with --filter-query. Default: DMTF:FQL.
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli instance get --help`:
@@ -1233,9 +1233,9 @@ Help text for ``pywbemcli instance get`` (see :ref:`instance get command`):
 
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
-                                      --namespace options and exit.
+                                      --namespace options.
 
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli instance invokemethod --help`:
@@ -1282,9 +1282,9 @@ Help text for ``pywbemcli instance invokemethod`` (see :ref:`instance invokemeth
 
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
-                                      --namespace options and exit.
+                                      --namespace options.
 
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli instance modify --help`:
@@ -1336,9 +1336,9 @@ Help text for ``pywbemcli instance modify`` (see :ref:`instance modify command`)
 
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
-                                      --namespace options and exit.
+                                      --namespace options.
 
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli instance query --help`:
@@ -1367,7 +1367,7 @@ Help text for ``pywbemcli instance query`` (see :ref:`instance query command`):
                                       The query language to be used with --query. Default: DMTF:CQL.
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       -s, --summary                   Show only a summary (count) of the objects.
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli instance references --help`:
@@ -1435,9 +1435,9 @@ Help text for ``pywbemcli instance references`` (see :ref:`instance references c
       --fql, --filter-query-language QUERY-LANGUAGE
                                       The filter query language to be used with --filter-query. Default: DMTF:FQL.
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
-                                      --namespace options and exit.
+                                      --namespace options.
 
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli instance shrub --help`:
@@ -1493,9 +1493,9 @@ Help text for ``pywbemcli instance shrub`` (see :ref:`instance shrub command`):
                                       paths are displayed.
 
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
-                                      --namespace options and exit.
+                                      --namespace options.
 
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli qualifier --help`:
@@ -1522,7 +1522,7 @@ Help text for ``pywbemcli qualifier`` (see :ref:`qualifier command group`):
       can also be specified before the 'qualifier' keyword.
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
     Commands:
       get        Get a qualifier declaration.
@@ -1553,7 +1553,7 @@ Help text for ``pywbemcli qualifier enumerate`` (see :ref:`qualifier enumerate c
     Command Options:
       -n, --namespace NAMESPACE  Namespace to use for this command, instead of the default namespace of the connection.
       -s, --summary              Show only a summary (count) of the objects.
-      -h, --help                 Show this message and exit.
+      -h, --help                 Show this help message.
 
 
 .. _`pywbemcli qualifier get --help`:
@@ -1579,7 +1579,7 @@ Help text for ``pywbemcli qualifier get`` (see :ref:`qualifier get command`):
 
     Command Options:
       -n, --namespace NAMESPACE  Namespace to use for this command, instead of the default namespace of the connection.
-      -h, --help                 Show this message and exit.
+      -h, --help                 Show this help message.
 
 
 .. _`pywbemcli repl --help`:
@@ -1606,7 +1606,7 @@ Help text for ``pywbemcli repl`` (see :ref:`repl command`):
       Pywbemcli may be terminated from this mode by entering <CTRL-D>, :q, :quit, :exit
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
 
 .. _`pywbemcli server --help`:
@@ -1632,7 +1632,7 @@ Help text for ``pywbemcli server`` (see :ref:`server command group`):
       can also be specified before the 'server' keyword.
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
     Commands:
       namespaces    List the namespaces of the server.
@@ -1663,7 +1663,7 @@ Help text for ``pywbemcli server brand`` (see :ref:`server brand command`):
       the brand information from multiple sources.
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
 
 .. _`pywbemcli server centralinsts --help`:
@@ -1707,7 +1707,7 @@ Help text for ``pywbemcli server centralinsts`` (see :ref:`server centralinsts c
 
       --rd, --reference-direction [snia|dmtf]
                                       Navigation direction for association.  [default: dmtf]
-      -h, --help                      Show this message and exit.
+      -h, --help                      Show this help message.
 
 
 .. _`pywbemcli server info --help`:
@@ -1729,7 +1729,7 @@ Help text for ``pywbemcli server info`` (see :ref:`server info command`):
       The information includes CIM namespaces and server brand.
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
 
 .. _`pywbemcli server interop --help`:
@@ -1749,7 +1749,7 @@ Help text for ``pywbemcli server interop`` (see :ref:`server interop command`):
       Get the Interop namespace of the server.
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
 
 .. _`pywbemcli server namespaces --help`:
@@ -1769,7 +1769,7 @@ Help text for ``pywbemcli server namespaces`` (see :ref:`server namespaces comma
       List the namespaces of the server.
 
     Command Options:
-      -h, --help  Show this message and exit.
+      -h, --help  Show this help message.
 
 
 .. _`pywbemcli server profiles --help`:
@@ -1800,5 +1800,5 @@ Help text for ``pywbemcli server profiles`` (see :ref:`server profiles command`)
     Command Options:
       -o, --organization ORG-NAME  Filter by the defined organization. (ex. -o DMTF
       -p, --profile PROFILE-NAME   Filter by the profile name. (ex. -p Array
-      -h, --help                   Show this message and exit.
+      -h, --help                   Show this help message.
 

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -35,7 +35,7 @@ from ._common import display_cim_objects, filter_namelist, \
 from ._common_options import add_options, propertylist_option, \
     names_only_option, include_classorigin_class_option, namespace_option,  \
     summary_option, multiple_namespaces_option, association_filter_option, \
-    indication_filter_option, experimental_filter_option
+    indication_filter_option, experimental_filter_option, help_option
 from ._displaytree import display_class_tree
 from ._click_extensions import PywbemcliGroup, PywbemcliCommand
 
@@ -80,6 +80,7 @@ local_only_class_option = [              # pylint: disable=invalid-name
 
 @cli.group('class', cls=PywbemcliGroup, options_metavar=GENERAL_OPTS_TXT,
            subcommand_metavar=SUBCMD_HELP_TXT)
+@add_options(help_option)
 def class_group():
     """
     Command group for CIM classes.
@@ -109,6 +110,7 @@ def class_group():
 @add_options(association_filter_option)
 @add_options(indication_filter_option)
 @add_options(experimental_filter_option)
+@add_options(help_option)
 @click.pass_obj
 def class_enumerate(context, classname, **options):
     """
@@ -148,6 +150,7 @@ def class_enumerate(context, classname, **options):
 @add_options(include_classorigin_class_option)
 @add_options(propertylist_option)
 @add_options(namespace_option)
+@add_options(help_option)
 @click.pass_obj
 def class_get(context, classname, **options):
     """
@@ -180,6 +183,7 @@ def class_get(context, classname, **options):
                    'Some servers may still reject the class deletion. '
                    'Default: Reject command if the class has any instances.')
 @add_options(namespace_option)
+@add_options(help_option)
 @click.pass_obj
 def class_delete(context, classname, **options):
     """
@@ -218,6 +222,7 @@ def class_delete(context, classname, **options):
                    'May be specified multiple times. '
                    'Default: No input parameters.')
 @add_options(namespace_option)
+@add_options(help_option)
 @click.pass_obj
 def class_invokemethod(context, classname, methodname, **options):
     """
@@ -264,6 +269,7 @@ def class_invokemethod(context, classname, methodname, **options):
 @add_options(names_only_option)
 @add_options(namespace_option)
 @add_options(summary_option)
+@add_options(help_option)
 @click.pass_obj
 def class_references(context, classname, **options):
     """
@@ -317,6 +323,7 @@ def class_references(context, classname, **options):
 @add_options(names_only_option)
 @add_options(namespace_option)
 @add_options(summary_option)
+@add_options(help_option)
 @click.pass_obj
 def class_associators(context, classname, **options):
     """
@@ -356,6 +363,7 @@ def class_associators(context, classname, **options):
 @add_options(association_filter_option)
 @add_options(indication_filter_option)
 @add_options(experimental_filter_option)
+@add_options(help_option)
 @click.pass_obj
 def class_find(context, classname_glob, **options):
     """
@@ -396,6 +404,7 @@ def class_find(context, classname_glob, **options):
               help='Show the superclass hierarchy. '
                    'Default: Show the subclass hierarchy.')
 @add_options(namespace_option)
+@add_options(help_option)
 @click.pass_obj
 def class_tree(context, classname, **options):
     """

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -34,6 +34,7 @@ from .pywbemcli import cli
 from ._common import CMD_OPTS_TXT, GENERAL_OPTS_TXT, \
     SUBCMD_HELP_TXT, pick_one_from_list, format_table, \
     raise_pywbem_error_exception, validate_output_format
+from ._common_options import add_options, help_option
 from ._pywbem_server import PywbemServer
 from ._connection_repository import ConnectionRepository
 from ._context_obj import ContextObj
@@ -42,6 +43,7 @@ from ._click_extensions import PywbemcliGroup, PywbemcliCommand
 
 @cli.group('connection', cls=PywbemcliGroup, options_metavar=GENERAL_OPTS_TXT,
            subcommand_metavar=SUBCMD_HELP_TXT)
+@add_options(help_option)
 def connection_group():
     """
     Command group for WBEM connection definitions.
@@ -61,6 +63,7 @@ def connection_group():
 
 @connection_group.command('export', cls=PywbemcliCommand,
                           options_metavar=CMD_OPTS_TXT)
+@add_options(help_option)
 @click.pass_obj
 def connection_export(context):
     """
@@ -85,6 +88,7 @@ def connection_export(context):
               default=False,
               help='If set, show existing password in results. Otherwise, '
                    'password is masked')
+@add_options(help_option)
 @click.pass_obj
 def connection_show(context, name, **options):
     """
@@ -125,6 +129,7 @@ def connection_show(context, name, **options):
 @connection_group.command('delete', cls=PywbemcliCommand,
                           options_metavar=CMD_OPTS_TXT)
 @click.argument('name', type=str, metavar='NAME', required=False)
+@add_options(help_option)
 @click.pass_obj
 def connection_delete(context, name):
     """
@@ -149,6 +154,7 @@ def connection_delete(context, name):
               help='If set, the connection is set to be the default connection '
                    ' in the connections file in addition to setting it as the '
                    'current connection.')
+@add_options(help_option)
 @click.pass_obj
 def connection_select(context, name, **options):
     """
@@ -192,6 +198,7 @@ def connection_select(context, name, **options):
 
 @connection_group.command('test', cls=PywbemcliCommand,
                           options_metavar=CMD_OPTS_TXT)
+@add_options(help_option)
 @click.pass_obj
 def connection_test(context):
     """
@@ -211,6 +218,7 @@ def connection_test(context):
 @connection_group.command('save', cls=PywbemcliCommand,
                           options_metavar=CMD_OPTS_TXT)
 @click.argument('name', type=str, metavar='NAME', required=True)
+@add_options(help_option)
 @click.pass_obj
 def connection_save(context, name):
     """
@@ -237,6 +245,7 @@ def connection_save(context, name):
               default=False,
               help='If set, display the full table. Otherwise display '
                    'a brief view(name, server, mock_server columns).')
+@add_options(help_option)
 @click.pass_obj
 def connection_list(context, **options):
     """

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -39,7 +39,7 @@ from ._common_options import add_options, propertylist_option, \
     names_only_option, include_classorigin_instance_option, namespace_option, \
     summary_option, verify_option, multiple_namespaces_option, \
     association_filter_option, indication_filter_option, \
-    experimental_filter_option
+    experimental_filter_option, help_option
 
 from ._cimvalueformatter import mof_escaped
 
@@ -151,7 +151,7 @@ help_instancename_option = [              # pylint: disable=invalid-name
     click.option('--hi', '--help-instancename', 'help_instancename',
                  is_flag=True, required=False, is_eager=True,
                  help='Show help message for specifying INSTANCENAME including '
-                      'use of the --key and --namespace options and exit.')]
+                      'use of the --key and --namespace options.')]
 
 
 ##########################################################################
@@ -164,6 +164,7 @@ help_instancename_option = [              # pylint: disable=invalid-name
 
 @cli.group('instance', cls=PywbemcliGroup, options_metavar=GENERAL_OPTS_TXT,
            subcommand_metavar=SUBCMD_HELP_TXT)
+@add_options(help_option)
 def instance_group():
     """
     Command group for CIM instances.
@@ -193,6 +194,7 @@ def instance_group():
 @add_options(summary_option)
 @add_options(filter_query_option)
 @add_options(filter_query_language_option)
+@add_options(help_option)
 @click.pass_obj
 def instance_enumerate(context, classname, **options):
     """
@@ -231,6 +233,7 @@ def instance_enumerate(context, classname, **options):
 @add_options(keybinding_key_option)
 @add_options(namespace_option)
 @add_options(help_instancename_option)
+@add_options(help_option)
 @click.pass_obj
 def instance_get(context, instancename, **options):
     """
@@ -261,6 +264,7 @@ def instance_get(context, instancename, **options):
 @add_options(keybinding_key_option)
 @add_options(namespace_option)
 @add_options(help_instancename_option)
+@add_options(help_option)
 @click.pass_obj
 def instance_delete(context, instancename, **options):
     """
@@ -283,6 +287,7 @@ def instance_delete(context, instancename, **options):
 @add_options(property_create_option)
 @add_options(verify_option)
 @add_options(namespace_option)
+@add_options(help_option)
 @click.pass_obj
 def instance_create(context, classname, **options):
     """
@@ -327,6 +332,7 @@ def instance_create(context, classname, **options):
 @add_options(keybinding_key_option)
 @add_options(namespace_option)
 @add_options(help_instancename_option)
+@add_options(help_option)
 @click.pass_obj
 def instance_modify(context, instancename, **options):
     """
@@ -383,6 +389,7 @@ def instance_modify(context, instancename, **options):
 @add_options(filter_query_option)
 @add_options(filter_query_language_option)
 @add_options(help_instancename_option)
+@add_options(help_option)
 @click.pass_obj
 def instance_associators(context, instancename, **options):
     """
@@ -435,6 +442,7 @@ def instance_associators(context, instancename, **options):
 @add_options(filter_query_option)
 @add_options(filter_query_language_option)
 @add_options(help_instancename_option)
+@add_options(help_option)
 @click.pass_obj
 def instance_references(context, instancename, **options):
     """
@@ -482,6 +490,7 @@ def instance_references(context, instancename, **options):
 @add_options(keybinding_key_option)
 @add_options(namespace_option)
 @add_options(help_instancename_option)
+@add_options(help_option)
 @click.pass_obj
 def instance_invokemethod(context, instancename, methodname, **options):
     """
@@ -529,6 +538,7 @@ def instance_invokemethod(context, instancename, methodname, **options):
               format(default=DEFAULT_QUERY_LANGUAGE))
 @add_options(namespace_option)
 @add_options(summary_option)
+@add_options(help_option)
 @click.pass_obj
 def instance_query(context, query, **options):
     """
@@ -554,6 +564,7 @@ def instance_query(context, query, **options):
 @add_options(experimental_filter_option)
 @click.option('-s', '--sort', is_flag=True, required=False,
               help='Sort by instance count. Otherwise sorted by class name.')
+@add_options(help_option)
 @click.pass_obj
 def instance_count(context, classname, **options):
     """
@@ -614,6 +625,7 @@ def instance_count(context, classname, **options):
                    'for all instances and the "CreationClassName" key.  When'
                    'this option is used the full instance paths are displayed.')
 @add_options(help_instancename_option)
+@add_options(help_option)
 @click.pass_obj
 def instance_shrub(context, instancename, **options):
     """

--- a/pywbemtools/pywbemcli/_cmd_qualifier.py
+++ b/pywbemtools/pywbemcli/_cmd_qualifier.py
@@ -30,12 +30,14 @@ from .pywbemcli import cli
 from ._common import display_cim_objects, sort_cimobjects, \
     raise_pywbem_error_exception, validate_output_format, \
     CMD_OPTS_TXT, GENERAL_OPTS_TXT, SUBCMD_HELP_TXT
-from ._common_options import add_options, namespace_option, summary_option
+from ._common_options import add_options, namespace_option, summary_option, \
+    help_option
 from ._click_extensions import PywbemcliGroup, PywbemcliCommand
 
 
 @cli.group('qualifier', cls=PywbemcliGroup, options_metavar=GENERAL_OPTS_TXT,
            subcommand_metavar=SUBCMD_HELP_TXT)
+@add_options(help_option)
 def qualifier_group():
     """
     Command group for CIM qualifier declarations.
@@ -58,6 +60,7 @@ def qualifier_group():
 @click.argument('qualifiername', type=str, metavar='QUALIFIERNAME',
                 required=True,)
 @add_options(namespace_option)
+@add_options(help_option)
 @click.pass_obj
 def qualifier_get(context, qualifiername, **options):
     """
@@ -78,6 +81,7 @@ def qualifier_get(context, qualifiername, **options):
                          options_metavar=CMD_OPTS_TXT)
 @add_options(namespace_option)
 @add_options(summary_option)
+@add_options(help_option)
 @click.pass_obj
 def qualifier_enumerate(context, **options):
     """

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -31,6 +31,7 @@ from pywbem import ValueMapping, Error
 from .pywbemcli import cli
 from ._common import format_table, raise_pywbem_error_exception, \
     validate_output_format, CMD_OPTS_TXT, GENERAL_OPTS_TXT, SUBCMD_HELP_TXT
+from ._common_options import add_options, help_option
 from ._click_extensions import PywbemcliGroup, PywbemcliCommand
 
 # NOTE: A number of the options use double-dash as the short form.  In those
@@ -41,6 +42,7 @@ from ._click_extensions import PywbemcliGroup, PywbemcliCommand
 
 @cli.group('server', cls=PywbemcliGroup, options_metavar=GENERAL_OPTS_TXT,
            subcommand_metavar=SUBCMD_HELP_TXT)
+@add_options(help_option)
 def server_group():
     """
     Command group for WBEM servers.
@@ -58,6 +60,7 @@ def server_group():
 
 @server_group.command('namespaces', cls=PywbemcliCommand,
                       options_metavar=CMD_OPTS_TXT)
+@add_options(help_option)
 @click.pass_obj
 def server_namespaces(context, **options):
     """
@@ -69,6 +72,7 @@ def server_namespaces(context, **options):
 
 @server_group.command('interop', cls=PywbemcliCommand,
                       options_metavar=CMD_OPTS_TXT)
+@add_options(help_option)
 @click.pass_obj
 def server_interop(context):
     """
@@ -80,6 +84,7 @@ def server_interop(context):
 
 @server_group.command('brand', cls=PywbemcliCommand,
                       options_metavar=CMD_OPTS_TXT)
+@add_options(help_option)
 @click.pass_obj
 def server_brand(context):
     """
@@ -95,6 +100,7 @@ def server_brand(context):
 
 @server_group.command('info', cls=PywbemcliCommand,
                       options_metavar=CMD_OPTS_TXT)
+@add_options(help_option)
 @click.pass_obj
 def server_info(context):
     """
@@ -113,6 +119,7 @@ def server_info(context):
 @click.option('-p', '--profile', type=str, metavar='PROFILE-NAME',
               required=False,
               help='Filter by the profile name. (ex. -p Array')
+@add_options(help_option)
 @click.pass_obj
 def server_profiles(context, **options):
     """
@@ -158,6 +165,7 @@ def server_profiles(context, **options):
               default='dmtf',
               show_default=True,
               help='Navigation direction for association.')
+@add_options(help_option)
 @click.pass_obj
 def centralinsts(context, **options):
     """

--- a/pywbemtools/pywbemcli/_common_options.py
+++ b/pywbemtools/pywbemcli/_common_options.py
@@ -113,6 +113,9 @@ experimental_filter_option = [              # pylint: disable=invalid-name
                       'experimental (--no-iexperimental). If the option is not '
                       'defined no filtering occurs')]
 
+help_option = [              # pylint: disable=invalid-name
+    click.help_option('-h', '--help', help='Show this help message.')]
+
 
 def add_options(options):
     """

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -37,6 +37,7 @@ from pywbem import LOGGER_SIMPLE_NAMES, \
 from ._context_obj import ContextObj, display_click_context
 from ._common import GENERAL_OPTS_TXT, SUBCMD_HELP_TXT, TABLE_FORMATS, \
     CIM_OBJECT_OUTPUT_FORMATS
+from ._common_options import add_options, help_option
 from ._pywbem_server import PywbemServer
 from .config import DEFAULT_NAMESPACE, \
     PYWBEMCLI_PROMPT, PYWBEMCLI_HISTORY_FILE, DEFAULT_MAXPULLCNT, \
@@ -246,7 +247,8 @@ CONTEXT_SETTINGS = dict(
                    format(ev=PywbemServer.pdb_envvar))
 @click.version_option(
     message='%(prog)s, version %(version)s\n' + PYWBEM_VERSION,
-    help='Show the version of this command and the pywbem package and exit.')
+    help='Show the version of this command and the pywbem package.')
+@add_options(help_option)
 @click.pass_context
 def cli(ctx, server, svr_name, default_namespace, user, password, timeout,
         verify, certfile, keyfile, ca_certs, output_format, use_pull,
@@ -596,6 +598,7 @@ def cli(ctx, server, svr_name, default_namespace, user, password, timeout,
 
 
 @cli.command('help', options_metavar=GENERAL_OPTS_TXT)
+@add_options(help_option)
 @click.pass_context
 def repl_help(ctx):  # pylint: disable=unused-argument
     """
@@ -622,6 +625,7 @@ The following can be entered in interactive mode:
 
 
 @cli.command('repl', options_metavar=GENERAL_OPTS_TXT)
+@add_options(help_option)
 @click.pass_context
 def repl(ctx):
     """

--- a/tests/unit/common_options_help_lines.py
+++ b/tests/unit/common_options_help_lines.py
@@ -26,7 +26,7 @@ whitespace-tolerant test for whether the expected text is in the actual text.
 # defined with underscore and not dash
 
 CMD_OPTION_HELP_HELP_LINE = \
-    '-h, --help Show this message and exit.'
+    '-h, --help Show this help message.'
 
 CMD_OPTION_VERIFY_HELP_LINE = \
     '-V, --verify Prompt for confirmation before performing a change'

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -142,8 +142,8 @@ General Options:
   --pdb                           Pause execution in the built-in pdb debugger just before executing the command within
                                   pywbemcli. Default: EnvVar PYWBEMCLI_PDB, or false.
 
-  --version                       Show the version of this command and the pywbem package and exit.
-  -h, --help                      Show this message and exit.
+  --version                       Show the version of this command and the pywbem package.
+  -h, --help                      Show this help message.
 
 Commands:
   class       Command group for CIM classes.
@@ -167,7 +167,7 @@ REPL_HELP = """Usage: pywbemcli [GENERAL-OPTIONS] repl
   Pywbemcli may be terminated from this mode by entering <CTRL-D>, :q, :quit, :exit
 
 Command Options:
-  -h, --help  Show this message and exit.
+  -h, --help  Show this help message.
 """  # noqa:E501 pylint: disable=line-too-long
 
 INTERACTIVE_HELP = """


### PR DESCRIPTION
Changes are:

* --version general option:
  - old: "Show the version of this command and the pywbem package and exit."
  - new: "Show the version of this command and the pywbem package."

* -h, --help option at any level:
  - old: "Show this message and exit."
  - new: "Show this help message."

* --hi, --help-instancename command option:
  - old: "Show help message for specifying INSTANCENAME including use of the --key and --namespace options and exit."
  - new: "Show help message for specifying INSTANCENAME including use of the --key and --namespace options."

Unchanged and already consistent:

* help command:
   - COMMAND --help              Show help message for pywbemcli command COMMAND.
    - help                        Show this help message.
    - :?, :h, :help               Show help message about interactive mode.
