### PR TITLE
Fixes #644: Fixed temporary install of pywbem 1.0.0b1 in CI runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -418,10 +418,11 @@ install_$(package_name)_$(pymn).done: Makefile pip_upgrade_$(pymn).done requirem
 	@echo "makefile: Installing $(package_name) (editable) and its Python runtime prerequisites (with PACKAGE_LEVEL=$(PACKAGE_LEVEL))"
 	-$(call RM_FUNC,$@)
 	-$(call RMDIR_FUNC,build $(package_name).egg-info .eggs)
-# TODO: Remove the following workarouind once pywbem 1.0.0 is releaed.
+# TODO: Remove the following workaround once pywbem 1.0.0 is releaed.
 ifeq ($(PACKAGE_LEVEL),latest)
 	@echo "makefile: Installing pywbem 1.0.0b1 as long as 1.0.0 is not yet released"
-	-$(PIP_INSTALL_CMD) $(pip_level_opts) pywbem=1.0.0b1
+	$(PIP_INSTALL_CMD) $(pip_level_opts) pywbem==1.0.0b1
+	@echo "makefile: Done installing pywbem 1.0.0b1 as long as 1.0.0 is not yet released"
 endif
 	$(PIP_INSTALL_CMD) $(pip_level_opts) -r requirements.txt
 	$(PIP_INSTALL_CMD) $(pip_level_opts) -e .


### PR DESCRIPTION
No review needed.
Verified that pywbem 1.0.0b1 is actually installed now: https://travis-ci.org/github/pywbem/pywbemtools/jobs/701895705#L1225

The error that happens in the CI runs is fixed in PR #647.