### PR TITLE
Fixes #646: Fixed that recent change in pywbem mocker breaks sample test method provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -418,10 +418,11 @@ install_$(package_name)_$(pymn).done: Makefile pip_upgrade_$(pymn).done requirem
 	@echo "makefile: Installing $(package_name) (editable) and its Python runtime prerequisites (with PACKAGE_LEVEL=$(PACKAGE_LEVEL))"
 	-$(call RM_FUNC,$@)
 	-$(call RMDIR_FUNC,build $(package_name).egg-info .eggs)
-# TODO: Remove the following workarouind once pywbem 1.0.0 is releaed.
+# TODO: Remove the following workaround once pywbem 1.0.0 is releaed.
 ifeq ($(PACKAGE_LEVEL),latest)
 	@echo "makefile: Installing pywbem 1.0.0b1 as long as 1.0.0 is not yet released"
-	-$(PIP_INSTALL_CMD) $(pip_level_opts) pywbem=1.0.0b1
+	$(PIP_INSTALL_CMD) $(pip_level_opts) pywbem==1.0.0b1
+	@echo "makefile: Done installing pywbem 1.0.0b1 as long as 1.0.0 is not yet released"
 endif
 	$(PIP_INSTALL_CMD) $(pip_level_opts) -r requirements.txt
 	$(PIP_INSTALL_CMD) $(pip_level_opts) -e .

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,9 @@ Released: not yet
 
 * Pinned version of colorama to <0.4.0 for Python <=3.4.
 
+* Adjusted to changes in the pywbem mock support for method providers, in the
+  sample method provider simple_mock_invokemethod_pywbem_V1.py. (See issue #646)
+
 **Enhancements:**
 
 * Enabled installation using 'setup.py install' from unpacked source distribution

--- a/tests/unit/simple_mock_invokemethod_pywbem_V1.py
+++ b/tests/unit/simple_mock_invokemethod_pywbem_V1.py
@@ -59,14 +59,13 @@ class CIM_FooMethodProvider(MethodProvider):
 
         if isinstance(ObjectName, CIMInstanceName):
             instance_store = self.cimrepository.get_instance_store(namespace)
-            inst = self.find_instance(ObjectName, instance_store, copy=False)
-            if inst is None:
+            if not instance_store.object_exists(ObjectName):
                 raise CIMError(
                     CIM_ERR_NOT_FOUND,
-                    "Instance {0} does not exist in CIM repository, "
-                    "namespace {1}".format(ObjectName, namespace))
-        # This method expects a single parameter input
+                    "Instance {0} does not exist in CIM repository",
+                    format(ObjectName))
 
+        # This method expects a single parameter input
         return_params = []
         if MethodName.lower() == 'fuzzy':
             if Params:


### PR DESCRIPTION
**Note: This PR is on top of PR #645 in order to verify that it works with pywbem 1.0.0b1**