### PR TITLE
Refactor tests to pytest and remove a number of TODOS.

### DIFF
--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -464,7 +464,8 @@ def verify_operation(txt, msg=None):
     Parameters:
 
       txt (:term:`string`):
-        String that is prefixed to the prompt text.
+        String that is prefixed to the prompt text and defines the
+        verification request.
 
       msg (:class:`py:bool`):
         Optional parameter that if True causes an abort msg on the console.

--- a/tests/unit/cli_test_extensions.py
+++ b/tests/unit/cli_test_extensions.py
@@ -28,10 +28,6 @@ PYWBEM_1 = not PYWBEM_0
 # create it for the tests depending on pywbem version
 FAKEURL_STR = '//FakedUrl:5988' if PYWBEM_1 else '//FakedUrl'
 
-# TODO remove this.  Temp flag for condition that allows skipping tests that
-# are failing with pywbem 1.0.0
-ISSUE_100 = False
-
 
 class CLITestsBase(object):
     # pylint: disable=too-few-public-methods, useless-object-inheritance

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -239,6 +239,7 @@ class CIM_Foo_sub_sub : CIM_Foo_sub {
 
 };
 """
+# TODO: This never referenced
 REFERENCES_CLASS_RTN = [
     FAKEURL_STR + '/root/cimv2:TST_Lineage',
     'class TST_Lineage {',
@@ -1505,10 +1506,6 @@ TEST_CASES = [
 # namespace
 # TODO: add test for  errors: class invalid, namespace invalid
 # other tests.  Test local-only on top level
-
-
-# TODO the following two test classes should be removed as I believe they
-# are redundant.
 
 
 class TestSubcmdClass(CLITestsBase):  # pylint: disable=too-few-public-methods

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -954,7 +954,7 @@ TESTCASES_RESOLVE_PROPERTYLIST = [
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_RESOLVE_PROPERTYLIST)
 @simplified_test_function
-def test_propertylist(testcase, pl_str, exp_pl):
+def test_resolve_propertylist(testcase, pl_str, exp_pl):
     """Test for resolve_propertylist function"""
     # The code to be tested
 
@@ -975,7 +975,7 @@ TESTCASES_COMPARE_INSTANCES = [
     # * kwargs: Keyword arguments for the test function and response:
     #   * inst1: first instance for compare
     #   * inst2: second instance for compare
-    #   * result: TODO
+    #   * result: Boolean. Expect result
     # * exp_exc_types: Expected exception type(s), or None.
     # * exp_warn_types: Expected warning type(s), or None.
     # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
@@ -1085,15 +1085,13 @@ def test_compare_instances(testcase, inst1, inst2, result):
     assert tst_rtn == result
 
 
-# TODO: The mock for the following test is broken. Not sure yet how to
-# fix it
 TESTCASES_VERIFY_OPERATION = [
     # TESTCASES for verify_operation
     #
     # Each list item is a testcase tuple with these items:
     # * desc: Short testcase description.
     # * kwargs: Keyword arguments for the test function and response:
-    #   * txt: Text that would be fdisplayed
+    #   * txt: Text that would be displayed
     #   * abort_msg: message that outputs with abort if response is n
     #   * result: True or False
     # * exp_exc_types: Expected exception type(s), or None.
@@ -1129,23 +1127,23 @@ TESTCASES_VERIFY_OPERATION = [
 @simplified_test_function
 def test_verify_operation(testcase, txt, clickconfirm, abort_msg, result):
     """
-    This method mocks the click.confirm function to generate a response
-    to the verify operation function. It mocks both the click_confirm
-    and the click_echo. Mock Click.confirm returns a value defined by
-    the test. Mock click.echo confirms data in call to click_echo
+    This method mocks the click.confirm and click_echo function to generate a
+    response to the verify operation function. Mock Click.confirm returns a
+    value defined by the test. Mock click.echo confirms data in call to
+    click_echo
     """
 
-    # TODO: This does not really test the abort_msg that is output
-    # only in some conditions, it just hides it since the mock is
+    # NOTE: This does not really test the abort_msg that is output
+    # in some conditions, it just hides it since the mock of echo is
     # defined with called_with=txt
-    @patch('pywbemtools.pywbemcli.click.confirm', return_value=clickconfirm)
+    @patch('pywbemtools.pywbemcli.click.confirm', called_with=txt,
+           return_value=clickconfirm)
     @patch('pywbemtools.pywbemcli.click.echo', called_with=txt)
     def run_verify_operation(txt, mock_click_confirm, mock_click_echo):
         # pylint: disable=unused-argument
         return verify_operation(txt, abort_msg)
 
     # The code to be tested
-    # pylint: disable=no-value-for-parameter
     rtn = run_verify_operation(txt)
 
     # Ensure that exceptions raised in the remainder of this function
@@ -1604,7 +1602,6 @@ class SorterTest(unittest.TestCase):
         instances_sorted = sort_cimobjects(instances)
         self.assertEqual(len(instances), len(instances_sorted))
         self.assertEqual(instances_sorted[0].classname, 'CIM_Boo')
-        # TODO create multiple and test result
 
     def test_sort_qualifierdecls(self):
         """Test ability to sort list of qualifier declaractions"""
@@ -1803,7 +1800,6 @@ class CreateCIMInstanceTest(unittest.TestCase):
         act_inst = create_ciminstance(cls, kv_properties)
         self.assertEqual(exp_inst, act_inst)
 
-    # TODO add datetime property
     def test_scalar_instance(self):
         """
         Creates an instance from cmd line parameters and tests against
