### PR TITLE
Fixes #626: Appveyor: Python version; language vars; skip missing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,6 @@ environment:
 #      PIP_CMD: pip
 #      CYGWIN_PYTHON_DEVEL: python27-devel
 
-# TODO: Disabled because tox does nothing in this env.
 #    - TOX_ENV: cygwin32_py36
 #      UNIX_PATH: C:\cygwin\bin
 #      PYTHON_CMD: python3.6
@@ -86,7 +85,6 @@ environment:
 #      LC_ALL: C.UTF-8
 #      LANG: C.UTF-8
 
-# TODO: Disabled because tox does nothing in this env.
 #    - TOX_ENV: cygwin32_py37
 #      UNIX_PATH: C:\cygwin\bin
 #      PYTHON_CMD: python3.7
@@ -103,7 +101,6 @@ environment:
 #      LC_ALL: C.UTF-8
 #      LANG: C.UTF-8
 
-# TODO: Disabled because tox does nothing in this env.
 #    - TOX_ENV: cygwin32_py38
 #      UNIX_PATH: C:\cygwin\bin
 #      PYTHON_CMD: python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,11 @@ envlist =
     cygwin64_py37
     cygwin32_py38
     cygwin64_py38
-skip_missing_interpreters = true
+
+# For Appveyor, missing interpreters should fail. For local use, you may
+# want to allow to skip missing interpreters.
+skip_missing_interpreters = false
+
 skipsdist = true
 
 [testenv]
@@ -55,6 +59,9 @@ passenv =
     INCLUDE
     CPATH
     CFLAGS
+    LANG
+    LC_ALL
+    LC_CTYPE
     LIB
     LIBRARY_PATH
     LDFLAGS
@@ -101,77 +108,56 @@ basepython = python3.7
 platform = linux2|darwin
 basepython = python3.8
 
+# Note: The basepython file paths for the win64* tox environments are set for
+#       Appveyor CI.
+
 [testenv:win64_py27_32]
 platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python27;{env:PATH}
+basepython = C:\Python27\python.exe
 
 [testenv:win64_py27_64]
 platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python27-x64;{env:PATH}
+basepython = C:\Python27-x64\python.exe
 
 [testenv:win64_py34_32]
 platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python34;{env:PATH}
+basepython = C:\Python34\python.exe
 
 [testenv:win64_py34_64]
 platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python34-x64;{env:PATH}
+basepython = C:\Python34-x64\python.exe
 
 [testenv:win64_py35_32]
 platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python35;{env:PATH}
+basepython = C:\Python35\python.exe
 
 [testenv:win64_py35_64]
 platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python35-x64;{env:PATH}
+basepython = C:\Python35-x64\python.exe
 
 [testenv:win64_py36_32]
 platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python36;{env:PATH}
+basepython = C:\Python36\python.exe
 
 [testenv:win64_py36_64]
 platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python36-x64;{env:PATH}
+basepython = C:\Python36-x64\python.exe
 
 [testenv:win64_py37_32]
 platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python37;{env:PATH}
+basepython = C:\Python37\python.exe
 
 [testenv:win64_py37_64]
 platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python37-x64;{env:PATH}
+basepython = C:\Python37-x64\python.exe
 
 [testenv:win64_py38_32]
 platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python38;{env:PATH}
+basepython = C:\Python38\python.exe
 
 [testenv:win64_py38_64]
 platform = win32
-basepython = python
-setenv =
-    PATH = C:\Python38-x64;{env:PATH}
+basepython = C:\Python38-x64\python.exe
 
 [testenv:cygwin32_py27]
 platform = cygwin


### PR DESCRIPTION
This fixes the issue that on Appveyor, Python 2.7 was always used. Therefore, it has been set to priority. For more details, see commit message.

Appveyor build https://ci.appveyor.com/project/KSchopmeyer/pywbemtools/builds/33591330 tests this PR with a temporary commit on top that enabled additional environments to test the PR.