### PR TITLE
Fixes issue #657 - Losing output instances in shrub when host name used

### DIFF
--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -1374,7 +1374,7 @@ def cmd_instance_shrub(context, instancename, options):
         instancepath = get_instancename(context, instancename, options)
 
         # Collect the data for the shrub
-        shrub = AssociationShrub(context, instancepath,
+        shrub = AssociationShrub(context.conn, instancepath,
                                  Role=options['role'],
                                  AssocClass=options['assoc_class'],
                                  ResultRole=options['result_role'],

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -851,7 +851,7 @@ def process_invokemethod(context, objectname, methodname, options):
 
     Parameters:
 
-      objectname (:term:`string` or :class:`~pywbem.CIMInstanceName` or :class:`~pywbem.CIMInstanceName`)  # noqa: E501
+      objectname (:term:`string` or :class:`~pywbem.CIMClassName` or :class:`~pywbem.CIMInstanceName`)  # noqa: E501
 
       methodname (:term:`string`):
         The name of the method to be executed

--- a/tests/unit/test_instance_cmds.py
+++ b/tests/unit/test_instance_cmds.py
@@ -2775,15 +2775,12 @@ interop      TST_MemberOfFamilyCollection  3
      None, OK],
 
     # Test simple mock association with namespace and host in INSTANCENAME
-
-    # TODO #657: Instance shrub command misses associated instances when
-    #      specifying host and namespace. Test marked as failing.
-    ['Verify instance command shrub, simple tree',
+    ['Verify instance command shrub, INSTANCENAME with host and namespace',
      ['shrub', '//FakedUrl/root/cimv2:TST_Person.name="Mike"', '--fullpath'],
      {'stdout': SIMPLE_SHRUB_TREE,
       'rc': 0,
       'test': 'innows'},
-     ASSOC_MOCK_FILE, FAIL],
+     ASSOC_MOCK_FILE, RUN],
 
     ['Verify instance command shrub, simple tree, namespace in INSTNAME',
      ['shrub', 'root/cimv2:TST_Person.name="Mike"', '--fullpath'],
@@ -2881,13 +2878,21 @@ interop      TST_MemberOfFamilyCollection  3
       'test': 'innows'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance command shrub, simple tableno ns in request',
+    ['Verify instance command shrub, simple table; ns in request',
      {'args': ['shrub', 'root/cimv2:TST_Person.name="Mike"'],
       'general': ['--output-format', 'plain']},
      {'stdout': SIMPLE_SHRUB_TABLE1,
       'rc': 0,
       'test': 'innows'},
      ASSOC_MOCK_FILE, OK],
+
+    ['Verify instance command shrub, simple table; ns/host in request',
+     {'args': ['shrub', '//FakedUrl/root/cimv2:TST_Person.name="Mike"'],
+      'general': ['--output-format', 'plain']},
+     {'stdout': SIMPLE_SHRUB_TABLE1,
+      'rc': 0,
+      'test': 'innows'},
+     ASSOC_MOCK_FILE, RUN],
 
     ['Verify instance command shrub, simple tree with namespace',
      ['shrub', 'TST_Person.name="Mike"', '--fullpath'],


### PR DESCRIPTION
Not all the instances were produced on output when the host name was
included in the instancename.

In general, the host name is of no value so we remove it at the
beginning of the method.  The call must be for the current host since
pywbemcli cannot dynamically connect to any other host.

Took the opportunity to clean up some other code.

1. Refactored the AssociationShrub by

   a. Moving one group of code to a new method

   b. Replacing the local sort_instances and sore_instancenames
      with the general sort_cimobjects

2. Add documentation to AssociationShrub methods.

3. Replaced the context parameter in AssociationShrub with conn since
   only the conn is used from the context.

4. Fixed minor documentation errors in common.