@@ -1819,7 +1815,9 @@ class CreateCIMInstanceTest(unittest.TestCase):
                           'Sint32p': CIMProperty('Sint32p', -99, type='sint32'),
                           'Uint64p': CIMProperty('Uint64p', 999, type='uint64'),
                           'Sint64p': CIMProperty('Sint64p', -99, type='sint64'),
-
+                          'Dtp': CIMProperty('Dtp',
+                                             "19991224120000.000000+360",
+                                             type='datetime'),
                           'Strp': CIMProperty('Strp', 'hoho', type='string')}
 
         exp_inst = CIMInstance('CIM_Foo',
@@ -1827,7 +1825,8 @@ class CreateCIMInstanceTest(unittest.TestCase):
 
         kv_properties = ['ID=Testid', 'Boolp=true', 'Uint8p=220', 'Sint8p=-120',
                          'Uint32p=999', 'Sint32p=-99', 'Uint64p=999',
-                         'Sint64p=-99', 'Strp=hoho']
+                         'Sint64p=-99', 'Strp=hoho',
+                         'Dtp=19991224120000.000000+360']
         act_inst = create_ciminstance(cls, kv_properties)
 
         # mock the echo to hide output
@@ -1904,7 +1903,6 @@ class CreateCIMInstanceTest(unittest.TestCase):
 
         self.assertEqual(exp_inst, act_inst)
 
