### PR TITLE
Fixes issue  #660, show default connection file in general help

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,8 @@ Released: not yet
 
 **Enhancements:**
 
+* Modify general help to display the full path of the default connections file.
+  (See issue #660)
 
 **Known issues:**
 
@@ -45,7 +47,7 @@ Released: 2020-07-12
 
 * The default location for the connections file (pywbemcli_connection_definitions.yaml)
   has been moved from the users current directory to the users home directory.
-  A general option "connections_file" allows the user to set other directories
+  A general option (``connections_file``) allows the user to set other directories
   and file names for this file. (See issue #596)
 
 **Deprecations:**
@@ -104,10 +106,10 @@ Released: 2020-07-12
   predictable: First the sorted key properties, then the sorted non-key
   properties. (Part of fix for issue #650)
 
-* Modify connection file location functionality so that default is
-  the users home directory but any other directory can be specified using the
-  general option "connections_file" which has a corresponding environment
-  variable.  (See issue #596)
+* Modify connections file location functionality so that the default file
+  location is the users home directory. Any other directory and filename can
+  be specified using the general option ``connections_file`` which has a
+  corresponding environment variable.  (See issue #596)
 
 **Cleanup**
 

--- a/pywbemtools/pywbemcli/_connection_repository.py
+++ b/pywbemtools/pywbemcli/_connection_repository.py
@@ -38,7 +38,6 @@ if six.PY2:
 # Normal definition for location of connection file
 DEFAULT_CONNECTIONS_FILE = 'pywbemcli_connection_definitions.yaml'
 
-LOCAL_CONNECTIONS_PATH = os.path.join(os.getcwd(), DEFAULT_CONNECTIONS_FILE)
 HOME_CONNECTIONS_PATH = os.path.join(os.path.expanduser("~"),
                                      DEFAULT_CONNECTIONS_FILE)
 

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -41,7 +41,7 @@ from ._pywbem_server import PywbemServer
 from .config import DEFAULT_NAMESPACE, \
     PYWBEMCLI_PROMPT, PYWBEMCLI_HISTORY_FILE, DEFAULT_MAXPULLCNT, \
     DEFAULT_CONNECTION_TIMEOUT, MAX_TIMEOUT, USE_AUTOSUGGEST
-from ._connection_repository import ConnectionRepository
+from ._connection_repository import ConnectionRepository, HOME_CONNECTIONS_PATH
 from ._click_extensions import PywbemcliTopGroup
 from ._utils import deprecation_warning
 
@@ -263,9 +263,9 @@ def validate_connections_file(connections_repo):
               envvar=PywbemServer.connections_file_envvar,
               help='File path of a YAML file containing named connection '
                    'definitions. The default if this option is not specified '
-                   'is the file name "{df}" in the users home directory. '
+                   'is the file "{df}" (in the users home directory). '
                    'EnvVar ({ev})'.
-                   format(df=DEFAULT_CONNECTIONS_FILE,
+                   format(df=HOME_CONNECTIONS_PATH,
                           ev=PywbemServer.connections_file_envvar))
 @click.option('--pdb', is_flag=True,
               # defaulted in code

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -29,6 +29,8 @@ import pywbem
 
 from .cli_test_extensions import CLITestsBase, PYWBEM_0, PYWBEM_1
 
+from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
+
 SCRIPT_DIR = os.path.dirname(__file__)
 
 SIMPLE_MOCK_FILE_PATH = os.path.join(SCRIPT_DIR, 'simple_mock_model.mof')
@@ -38,189 +40,84 @@ BAD_PY_FILE_PATH = os.path.join(SCRIPT_DIR, 'py_with_error.py')
 BAD_PY_ERR_STRTUP_PATH = os.path.join(SCRIPT_DIR, 'py_err_processatstartup.py')
 MOCK_PW_PROMPT_PATH = os.path.join(SCRIPT_DIR, 'mock_password_prompt.py')
 
-# pylint: disable=line-too-long
-GENERAL_HELP = """Usage: pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS] [COMMAND-OPTIONS]
+GENERAL_HELP_LINES = [
+    """
+    Usage: pywbemcli [GENERAL-OPTIONS] COMMAND [ARGS] [COMMAND-OPTIONS]
 
-  Pywbemcli is a command line WBEM client that uses the DMTF CIM-XML protocol
-  to communicate with WBEM servers. Pywbemcli can:
+      Pywbemcli is a command line WBEM client that uses the DMTF CIM-XML
+      protocol
+      to communicate with WBEM servers. Pywbemcli can:
 
-  * Manage the information in WBEM servers CIM objects using the
-    operations defined in the DMTF specification.  It can manage CIM
-    classes, CIM instances and CIM qualifier declarations in the WBEM
-    Server and execute CIM methods and queries on the server.
+      * Manage the information in WBEM servers CIM objects using the
+        operations defined in the DMTF specification.  It can manage CIM
+        classes, CIM instances and CIM qualifier declarations in the WBEM
+        Server and execute CIM methods and queries on the server.
 
-  * Inspect WBEM server characteristics including namespaces, registered
-    profiles, and other server information.
+      * Inspect WBEM server characteristics including namespaces, registered
+        profiles, and other server information.
 
-  * Capture detailed information on communication with the WBEM
-    server including time statistics and logs of the operations.
+      * Capture detailed information on communication with the WBEM
+        server including time statistics and logs of the operations.
 
-  * Maintain a persistent list of named connections to WBEM servers
-    and execute operations on them by name.
+      * Maintain a persistent list of named connections to WBEM servers
+        and execute operations on them by name.
 
-  Pywbemcli implements command groups and commands to execute the CIM-XML
-  operations defined by the DMTF CIM Operations Over HTTP specification
-  (DSP0200).
+      Pywbemcli implements command groups and commands to execute the CIM-XML
+      operations defined by the DMTF CIM Operations Over HTTP specification
+      (DSP0200).
 
-  The general options shown below can also be specified on any of the
-  commands, positioned right after the 'pywbemcli' command name.
+      The general options shown below can also be specified on any of the
+      commands, positioned right after the 'pywbemcli' command name.
 
-  The width of help texts of this command can be set with the
-  PYWBEMCLI_TERMWIDTH environment variable.
+      The width of help texts of this command can be set with the
+      PYWBEMCLI_TERMWIDTH environment variable.
 
-  For more detailed documentation, see:
+      For more detailed documentation, see:
 
-      https://pywbemtools.readthedocs.io/en/stable/
+      https://pywbemtools.readthedocs.io/en/stable/""",
+    CMD_OPTION_HELP_HELP_LINE,
+    "General Options:",
+    "-n, --name NAME Use the WBEM server defined by the WBEM",
+    "-m, --mock-server FILE  Use a mock WBEM server that is automatically",
+    "-s, --server URL  Use the WBEM server at the specified URL with",
+    "-u, --user TEXT   User name for the WBEM server. Default: EnvVar",
+    "-p, --password TEXT  Password for the WBEM server. Default: EnvVar",
+    "--verify / --no-verify  If --verify, client verifies the X.509 server",
+    "--ca-certs CACERTS  Certificates used to validate the certificate",
+    "-c, --certfile FILE  Path name of a PEM file containing a X.509",
+    "-t, --timeout INT  Client-side timeout in seconds for operations",
+    "-U, --use-pull [yes|no|either] Determines whether pull operations are ",
+    "--pull-max-cnt INT  Maximum number of instances to be returned by",
+    "-T, --timestats   Show time statistics of WBEM server",
+    "-d, --default-namespace NAMESPACE Default namespace, to be used when ",
+    "-o, --output-format FORMAT Output format for the command result. The",
+    "-l, --log COMP[=DEST[:DETAIL]]",
+    "Enable logging of the WBEM operations,",
+    "-C, --connections-file FILE PATH"
+    "File path of a YAML file containing named",
+    "pywbemcli_connection_definitions.yaml",
+    "-v, --verbose / --no-verbose Display extra information about the",
+    "--deprecation-warnings / --no-deprecation-warnings",
+    "--pdb    Pause execution in the built-in pdb debugger",
+    "--version   Show the version of this command and the",
+    """Commands:
+      class       Command group for CIM classes.
+      instance    Command group for CIM instances.
+      qualifier   Command group for CIM qualifier declarations.
+      server      Command group for WBEM servers.
+      connection  Command group for WBEM connection definitions.
+      help        Show help message for interactive mode.
+      repl        Enter interactive mode (default)."""
 
-General Options:
-  -n, --name NAME                 Use the WBEM server defined by the WBEM
-                                  connection definition NAME. This option is
-                                  mutually exclusive with the --server and
-                                  --mock-server options, since each defines a
-                                  WBEM server. Default: EnvVar PYWBEMCLI_NAME,
-                                  or none.
-
-  -m, --mock-server FILE          Use a mock WBEM server that is automatically
-                                  created in pywbemcli and populated with CIM
-                                  objects that are defined in the specified MOF
-                                  file or Python script file. See the pywbemcli
-                                  documentation for more information. This
-                                  option may be specified multiple times, and is
-                                  mutually exclusive with the --server and
-                                  --name options, since each defines a WBEM
-                                  server. Default: EnvVar PYWBEMCLI_MOCK_SERVER,
-                                  or none.
-
-  -s, --server URL                Use the WBEM server at the specified URL with
-                                  format: [SCHEME://]HOST[:PORT]. SCHEME must be
-                                  "https" (default) or "http". HOST is a short
-                                  or long hostname or literal IPV4/v6 address.
-                                  PORT defaults to 5989 for https and 5988 for
-                                  http. This option is mutually exclusive with
-                                  the --mock-server and --name options, since
-                                  each defines a WBEM server. Default: EnvVar
-                                  PYWBEMCLI_SERVER, or none.
-
-  -u, --user TEXT                 User name for the WBEM server. Default: EnvVar
-                                  PYWBEMCLI_USER, or none.
-
-  -p, --password TEXT             Password for the WBEM server. Default: EnvVar
-                                  PYWBEMCLI_PASSWORD, or prompted for if --user
-                                  specified.
-
-  --verify / --no-verify          If --verify, client verifies the X.509 server
-                                  certificate presented by the WBEM server
-                                  during TLS/SSL handshake. If --no-verify
-                                  client bypasses verification. Default: EnvVar
-                                  PYWBEMCLI_VERIFY, or "--verify".
-
-  --ca-certs CACERTS              Certificates used to validate the certificate
-                                  presented by the WBEM server during TLS/SSL
-                                  handshake: FILE: Use the certs in the
-                                  specified PEM file; DIR: Use the certs in the
-                                  PEM files in the specified directory;
-                                  "certifi" (pywbem 1.0 or later): Use the certs
-                                  provided by the certifi Python package;
-                                  Default: EnvVar PYWBEMCLI_CA_CERTS, or
-                                  "certifi" (pywbem 1.0 or later), or the certs
-                                  in the PEM files in the first existing
-                                  directory from from a system defined list of
-                                  directories (pywbem before 1.0).
-
-  -c, --certfile FILE             Path name of a PEM file containing a X.509
-                                  client certificate that is used to enable
-                                  TLS/SSL 2-way authentication by presenting the
-                                  certificate to the WBEM server during TLS/SSL
-                                  handshake. Default: EnvVar PYWBEMCLI_CERTFILE,
-                                  or none.
-
-  -k, --keyfile FILE              Path name of a PEM file containing a X.509
-                                  private key that belongs to the certificate in
-                                  the --certfile file. Not required if the
-                                  private key is part of the --certfile file.
-                                  Default: EnvVar PYWBEMCLI_KEYFILE, or none.
-
-  -t, --timeout INT               Client-side timeout in seconds for operations
-                                  with the WBEM server. Default: EnvVar
-                                  PYWBEMCLI_TIMEOUT, or 30.
-
-  -U, --use-pull [yes|no|either]  Determines whether pull operations are used
-                                  for operations with the WBEM server that
-                                  return lists of instances, as follows: "yes"
-                                  uses pull operations and fails if not
-                                  supported by the server; "no" uses traditional
-                                  operations; "either" (default) uses pull
-                                  operations if supported by the server, and
-                                  otherwise traditional operations. Default:
-                                  EnvVar PYWBEMCLI_USE_PULL, or "either".
-
-  --pull-max-cnt INT              Maximum number of instances to be returned by
-                                  the WBEM server in each open or pull response,
-                                  if pull operations are used. This is a tuning
-                                  parameter that does not affect the external
-                                  behavior of the commands. Default: EnvVar
-                                  PYWBEMCLI_PULL_MAX_CNT, or 1000
-
-  -T, --timestats                 Show time statistics of WBEM server
-                                  operations.
-
-  -d, --default-namespace NAMESPACE
-                                  Default namespace, to be used when commands do
-                                  not specify the --namespace command option.
-                                  Default: EnvVar PYWBEMCLI_DEFAULT_NAMESPACE,
-                                  or root/cimv2.
-
-  -o, --output-format FORMAT      Output format for the command result. The
-                                  default and allowed output formats are command
-                                  specific. The default output_format is None so
-                                  that each command selects its own default
-                                  format. FORMAT is: table formats:
-                                  [table|plain|simple|grid|psql|rst|html]; CIM
-                                  object formats: [mof|xml|repr|txt]]; TEXT
-                                  formats: [text].
-
-  -l, --log COMP[=DEST[:DETAIL]],...
-                                  Enable logging of the WBEM operations, defined
-                                  by a list of log configuration strings with:
-                                  COMP: [api|http|all]; DEST: [file|stderr],
-                                  default: file; DETAIL: [all|paths|summary],
-                                  default: all. Default: EnvVar PYWBEMCLI_LOG,
-                                  or all.
-
-  -v, --verbose / --no-verbose    Display extra information about the
-                                  processing.
-
-  --deprecation-warnings / --no-deprecation-warnings
-                                  Enable deprecation warnings. Default: EnvVar
-                                  PYWBEMCLI_DEPRECATION_WARNINGS, or true.
-
-  -C, --connections-file FILE PATH
-                                  File path of a YAML file containing named
-                                  connection definitions. The default if this
-                                  option is not specified is the file name
-                                  "pywbemcli_connection_definitions.yaml" in the
-                                  users home directory. EnvVar
-                                  (PYWBEMCLI_CONNECTIONS_FILE)
-
-  --pdb                           Pause execution in the built-in pdb debugger
-                                  just before executing the command within
-                                  pywbemcli. Default: EnvVar PYWBEMCLI_PDB, or
-                                  false.
-
-  --version                       Show the version of this command and the
-                                  pywbem package.
-
-  -h, --help                      Show this help message.
-
-Commands:
-  class       Command group for CIM classes.
-  instance    Command group for CIM instances.
-  qualifier   Command group for CIM qualifier declarations.
-  server      Command group for WBEM servers.
-  connection  Command group for WBEM connection definitions.
-  help        Show help message for interactive mode.
-  repl        Enter interactive mode (default).
-"""  # noqa: E501
+    # "Commands:",
+    # "class Command group for CIM classes.",
+    # "instance Command group for CIM instances.",
+    # "qualifier Command group for CIM qualifier declarations.",
+    # "server Command group for WBEM servers.",
+    # "connection Command group for WBEM connection definitions.",
+    # "help Show help message for interactive mode.",
+    # "repl Enter interactive mode (default)."
+]
 
 # pylint: disable=line-too-long
 REPL_HELP = """Usage: pywbemcli [GENERAL-OPTIONS] repl
@@ -289,21 +186,19 @@ TEST_CASES = [
     #     the debugger, if 'verbose' print verbose messages, if False the test
     #     is skipped.
 
-    ['Verify -help response.',
+    ['Verify help command --help response lines',
      {'general': ['--help'],
       'cmdgrp': 'class',
       'args': ['get', 'blah']},
-     {'stdout': GENERAL_HELP,
-      'rc': 0,
+     {'stdout': GENERAL_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify -h response.',
+    ['Verify help command -h response lines',
      {'general': ['--help'],
       'cmdgrp': 'class',
       'args': ['get', 'blah']},
-     {'stdout': GENERAL_HELP,
-      'rc': 0,
+     {'stdout': GENERAL_HELP_LINES,
       'test': 'innows'},
      None, OK],
 


### PR DESCRIPTION
Modifies the general help to include the actual help file path in the
help text for the --connections-file general option.

To do this we had to modify the general help text from a single compare
of the complete file to compare of individual components of the help
output.