### PR TITLE
Fixes #642: Use compile_schema_classes() instead of deprecated compile_dmtf_schema()

### DIFF
--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -659,7 +659,7 @@ def create_ciminstancename(cim_class, kv_keys):
     return instance_path
 
 
-def create_ciminstance(cim_class, kv_properties, property_list=None):
+def create_ciminstance(cim_class, kv_properties):
     """
     Create a CIMInstance object from the input parameters.
 
@@ -671,10 +671,6 @@ def create_ciminstance(cim_class, kv_properties, property_list=None):
       kv_properties (tuple):
         A tuple of name/value pairs representing the properties and their
         values that are to be constructed for the instance. Required
-
-      property_list (list):
-        a list of properties that is to be the list that is supplied
-        when the instance is created. Optional
 
     Returns:
         CIMInstance
@@ -706,9 +702,7 @@ def create_ciminstance(cim_class, kv_properties, property_list=None):
                                                cl_prop.is_array,
                                                value_str, ex))
 
-    new_inst = CIMInstance(cim_class.classname,
-                           properties=properties,
-                           property_list=property_list)
+    new_inst = CIMInstance(cim_class.classname, properties=properties)
 
     return new_inst
 

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -70,6 +70,8 @@ _PYWBEM_VERSION = parse_version(__version__)
 # pywbem 1.0.0b1 or later
 PYWBEM_1_0_0B1 = _PYWBEM_VERSION.release >= (1, 0, 0) and \
     _PYWBEM_VERSION.dev is None
+# pywbem 1.0.0 (dev, beta, final) or later
+PYWBEM_1_0_0 = _PYWBEM_VERSION.release >= (1, 0, 0)
 
 
 TESTCASES_ISCLASSNAME = [
@@ -281,14 +283,23 @@ TESTCASES_FORMAT_KEYBINDINGS = [
           exp_rtn='kEY1="Ham and eggs",key2="More eggs"'),
      None, None, True),
 
-    ('Verify multiple keys binding multiple key types',
+    ('Verify multiple unsorted keys binding multiple key types, pywbem >=1.0',
+     dict(kb=[('Name', 'Foo'),
+              ('Number', Uint8(42)),
+              ('Boolean', False),
+              ('Ref', CIMInstanceName('CIM_Bar'))],
+          width=100,
+          exp_rtn='Boolean=FALSE,Name="Foo",Number=42,Ref="/:CIM_Bar"'),
+     None, None, PYWBEM_1_0_0),
+
+    ('Verify multiple unsorted keys binding multiple key types, pywbem <1.0',
      dict(kb=[('Name', 'Foo'),
               ('Number', Uint8(42)),
               ('Boolean', False),
               ('Ref', CIMInstanceName('CIM_Bar'))],
           width=100,
           exp_rtn='Name="Foo",Number=42,Boolean=FALSE,Ref="/:CIM_Bar"'),
-     None, None, True),
+     None, None, not PYWBEM_1_0_0),
 
     ('Verify mutliple keys that fold into multiple lines',
      dict(kb=[('kEY1', u'Ham'), ('key2', 3)],
@@ -323,15 +334,6 @@ TESTCASES_FORMAT_KEYBINDINGS = [
           width=8,
           exp_rtn=('k1=1,k2=2\nk3=3,k4=4\nk5=5,k6=6\nk7=7,k8=8')),
      None, None, False),
-
-    ('Verify multiple keys binding with spaces in keys',
-     dict(kb=[('Name', 'Foo'),
-              ('Number', Uint8(42)),
-              ('Boolean', False),
-              ('Ref', CIMInstanceName('CIM_Bar'))],
-          width=4,
-          exp_rtn='Name="Foo"\nNumber=42\nBoolean=FALSE\nRef="/:CIM_Bar"'),
-     None, None, True),
 
     # Test no keys
     ('Verify no keys',
@@ -439,13 +441,13 @@ TESTCASES_SHORT_PATH = [
      None, None, True),
 
     ('Verify multiple keys binding multiple key types',
-     dict(kb=[('Name', 'Foo'),
+     dict(kb=[('Boolean', False),
+              ('Name', 'Foo'),
               ('Number', Uint8(42)),
-              ('Boolean', False),
               ('Ref', CIMInstanceName('CIM_Bar'))],
           rpl={},
           fp=False,
-          exp_rtn='/:cln.Name="Foo",Number=42,Boolean=FALSE,Ref="/:CIM_Bar"'),
+          exp_rtn='/:cln.Boolean=FALSE,Name="Foo",Number=42,Ref="/:CIM_Bar"'),
      None, None, True),
 ]
 

--- a/tests/unit/testmock/wbemserver_mock.py
+++ b/tests/unit/testmock/wbemserver_mock.py
@@ -11,7 +11,7 @@ import os
 
 from pywbem import ValueMapping, CIMInstance, CIMInstanceName, CIMError, \
     CIM_ERR_ALREADY_EXISTS
-from pywbem_mock import FakedWBEMConnection
+from pywbem_mock import FakedWBEMConnection, DMTFCIMSchema
 
 # from .dmtf_mof_schema_def import DMTF_TEST_SCHEMA_VER
 
@@ -215,11 +215,21 @@ class WbemServerMock(object):
             if er.status_code != CIM_ERR_ALREADY_EXISTS:
                 raise
 
-        self.conn.compile_dmtf_schema(
-            self.dmtf_schema_ver, self.schema_dir,
-            class_names=self.server_mock_data['class_names'],
-            namespace=namespace,
-            verbose=self.verbose)
+        if hasattr(self.conn, 'compile_schema_classes'):
+            schema = DMTFCIMSchema(self.dmtf_schema_ver, self.schema_dir,
+                                   use_experimental=False,
+                                   verbose=self.verbose)
+            self.conn.compile_schema_classes(
+                self.server_mock_data['class_names'],
+                schema.schema_pragma_file,
+                namespace=namespace,
+                verbose=self.verbose)
+        else:
+            self.conn.compile_dmtf_schema(
+                self.dmtf_schema_ver, self.schema_dir,
+                class_names=self.server_mock_data['class_names'],
+                namespace=namespace,
+                verbose=self.verbose)
 
         for filename in self.pg_schema_files:
             filepath = os.path.join(self.pg_schema_dir, filename)


### PR DESCRIPTION
This is done in such a way that it work on both pywbem 0.17 and pywbem 1.0.0