### PR TITLE
Fixes #606: Fix connection test cmd

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,6 +25,9 @@ Released: not yet
 * Fixed yaml.RepresenterError during 'connection save' command. This introduced
   a dependency on the yamlloader package. (see issue #603).
 
+* Fixed possible issue where the `connection test` command would fail on a
+  server that did not support class operations.  (See issue #606)
+
 **Enhancements:**
 
 * Enabled installation using 'setup.py install' from unpacked source distribution
@@ -35,6 +38,10 @@ Released: not yet
   a single format ``text``. This format outputs the command result as a
   text string to the console and is use for simple commands like
   ``server interop`` that only output one piece of data. (see issue #594)
+
+* Extended the command `connection test` so that it will also test for existence
+  of the DMTF pull operations.  It tests for all of the operations and
+  reports success or failure on each operation.
 
 
 **Cleanup**

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,7 +36,11 @@ Released: not yet
   text string to the console and is use for simple commands like
   ``server interop`` that only output one piece of data. (see issue #594)
 
+
 **Cleanup**
+
+* Adds command to test connection for existence of  the pull operations
+  (connection test-pull)
 
 **Known issues:**
 

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -853,7 +853,10 @@ Help text for ``pywbemcli connection test`` (see :ref:`connection test command`)
         pywbemcli --name mysrv connection test
 
     Command Options:
-      -h, --help  Show this help message.
+      --test-pull  If set, the connection is tested to determine if theDMTF defined pull operations (ex.
+                   OpenEnumerateInstancesare implemented since these are optional.
+
+      -h, --help   Show this help message.
 
 
 .. _`pywbemcli help --help`:

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -1558,9 +1558,18 @@ Connection test command
 The ``connection test`` command executes a single predefined operation on
 the current connection to verify that accessing the WBEM server works.
 
-The predefined operation is ``EnumerateClasses``.
+The predefined operation is ``EnumerateClasses`` which attempts to enumerate
+the classes in the default namespace of the WBEM Server.  Even if the server
+does not support the classes operations, this command should return a
+CIMError indicating that WBEM is supported (ex. CIM_ERR_NOT_SUPPORTED)
+indicating that WBEM is supported by the server.
 
-If the server accepts the request, a simple text ``Connection successful``
+If the `--test-pull` command option is included, pywbemcli will issue an
+instances request for each of the DMTF defined pull operations and report the
+results. This could be important because the pull operations are defined
+as optional and some server may not include them.
+
+If the server accepts the request, a simple text ``OK <server url``
 will be returned.
 
 The following example defines the connection with ``--server``, ``--user``,
@@ -1608,11 +1617,11 @@ Command history is available in the :ref:`interactive mode` either by using
 <UP-ARROW> and <DOWN-ARROW> keys to step through the history file or by using
 incremental search of the command history.
 
-The incremental search is initiated by <CTRL-r> and does a search based on a
-string entered after the <CTRL-r> for the last command containing the search
-string. The search string may be modified and <UP_ARROW>, <DOWN-ARROW> will
-find other commands containing the search string. Hitting <ENTER> selects
-the currently shown command.
+An incremental search is initiated by <CTRL-r> (similar to some shells like
+bash) and does a search based on a string entered after the <CTRL-r> for the
+last command containing the search string. The search string may be modified
+and <UP_ARROW>, <DOWN-ARROW> will find other commands containing the search
+string. Hitting <ENTER> selects the currently shown command.
 
 see :ref:`interactive mode` for more details on using this mode and the
 search.

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -194,33 +194,9 @@ def centralinsts(context, **options):
     context.execute_cmd(lambda: cmd_server_centralinsts(context, options))
 
 
-# TODO: reactivate and implement this in version 0.6.0
-# @server_group.command('test_pull', options_metavar=CMD_OPTS_TXT)
-# @click.pass_obj
-# def server_test_pull(context):
-#    """
-#    Test existence of pull opeations.
-#
-#    Test whether the pull WBEMConnection methods (ex. OpenEnumerateInstances)
-#    exist on the WBEM server.
-#
-#    This command tests all of the pull operations and reports any that
-#    return a NOT_SUPPORTED response.
-#    """
-#    context.execute_cmd(lambda: cmd_server_test_pull(context))
-
-
 ###############################################################
 #         Server cmds
 ###############################################################
-
-def cmd_server_test_pull(context):
-    """
-        Test the execution of pull operations against the target server.
-        Executes pull operations and reports whether pull is supported.
-
-    """
-    raise click.ClickException('test_pull Not implemented')
 
 
 def cmd_server_namespaces(context):

--- a/tests/unit/test_connection_cmds.py
+++ b/tests/unit/test_connection_cmds.py
@@ -471,9 +471,31 @@ ca-certs
 
     ['Verify connection command test',
      ['test'],
-     {'stdout': "Connection successful",
+     {'stdout': "Connection OK: FakedUrl",
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
+
+    ['Verify connection command test with pull option',
+     ['test', '--test-pull'],
+     {'stdout': ["Pull Operation test results (Connection OK): FakedUrl",
+                 "Operation                    Result",
+                 "OpenEnumerateInstances       OK",
+                 "OpenEnumerateInstancePaths   OK",
+                 "OpenAssociatorInstances      OK",
+                 "OpenAssociatorInstancePaths  OK",
+                 "OpenReferenceInstances       OK",
+                 "OpenReferenceInstancePaths   OK",
+                 "OpenQueryInstances           14 "
+                 "(CIM_ERR_QUERY_LANGUAGE_NOT_SUPPORTED): FilterQueryLanguage "
+                 "'DMTF:CQL' not supported"],
+      'test': 'innows'},
+     SIMPLE_MOCK_FILE, OK],
+
+    # TODO: Future; Add test for --pull-options where the mocker has
+    # pull disabled.  Note that this must be a completely new test, not
+    # just the existing because there is no external way to turh off
+    # the mocker operations without creating a new python file to load and
+    # execute.so it is marked future
 
     ['Verify connection command delete test2',
      ['delete', 'test2'],
@@ -685,7 +707,7 @@ ca-certs
     ['Verify connection command test against existing mock def',
      {'args': ['test'],
       'general': ['--name', 'mocktest']},
-     {'stdout': "Connection successful",
+     {'stdout': "Connection OK: FakedUrl",
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'exists'}},
      None, OK],


### PR DESCRIPTION
Fixes issue with connection test for server that does not have class operations.

Also adds option --test-pull to test for existence of the pull operations.

Adds tests and doc update