### PR TITLE
Fixes #556: connection list table

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -177,6 +177,15 @@ Released: not yet
 
 * Increased minimum version of pywbem to 0.17.0 (See issue #571)
 
+* Add option `--full` to `connection list` to create both a brief table
+  output that only has 3 columns (name, server, mock-server) as default but
+  when the option is set all of the columns currently in the report. We did
+  this because it appears that the most frequent use of this command is to just
+  get the name of the various servers defined within an 80 column display.
+  This also now shows empty columns where the original report hid any columns
+  that were empty. (See issue #556)
+
+
 **Cleanup:**
 
 * Test: Enabled Python warning suppression for PendingDeprecationWarning

--- a/docs/pywbemcli/cmdlineinterface.rst
+++ b/docs/pywbemcli/cmdlineinterface.rst
@@ -30,14 +30,15 @@ The command line can contain the following components:
   on the pywbemcli general options.
 
 * **COMMAND** - A name of a command which may consist of:
-  * <group name> <command name> for those commands that are defined in
-    groups (ex. `class find`).
-  * Just the group name (ex. `class`).
-  * <command name> for those commands that are not part of a group. (``repl``
-    and ``help``) that are not in any command group.
+   * <group name> <command name> for commands that are defined within
+     groups (ex. ``class find``).
+   * <group name> (ex. ``class``) to show group help including list of  command
+     within the group.
+   * <command name> for those commands that are not part of a group. For
+     example ``repl`` and ``help`` that are not in any command group.
 * **ARGS** - Arguments for a command.
-* **COMMAND-OPTIONS** - Command options; they apply only to a particular
-  command.
+* **COMMAND-OPTIONS** - Options that apply only to a particular
+  COMMAND.
 
 
 Options are prefixed with the characters ``-`` for the short form or ``--`` for

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -702,6 +702,9 @@ Help text for ``pywbemcli connection list`` (see :ref:`connection list command`)
       See also the 'connection select' command.
 
     Command Options:
+      -f, --full  If set, display the full table. Otherwise display  a brief view(name, server, mock_server columns). This
+                  table does not show the ca_certs field.
+
       -h, --help  Show this message and exit.
 
 

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -702,9 +702,7 @@ Help text for ``pywbemcli connection list`` (see :ref:`connection list command`)
       See also the 'connection select' command.
 
     Command Options:
-      -f, --full  If set, display the full table. Otherwise display  a brief view(name, server, mock_server columns). This
-                  table does not show the ca_certs field.
-
+      -f, --full  If set, display the full table. Otherwise display a brief view(name, server, mock_server columns).
       -h, --help  Show this message and exit.
 
 

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -1311,7 +1311,7 @@ See :ref:`pywbemcli connection export --help` for the exact help output of the c
 .. _`Connection list command`:
 
 Connection list command
-^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``connection list`` command lists the connection definitions in the
 :term:`connections file` and also the current connection if it has not been
@@ -1331,19 +1331,55 @@ The default connection, if defined, is marked with `#` in the Name column.
     pywbemcli> --server http://localhost --user me --password mypw --no-verify connection save me
 
     pywbemcli> --server http://blahblah connection list
-    WBEM server connections:  (#: default, *: current)
-    +--------------+------------------+-------------+-------------+-----------+----------+----------------------------------------+
-    | name         | server           | namespace   | user        |   timeout | verify   | mock-server                            |
-    |--------------+------------------+-------------+-------------+-----------+----------+----------------------------------------|
-    | *blahblah    | http://blah      | root/cimv2  |             |        45 | False    |                                        |
-    | mock1        |                  | root/cimv2  |             |           | False    | tests/unit/simple_mock_model.mof       |
-    | mockalltypes |                  | root/cimv2  |             |        30 | False    | tests/unit/all_types.mof               |
-    | mockassoc    |                  | root/cimv2  |             |        30 | False    | tests/unit/simple_assoc_mock_model.mof |
-    | mockext      |                  | root/cimv2  |             |        30 | False    | tests/unit/simple_mock_model_ext.mof   |
-    | op           | http://localhost | root/cimv2  | xxxxxxxxxxx |           | False    |                                        |
-    | test3        |                  | root/cimv2  |             |           | False    | tests/unit/simple_mock_model.mof       |
-    |              |                  |             |             |           |          | tests/unit/mock_confirm_y.py           |
-    +--------------+------------------+-------------+-------------+-----------+----------+----------------------------------------+
+    WBEM server connections(brief):  (#: default, *: current)
+    +--------------+------------------+----------------------------------------+
+    | name         | server           | mock-server                            |
+    |--------------+------------------+----------------------------------------|
+    | *blahblah    | http://blah      |                                        |
+    | mock1        |                  | tests/unit/simple_mock_model.mof       |
+    | mockalltypes |                  | tests/unit/all_types.mof               |
+    | mockassoc    |                  | tests/unit/simple_assoc_mock_model.mof |
+    | mockext      |                  | tests/unit/simple_mock_model_ext.mof   |
+    | op           | http://localhost |                                        |
+    | test3        |                  | tests/unit/simple_mock_model.mof       |
+    |              |                  | tests/unit/mock_confirm_y.py           |
+    +--------------+------------------+----------------------------------------+
+
+A more complete display of the server parameters is available with the
+`--full` option as follows:
+
+.. code-block:: text
+
+    pywbemcli> connection list --full
+
+    WBEM server connections(full): (#: default, *: current)
+    +--------------+----------------------+------------------------+-------------+-----------+------------+----------+------------+-----------+--------------------------------------------------+
+    | name         | server               | namespace              | user        |   timeout | use_pull   | verify   | certfile   | keyfile   | mock-server                                      |
+    +==============+======================+========================+=============+===========+============+==========+============+===========+==================================================+
+    | #mockassoc   |                      | root/cimv2             |             |        30 |            | True     |            |           | tests/unit/simple_assoc_mock_model.mof           |
+    +--------------+----------------------+------------------------+-------------+-----------+------------+----------+------------+-----------+--------------------------------------------------+
+    | alltypes     |                      | root/cimv2             |             |        30 |            | True     |            |           | tests/unit/all_types.mof                         |
+    +--------------+----------------------+------------------------+-------------+-----------+------------+----------+------------+-----------+--------------------------------------------------+
+    | complexassoc |                      | root/cimv2             |             |        30 |            | True     |            |           | tests/unit/complex_assoc_model.mof               |
+    +--------------+----------------------+------------------------+-------------+-----------+------------+----------+------------+-----------+--------------------------------------------------+
+    | mock1        |                      | root/cimv2             |             |        30 |            | True     |            |           | tests/unit/simple_mock_model.mof                 |
+    +--------------+----------------------+------------------------+-------------+-----------+------------+----------+------------+-----------+--------------------------------------------------+
+    | mock1ext     |                      | root/cimv2             |             |        30 |            | True     |            |           | tests/unit/simple_mock_model_ext.mof             |
+    +--------------+----------------------+------------------------+-------------+-----------+------------+----------+------------+-----------+--------------------------------------------------+
+    | mock1interop |                      | interop                |             |        30 |            | True     |            |           | tests/unit/simple_mock_model.mof                 |
+    +--------------+----------------------+------------------------+-------------+-----------+------------+----------+------------+-----------+--------------------------------------------------+
+    | ophttp       | http://localhost     | root/cimv2             |             |        30 |            | True     |            |           |                                                  |
+    +--------------+----------------------+------------------------+-------------+-----------+------------+----------+------------+-----------+--------------------------------------------------+
+    | ophttps      | https://localhost    | root/cimv2             | blahblah    |        30 |            | False    |            |           |                                                  |
+    +--------------+----------------------+------------------------+-------------+-----------+------------+----------+------------+-----------+--------------------------------------------------+
+    | opt          | https://blah         | root/cimv2             |             |        45 |            | False    | c1.pem     | k1.pem    |                                                  |
+    +--------------+----------------------+------------------------+-------------+-----------+------------+----------+------------+-----------+--------------------------------------------------+
+    | test1        |                      | root/cimv2             |             |        30 |            | True     |            |           | tests/unit/simple_assoc_mock_model.mof           |
+    +--------------+----------------------+------------------------+-------------+-----------+------------+----------+------------+-----------+--------------------------------------------------+
+
+
+`Connection list` does not display the password or the ca-certs fields.  See
+:ref:`Connection show command` to display these fields.
 
 See :ref:`pywbemcli connection list --help` for the exact help output of the command.
 

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -1378,8 +1378,9 @@ A more complete display of the server parameters is available with the
     +--------------+----------------------+------------------------+-------------+-----------+------------+----------+------------+-----------+--------------------------------------------------+
 
 
-`Connection list` does not display the password or the ca-certs fields.  See
-:ref:`Connection show command` to display these fields.
+`Connection list` does not display some fields such as the ca-certs field.  See
+:ref:`Connection show command` for more detailed display of individual fields
+used by the server.
 
 See :ref:`pywbemcli connection list --help` for the exact help output of the command.
 

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -236,8 +236,7 @@ def connection_save(context, name):
 @click.option('-f', '--full', is_flag=True,
               default=False,
               help='If set, display the full table. Otherwise display '
-                   ' a brief view(name, server, mock_server columns). '
-                   'This table does not show the ca_certs field.')
+                   'a brief view(name, server, mock_server columns).')
 @click.pass_obj
 def connection_list(context, **options):
     """

--- a/tests/unit/test_connection_cmds.py
+++ b/tests/unit/test_connection_cmds.py
@@ -72,6 +72,7 @@ CONNECTION_EXPORT_HELP_LINES = [
 CONNECTION_LIST_HELP_LINES = [
     'Usage: pywbemcli [GENERAL-OPTIONS] connection list [COMMAND-OPTIONS]',
     'List the WBEM connection definitions.',
+    '-f, --full  If set, display the full table. Otherwise display  a brief',
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
@@ -224,7 +225,7 @@ TEST_CASES = [
      {'general': ['-o', 'simple'],
       'args': ['list']},
      {'stdout': [
-         "WBEM server connections:", ""],
+         "WBEM server connections(brief):", ""],
       'test': 'innows'},
      None, OK],
 
@@ -327,12 +328,15 @@ TEST_CASES = [
     ['Verify connection command list with 2 servers defined',
      {'general': ['--output-format', 'plain'],
       'args': ['list']},
-     {'stdout': ['WBEM server connections:',
-                 'name server namespace user timeout verify',
-                 "test1 http://blah root/cimv2 30  True",
-                 "test2 http://blahblah  root/cimv2 fred 18  False"],
+     {'stdout': ['WBEM server connections(brief): (#: default, *: current)',
+                 'name    server           mock-server',
+                 'test1   http://blah',
+                 'test2   http://blahblah'],
       'test': 'innows'},
      None, OK],
+
+
+
 
     ['Verify connection command select test2',
      ['select', 'test2', '--default'],
@@ -363,11 +367,45 @@ TEST_CASES = [
      'next pywbemcli call',
      {'general': ['--output-format', 'plain'],
       'args': ['list']},
-     {'stdout': ['WBEM server connections:',
-                 '(#: default, *: current)',
-                 'name    server          namespace  user timeout verify',
-                 'test1   http://blah     root/cimv2           30   True',
-                 '*#test2 http://blahblah root/cimv2 fred      18  False', ],
+     {'stdout': ['WBEM server connections(brief): (#: default, *: current)',
+                 'name     server           mock-server',
+                 '*#test2  http://blahblah',
+                 'test1    http://blah'],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection command list with 2 servers defined, not sel after '
+     'next pywbemcli call',
+     {'general': ['--output-format', 'plain'],
+      'args': ['list']},
+     {'stdout': ['WBEM server connections(brief): (#: default, *: current)',
+                 'name    server           mock-server',
+                 'test1   http://blah',
+                 'test2   http://blahblah'],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection command list with 2 servers defined, not sel after '
+     'next pywbemcli call --full',
+     {'general': ['--output-format', 'plain'],
+      'args': ['list', '--full']},
+     {'stdout': ['WBEM server connections(full): (#: default, *: current)',
+                 'name   server namespace  user  timeout  use_pull  verify  '
+                 'certfile  keyfile  mock-server',
+                 '*#test2  http://blahblah  root/cimv2 fred 18 False',
+                 'test1  http://blah  root/cimv2 30  True'],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify connection command list with 2 servers defined, not sel after '
+     'next pywbemcli call -f',
+     {'general': ['--output-format', 'plain'],
+      'args': ['list', '-f']},
+     {'stdout': ['WBEM server connections(full): (#: default, *: current)',
+                 'name   server namespace  user  timeout  use_pull  verify  '
+                 'certfile  keyfile  mock-server',
+                 '*#test2  http://blahblah  root/cimv2 fred 18 False',
+                 'test1  http://blah  root/cimv2 30  True'],
       'test': 'innows'},
      None, OK],
 
@@ -395,7 +433,7 @@ TEST_CASES = [
      {'general': ['-o', 'simple'],
       'args': ['list']},
      {'stdout': [
-         "WBEM server connections:", ""],
+         "WBEM server connections(brief):", ""],
       'test': 'innows',
       'file': {'before': 'none', 'after': 'none'}},
      None, OK],
@@ -741,8 +779,8 @@ TEST_CASES = [
     ['Verify connection list with current server from general options, plain',
      {'args': ['list'],
       'general': ['--server', 'http://blah', '--output-format', 'plain']},
-     {'stdout': ['WBEM server connections: (#: default, *: current)',
-                 '*not-saved http://blah root/cimv2  30 True'],
+     {'stdout': ['WBEM server connections(brief): (#: default, *: current)',
+                 '*not-saved http://blah'],
       'test': 'innows',
       'file': {'before': 'none', 'after': 'none'}},
      None, OK],
@@ -767,13 +805,13 @@ TEST_CASES = [
      {'args': ['list'],
       'general': ['--output-format', 'table', '--server', 'http://blah']},
      {'stdout': """
-WBEM server connections: (#: default, *: current)
-+------------+-------------+-------------+-----------+----------+
-| name       | server      | namespace   |   timeout | verify   |
-|------------+-------------+-------------+-----------+----------|
-| *not-saved | http://blah | root/cimv2  |        30 | True     |
-| svrtest    | http://blah | root/cimv2  |        30 | True     |
-+------------+-------------+-------------+-----------+----------+
+WBEM server connections(brief): (#: default, *: current)
++------------+-------------+---------------+
+| name       | server      | mock-server   |
+|------------+-------------+---------------|
+| *not-saved | http://blah |               |
+| svrtest    | http://blah |               |
++------------+-------------+---------------+
 """,
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'exists'}},


### PR DESCRIPTION
1. Create new connection list table with only 3 columns.  and flag in connection list to select the full table

2. Remove the hide-empty-rows from the current  table output which is the --full table.

Add tests and modify doc