-    # TODO add datetime property
     def test_array_instance(self):
         """
         Creates an instance from cmd line parameters and tests against
@@ -1984,44 +1982,44 @@ class CreateCIMInstanceTest(unittest.TestCase):
 ######################################################
 
 # Class definitions for create_instancename
-cls1 = dict(classname='CIM_Foo',
-            properties=[
-                CIMProperty(
-                    'P1', None, type='string',
-                    qualifiers=[
-                        CIMQualifier('Key', value=True)
-                    ]
-                ),
-                CIMProperty('P2', value='Cheese'),
-            ])
+class_dict1 = dict(classname='CIM_Foo',
+                   properties=[
+                       CIMProperty(
+                           'P1', None, type='string',
+                           qualifiers=[
+                               CIMQualifier('Key', value=True)
+                           ]
+                       ),
+                       CIMProperty('P2', value='Cheese'),
+                   ])
 
-cls2 = dict(classname='CIM_Foo',
-            properties=[
-                CIMProperty(
-                    'P1', None, type='string',
-                    qualifiers=[
-                        CIMQualifier('Key', value=True)
-                    ]
-                ),
-                CIMProperty(
-                    'P2', None, type='string',
-                    qualifiers=[
-                        CIMQualifier('Key', value=True)
-                    ]
-                ),
-                CIMProperty(
-                    'P3', None, type='uint32',
-                    qualifiers=[
-                        CIMQualifier('Key', value=True)
-                    ]
-                ),
-                CIMProperty('P4', value='Cheese',),
-            ])
+class_dict2 = dict(classname='CIM_Foo',
+                   properties=[
+                       CIMProperty(
+                           'P1', None, type='string',
+                           qualifiers=[
+                               CIMQualifier('Key', value=True)
+                           ]
+                       ),
+                       CIMProperty(
+                           'P2', None, type='string',
+                           qualifiers=[
+                               CIMQualifier('Key', value=True)
+                           ]
+                       ),
+                       CIMProperty(
+                           'P3', None, type='uint32',
+                           qualifiers=[
+                               CIMQualifier('Key', value=True)
+                           ]
+                       ),
+                       CIMProperty('P4', value='Cheese',),
+                   ])
 
 
 # TODO: add one class with ref property as key. Is that even allowed?
 
-# Testcases for format_inst_to_table()
+# Testcases for create_instancename()
 
 # Each list item is a testcase tuple with these items:
 # * desc: Short testcase description.
@@ -2037,7 +2035,7 @@ TESTCASES_CREATE_INSTNAME = [
     (
         "Verify simple key creation with single string key",
         dict(
-            cls_kwargs=cls1,
+            cls_kwargs=class_dict1,
             kv_args=['P1=Fred'],
             exp_iname=CIMInstanceName(u'CIM_Foo',
                                       keybindings=[('P1', 'Fred')]),
@@ -2046,7 +2044,7 @@ TESTCASES_CREATE_INSTNAME = [
     (
         "Verify simple key creation with single string key with space",
         dict(
-            cls_kwargs=cls1,
+            cls_kwargs=class_dict1,
             kv_args=['P1="Fred Fred"'],
             exp_iname=CIMInstanceName(u'CIM_Foo',
                                       keybindings=[('P1', "Fred Fred")]),
@@ -2056,7 +2054,7 @@ TESTCASES_CREATE_INSTNAME = [
     (
         "Verify simple key creation with single string key case independent",
         dict(
-            cls_kwargs=cls1,
+            cls_kwargs=class_dict1,
             kv_args=['p1="Fred Fred"'],
             exp_iname=CIMInstanceName(u'CIM_Foo',
                                       keybindings=[('P1', "Fred Fred")]),
@@ -2065,7 +2063,7 @@ TESTCASES_CREATE_INSTNAME = [
     (
         "Verify simple key creation with invalid key name",
         dict(
-            cls_kwargs=cls1,
+            cls_kwargs=class_dict1,
             kv_args=['Px=Fred'],
             exp_iname=None
         ),
@@ -2073,7 +2071,7 @@ TESTCASES_CREATE_INSTNAME = [
     (
         "Verify simple key creation with two string keys and one int",
         dict(
-            cls_kwargs=cls2,
+            cls_kwargs=class_dict2,
             kv_args=['P1=Fred', 'P2=John', 'P3=1'],
             exp_iname=CIMInstanceName(u'CIM_Foo',
                                       keybindings=[('P1', "Fred"),
@@ -2083,25 +2081,34 @@ TESTCASES_CREATE_INSTNAME = [
     (
         "Verify simple key creation with two string keys and one big int",
         dict(
-            cls_kwargs=cls2,
+            cls_kwargs=class_dict2,
             kv_args=['P1=Fred', 'P2=John', 'P3=123456'],
             exp_iname=CIMInstanceName(u'CIM_Foo',
                                       keybindings=[('P1', "Fred"),
                                                    ('P2', 'John'),
                                                    ('P3', 123456)]),
         ),
-        None, None, True, ),
+        None, None, True),
     (
         "Verify simple key creation with unicode char",
         dict(
-            cls_kwargs=cls1,
+            cls_kwargs=class_dict1,
             kv_args=[u'P1=Fred\u0344\u0352'],
             exp_iname=CIMInstanceName(
                 u'CIM_Foo', keybindings=[('P1', u'Fred\u0344\u0352')]),
         ),
-        None, None, True, ),
+        None, None, True),
+    (
+        "Verify simple key creation no value",
+        dict(
+            cls_kwargs=class_dict1,
+            kv_args=[u'P1='],
+            exp_iname=CIMInstanceName(
+                u'CIM_Foo', keybindings=[('P1', u'Fred\u0344\u0352')]),
+        ),
+        click.ClickException, None, True),
 ]
-# TODO key with no value, datetime key
+# TODO reference property key(This is very hard to define on cmd line)
 
 
 @pytest.mark.parametrize(
@@ -2428,7 +2435,8 @@ def test_fold_strings(testcase, input_str, max_width, brk_long_wds, brk_hyphen,
     assert act_rtn == exp_rtn
 
 
-# TODO this is a pytest. param
+# NOTE: The following methods are testcase parameters.  They define instances
+# used in TESTCASES_FMT_INSTANCE_AS_ROWS
 def simple_instance(pvalue=None):
     """
     Build a simple instance to test and return that instance. If the param
@@ -2636,8 +2644,6 @@ TESTCASES_FMT_INSTANCE_AS_ROWS = [
         None, None, True, ),
 ]
 
