### PR TITLE
Fixes #598: add-index-entries

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -232,6 +232,10 @@ Released: 2020-04-10
 * Added documentation on incremental search option to search the command
   history file in interactive mode. (See issue #595)
 
+* Added documentation index entries for commands, command groups, etc. (see
+  issue #598)
+
+
 
 pywbemtools 0.5.0
 -----------------

--- a/docs/pywbemcli/cmdlineinterface.rst
+++ b/docs/pywbemcli/cmdlineinterface.rst
@@ -14,8 +14,8 @@
 ..
 
 .. index::
-    single; pywbemcli command line interface
-    single; command line interface
+    single: pywbemcli command line interface
+    single: command line interface
 
 .. _`Pywbemcli command line interface`:
 
@@ -58,7 +58,7 @@ Options are prefixed with the characters ``-`` for the short form or ``--`` for
 the long form (ex. ``-n`` or ``--namespace``). The other components do not
 begin with ``-``.
 
-.. index:: pair command groups; command interface
+.. index:: pair: command groups; command interface
 
 Command groups are named after the objects the commands operate on
 (ex. ``class``, ``instance``, ``qualifier``, ``server``). Executing

--- a/docs/pywbemcli/cmdlineinterface.rst
+++ b/docs/pywbemcli/cmdlineinterface.rst
@@ -13,6 +13,10 @@
 .. limitations under the License.
 ..
 
+.. index::
+    single; pywbemcli command line interface
+    single; command line interface
+
 .. _`Pywbemcli command line interface`:
 
 Pywbemcli command line interface
@@ -25,9 +29,13 @@ Pywbemcli provides a command line interface(CLI) interaction with WBEM servers.
 
 The command line can contain the following components:
 
+.. index:: pair: General Options; command components
+
 * **GENERAL-OPTIONS** - General options; they apply to all commands.
   See :ref:`Using the pywbemcli command line general options` for information
   on the pywbemcli general options.
+
+.. index:: pair: command components; command components
 
 * **COMMAND** - A name of a command which may consist of:
    * <group name> <command name> for commands that are defined within
@@ -36,14 +44,21 @@ The command line can contain the following components:
      within the group.
    * <command name> for those commands that are not part of a group. For
      example ``repl`` and ``help`` that are not in any command group.
+
+.. index:: pair: command arguments; command components
+
 * **ARGS** - Arguments for a command.
+
+.. index:: pair: command interface; Command Options
+
 * **COMMAND-OPTIONS** - Options that apply only to a particular
   COMMAND.
-
 
 Options are prefixed with the characters ``-`` for the short form or ``--`` for
 the long form (ex. ``-n`` or ``--namespace``). The other components do not
 begin with ``-``.
+
+.. index:: pair command groups; command interface
 
 Command groups are named after the objects the commands operate on
 (ex. ``class``, ``instance``, ``qualifier``, ``server``). Executing
@@ -74,14 +89,14 @@ the MOF output format. The option ``--output-format`` is a general option
 and ``--namespace`` is a command option.
 
 .. index::
-   single: tab-completion
-   single: auto-completion
+   pair: tab-completion; auto-completion
    single: auto-suggestion
 
 Pywbemcli supports several modes of tab-completion, auto-completion suggestions
 depending on whether it is in command or interactive mode. This is detailed
 in the following sections.
 
+.. index:: single: Modes of operation
 
 .. _`Modes of operation`:
 
@@ -94,6 +109,8 @@ Pywbemcli supports two modes of operation:
 * `Interactive mode`_: Invoking an interactive pywbemcli shell for typing
   pywbemcli commands.
 
+.. index:: pair: interactive mode; command modes
+.. index:: pair: interactive mode; modes of operation
 
 .. _`Command mode`:
 
@@ -159,6 +176,8 @@ for its command line handling. See
 `Bash Complete in the Click documentation <https://click.palletsprojects.com/en/7.x/bashcomplete/>`_
 for additional features of the Bash tab completion of pywbemcli.
 
+.. index:: pair: interactive mode; command modes
+.. index:: pair: interactive mode; modes of operation
 
 .. _`Interactive mode`:
 
@@ -364,6 +383,7 @@ starting with the given text, the completion will be shown as gray text behind
 the current input. Pressing the right arrow → or c-e will insert this
 suggestion.
 
+.. index:: pair: Error handling; exit codes
 
 .. _`Error handling`:
 
@@ -384,8 +404,8 @@ Pywbemcli terminates with one of the following program exit codes:
 
   Examples for errors reported that way:
 
-  * Local system issues, e.g. pywbemcli history file or connections file cannot
-    be written to.
+  * Local system issues, e.g. pywbemcli history file or term:`connections file`
+    cannot be written to.
 
   * WBEM server access issues, e.g. pywbemcli cannot connect to or authenticate
     with the WBEM server. This includes CIM errors about failed authentication

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -28,6 +28,7 @@ commands, see :ref:`Pywbemcli command line interface`.
 **NOTE:** Many of the examples below use the :ref:`--mock-server general option`
 with mock files that are located in the pywbemtools ``tests/unit`` subdirectory.
 
+.. index:: pair: command groups; class commands
 
 .. _`Class command group`:
 
@@ -47,6 +48,9 @@ The ``class`` command group has commands that act on CIM classes:
 
 See :ref:`pywbemcli class --help`.
 
+.. index::
+    pair: class commands; class associators
+    single: associators; class
 
 .. _`Class associators command`:
 
@@ -65,8 +69,8 @@ displayed, using :term:`CIM object output formats` or
 :term:`Table output formats`. Otherwise, the class definition is displayed,
 using :term:`CIM object output formats`.
 
-Note: This command returns the class associators, not the instance associators.
-The :ref:`Instance associators command` returns the instance associators.
+Note: This command returns class associations. The :ref:`Instance associators
+command` returns instance associations.
 
 Example:
 
@@ -77,6 +81,8 @@ Example:
 
 See :ref:`pywbemcli class associators --help` for the exact help output of the command.
 
+.. index:: pair: class commands; class delete
+.. index:: delete classes; class commands
 
 .. _`Class delete command`:
 
@@ -109,6 +115,7 @@ Example:
 
 See :ref:`pywbemcli class delete --help` for the exact help output of the command.
 
+.. index:: pair: class commands; class enumerate
 
 .. _`Class enumerate command`:
 
@@ -117,6 +124,8 @@ Class enumerate command
 
 The ``class enumerate`` command enumerates the subclasses of the specified
 class, or the root classes of the class hierarchy.
+
+.. index:: pair: CLASSNAME argument; class enumerate
 
 If the ``CLASSNAME`` argument is specified, the command enumerates the
 subclasses of the class named with the ``CLASSNAME`` argument in the
@@ -158,6 +167,8 @@ default namespace:
 
 See :ref:`pywbemcli class enumerate --help` for the exact help output of the command.
 
+.. index:: pair: class commands; class find
+.. index:: pair: find command; class group
 
 .. _`Class find command`:
 
@@ -170,7 +181,7 @@ argument in all namespaces of the connection, or otherwise in the specified
 namespaces if the ``-namespace``/``-n`` command option is specified one or more
 times.
 
-.. index:: qualifier filters
+.. index:: pair: qualifier filters; class find command
 
 The ``--association``/``--no-association``, ``--indication``/``--no-indication``,
 and ``--experimental``/``--no-experimental`` options filter the returned
@@ -226,6 +237,7 @@ The command displays the namespaces and class names of the result using the
 
 See :ref:`pywbemcli class find --help` for the exact help output of the command.
 
+.. index:: pair: class commands; class get
 
 .. _`Class get command`:
 
@@ -283,6 +295,7 @@ The following example shows getting the MOF representation of the class
 
 See :ref:`pywbemcli class get --help` for the exact help output of the command.
 
+.. index:: pair: class commands; class invokemethod
 
 .. _`Class invokemethod command`:
 
@@ -318,6 +331,7 @@ Example:
 
 See :ref:`pywbemcli class invokemethod --help` for the exact help output of the command.
 
+.. index:: pair: class commands; class references
 
 .. _`Class references command`:
 
@@ -347,6 +361,7 @@ The :ref:`Instance references command` returns the instance references.
 
 See :ref:`pywbemcli class references --help` for the exact help output of the command.
 
+.. index:: pair: class commands; class tree
 
 .. _`Class tree command`:
 
@@ -383,6 +398,7 @@ Example:
 
 See :ref:`pywbemcli class tree --help` for the exact help output of the command.
 
+.. index:: pair: command groups; instance commands
 
 .. _`Instance command group`:
 
@@ -405,6 +421,9 @@ The ``instance`` command group has commands that act on CIM instances:
 
 See :ref:`pywbemcli instance --help`.
 
+.. index::
+    pair: instance commands; instance associators
+    single: associators; instance
 
 .. _`Instance associators command`:
 
@@ -448,6 +467,7 @@ Example:
 
 See :ref:`pywbemcli instance associators --help` for the exact help output of the command.
 
+.. index:: pair: instance commands; instance count
 
 .. _`Instance count command`:
 
@@ -470,8 +490,7 @@ match the specified :term:`Unix-style path name pattern` are counted. If the
 ``CLASSNAME-GLOB`` argument is not specified all instances of all classes in
 the target namespaces are counted.
 
-.. index::
-   single: qualifier filters
+.. index:: pair: qualifier filters; instance count command
 
 The ``--association``/``--no-association``, ``--indication``/``--no-indication``,
 and ``--experimental``/``--no-experimental`` options filter the returned
@@ -510,6 +529,7 @@ instances for each class.
 
 See :ref:`pywbemcli instance count --help` for the exact help output of the command.
 
+.. index:: pair: instance commands; instance create
 
 .. _`Instance create command`:
 
@@ -543,6 +563,7 @@ scalar and one array property:
 
 See :ref:`pywbemcli instance create --help` for the exact help output of the command.
 
+.. index:: pair: instance commands; instance delete
 
 .. _`Instance delete command`:
 
@@ -564,6 +585,7 @@ escape the double quote on the terminal:
 
 See :ref:`pywbemcli instance delete --help` for the exact help output of the command.
 
+.. index:: pair: instance commands; instance enumerate
 
 .. _`Instance enumerate command`:
 
@@ -602,6 +624,7 @@ The following example returns two instances as MOF:
 
 See :ref:`pywbemcli instance enumerate --help` for the exact help output of the command.
 
+.. index:: pair: instance commands; instance get
 
 .. _`Instance get command`:
 
@@ -645,6 +668,7 @@ or using the keys wildcard:
 
 See :ref:`pywbemcli instance get --help` for the exact help output of the command.
 
+.. index:: pair: instance commands; instance invokemethod
 
 .. _`Instance invokemethod command`:
 
@@ -691,6 +715,7 @@ Or using the wildcard to create a selection list for the instance names
 
 See :ref:`pywbemcli instance invokemethod --help` for the exact help output of the command.
 
+.. index:: pair: instance commands; instance modify
 
 .. _`Instance modify command`:
 
@@ -731,6 +756,7 @@ scalar and one array property:
 
 See :ref:`pywbemcli instance modify --help` for the exact help output of the command.
 
+.. index:: pair: instance commands; instance references
 
 .. _`Instance references command`:
 
@@ -765,6 +791,7 @@ Example:
 
 See :ref:`pywbemcli instance references --help` for the exact help output of the command.
 
+.. index:: pair: instance commands; instance query
 
 .. _`Instance query command`:
 
@@ -785,6 +812,8 @@ Valid output formats are :term:`CIM object output formats` or
 :term:`Table output formats`.
 
 See :ref:`pywbemcli instance query --help` for the exact help output of the command.
+
+.. index:: pair: instance commands; instance shrub
 
 .. _`Instance shrub command`:
 
@@ -889,8 +918,9 @@ Example:
     |           |                   |              |                    | InstanceID=8(refinst:2) |
     +-----------+-------------------+--------------+--------------------+-------------------------+
 
+.. index:: pair: command groups; qualifier commands
 
-.. _`qualifier command group`:
+.. _`Qualifier command group`:
 
 Qualifier command group
 -----------------------
@@ -902,6 +932,7 @@ declarations:
 * :ref:`qualifier enumerate command` - List the qualifier declarations in a
   namespace.
 
+.. index:: pair: qualifier commands; qualifier get
 
 .. _`Qualifier get command`:
 
@@ -929,6 +960,7 @@ default namespace:
 
 See :ref:`pywbemcli qualifier get --help` for the exact help output of the command.
 
+.. index:: pair: qualifier commands; qualifier enumerate
 
 .. _`Qualifier enumerate command`:
 
@@ -969,6 +1001,7 @@ namespace as a table:
 
 See :ref:`pywbemcli qualifier enumerate --help` for the exact help output of the command.
 
+.. index:: pair: command groups; server commands
 
 .. _`Server command group`:
 
@@ -986,6 +1019,7 @@ WBEM server itself:
 * :ref:`Server namespaces command` - List the namespaces of the server.
 * :ref:`Server profiles command` - List management profiles advertized by the server.
 
+.. index:: pair: server commands; server brand
 
 .. _`Server brand command`:
 
@@ -1016,6 +1050,7 @@ Example:
 
 See :ref:`pywbemcli server brand --help` for the exact help output of the command.
 
+.. index:: pair: server commands; server info
 
 .. _`Server info command`:
 
@@ -1061,6 +1096,7 @@ Example:
 
 See :ref:`pywbemcli server info --help` for the exact help output of the command.
 
+.. index:: pair: server commands; server interop
 
 .. _`Server interop command`:
 
@@ -1086,6 +1122,7 @@ Example:
 
 See :ref:`pywbemcli server interop --help` for the exact help output of the command.
 
+.. index:: pair: server commands; server namespaces
 
 .. _`Server namespaces command`:
 
@@ -1118,6 +1155,7 @@ Example:
 
 See :ref:`pywbemcli server namespaces --help` for the exact help output of the command.
 
+.. index:: pair: server commands; server profiles
 
 .. _`Server profiles command`:
 
@@ -1166,6 +1204,7 @@ Example:
 
 See :ref:`pywbemcli server profiles --help` for the exact help output of the command.
 
+.. index:: pair: server commands; server centralinsts
 
 .. _`Server centralinsts command`:
 
@@ -1198,6 +1237,7 @@ Example:
 
 See :ref:`pywbemcli server centralinsts --help` for the exact help output of the command.
 
+.. index:: pair: command groups;connection commands
 
 .. _`Connection command group`:
 
@@ -1207,9 +1247,14 @@ Connection command group
 The ``connection`` command group has commands that manage named connection
 definitions that are persisted in a :term:`connections file`.
 This allows maintaining multiple connection definitions and then using any
-one via the :ref:`--name general option`.
+one via the :ref:`--name general option`. Only a single connection is
+active (selected) at any point in time but the connection connection can
+be selected on the pywbemcli command line (:ref:`--name general option`) or
+changed within an interactive session using the :ref:`Connection select command`
 
-The attributes of each connection definition in the connections file are:
+.. index:: pair: connections file; persistent connection attributes
+
+The attributes of each connection definition in the :term:`connections file` are:
 
 * **name** - name of the connection definition. See :ref:`--name general option`.
 * **server** - URL of the WBEM server, or None if the connection definition is
@@ -1217,6 +1262,8 @@ The attributes of each connection definition in the connections file are:
 * **default-namespace** - default namespace for the WBEM server. See :ref:`--default-namespace general option`.
 * **user** - user name for the WBEM server. See :ref:`--user general option`.
 * **password** - password for the WBEM server. See :ref:`--password general option`.
+* **use-pull** - determines whether the pull operations are to be used for
+  the WBEM server. See :ref:`--use-pull general option`.
 * **verify** - a boolean flag controlling whether the pywbem client verifies
   any certificate received from the WBEM server. See :ref:`--verify general option`.
 * **certfile** - path name of the server certificate file. See :ref:`--certfile general option`.
@@ -1236,6 +1283,7 @@ The commands in this group are:
 * :ref:`Connection show command` - Show connection info of a WBEM connection definition.
 * :ref:`Connection test command` - Test the current connection with a predefined WBEM request.
 
+.. index:: pair: connection commands; connection delete
 
 .. _`Connection delete command`:
 
@@ -1271,6 +1319,7 @@ Example that deletes a connection definition by selecting it:
 
 See :ref:`pywbemcli connection delete --help` for the exact help output of the command.
 
+.. index:: pair: connection commands; connection export
 
 .. _`Connection export command`:
 
@@ -1305,6 +1354,7 @@ as follows:
 
 See :ref:`pywbemcli connection export --help` for the exact help output of the command.
 
+.. index:: pair: connection commands; connection list
 
 .. _`Connection list command`:
 
@@ -1382,6 +1432,7 @@ used by the server.
 
 See :ref:`pywbemcli connection list --help` for the exact help output of the command.
 
+.. index:: pair: connection commands; connection save
 
 .. _`Connection save command`:
 
@@ -1397,6 +1448,7 @@ without notice.
 
 See :ref:`pywbemcli connection save --help` for the exact help output of the command.
 
+.. index:: pair: connection commands; connection select
 
 .. _`Connection select command`:
 
@@ -1457,6 +1509,7 @@ mode of pywbemcli:
 
 See :ref:`pywbemcli connection select --help` for the exact help output of the command.
 
+.. index:: pair: connection commands; connection show
 
 .. _`Connection show command`:
 
@@ -1491,6 +1544,7 @@ The ``connection show`` command shows information about a connection definition:
 
 See :ref:`pywbemcli connection show --help` for the exact help output of the command.
 
+.. index:: pair: connection commands; connection test
 
 .. _`Connection test command`:
 
@@ -1519,6 +1573,7 @@ and ``--password`` and executes the test with successful result:
 
 See :ref:`pywbemcli connection test --help` for the exact help output of the command.
 
+.. index:: pair: repl; command
 
 .. _`Repl command`:
 
@@ -1528,6 +1583,7 @@ Repl command
 .. index::
     single: repl command
     pair: command; repl
+    pair: repl; interactive mode
 
 The ``repl`` command sets pywbemcli into the :ref:`interactive mode`. Pywbemcli
 can be started in the :ref:`interactive mode` either by entering:
@@ -1561,6 +1617,7 @@ the currently shown command.
 see :ref:`interactive mode` for more details on using this mode and the
 search.
 
+.. index:: pair: help; command
 
 .. _`Help command`:
 

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -82,7 +82,7 @@ Example:
 See :ref:`pywbemcli class associators --help` for the exact help output of the command.
 
 .. index:: pair: class commands; class delete
-.. index:: delete classes; class commands
+.. index:: pair: delete classes; class commands
 
 .. _`Class delete command`:
 

--- a/docs/pywbemcli/generaloptions.rst
+++ b/docs/pywbemcli/generaloptions.rst
@@ -3,6 +3,7 @@
 Using the pywbemcli command line general options
 ------------------------------------------------
 
+.. index:: single: general options
 
 .. _`Oveview of the general options`:
 
@@ -74,6 +75,7 @@ specified in the command line invocation:
     |             |         |         |         | REFERENCE | ToSubclass      |
     +-------------+---------+---------+---------+-----------+-----------------+
 
+.. index:: pair WBEM server; defining the WBEM server
 
 .. _`Defining the WBEM server`:
 
@@ -104,7 +106,7 @@ the following arguments :
    * The :ref:`--timeout general option` defines the client side timeout
      for operations.
 
-2. Define a mock WBEM server by using the :ref:`--mock-server general option`.
+2. Define a mock WBEM server () by using the :ref:`--mock-server general option`.
 
    The mock WBEM server is part of pywbemcli and allows testing or
    demonstrating pywbemcli without having access to a real WBEM server.
@@ -143,6 +145,8 @@ operations executed against the WBEM server, either the APIs executed in pywbem,
 or the HTTP requests and responses and the time statistics for these
 operations.
 
+.. index:: single: --log
+
 The :ref:`--log general option` provides the capability to log information about
 this flow including:
 
@@ -171,6 +175,7 @@ file ``pywbemcli.log``:
        </CIM>
    . . .
 
+.. index:: pair: controlling output format; output format
 
 .. _`Controlling output formats`:
 
@@ -205,6 +210,7 @@ General options descriptions
 This section defines in detail the requirements, characteristics, and any special
 syntax of each general option.
 
+.. index:: triple: --server; general options; server
 
 .. _`--server general option`:
 
@@ -243,6 +249,7 @@ Examples for the argument value of this option include:
     https://10.2.3.9              # https, port 5989, IPv4 address 10.2.3.9
     http://[2001:db8::1234-eth0]  # http, port 5988, IPv6 address 2001:db8::1234, interface eth0
 
+.. index:: triple: --name; general options; name
 
 .. _`--name general option`:
 
@@ -275,6 +282,7 @@ in the connections file, and then uses that connection to execute
 See :ref:`Connection command group` for more information on managing
 connections.
 
+.. index:: triple: --default-namespace; general options; default-namespace
 
 .. _`--default-namespace general option`:
 
@@ -302,6 +310,7 @@ the ``class find`` command.
 The argument value of the ``--user``/``-u`` general option is a string that is
 the user name for authenticating with the WBEM server.
 
+.. index:: triple: --password; general options; password
 
 .. _`--password general option`:
 
@@ -375,6 +384,7 @@ any subsequent pywbemcli commands:
     $ pywbemcli server namespaces
     . . . <list of namespaces for the defined server>
 
+.. index:: triple: --timeout; general options; timeout
 
 .. _`--timeout general option`:
 
@@ -388,6 +398,7 @@ that closes a WBEM connection if there is no response to a request to the WBEM
 server in the time defined by this value. Pywbemcli defaults to a
 predefined timeout (normally 30 seconds) if this option is not defined.
 
+.. index:: triple: --verify; general options; verify
 
 .. _`--verify general option`:
 
@@ -405,6 +416,7 @@ This general option uses the approach with two long option names to allow the
 user to specifically enable or disable certificate verification when this
 general option is used in interactive mode.
 
+.. index:: triple: --certfile; general options; certfile
 
 .. _`--certfile general option`:
 
@@ -422,6 +434,7 @@ resulting in 1-way authentication during the TLS/SSL handshake.
 For more information on authentication types, see:
 https://pywbem.readthedocs.io/en/stable/client/security.html#authentication-types
 
+.. index:: triple: --keyfile; general options; keyfile
 
 .. _`--keyfile general option`:
 
@@ -439,6 +452,7 @@ Not required if the private key is part of the file defined in the
 key file. The client private key should then be part of the file defined by
 ``--certfile``.
 
+.. index:: triple: --ca-certs; general options; ca-certs
 
 .. _`--ca-certs general option`:
 
@@ -491,6 +505,7 @@ bypasses client side verification of the WBEM server certificate.
 .. _certifi package: https://certifi.io/en/latest/
 .. _Mozilla Included CA Certificate List: https://wiki.mozilla.org/CA/Included_Certificates
 
+.. index:: triple: --timestats; general options; timestats
 
 .. _`--timestats general option`:
 
@@ -503,6 +518,7 @@ statistics on the interactions with the WBEM server.  If enabled, the
 time statistics are output after each command is executed including the
 operations executed, the size of the operations, and the execution time.
 
+.. index:: triple: --use-pull; general options; use-pull
 
 .. _`--use-pull general option`:
 
@@ -522,6 +538,7 @@ for the argument value are as follows:
 * ``either`` - (default) pywbem tries both; first pull operations and then
   :term:`traditional operations`.
 
+.. index:: triple: --pull-max-cnt; general options; pull-max-cnt
 
 .. _`--pull-max-cnt general option`:
 
@@ -535,6 +552,7 @@ to be returned for each pull request if pull operations are used. This must
 be a positive non-zero integer. The default is 1000. See :ref:`Pywbemcli and the
 DMTF pull operations` for more information on pull operations.
 
+.. index:: triple: --mock-server; general options; mock-server
 
 .. _`--mock-server general option`:
 
@@ -574,6 +592,7 @@ connection named ``mymockserver``:
 See chapter :ref:`Mock WBEM server support` for more information on defining
 the files for a mock server.
 
+.. index:: triple: --output-format; general options; output-format
 
 .. _`--output-format general option`:
 
@@ -586,6 +605,7 @@ is displayed. The default output format depends on the command.
 
 For details, see :ref:`Output formats`.
 
+.. index:: triple: --log; general options; log
 
 .. _`--log general option`:
 
@@ -598,6 +618,7 @@ server.
 
 For details, see :ref:`Pywbemcli defined logging`.
 
+.. index:: triple: --verbose; general options; verbose
 
 .. _`--verbose general option`:
 
@@ -612,6 +633,7 @@ normally return nothing upon successful execution(ex. instance delete,
 instance enumerate that returns no CIM objects) to indicate the successful
 command completion.
 
+.. index:: triple: --pdb; general options; pdb
 
 .. _`--pdb general option`:
 
@@ -628,6 +650,7 @@ built-in pdb debugger.
 
 .. _`pdb debugger commands`: https://docs.python.org/2.7/library/pdb.html#debugger-commands
 
+.. index:: triple: --version; general options; version
 
 .. _`--version general option`:
 
@@ -637,6 +660,7 @@ built-in pdb debugger.
 The ``--version`` general option displays the version of the pywbemcli
 command and the version of the pywbem package used by it, and then exits.
 
+.. index:: triple: --help; general options; help
 
 .. _`--help general option`:
 
@@ -646,6 +670,7 @@ command and the version of the pywbem package used by it, and then exits.
 The ``--help``/``-h`` general option displays help text which describes the
 command groups and general options, and then exits.
 
+.. index:: pair: environment variables; general options
 
 .. _`Environment variables for general options`:
 
@@ -724,6 +749,12 @@ any subsequent pywbemcli commands:
     $ pywbemcli server namespaces
     . . . <list of namespaces for the defined server>
 
+
+.. index::
+    pair: pull operations; general options
+        single: --use-pull
+        single: --pull-max-count
+        single: traditional operations
 
 .. _`Pywbemcli and the DMTF pull operations`:
 
@@ -837,6 +868,7 @@ rejected with an exception.  For example, the command
 ``class enumerate`` only supports the CIM object formats and will generate an
 exception if the command ``pywbemcli -o table class enumerate`` is entered.
 
+.. index:: single: output formats
 
 .. _`Output formats for groups and commands`:
 
@@ -926,6 +958,8 @@ NOTES:
 
 1. While the display of classes allows only CIM object display format (`mof`, etc.) the display with
    the --names-only or --summary formats allows table output also.
+
+.. index:: pair: output formats; table formats
 
 .. _`Table formats`:
 
@@ -1044,6 +1078,10 @@ single command ``class find CIM_Foo``:
 .. _`LaTeX`: https://en.wikibooks.org/wiki/LaTeX/Tables
 .. _`JSON`: http://json.org/example.html
 
+
+.. index::
+    pair: CIM object output formats; output formats
+        pair: output formats; MOF
 
 .. _`CIM object formats`:
 
@@ -1259,6 +1297,8 @@ pywbemcli.log as follows showing the input parameters to the pywbem method
     2019-07-09 18:27:22,103-pywbem.api.1-27716-Request:1-27716 EnumerateClassNames(ClassName=None, DeepInheritance=False, namespace=None)
     2019-07-09 18:27:22,142-pywbem.api.1-27716-Return:1-27716 EnumerateClassNames(list of str; count=103)
 
+
+.. index:: single: connection definitions
 
 .. _`Pywbemcli persisted connection definitions`:
 

--- a/docs/pywbemcli/generaloptions.rst
+++ b/docs/pywbemcli/generaloptions.rst
@@ -75,7 +75,7 @@ specified in the command line invocation:
     |             |         |         |         | REFERENCE | ToSubclass      |
     +-------------+---------+---------+---------+-----------+-----------------+
 
-.. index:: pair WBEM server; defining the WBEM server
+.. index:: pair: WBEM server; defining the WBEM server
 
 .. _`Defining the WBEM server`:
 
@@ -106,7 +106,7 @@ the following arguments :
    * The :ref:`--timeout general option` defines the client side timeout
      for operations.
 
-2. Define a mock WBEM server () by using the :ref:`--mock-server general option`.
+2. Define a mock WBEM server by using the :ref:`--mock-server general option`.
 
    The mock WBEM server is part of pywbemcli and allows testing or
    demonstrating pywbemcli without having access to a real WBEM server.
@@ -752,9 +752,9 @@ any subsequent pywbemcli commands:
 
 .. index::
     pair: pull operations; general options
-        single: --use-pull
-        single: --pull-max-count
-        single: traditional operations
+    single: --use-pull
+    single: --pull-max-count
+    single: traditional operations
 
 .. _`Pywbemcli and the DMTF pull operations`:
 
@@ -1081,7 +1081,7 @@ single command ``class find CIM_Foo``:
 
 .. index::
     pair: CIM object output formats; output formats
-        pair: output formats; MOF
+    pair: output formats; MOF
 
 .. _`CIM object formats`:
 

--- a/docs/pywbemcli/mock_support.rst
+++ b/docs/pywbemcli/mock_support.rst
@@ -1,3 +1,5 @@
+.. index:: pair: Mock WBEM server support; server mock
+
 .. _`Mock WBEM server support`:
 
 Mock WBEM server support
@@ -9,29 +11,33 @@ Mock support overview
 ---------------------
 
 Pywbemcli has support for mocking a WBEM server with the general option
-``--mock-server/-m``. This allows executing pywbemcli against a mock
-WBEM server that is automatically created in pywbemcli, rather than a real
-WBEM server.
+:ref:`--mock-server general option` (``--mock-server/-m``) . This allows
+executing pywbemcli against a mock WBEM server that is automatically created in
+pywbemcli, rather than a real WBEM server.
 
-The ``--mock-server`` option is mutually exclusive with the ``--server`` and
-``--name`` options, since each defines a WBEM server.
+The :ref:`--mock-server general option` is mutually exclusive with the
+:ref:`--server general option` and :ref:`--name general option`, since each
+defines a WBEM server.
 
 The automatically created mock WBEM server has a in-memory repository for
 CIM objects (qualifier declarations, classes, and instances) and supports
 CIM namespaces. The operations performed against the mock WBEM server cause
 that mock repository to be inspected or manipulated accordingly.
 
-The mock repository can be loaded with CIM objects from files specified as
-an argument to the ``--mock-server`` option. Each use of the option specifies
-one file path of such a file. The option may be used multiple times and each
-specified file is processed sequentially, in the sequence of the options
-on the command line.
+The mock repository can be loaded with CIM objects from files specified as an
+argument to the :ref:`--mock-server general option`. Each use of the option
+specifies one file path of such a file. The option may be used multiple times
+and each specified file is processed sequentially, in the sequence of the
+options on the command line.
 
 The following types of files are supported for the ``--mock-server`` option:
 
+.. index:: pair: MOF; server mock
+.. index:: pair: compile_string(); mock setup methods
+
 * **MOF files**: If the file extension is ``.mof``, the file is considered a
   :term:`MOF` file. Pywbemcli compiles the MOF in the file and adds the
-  resulting CIM objects into the mock repository.
+  resulting CIM objects to the mock repository.
 
   The MOF file may define CIM qualifier declarations, CIM classes and CIM
   instances.
@@ -42,6 +48,8 @@ The following types of files are supported for the ``--mock-server`` option:
   option).
 
   If a CIM object already exists in the repository, it is updated accordingly.
+
+.. index:: triple: Python files; server mock; add_cimobjects()
 
 * **Python files**: If the file extension is ``.py``, the file is considered
   a Python file. The file is executed using Python's ``exec()`` (i.e. with
@@ -77,6 +85,9 @@ Pywbemcli logging (``-l`` or ``--log`` general option) can be used together
 with the mock support. Since the mock support does not use HTTP(S), only the
 "api" component in the log configuration string will generate any log output.
 
+.. index::
+    pair: Creating files for mock repository; server mock
+    pair: MOF; server mock
 
 .. _`Creating files for the mock repository`:
 
@@ -137,6 +148,9 @@ and then to enumerate its CIM class names is::
 
     $ pywbemcli --mock-server tst_file.mof class enumerate --names-only
     CIM_Foo
+
+
+.. index:: pair: add_cim_objects(); mock setup methods
 
 The following is Python code (in a file ``tst_file.py``) that will add the same
 CIM objects as in the MOF file to the mock repository using


### PR DESCRIPTION
Adds index entries for:

1. command groups to commands

2. commands to command groups

3. general options

4. the major modes (interactive, command)

5. the components of the command line

I learned in writing a couple of books that creating an index is an endless task since you are trying to figure out what things the user looks for based on relationships to other parts of the document or words that might have meaning to the user..  So we can only take on some limited items, like indexing the sections with keywords, relating commands/groups etc.   

I suggest that this is just a start but enough to consider committing.