### PR TITLE
0.6: Fixed yaml.RepresenterError during 'connection save' command

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,9 @@ Released: not yet
 
 * Fixed incorrect connection list output in readme files (see issue #593).
 
+* Fixed yaml.RepresenterError during 'connection save' command. This introduced
+  a dependency on the yamlloader package. (see issue #603).
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -93,6 +93,7 @@ prompt-toolkit==1.0.15; python_version == '2.7'
 prompt-toolkit==2.0.1; python_version >= '3.4'
 PyYAML==5.1
 pydicti==1.1.3
+yamlloader==0.5.5
 
 # Indirect dependencies for install (not in requirements.txt)
 

--- a/pywbemtools/pywbemcli/_connection_repository.py
+++ b/pywbemtools/pywbemcli/_connection_repository.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import, print_function
 
 import os
 import yaml
+import yamlloader
 import six
 
 from ._pywbem_server import PywbemServer
@@ -258,11 +259,12 @@ class ConnectionRepository(object):
             tmpfile = '{}.tmp'.format(self._connections_file)
 
             with self.open_file(tmpfile, 'w') as _fp:
-                data = yaml.safe_dump(yaml_dict,
-                                      encoding=None,
-                                      allow_unicode=True,
-                                      default_flow_style=False,
-                                      indent=4)
+                data = yaml.dump(yaml_dict,
+                                 encoding=None,
+                                 allow_unicode=True,
+                                 default_flow_style=False,
+                                 indent=4,
+                                 Dumper=yamlloader.ordereddict.CSafeDumper)
                 data = data.replace('\n\n', '\n')  # YAML dump dups newlines
                 _fp.write(data)
                 _fp.flush()

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ pydicti>=1.1.3
 PyYAML>=5.1; python_version == '2.7'
 PyYAML>=5.1,<5.3; python_version == '3.4'
 PyYAML>=5.1; python_version > '3.4'
+yamlloader>=0.5.5


### PR DESCRIPTION
Rolls back PR #608 into 0.6.1.