-# TODO: See line 973. We have some test duplication.
-
 
 @pytest.mark.parametrize(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
@@ -2778,8 +2784,7 @@ def test_print_insts_as_table(
         "End\n".format(desc, stdout, exp_stdout)
 
 
-# TODO Test compare and failure in compare_obj
+# TODO Test compare and failure in compare_obj and with errors.
 
-# TODO Test compare with errors
 
 # NOTE: Format table tests are in test_tableformat.py

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -409,7 +409,6 @@ TEST_CASES = [
       'test': 'in'},
      None, SKIP],
 
-    # TODO: This fails with pywbemcli version 0.5.0 PY2. Temporarily disabled
     ['Verify --version general option.',
      {'general': ['-s', 'http://blah', '--version'],
       'cmdgrp': 'connection',
@@ -418,7 +417,7 @@ TEST_CASES = [
                  r'^pywbem, version [0-9]+\.[0-9]+\.[0-9]+'],
       'rc': 0,
       'test': 'regex'},
-     None, FAIL],
+     None, OK],
 
     #
     #  Test --verify and --no-verify general option using the connection show
@@ -997,10 +996,6 @@ TEST_CASES = [
       'rc': 0,
       'test': 'innows'},
      None, OK],
-
-    # TODO: test use --name with valid name in interactive mode.
-    # This should go where we hav e a valid connection file.
-    # See below
 
     #
     #   The following is a sequence. Creates a server and changes almost all

--- a/tests/unit/test_qualdecl_cmds.py
+++ b/tests/unit/test_qualdecl_cmds.py
@@ -94,11 +94,6 @@ Qualifier Override : string,
 
 """
 
-QD_GET_MOCK = """Qualifier Description : string,
-    Scope(any),
-    Flavor(EnableOverride, ToSubclass, Translatable);
-
-"""
 
 QD_TBL_OUT = """Qualifier Declarations
 +-------------+---------+---------+---------+-------------+-----------------+
@@ -145,8 +140,6 @@ QD_TBL_GET_OUT = """Qualifier Declarations
 |          |         |         |         | INDICATION  |                |
 +----------+---------+---------+---------+-------------+----------------+
 """
-
-# TODO: Add tests for xml, repr, txt formats.
 
 # The following variables are used to control tests executed during
 # development of tests
@@ -233,10 +226,12 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify qualifier command get  Description',
+    ['Verify qualifier command get  Description qual decl',
      ['get', 'Description'],
-     {'stdout': QD_GET_MOCK,
-      'test': 'lines'},
+     {'stdout': "Qualifier Description : string,\n"
+                "    Scope(any),\n"
+                "    Flavor(EnableOverride, ToSubclass, Translatable);\n",
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify qualifier command get invalid qual decl name .',
@@ -252,6 +247,27 @@ TEST_CASES = [
      {'stdout': ['<QUALIFIER.DECLARATION( | .+ )NAME="Description"',
                  '<SCOPE( | .+ )ASSOCIATION="true"'],
       'test': 'regex'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify qualifier command get  Description outputformat repr',
+     {'args': ['get', 'Description'],
+      'general': ['--output-format', 'repr']},
+     {'stdout': "CIMQualifierDeclaration(name='Description', value=None, "
+                "type='string', is_array=False, array_size=None, "
+                "scopes=NocaseDict({'CLASS': False, 'ASSOCIATION': False, "
+                "'INDICATION': False, 'PROPERTY': False, 'REFERENCE': False, "
+                "'METHOD': False, 'PARAMETER': False, 'ANY': True}), "
+                "tosubclass=True, overridable=True, translatable=True, "
+                "toinstance=None)",
+      'test': 'innows'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify qualifier command get  Description outputformat txt',
+     {'args': ['get', 'Description'],
+      'general': ['--output-format', 'txt']},
+     {'stdout': "CIMQualifierDeclaration(name='Description', value=None, "
+                "type='string', is_array=False, ...)",
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify qualifier command -o grid enumerate produces table out',

--- a/tests/unit/test_tableformat.py
+++ b/tests/unit/test_tableformat.py
@@ -34,9 +34,11 @@ from pywbemtools.pywbemcli._common import format_table, fold_strings
 
 VERBOSE = False
 
-# TODO ks rewrite this test for pytest.  Note that the capture IO
+# TODO FUTURE: ks rewrite this test for pytest.  Note that the capture IO
 #      may be different in that they have fixtures such as capsys
-#      to capture output that may replace StringIO used below.
+#      to capture output that may replace StringIO used below. This should
+#      wait until we conclude that we can use a form of simplified_test
+#      with capsys.
 
 
 class BaseTableTests(unittest.TestCase):


### PR DESCRIPTION
This is a first part of a refactor of the tests to eliminate TODOs and move more of the tests to pytest.  No changes to the pywbemcli code.

Refactor tests_pywbemserver.py to pytest

Fix TODOs in test_qualifier_cmds.py

Remove TODO in cli_test_extensions.py

Added more tests for several cases where we had TODOs, in  particular
adding parameters

Enabled some tests that we had marked Failed.

Removed some erroneous TODOs

Clarified some TODOs