### PR TITLE
Refactor tree display code

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -73,6 +73,10 @@ Released: not yet
 * Adds command to test connection for existence of  the pull operations
   (connection test-pull)
 
+* Refactored display_class_tree() and other functions in _displaytree.py  and
+  _cmd_class.py cmd_class_tree function to eliminate boundary conditions, and
+  clarify code.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/pywbemtools/pywbemcli/_displaytree.py
+++ b/pywbemtools/pywbemcli/_displaytree.py
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Click Command definition for the qualifer command group  which includes
-cmds for get and enumerate for CIM qualifier types.
+Functions to build a tree dictionary and also a displayable tree in ascii
+from a list of CIM classes.
 """
 
 from __future__ import absolute_import, print_function
@@ -42,7 +42,7 @@ def build_tree(class_subclass_dict, top_class):
         Build dictionary of the class/subclass relationships for class cn
         in dictionary of class_subclass names. This maps the input dictionary
         that is a flat class_name: [subclass_name] dictionary to a tree
-        dictionary for the hiearchy of classes.
+        of dictionaries for the hiearchy of classes.
 
         Returns dictionary of dictionaries in form suitable for asciitree
 
@@ -50,6 +50,13 @@ def build_tree(class_subclass_dict, top_class):
           class_to_subclass_dict:
             Dictionary with all classes to be in as keys and the corresponding
             subclasses for each class as a list of classnames
+
+          cln (:term:`string`):
+            Class for which a tree node will be generated.  An empty node
+            is generated if class not in class_to_subclass_dict.
+
+        Returns:
+          Structure of nested dictionaries defining the class/subclass structure
         """
         node_dict = odicti()
         # If there is no subclass, the class will not exist in this dictionary
@@ -59,46 +66,43 @@ def build_tree(class_subclass_dict, top_class):
             if cln_list:
                 for key in cln_list:
                     node_dict[key] = _tree_node(class_to_subclass_dict, key)
-            else:
-                node_dict = odicti()
-        else:
-            return odicti()
-
         return node_dict
 
     rtn_dict = odicti()
     # _tree_node generates dictionary node for elements in class-subclass
-    # dictionary and returns complete node structure
+    # dictionary and returns complete node structure. This is recursive,
+    # with _tree_node recursively calling until there are no subclasses.
     rtn_dict[top_class] = _tree_node(class_subclass_dict, top_class)
     return rtn_dict
 
 
-def display_class_tree(classes, top_class=None):
+def build_class_tree_dict(classes, top_class=None):
     """
-    Display the list of classes as a left justified tree  in ascii to the
-    click.echo output.
-
+    Build a hierarchical dictionary of classes (each dictionary entry
+    defines  a single classname: list of subclasses
     Parameters:
 
-      classes (list of :class:`~pywbem.CIMClass`):
-        This is the classes that will be included in the display
-        including the top_class. If the top_class is None an
-        artificial top_class named 'root' will be added by this
-        function.
+        classes (list of :class:`~pywbem.CIMClass`)
+            List of classes to be included in the tree including at least
+            the classname and superclass name.  All other parameters are
+            ignored
 
-      top_class (:term:`string`):
-        The top level class to display or None.
+        top_class (:term: `string`)
+            The top level class to display or None if the display is
+            from root. In that case, the tree builder attaches a top node
+            named "root"
     """
 
     # Build dictionary of classname : superclassname from list of CIM classes
     cln_to_supercln = {cln.classname: cln.superclass for cln in classes}
 
+    # Sort so there is a fixed order to the resulting tree.
     cln_supercln_sorted = odicti()
     for key in sorted(cln_to_supercln.keys()):
         cln_supercln_sorted[key] = cln_to_supercln[key]
     cln_to_supercln = cln_supercln_sorted
 
-    # if top_class is none, create artifical root
+    # If top_class is none, create artifical root
     if top_class is None:
         for cln in cln_to_supercln:
             if not cln_to_supercln[cln]:
@@ -113,7 +117,21 @@ def display_class_tree(classes, top_class=None):
     [subcln_in_cln.setdefault(v, []).append(k) for (k, v) in
         six.iteritems(cln_to_supercln)]  # noqa: F841
 
-    tree = build_tree(subcln_in_cln, top_class)
+    return build_tree(subcln_in_cln, top_class)
 
+
+def display_class_tree(classes, top_class=None):
+    """
+    Build and display in ASCII output a tree of classes.
+
+    Parameters:
+        classes (list of :class:`~pywbem.CIMClass`)
+
+        top_class (:term: `string`)
+            The top level class to display or None if the display is
+            from root.
+
+    """
+    tree = build_class_tree_dict(classes, top_class=top_class)
     tr = LeftAligned()
     click.echo(tr(tree))

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -1119,12 +1119,27 @@ TEST_CASES = [
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
+    ['Verify class command tree top down starting at leaf class',
+     ['tree', 'CIM_Foo_sub'],
+     {'stdout': """CIM_Foo_sub_sub
+""",
+      'test': 'innows'},
+     SIMPLE_MOCK_FILE, OK],
+
     ['Verify class command tree bottom up. -s',
      ['tree', '-s', 'CIM_Foo_sub_sub'],
      {'stdout': """root
     +-- CIM_Foo
         +-- CIM_Foo_sub
             +-- CIM_Foo_sub_sub
+""",
+      'test': 'innows'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify class command tree -s from top class',
+     ['tree', '-s', 'CIM_Foo'],
+     {'stdout': """root
+    +-- CIM_Foo
 """,
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],


### PR DESCRIPTION
Refactor the code in the _displaytree.py module to make it more comprehensible, faster, and correct an outstanding issue where we were not always displaying the tree in the same order and ignoreing possible issues of classname case-independence

This also adds tests for boundary conditions of the "class tree" command

This pr does not have a defined issue since it does not change external behavior.

It was tested against both 0.17 and 1.0.0 b2 and handles the full 400+ class hiearchy tree display in about 4 seconds.