### PR TITLE
0.6: Pinned pywbem to <1.0.0

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -23,6 +23,10 @@ Released: not yet
 * Fixed yaml.RepresenterError during 'connection save' command. This introduced
   a dependency on the yamlloader package. (see issue #603).
 
+* Pinned pywbem to <1.0.0 due to the incompatibilities it will introduce.
+  Support for working with pywbem 1.0.0 will be added in pywbemtools 0.7.0, and
+  will not be rolled back into earlier versions of pywbemtools (see issue #616).
+
 **Enhancements:**
 
 **Cleanup:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 
 # Direct dependencies (except pip, setuptools, wheel):
 
-pywbem>=0.17.0
+pywbem>=0.17.0,<1.0.0
 # git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
 
 six>=1.10.0


### PR DESCRIPTION
No review needed.