### PR TITLE
Fixes #663: connection file load failure

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -91,6 +91,12 @@ Released: not yet
   _cmd_class.py cmd_class_tree function to eliminate boundary conditions, and
   clarify code.
 
+* Extended parameter type testing in class PywbemServer so that all
+  constructor parameters are value tested.  This specifically fixes issue
+  where we were depending on WBEMConnection to test types of ca_certs
+  and invalid data types could get into the connections file. (See issue
+  #663).
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -70,13 +70,12 @@ Help text for ``pywbemcli``:
                                       during TLS/SSL handshake. If --no-verify client bypasses verification. Default: EnvVar
                                       PYWBEMCLI_VERIFY, or "--verify".
 
-      --ca-certs CACERTS              Certificates to be used for validating the certificate presented by the WBEM server
-                                      during TLS/SSL handshake: FILE: Use the certs in the specified PEM file; DIR: Use the
-                                      certs in the PEM files in the specified directory; "certifi" (pywbem 1.0 or later):
-                                      Use the certs provided by the certifi Python package; Default: EnvVar
-                                      PYWBEMCLI_CA_CERTS, or "certifi" (pywbem 1.0 or later), or the certs in the PEM files
-                                      in the first existing directory from from a list of system directories (pywbem before
-                                      1.0).
+      --ca-certs CACERTS              Certificates used to validate the certificate presented by the WBEM server during
+                                      TLS/SSL handshake: FILE: Use the certs in the specified PEM file; DIR: Use the certs
+                                      in the PEM files in the specified directory; "certifi" (pywbem 1.0 or later): Use the
+                                      certs provided by the certifi Python package; Default: EnvVar PYWBEMCLI_CA_CERTS, or
+                                      "certifi" (pywbem 1.0 or later), or the certs in the PEM files in the first existing
+                                      directory from from a system defined list of directories (pywbem before 1.0).
 
       -c, --certfile FILE             Path name of a PEM file containing a X.509 client certificate that is used to enable
                                       TLS/SSL 2-way authentication by presenting the certificate to the WBEM server during

--- a/pywbemtools/pywbemcli/_connection_repository.py
+++ b/pywbemtools/pywbemcli/_connection_repository.py
@@ -25,8 +25,8 @@ from __future__ import absolute_import, print_function
 
 import os
 import yaml
-import yamlloader
 import six
+import yamlloader
 import click
 
 from ._pywbem_server import PywbemServer
@@ -221,8 +221,6 @@ class ConnectionRepository(object):
                     dict_ = yaml.safe_load(_fp)
                     # put all the connection definitions into a group
                     # in the connection file
-                    # TODO: on file created with touch this responds
-                    # TypeError: 'NoneType' object is not subscriptable
                     connections_dict = dict_[
                         ConnectionRepository.connections_group_name]
 
@@ -236,8 +234,14 @@ class ConnectionRepository(object):
                             self._loaded = True
                     except KeyError as ke:
                         raise KeyError("Items missing from record {0} in "
-                                       "connections file {1}".format
+                                       "connections file. Exception {1}".format
                                        (ke, self._connections_file))
+                    except TypeError as te:
+                        raise TypeError('Invalid object type in connections '
+                                        'file: "{0}"; server name: "{1}". '
+                                        'Item: {2}'.
+                                        format(self._connections_file, name,
+                                               te))
                 except ValueError as ve:
                     raise ValueError("Invalid YAML in connections file {0}. "
                                      "Exception {1}".format

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -149,8 +149,8 @@ def validate_connections_file(connections_repo):
 @click.option('--ca-certs', type=str, metavar="CACERTS",
               default=None,  # defaulted in code
               envvar=PywbemServer.ca_certs_envvar,
-              help='Certificates to be used for validating the certificate '
-                   'presented by the WBEM server during TLS/SSL handshake: '
+              help='Certificates used to validate the certificate presented '
+                   'by the WBEM server during TLS/SSL handshake: '
                    'FILE: Use the certs in the specified PEM file; '
                    'DIR: Use the certs in the PEM files in the specified '
                    'directory; '
@@ -158,7 +158,7 @@ def validate_connections_file(connections_repo):
                    'the certifi Python package; '
                    'Default: EnvVar {ev}, or "certifi" (pywbem 1.0 or later), '
                    'or the certs in the PEM files in the first existing '
-                   'directory from from a list of system directories '
+                   'directory from from a system defined list of directories '
                    '(pywbem before 1.0).'.
                    format(ev=PywbemServer.ca_certs_envvar))
 @click.option('-c', '--certfile', type=str, metavar="FILE",
@@ -426,6 +426,8 @@ def cli(ctx, server, connection_name, default_namespace, user, password,
     resolved_default_namespace = default_namespace or DEFAULT_NAMESPACE
     resolved_timestats = timestats or DEFAULT_TIMESTATS
     resolved_verify = DEFAULT_VERIFY if verify is None else verify
+
+    # There is no default ca_certs
     resolved_ca_certs = ca_certs  # None should be passed on
 
     # Create the connections repository object that will be included in the

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -114,17 +114,17 @@ General Options:
                                   client bypasses verification. Default: EnvVar
                                   PYWBEMCLI_VERIFY, or "--verify".
 
-  --ca-certs CACERTS              Certificates to be used for validating the
-                                  certificate presented by the WBEM server
-                                  during TLS/SSL handshake: FILE: Use the certs
-                                  in the specified PEM file; DIR: Use the certs
-                                  in the PEM files in the specified directory;
+  --ca-certs CACERTS              Certificates used to validate the certificate
+                                  presented by the WBEM server during TLS/SSL
+                                  handshake: FILE: Use the certs in the
+                                  specified PEM file; DIR: Use the certs in the
+                                  PEM files in the specified directory;
                                   "certifi" (pywbem 1.0 or later): Use the certs
                                   provided by the certifi Python package;
                                   Default: EnvVar PYWBEMCLI_CA_CERTS, or
                                   "certifi" (pywbem 1.0 or later), or the certs
                                   in the PEM files in the first existing
-                                  directory from from a list of system
+                                  directory from from a system defined list of
                                   directories (pywbem before 1.0).
 
   -c, --certfile FILE             Path name of a PEM file containing a X.509
@@ -563,21 +563,22 @@ TEST_CASES = [
     #  Test errors with --name option, --mock-server option
     #
 
-    ['Verify -n option with non-existend connection file fails',
-     {'general': ['-n', 'fred', '--connections-file', './blah.yaml'],
+    ['Verify -n option with non-existent connection file fails',
+     {'general': ['-n', 'fred', '--connections-file', './filenotfound.yaml'],
       'cmdgrp': 'connection',
       'args': ['show']},
-     {'stderr': ['Connections file: "./blah.yaml" does not exist.',
+     {'stderr': ['Connections file: "./filenotfound.yaml" does not exist.',
                  'Aborted!'],
       'rc': 1,
       'test': 'innows'},
      None, OK],
 
     ['Verify --name with non-existend connection file fails',
-     {'general': ['--name', 'fred', '--connections-file', './blah.yaml'],
+     {'general': ['--name', 'fred', '--connections-file',
+                  './filenotfound.yaml'],
       'cmdgrp': 'connection',
       'args': ['show']},
-     {'stderr': ['Connections file: "./blah.yaml" does not exist.',
+     {'stderr': ['Connections file: "./filenotfound.yaml" does not exist.',
                  'Aborted!'],
       'rc': 1,
       'test': 'innows'},


### PR DESCRIPTION
Fixes issues where connection file load from yaml not type validated.
Also extends exception messages to clarify problem in each case.

The original problem that caused this was a side issue, somewhere
invalid data had gotten into a pywbemcli_connection_definitions.yaml
file (ca_certs had a list type). The old pywbem did not catch this
but the spec was always string and not list of strings.

However, it pointed out that we were not doing enough testing in
the Pywbem_Server class constructor and methods so we added validation on the property setters and textended the tests to include tests of these errors.