### PR TITLE
fixes issue #224 py2 click-repl exception when command entered

### DIFF
--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -786,7 +786,7 @@ Help text for ``pywbemcli connection select`` (see :ref:`connection select comma
           . . .
 
     Command Options:
-      -d, --default  If set, the connection is set to be the default connection  in the connections file in addition to
+      -d, --default  If set, the connection is set to be the default connection in the connections file in addition to
                      setting it as the current connection.
 
       -h, --help     Show this help message.

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -53,22 +53,22 @@ from ._click_extensions import PywbemcliGroup, PywbemcliCommand
 no_qualifiers_class_option = [              # pylint: disable=invalid-name
     click.option('--nq', '--no-qualifiers', 'no_qualifiers', is_flag=True,
                  default=True,
-                 help='Do not include qualifiers in the returned class(es). '
+                 help=u'Do not include qualifiers in the returned class(es). '
                       'Default: Include qualifiers.')]
 
 deep_inheritance_class_option = [              # pylint: disable=invalid-name
     click.option('--di', '--deep-inheritance', 'deep_inheritance', is_flag=True,
                  default=False,
-                 help='Include the complete subclass hierarchy of the '
+                 help=u'Include the complete subclass hierarchy of the '
                       'requested classes in the result set. '
                       'Default: Do not include subclasses.')]
 
 local_only_class_option = [              # pylint: disable=invalid-name
     click.option('--lo', '--local-only', 'local_only', is_flag=True,
                  default=False,
-                 help='Do not include superclass properties and methods in '
-                      'the returned class(es). '
-                      'Default: Include superclass properties and methods.')]
+                 help=u'Do not include superclass properties and methods in '
+                      u'the returned class(es). '
+                      u'Default: Include superclass properties and methods.')]
 
 
 ##########################################################################
@@ -180,7 +180,7 @@ def class_get(context, classname, **options):
                      options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True,)
 @click.option('-f', '--force', is_flag=True, default=False,
-              help='Delete any instances of the class as well. '
+              help=u'Delete any instances of the class as well. '
                    'Some servers may still reject the class deletion. '
                    'Default: Reject command if the class has any instances.')
 @add_options(namespace_option)
@@ -219,7 +219,7 @@ def class_delete(context, classname, **options):
 @click.argument('methodname', type=str, metavar='METHODNAME', required=True)
 @click.option('-p', '--parameter', type=str, metavar='PARAMETERNAME=VALUE',
               required=False, multiple=True,
-              help='Specify a method input parameter with its value. '
+              help=u'Specify a method input parameter with its value. '
                    'May be specified multiple times. '
                    'Default: No input parameters.')
 @add_options(namespace_option)
@@ -259,11 +259,11 @@ def class_invokemethod(context, classname, methodname, **options):
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True)
 @click.option('--rc', '--result-class', 'result_class', type=str,
               required=False, metavar='CLASSNAME',
-              help='Filter the result set by result class name. '
+              help=u'Filter the result set by result class name. '
                    'Subclasses of the specified class also match.')
 @click.option('-r', '--role', type=str, required=False,
               metavar='PROPERTYNAME',
-              help='Filter the result set by source end role name.')
+              help=u'Filter the result set by source end role name.')
 @add_options(no_qualifiers_class_option)
 @add_options(include_classorigin_class_option)
 @add_options(propertylist_option)
@@ -306,18 +306,18 @@ def class_references(context, classname, **options):
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True)
 @click.option('--ac', '--assoc-class', 'assoc_class', type=str, required=False,
               metavar='CLASSNAME',
-              help='Filter the result set by association class name. '
+              help=u'Filter the result set by association class name. '
                    'Subclasses of the specified class also match.')
 @click.option('--rc', '--result-class', 'result_class', type=str,
               required=False, metavar='CLASSNAME',
-              help='Filter the result set by result class name. '
+              help=u'Filter the result set by result class name. '
                    'Subclasses of the specified class also match.')
 @click.option('-r', '--role', type=str, required=False,
               metavar='PROPERTYNAME',
-              help='Filter the result set by source end role name.')
+              help=u'Filter the result set by source end role name.')
 @click.option('--rr', '--result-role', 'result_role', type=str, required=False,
               metavar='PROPERTYNAME',
-              help='Filter the result set by far end role name.')
+              help=u'Filter the result set by far end role name.')
 @add_options(no_qualifiers_class_option)
 @add_options(include_classorigin_class_option)
 @add_options(propertylist_option)
@@ -360,7 +360,7 @@ def class_associators(context, classname, **options):
                 required=True)
 @add_options(multiple_namespaces_option)
 @click.option('-s', '--sort', is_flag=True, required=False,
-              help='Sort by namespace. Default is to sort by classname')
+              help=u'Sort by namespace. Default is to sort by classname')
 @add_options(association_filter_option)
 @add_options(indication_filter_option)
 @add_options(experimental_filter_option)
@@ -402,7 +402,7 @@ def class_find(context, classname_glob, **options):
 @class_group.command('tree', cls=PywbemcliCommand, options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME', required=False)
 @click.option('-s', '--superclasses', is_flag=True, default=False,
-              help='Show the superclass hierarchy. '
+              help=u'Show the superclass hierarchy. '
                    'Default: Show the subclass hierarchy.')
 @add_options(namespace_option)
 @add_options(help_option)

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -40,6 +40,12 @@ from ._pywbem_server import PywbemServer
 from ._context_obj import ContextObj
 from ._click_extensions import PywbemcliGroup, PywbemcliCommand
 
+# Issue 224 - Exception in prompt-toolkit with python 2.7. Caused because
+# with prompt-toolkit 2 + the completer requires unicode and click_repl not
+# passing help as unicode in options as unicode
+# NOTE: Insure that all option help attributes are unicode to get around this
+#       issue
+
 
 @cli.group('connection', cls=PywbemcliGroup, options_metavar=GENERAL_OPTS_TXT,
            subcommand_metavar=SUBCMD_HELP_TXT)
@@ -86,8 +92,8 @@ def connection_export(context):
 @click.argument('name', type=str, metavar='NAME', required=False)
 @click.option('--show-password', is_flag=True,
               default=False,
-              help='If set, show existing password in results. Otherwise, '
-                   'password is masked')
+              help=u'If set, show existing password in results. Otherwise, '
+                   u'password is masked')
 @add_options(help_option)
 @click.pass_obj
 def connection_show(context, name, **options):
@@ -151,9 +157,9 @@ def connection_delete(context, name):
 @click.argument('name', type=str, metavar='NAME', required=False)
 @click.option('-d', '--default', is_flag=True,
               default=False,
-              help='If set, the connection is set to be the default connection '
-                   ' in the connections file in addition to setting it as the '
-                   'current connection.')
+              help=u'If set, the connection is set to be the default '
+                   u'connection in the connections file in addition to setting '
+                   u'it as the current connection.')
 @add_options(help_option)
 @click.pass_obj
 def connection_select(context, name, **options):
@@ -200,9 +206,9 @@ def connection_select(context, name, **options):
                           options_metavar=CMD_OPTS_TXT)
 @click.option('--test-pull', is_flag=True,
               default=False,
-              help='If set, the connection is tested to determine if the'
-                   'DMTF defined pull operations (ex. OpenEnumerateInstances'
-                   'are implemented since these are optional.')
+              help=u'If set, the connection is tested to determine if the'
+                   u'DMTF defined pull operations (ex. OpenEnumerateInstances'
+                   u'are implemented since these are optional.')
 @add_options(help_option)
 @click.pass_obj
 def connection_test(context, **options):
@@ -248,8 +254,8 @@ def connection_save(context, name):
                           options_metavar=CMD_OPTS_TXT)
 @click.option('-f', '--full', is_flag=True,
               default=False,
-              help='If set, display the full table. Otherwise display '
-                   'a brief view(name, server, mock_server columns).')
+              help=u'If set, display the full table. Otherwise display '
+                   u'a brief view(name, server, mock_server columns).')
 @add_options(help_option)
 @click.pass_obj
 def connection_list(context, **options):

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -58,100 +58,106 @@ from ._cmd_class import get_namespaces, enumerate_classes_filtered
 # the corresponding option name, ex. 'include_qualifiers'. It should be
 # defined with underscore and not dash
 
+# Issue 224 - Exception in prompt-toolkit with python 2.7. Caused because
+# with prompt-toolkit 2 + the completer requires unicode and click_repl not
+# passing help as unicode in options as unicode
+# NOTE: Insure that all option help attributes are unicode to get around this
+#       issue
+
 
 # This is instance-only because the default is False for include-qualifiers
 # on instances but True on classes
 include_qualifiers_get_option = [              # pylint: disable=invalid-name
     click.option('--iq', '--include-qualifiers', 'include_qualifiers',
                  is_flag=True, required=False,
-                 help='Include qualifiers in the returned instance. '
-                      'Not all servers return qualifiers on instances. '
-                      'Default: Do not include qualifiers.')]
+                 help=u'Include qualifiers in the returned instance. '
+                      u'Not all servers return qualifiers on instances. '
+                      u'Default: Do not include qualifiers.')]
 
 include_qualifiers_list_option = [              # pylint: disable=invalid-name
     click.option('--iq', '--include-qualifiers', 'include_qualifiers',
                  is_flag=True, required=False,
-                 help='When traditional operations are used, include '
-                      'qualifiers in the returned instances. '
-                      'Some servers may ignore this option. '
-                      'By default, and when pull operations are used, '
-                      'qualifiers will never be included.')]
+                 help=u'When traditional operations are used, include '
+                      u'qualifiers in the returned instances. '
+                      u'Some servers may ignore this option. '
+                      u'By default, and when pull operations are used, '
+                      u'qualifiers will never be included.')]
 
 # specific to instance because DeepInheritance differs between class and
 # instance operations.
 deep_inheritance_enum_option = [              # pylint: disable=invalid-name
     click.option('--di', '--deep-inheritance', 'deep_inheritance',
                  is_flag=True, required=False,
-                 help='Include subclass properties in the returned '
-                      'instances. '
-                      'Default: Do not include subclass properties.')]
+                 help=u'Include subclass properties in the returned '
+                      u'instances. '
+                      u'Default: Do not include subclass properties.')]
 
 local_only_get_option = [              # pylint: disable=invalid-name
     click.option('--lo', '--local-only', 'local_only', is_flag=True,
                  required=False,
-                 help='Do not include superclass properties in the returned '
-                      'instance. '
-                      'Some servers may ignore this option. '
-                      'Default: Include superclass properties.')]
+                 help=u'Do not include superclass properties in the returned '
+                      u'instance. '
+                      u'Some servers may ignore this option. '
+                      u'Default: Include superclass properties.')]
 
 local_only_list_option = [              # pylint: disable=invalid-name
     click.option('--lo', '--local-only', 'local_only', is_flag=True,
                  required=False,
-                 help='When traditional operations are used, do not include '
-                      'superclass properties in the returned instances. '
-                      'Some servers may ignore this option. '
-                      'By default, and when pull operations are used, '
-                      'superclass properties will always be included.')]
+                 help=u'When traditional operations are used, do not include '
+                      u'superclass properties in the returned instances. '
+                      u'Some servers may ignore this option. '
+                      u'By default, and when pull operations are used, '
+                      u'superclass properties will always be included.')]
 
 property_create_option = [              # pylint: disable=invalid-name
     click.option('-p', '--property', type=str, metavar='PROPERTYNAME=VALUE',
                  required=False, multiple=True,
-                 help='Initial property value for the new instance. '
-                      'May be specified multiple times. '
-                      'Array property values are specified as a '
-                      'comma-separated list; embedded instances are not '
-                      'supported. '
-                      'Default: No initial properties provided.')]
+                 help=u'Initial property value for the new instance. '
+                      u'May be specified multiple times. '
+                      u'Array property values are specified as a '
+                      u'comma-separated list; embedded instances are not '
+                      u'supported. '
+                      u'Default: No initial properties provided.')]
 
 property_modify_option = [              # pylint: disable=invalid-name
     click.option('-p', '--property', type=str, metavar='PROPERTYNAME=VALUE',
                  required=False, multiple=True,
-                 help='Property to be modified, with its new value. '
-                      'May be specified once for each property to be '
-                      'modified. '
-                      'Array property values are specified as a '
-                      'comma-separated list; embedded instances are not '
-                      'supported. '
-                      'Default: No properties modified.')]
+                 help=u'Property to be modified, with its new value. '
+                      u'May be specified once for each property to be '
+                      u'modified. '
+                      u'Array property values are specified as a '
+                      u'comma-separated list; embedded instances are not '
+                      u'supported. '
+                      u'Default: No properties modified.')]
 
 keybinding_key_option = [              # pylint: disable=invalid-name
     click.option('-k', '--key', type=str, metavar='KEYNAME=VALUE',
                  required=False, multiple=True,
-                 help='Value for a key in keybinding of CIM instance name. '
-                      'May be specified multiple times. '
-                      'Allows defining keys without the issues of quotes. '
-                      'Default: No keybindings provided.')]
+                 help=u'Value for a key in keybinding of CIM instance name. '
+                      u'May be specified multiple times. '
+                      u'Allows defining keys without the issues of quotes. '
+                      u'Default: No keybindings provided.')]
 
 filter_query_language_option = [              # pylint: disable=invalid-name
     click.option('--fql', '--filter-query-language', 'filter_query_language',
                  type=str, metavar='QUERY-LANGUAGE', default=None,
-                 help='The filter query language to be used with '
-                      '--filter-query. '
-                      'Default: DMTF:FQL.')]
+                 help=u'The filter query language to be used with '
+                      u'--filter-query. '
+                      u'Default: DMTF:FQL.')]
 
 filter_query_option = [              # pylint: disable=invalid-name
     click.option('--fq', '--filter-query', 'filter_query', type=str,
                  metavar='QUERY-STRING', default=None,
-                 help='When pull operations are used, filter the instances in '
-                      'the result via a filter query. '
-                      'By default, and when traditional operations are used, '
-                      'no such filtering takes place.')]
+                 help=u'When pull operations are used, filter the instances in '
+                      u'the result via a filter query. '
+                      u'By default, and when traditional operations are used, '
+                      u'no such filtering takes place.')]
 
 help_instancename_option = [              # pylint: disable=invalid-name
     click.option('--hi', '--help-instancename', 'help_instancename',
                  is_flag=True, required=False, is_eager=True,
-                 help='Show help message for specifying INSTANCENAME including '
-                      'use of the --key and --namespace options.')]
+                 help=u'Show help message for specifying INSTANCENAME '
+                      u'including use of the --key and --namespace options.')]
 
 
 ##########################################################################
@@ -321,13 +327,13 @@ def instance_create(context, classname, **options):
 @add_options(property_modify_option)
 @click.option('--pl', '--propertylist', 'propertylist', multiple=True, type=str,
               default=None, required=False, metavar='PROPERTYLIST',
-              help='Reduce the properties to be modified (as per '
-              '--property) to a specific property list. '
-              'Multiple properties may be specified with either a '
-              'comma-separated list or by using the option multiple '
-              'times. The empty string will cause no properties to '
-              'be modified. '
-              'Default: Do not reduce the properties to be modified.')
+              help=u'Reduce the properties to be modified (as per '
+              u'--property) to a specific property list. '
+              u'Multiple properties may be specified with either a '
+              u'comma-separated list or by using the option multiple '
+              u'times. The empty string will cause no properties to '
+              u'be modified. '
+              u'Default: Do not reduce the properties to be modified.')
 @add_options(verify_option)
 @add_options(keybinding_key_option)
 @add_options(namespace_option)
@@ -367,18 +373,18 @@ def instance_modify(context, instancename, **options):
                 required=False)
 @click.option('--ac', '--assoc-class', 'assoc_class', type=str, required=False,
               metavar='CLASSNAME',
-              help='Filter the result set by association class name. '
-                   'Subclasses of the specified class also match.')
+              help=u'Filter the result set by association class name. '
+                   u'Subclasses of the specified class also match.')
 @click.option('--rc', '--result-class', 'result_class', type=str,
               required=False, metavar='CLASSNAME',
-              help='Filter the result set by result class name. '
-                   'Subclasses of the specified class also match.')
+              help=u'Filter the result set by result class name. '
+                   u'Subclasses of the specified class also match.')
 @click.option('-r', '--role', type=str, required=False,
               metavar='PROPERTYNAME',
-              help='Filter the result set by source end role name.')
+              help=u'Filter the result set by source end role name.')
 @click.option('--rr', '--result-role', 'result_role', type=str, required=False,
               metavar='PROPERTYNAME',
-              help='Filter the result set by far end role name.')
+              help=u'Filter the result set by far end role name.')
 @add_options(include_qualifiers_list_option)
 @add_options(include_classorigin_instance_option)
 @add_options(propertylist_option)
@@ -428,10 +434,10 @@ def instance_associators(context, instancename, **options):
                 required=False)
 @click.option('--rc', '--result-class', 'result_class', type=str,
               required=False, metavar='CLASSNAME',
-              help='Filter the result set by result class name. '
-                   'Subclasses of the specified class also match.')
+              help=u'Filter the result set by result class name. '
+                   u'Subclasses of the specified class also match.')
 @click.option('-r', '--role', type=str, required=False, metavar='PROPERTYNAME',
-              help='Filter the result set by source end role name.')
+              help=u'Filter the result set by source end role name.')
 @add_options(include_qualifiers_list_option)
 @add_options(include_classorigin_instance_option)
 @add_options(propertylist_option)
@@ -482,11 +488,11 @@ def instance_references(context, instancename, **options):
 @click.argument('methodname', type=str, metavar='METHODNAME', required=False)
 @click.option('-p', '--parameter', type=str, metavar='PARAMETERNAME=VALUE',
               required=False, multiple=True,
-              help='Specify a method input parameter with its value. '
-                   'May be specified multiple times. '
-                   'Array property values are specified as a comma-separated '
-                   'list; embedded instances are not supported. '
-                   'Default: No input parameters.')
+              help=u'Specify a method input parameter with its value. '
+                   u'May be specified multiple times. '
+                   u'Array property values are specified as a comma-separated '
+                   u'list; embedded instances are not supported. '
+                   u'Default: No input parameters.')
 @add_options(keybinding_key_option)
 @add_options(namespace_option)
 @add_options(help_instancename_option)
@@ -533,8 +539,8 @@ def instance_invokemethod(context, instancename, methodname, **options):
 @click.argument('query', type=str, required=True, metavar='QUERY-STRING')
 @click.option('--ql', '--query-language', 'query_language', type=str,
               metavar='QUERY-LANGUAGE', default=DEFAULT_QUERY_LANGUAGE,
-              help='The query language to be used with --query. '
-              'Default: {default}.'.
+              help=u'The query language to be used with --query. '
+              u'Default: {default}.'.
               format(default=DEFAULT_QUERY_LANGUAGE))
 @add_options(namespace_option)
 @add_options(summary_option)
@@ -563,7 +569,7 @@ def instance_query(context, query, **options):
 @add_options(indication_filter_option)
 @add_options(experimental_filter_option)
 @click.option('-s', '--sort', is_flag=True, required=False,
-              help='Sort by instance count. Otherwise sorted by class name.')
+              help=u'Sort by instance count. Otherwise sorted by class name.')
 @add_options(help_option)
 @click.pass_obj
 def instance_count(context, classname, **options):
@@ -603,26 +609,26 @@ def instance_count(context, classname, **options):
                 required=False)
 @click.option('--ac', '--assoc-class', 'assoc_class', type=str, required=False,
               metavar='CLASSNAME',
-              help='Filter the result set by association class name. '
+              help=u'Filter the result set by association class name. '
                    'Subclasses of the specified class also match.')
 @click.option('--rc', '--result-class', 'result_class', type=str,
               required=False, metavar='CLASSNAME',
-              help='Filter the result set by result class name. '
-                   'Subclasses of the specified class also match.')
+              help=u'Filter the result set by result class name. '
+                   u'Subclasses of the specified class also match.')
 @click.option('-r', '--role', type=str, required=False,
               metavar='PROPERTYNAME',
-              help='Filter the result set by source end role name.')
+              help=u'Filter the result set by source end role name.')
 @click.option('--rr', '--result-role', 'result_role', type=str, required=False,
               metavar='PROPERTYNAME',
-              help='Filter the result set by far end role name.')
+              help=u'Filter the result set by far end role name.')
 @add_options(keybinding_key_option)
 @add_options(namespace_option)
 @add_options(summary_option)
 @click.option('-f', '--fullpath', default=False, is_flag=True,
-              help='Normally the instance paths in the tree views are '
-                   'by hiding some keys with ~ to make the tree simpler '
-                   'to read. This includes keys that have the same value '
-                   'for all instances and the "CreationClassName" key.  When'
+              help=u'Normally the instance paths in the tree views are '
+                   u'by hiding some keys with ~ to make the tree simpler '
+                   u'to read. This includes keys that have the same value '
+                   u'for all instances and the "CreationClassName" key.  When'
                    'this option is used the full instance paths are displayed.')
 @add_options(help_instancename_option)
 @add_options(help_option)

--- a/pywbemtools/pywbemcli/_cmd_profile.py
+++ b/pywbemtools/pywbemcli/_cmd_profile.py
@@ -39,6 +39,12 @@ from ._click_extensions import PywbemcliGroup, PywbemcliCommand
 # the corresponding option name, ex. 'include_qualifiers'. It should be
 # defined with underscore and not dash
 
+# Issue 224 - Exception in prompt-toolkit with python 2.7. Caused because
+# with prompt-toolkit 2 + the completer requires unicode and click_repl not
+# passing help as unicode in options as unicode
+# NOTE: Insure that all option help attributes are unicode to get around this
+#       issue
+
 
 @cli.group('profile', cls=PywbemcliGroup, options_metavar=GENERAL_OPTS_TXT,
            subcommand_metavar=SUBCMD_HELP_TXT)
@@ -61,10 +67,10 @@ def profile_group():
                        options_metavar=CMD_OPTS_TXT)
 @click.option('-o', '--organization', type=str, metavar='ORG-NAME',
               required=False,
-              help='Filter by the defined organization. (ex. -o DMTF')
+              help=u'Filter by the defined organization. (ex. -o DMTF')
 @click.option('-p', '--profile', type=str, metavar='PROFILE-NAME',
               required=False,
-              help='Filter by the profile name. (ex. -p Array')
+              help=u'Filter by the profile name. (ex. -p Array')
 @add_options(help_option)
 @click.pass_obj
 def profile_list(context, **options):
@@ -90,27 +96,27 @@ def profile_list(context, **options):
                        options_metavar=CMD_OPTS_TXT)
 @click.option('-o', '--organization', type=str, metavar='ORG-NAME',
               required=False,
-              help='Filter by the defined organization. (ex. -o DMTF')
+              help=u'Filter by the defined organization. (ex. -o DMTF')
 @click.option('-p', '--profile', type=str, metavar='PROFILE-NAME',
               required=False,
-              help='Filter by the profile name. (ex. -p Array')
+              help=u'Filter by the profile name. (ex. -p Array')
 @click.option('--cc', '--central-class', 'central_class', type=str,
               metavar='CLASSNAME', required=False,
-              help='Optional. Required only if profiles supports only '
-              'scopig methodology')
+              help=u'Optional. Required only if profiles supports only '
+              u'scopig methodology')
 @click.option('--sc', '--scoping-class', 'scoping_class', type=str,
               metavar='CLASSNAME', required=False,
-              help='Optional. Required only if profiles supports only '
-              'scopig methodology')
+              help=u'Optional. Required only if profiles supports only '
+              u'scopig methodology')
 @click.option('--sp', '--scoping-path', 'scoping_path', type=str,
               metavar='CLASSLIST', required=False, multiple=True,
-              help='Optional. Required only if profiles supports only '
-              'scopig methodology. Multiples allowed')
+              help=u'Optional. Required only if profiles supports only '
+              u'scopig methodology. Multiples allowed')
 @click.option('--rd', '--reference-direction', 'reference_direction',
               type=click.Choice(['snia', 'dmtf']),
               default='dmtf',
               show_default=True,
-              help='Navigation direction for association.')
+              help=u'Navigation direction for association.')
 @add_options(help_option)
 @click.pass_obj
 def centralinsts(context, **options):

--- a/pywbemtools/pywbemcli/_cmd_qualifier.py
+++ b/pywbemtools/pywbemcli/_cmd_qualifier.py
@@ -34,6 +34,12 @@ from ._common_options import add_options, namespace_option, summary_option, \
     help_option
 from ._click_extensions import PywbemcliGroup, PywbemcliCommand
 
+# Issue 224 - Exception in prompt-toolkit with python 2.7. Caused because
+# with prompt-toolkit 2 + the completer requires unicode and click_repl not
+# passing help as unicode in options as unicode
+# NOTE: Insure that all option help attributes are unicode to get around this
+#       issue
+
 
 @cli.group('qualifier', cls=PywbemcliGroup, options_metavar=GENERAL_OPTS_TXT,
            subcommand_metavar=SUBCMD_HELP_TXT)

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -40,6 +40,12 @@ from ._click_extensions import PywbemcliGroup, PywbemcliCommand
 # the corresponding option name, ex. 'include_qualifiers'. It should be
 # defined with underscore and not dash
 
+# Issue 224 - Exception in prompt-toolkit with python 2.7. Caused because
+# with prompt-toolkit 2 + the completer requires unicode and click_repl not
+# passing help as unicode in options as unicode
+# NOTE: Insure that all option help attributes are unicode to get around this
+#       issue
+
 
 @cli.group('server', cls=PywbemcliGroup, options_metavar=GENERAL_OPTS_TXT,
            subcommand_metavar=SUBCMD_HELP_TXT)

--- a/pywbemtools/pywbemcli/_common_options.py
+++ b/pywbemtools/pywbemcli/_common_options.py
@@ -31,59 +31,59 @@ propertylist_option = [                      # pylint: disable=invalid-name
     click.option('--pl', '--propertylist', 'propertylist', multiple=True,
                  type=str,
                  default=None, metavar='PROPERTYLIST',
-                 help='Filter the properties included in the returned '
-                      'object(s). '
-                      'Multiple properties may be specified with either a '
-                      'comma-separated list or by using the option multiple '
-                      'times. Properties specified in this option that are '
-                      'not in the object(s) will be ignored. '
-                      'The empty string will include no properties. '
-                      'Default: Do not filter properties.')]
+                 help=u'Filter the properties included in the returned '
+                      u'object(s). '
+                      u'Multiple properties may be specified with either a '
+                      u'comma-separated list or by using the option multiple '
+                      u'times. Properties specified in this option that are '
+                      u'not in the object(s) will be ignored. '
+                      u'The empty string will include no properties. '
+                      u'Default: Do not filter properties.')]
 
 names_only_option = [                      # pylint: disable=invalid-name
     click.option('--no', '--names-only', 'names_only', is_flag=True,
                  required=False,
-                 help='Retrieve only the object paths (names). '
-                      'Default: Retrieve the complete objects including '
-                      'object paths.')]
+                 help=u'Retrieve only the object paths (names). '
+                      u'Default: Retrieve the complete objects including '
+                      u'object paths.')]
 
 include_classorigin_instance_option = [         # pylint: disable=invalid-name
     click.option('--ico', '--include-classorigin', 'include_classorigin',
                  is_flag=True, required=False,
-                 help='Include class origin information in the returned '
-                      'instance(s). '
-                      'Some servers may ignore this option. '
-                      'Default: Do not include class origin information.')]
+                 help=u'Include class origin information in the returned '
+                      u'instance(s). '
+                      u'Some servers may ignore this option. '
+                      u'Default: Do not include class origin information.')]
 
 include_classorigin_class_option = [            # pylint: disable=invalid-name
     click.option('--ico', '--include-classorigin', 'include_classorigin',
                  is_flag=True, required=False,
-                 help='Include class origin information in the returned '
-                      'class(es). '
-                      'Default: Do not include class origin information.')]
+                 help=u'Include class origin information in the returned '
+                      u'class(es). '
+                      u'Default: Do not include class origin information.')]
 
 namespace_option = [                     # pylint: disable=invalid-name
     click.option('-n', '--namespace', type=str,
                  required=False, metavar='NAMESPACE',
-                 help='Namespace to use for this command, instead of the '
-                      'default namespace of the connection.')]
+                 help=u'Namespace to use for this command, instead of the '
+                      u'default namespace of the connection.')]
 
 summary_option = [              # pylint: disable=invalid-name
     click.option('-s', '--summary', is_flag=True, required=False,
-                 help='Show only a summary (count) of the objects.')]
+                 help=u'Show only a summary (count) of the objects.')]
 
 verify_option = [              # pylint: disable=invalid-name
     click.option('-V', '--verify', is_flag=True, required=False,
-                 help='Prompt for confirmation before performing a change, '
-                      'to allow for verification of parameters. '
-                      'Default: Do not prompt for confirmation.')]
+                 help=u'Prompt for confirmation before performing a change, '
+                      u'to allow for verification of parameters. '
+                      u'Default: Do not prompt for confirmation.')]
 
 multiple_namespaces_option = [              # pylint: disable=invalid-name
     click.option('-n', '--namespace', type=str, multiple=True,
                  required=False, metavar='NAMESPACE',
-                 help='Add a namespace to the search scope. '
-                      'May be specified multiple times. '
-                      'Default: Search in all namespaces of the server.')]
+                 help=u'Add a namespace to the search scope. '
+                      u'May be specified multiple times. '
+                      u'Default: Search in all namespaces of the server.')]
 
 #
 #  The following options are implement the filtering of class request
@@ -92,29 +92,29 @@ multiple_namespaces_option = [              # pylint: disable=invalid-name
 association_filter_option = [              # pylint: disable=invalid-name
     click.option('--association/--no-association',
                  default=None,
-                 help='Filter the returned classes to return only indication '
-                      'classes (--association) or classes that are not '
-                      'associations(--no-association). If the option is not '
-                      'defined no filtering occurs')]
+                 help=u'Filter the returned classes to return only indication '
+                      u'classes (--association) or classes that are not '
+                      u'associations(--no-association). If the option is not '
+                      u'defined no filtering occurs')]
 
 indication_filter_option = [              # pylint: disable=invalid-name
     click.option('--indication/--no-indication',
                  default=None,
-                 help='Filter the returned classes to return only indication '
-                      'classes (--indication) or classes that are not '
-                      'indications (--no-indication). If the option is not '
-                      'defined no filtering occurs')]
+                 help=u'Filter the returned classes to return only indication '
+                      u'classes (--indication) or classes that are not '
+                      u'indications (--no-indication). If the option is not '
+                      u'defined no filtering occurs')]
 
 experimental_filter_option = [              # pylint: disable=invalid-name
     click.option('--experimental/--no-experimental',
                  default=None,
-                 help='Filter the returned classes to return only experimental '
-                      'classes (--experimental) or classes that are not '
-                      'experimental (--no-iexperimental). If the option is not '
-                      'defined no filtering occurs')]
+                 help=u'Filter the returned classes to return only '
+                      u'experimental classes (--experimental) or classes that '
+                      u'are not experimental (--no-iexperimental). If the '
+                      u'option is not defined no filtering occurs')]
 
 help_option = [              # pylint: disable=invalid-name
-    click.help_option('-h', '--help', help='Show this help message.')]
+    click.help_option('-h', '--help', help=u'Show this help message.')]
 
 
 def add_options(options):

--- a/pywbemtools/pywbemcli/config.py
+++ b/pywbemtools/pywbemcli/config.py
@@ -38,6 +38,8 @@ However, they should be used from the ``pywbemcli`` namespace.
 
 # This module is meant to be safe for 'import *'.
 
+# Issue 224: Some strings are unicode because of this issue.
+
 
 __all__ = ['DEFAULT_CONNECTION_TIMEOUT',
            'DEFAULT_NAMESPACE', 'PYWBEMCLI_PROMPT', 'PYWBEMCLI_HISTORY_FILE',
@@ -51,11 +53,11 @@ DEFAULT_CONNECTION_TIMEOUT = 30
 
 #: Specifies the default namespace uses if no default namespace is defined
 #: on the cmd line, environment variable, or a config file.
-DEFAULT_NAMESPACE = 'root/cimv2'
+DEFAULT_NAMESPACE = u'root/cimv2'
 
 #: Specifies the default query language to be used for exedquery operations
-#: when a query language is not specified in the request or config
-DEFAULT_QUERY_LANGUAGE = 'DMTF:CQL'
+#: when a query language is not specified in the request or config.
+DEFAULT_QUERY_LANGUAGE = u'DMTF:CQL'
 
 #: Characters for cmdline prompt when the pywbemcli repl is executing.
 #: The prompt is presented at the beginning of a line awaiting a command

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -95,154 +95,155 @@ def validate_connections_file(connections_repo):
 @click.option('-n', '--name', 'connection_name', type=str, metavar='NAME',
               # defaulted in code
               envvar=PywbemServer.name_envvar,
-              help='Use the WBEM server defined by the WBEM connection '
-                   'definition NAME. '
-                   'This option is mutually exclusive with the --server and '
-                   '--mock-server options, since each defines a WBEM server. '
-                   'Default: EnvVar {ev}, or none.'.
+              help=u'Use the WBEM server defined by the WBEM connection '
+                   u'definition NAME. '
+                   u'This option is mutually exclusive with the --server and '
+                   u'--mock-server options, since each defines a WBEM server. '
+                   u'Default: EnvVar {ev}, or none.'.
                    format(ev=PywbemServer.name_envvar))
 @click.option('-m', '--mock-server', type=str, multiple=True, metavar="FILE",
               # defaulted in code
               envvar=PywbemServer.mock_server_envvar,
-              help='Use a mock WBEM server that is automatically created in '
-                   'pywbemcli and populated with CIM objects that are defined '
-                   'in the specified MOF file or Python script file. '
-                   'See the pywbemcli documentation for more information. '
-                   'This option may be specified multiple times, and is '
-                   'mutually exclusive with the --server and --name options, '
+              help=u'Use a mock WBEM server that is automatically created in '
+                   u'pywbemcli and populated with CIM objects that are defined '
+                   u'in the specified MOF file or Python script file. '
+                   u'See the pywbemcli documentation for more information. '
+                   u'This option may be specified multiple times, and is '
+                   u'mutually exclusive with the --server and --name options, '
                    'since each defines a WBEM server. '
                    'Default: EnvVar {ev}, or none.'.
                    format(ev=PywbemServer.mock_server_envvar))
 @click.option('-s', '--server', type=str, metavar='URL',
               # defaulted in code
               envvar=PywbemServer.server_envvar,
-              help='Use the WBEM server at the specified URL with format: '
-                   '[SCHEME://]HOST[:PORT]. '
-                   'SCHEME must be "https" (default) or "http". '
-                   'HOST is a short or long hostname or literal IPV4/v6 '
-                   'address. '
-                   'PORT defaults to 5989 for https and 5988 for http. '
-                   'This option is mutually exclusive with the --mock-server '
-                   'and --name options, since each defines a WBEM server. '
-                   'Default: EnvVar {ev}, or none.'.
+              help=u'Use the WBEM server at the specified URL with format: '
+                   u'[SCHEME://]HOST[:PORT]. '
+                   u'SCHEME must be "https" (default) or "http". '
+                   u'HOST is a short or long hostname or literal IPV4/v6 '
+                   u'address. '
+                   u'PORT defaults to 5989 for https and 5988 for http. '
+                   u'This option is mutually exclusive with the --mock-server '
+                   u'and --name options, since each defines a WBEM server. '
+                   u'Default: EnvVar {ev}, or none.'.
                    format(ev=PywbemServer.server_envvar))
 @click.option('-u', '--user', type=str, metavar='TEXT',
               # defaulted in code
               envvar=PywbemServer.user_envvar,
-              help='User name for the WBEM server. '
-                   'Default: EnvVar {ev}, or none.'.
+              help=u'User name for the WBEM server. '
+                   u'Default: EnvVar {ev}, or none.'.
                    format(ev=PywbemServer.user_envvar))
 @click.option('-p', '--password', type=str, metavar='TEXT',
               # defaulted in code
               envvar=PywbemServer.password_envvar,
-              help='Password for the WBEM server. '
-                   'Default: EnvVar {ev}, or prompted for if --user specified.'.
+              help=u'Password for the WBEM server. '
+                   u'Default: EnvVar {ev}, or prompted for if --user '
+                   u'specified.'.
                    format(ev=PywbemServer.password_envvar))
 @click.option('--verify/--no-verify', 'verify', default=None,
               # defaulted in code
               envvar=PywbemServer.verify_envvar,
-              help='If --verify, client verifies the X.509 server '
-                   'certificate presented by the WBEM server during TLS/SSL '
-                   'handshake. If --no-verify client bypasses verification. '
-                   'Default: EnvVar {ev}, or "--verify".'.
+              help=u'If --verify, client verifies the X.509 server '
+                   u'certificate presented by the WBEM server during TLS/SSL '
+                   u'handshake. If --no-verify client bypasses verification. '
+                   u'Default: EnvVar {ev}, or "--verify".'.
                    format(ev=PywbemServer.verify_envvar))
 @click.option('--ca-certs', type=str, metavar="CACERTS",
               default=None,  # defaulted in code
               envvar=PywbemServer.ca_certs_envvar,
-              help='Certificates used to validate the certificate presented '
-                   'by the WBEM server during TLS/SSL handshake: '
-                   'FILE: Use the certs in the specified PEM file; '
-                   'DIR: Use the certs in the PEM files in the specified '
-                   'directory; '
-                   '"certifi" (pywbem 1.0 or later): Use the certs provided by '
-                   'the certifi Python package; '
-                   'Default: EnvVar {ev}, or "certifi" (pywbem 1.0 or later), '
-                   'or the certs in the PEM files in the first existing '
-                   'directory from from a system defined list of directories '
-                   '(pywbem before 1.0).'.
+              help=u'Certificates used to validate the certificate presented '
+                   u'by the WBEM server during TLS/SSL handshake: '
+                   u'FILE: Use the certs in the specified PEM file; '
+                   u'DIR: Use the certs in the PEM files in the specified '
+                   u'directory; '
+                   u'"certifi" (pywbem 1.0 or later): Use the certs provided '
+                   u'by the certifi Python package; '
+                   u'Default: EnvVar {ev}, or "certifi" (pywbem 1.0 or later), '
+                   u'or the certs in the PEM files in the first existing '
+                   u'directory from from a system defined list of directories '
+                   u'(pywbem before 1.0).'.
                    format(ev=PywbemServer.ca_certs_envvar))
 @click.option('-c', '--certfile', type=str, metavar="FILE",
               # defaulted in code
               envvar=PywbemServer.certfile_envvar,
-              help='Path name of a PEM file containing a X.509 client '
-                   'certificate that is used to enable TLS/SSL 2-way '
-                   'authentication by presenting the certificate to the '
-                   'WBEM server during TLS/SSL handshake. '
-                   'Default: EnvVar {ev}, or none.'.
+              help=u'Path name of a PEM file containing a X.509 client '
+                   u'certificate that is used to enable TLS/SSL 2-way '
+                   u'authentication by presenting the certificate to the '
+                   u'WBEM server during TLS/SSL handshake. '
+                   u'Default: EnvVar {ev}, or none.'.
                    format(ev=PywbemServer.certfile_envvar))
 @click.option('-k', '--keyfile', type=str, metavar='FILE',
               # defaulted in code
               envvar=PywbemServer.keyfile_envvar,
-              help='Path name of a PEM file containing a X.509 private key '
-                   'that belongs to the certificate in the --certfile file. '
-                   'Not required if the private key is part of the '
-                   '--certfile file. '
-                   'Default: EnvVar {ev}, or none.'.
+              help=u'Path name of a PEM file containing a X.509 private key '
+                   u'that belongs to the certificate in the --certfile file. '
+                   u'Not required if the private key is part of the '
+                   u'--certfile file. '
+                   u'Default: EnvVar {ev}, or none.'.
                    format(ev=PywbemServer.keyfile_envvar))
 @click.option('-t', '--timeout', type=click.IntRange(0, MAX_TIMEOUT),
               metavar='INT',
               # defaulted in code
               envvar=PywbemServer.timeout_envvar,
-              help='Client-side timeout in seconds for operations with the '
-                   'WBEM server. '
-                   'Default: EnvVar {ev}, or {default}.'.
+              help=u'Client-side timeout in seconds for operations with the '
+                   u'WBEM server. '
+                   u'Default: EnvVar {ev}, or {default}.'.
                    format(ev=PywbemServer.timeout_envvar,
                           default=DEFAULT_CONNECTION_TIMEOUT))
 @click.option('-U', '--use-pull', type=click.Choice(['yes', 'no', 'either']),
               # defaulted in code
               envvar=PywbemServer.use_pull_envvar,
-              help='Determines whether pull operations are used for '
-                   'operations with the WBEM server that return lists of '
-                   'instances, as follows: '
-                   '"yes" uses pull operations and fails if not supported by '
-                   'the server; '
-                   '"no" uses traditional operations; '
-                   '"either" (default) uses pull operations if supported by '
-                   'the server, and otherwise traditional operations. '
-                   'Default: EnvVar {ev}, or "either".'.
+              help=u'Determines whether pull operations are used for '
+                   u'operations with the WBEM server that return lists of '
+                   u'instances, as follows: '
+                   u'"yes" uses pull operations and fails if not supported by '
+                   u'the server; '
+                   u'"no" uses traditional operations; '
+                   u'"either" (default) uses pull operations if supported by '
+                   u'the server, and otherwise traditional operations. '
+                   u'Default: EnvVar {ev}, or "either".'.
                    format(ev=PywbemServer.use_pull_envvar))
 @click.option('--pull-max-cnt', type=int, metavar='INT',
               # defaulted in code
               envvar=PywbemServer.pull_max_cnt_envvar,
-              help='Maximum number of instances to be returned by the WBEM '
-                   'server in each open or pull response, if pull operations '
-                   'are used. '
-                   'This is a tuning parameter that does not affect the '
-                   'external behavior of the commands. '
-                   'Default: EnvVar {ev}, or {default}'.
+              help=u'Maximum number of instances to be returned by the WBEM '
+                   u'server in each open or pull response, if pull operations '
+                   u'are used. '
+                   u'This is a tuning parameter that does not affect the '
+                   u'external behavior of the commands. '
+                   u'Default: EnvVar {ev}, or {default}'.
                    format(ev=PywbemServer.pull_max_cnt_envvar,
                           default=DEFAULT_MAXPULLCNT))
 @click.option('-T', '--timestats', is_flag=True,
               # defaulted in code
-              help='Show time statistics of WBEM server operations.')
+              help=u'Show time statistics of WBEM server operations.')
 @click.option('-d', '--default-namespace', type=str, metavar='NAMESPACE',
               default=None,
               envvar=PywbemServer.defaultnamespace_envvar,
-              help='Default namespace, to be used when commands do not '
-                   'specify the --namespace command option. '
-                   'Default: EnvVar {ev}, or {default}.'.
+              help=u'Default namespace, to be used when commands do not '
+                   u'specify the --namespace command option. '
+                   u'Default: EnvVar {ev}, or {default}.'.
                    format(ev=PywbemServer.defaultnamespace_envvar,
                           default=DEFAULT_NAMESPACE))
 @click.option('-o', '--output-format', metavar='FORMAT',
-              help='Output format for the command result. '
-                   'The default and allowed output formats are command '
-                   'specific. '
-                   'The default output_format is None so that each command '
-                   'selects its own default format. '
-                   'FORMAT is: table formats: [{tb}]; CIM object '
-                   'formats: [{ob}]]; TEXT formats: [{tx}].'.
+              help=u'Output format for the command result. '
+                   u'The default and allowed output formats are command '
+                   u'specific. '
+                   u'The default output_format is None so that each command '
+                   u'selects its own default format. '
+                   u'FORMAT is: table formats: [{tb}]; CIM object '
+                   u'formats: [{ob}]]; TEXT formats: [{tx}].'.
                    format(tb='|'.join(OUTPUT_FORMAT_GROUPS['TABLE'][0]),
                           ob='|'.join(OUTPUT_FORMAT_GROUPS['CIM'][0]),
                           tx='|'.join(OUTPUT_FORMAT_GROUPS['TEXT'][0])))
 @click.option('-l', '--log', type=str, metavar='COMP[=DEST[:DETAIL]],...',
               # defaulted in code
               envvar=PywbemServer.log_envvar,
-              help='Enable logging of the WBEM operations, defined by a list '
-                   'of log configuration strings with: '
-                   'COMP: [{comp_choices}]; '
-                   'DEST: [{dest_choices}], default: {dest_default}; '
-                   'DETAIL: [{detail_choices}], default: {detail_default}. '
-                   'Default: EnvVar {ev}, or {default}.'.
+              help=u'Enable logging of the WBEM operations, defined by a list '
+                   u'of log configuration strings with: '
+                   u'COMP: [{comp_choices}]; '
+                   u'DEST: [{dest_choices}], default: {dest_default}; '
+                   u'DETAIL: [{detail_choices}], default: {detail_default}. '
+                   u'Default: EnvVar {ev}, or {default}.'.
                    format(comp_choices='|'.join(LOGGER_SIMPLE_NAMES),
                           dest_choices='|'.join(LOG_DESTINATIONS),
                           dest_default=DEFAULT_LOG_DESTINATION,
@@ -252,32 +253,32 @@ def validate_connections_file(connections_repo):
                           default='all'))
 @click.option('-v', '--verbose/--no-verbose',
               default=None,
-              help='Display extra information about the processing.')
+              help=u'Display extra information about the processing.')
 @click.option('--deprecation-warnings/--no-deprecation-warnings', is_flag=True,
               default=True,
               envvar=PywbemServer.deprecation_warnings_envvar,
-              help='Enable deprecation warnings. '
+              help=u'Enable deprecation warnings. '
               'Default: EnvVar {ev}, or true.'.
               format(ev=PywbemServer.deprecation_warnings_envvar))
 @click.option('-C', '--connections-file', metavar='FILE PATH',
               envvar=PywbemServer.connections_file_envvar,
-              help='File path of a YAML file containing named connection '
-                   'definitions. The default if this option is not specified '
-                   'is the file "{df}" (in the users home directory). '
-                   'EnvVar ({ev})'.
+              help=u'File path of a YAML file containing named connection '
+                   u'definitions. The default if this option is not specified '
+                   u'is the file "{df}" (in the users home directory). '
+                   u'EnvVar ({ev})'.
                    format(df=HOME_CONNECTIONS_PATH,
                           ev=PywbemServer.connections_file_envvar))
 @click.option('--pdb', is_flag=True,
               # defaulted in code
               envvar=PywbemServer.pdb_envvar,
-              help='Pause execution in the built-in pdb debugger just before '
-                   'executing the command within pywbemcli. '
-                   'Default: EnvVar {ev}, or false.'.
+              help=u'Pause execution in the built-in pdb debugger just before '
+                   u'executing the command within pywbemcli. '
+                   u'Default: EnvVar {ev}, or false.'.
                    format(ev=PywbemServer.pdb_envvar))
 @click.version_option(
     message='%(prog)s, version %(version)s\npywbem, version {}'.format(
         pywbem_version),
-    help='Show the version of this command and the pywbem package.')
+    help=u'Show the version of this command and the pywbem package.')
 @add_options(help_option)
 @click.pass_context
 def cli(ctx, server, connection_name, default_namespace, user, password,

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ asciitree>=0.3.3
 tabulate>=0.8.2
 prompt-toolkit>=2.0.1; python_version >= '3.4'
 # See pywbemtools issue # 192. The repl mode fails with unexpected Exception
-prompt-toolkit>=1.0.15,<2.0.0; python_version == '2.7'
+prompt-toolkit>=1.0.15,<3.0.0; python_version == '2.7'
 pydicti>=1.1.3
 # PyYAML 5.3 has removed support for Python 3.4
 PyYAML>=5.1; python_version == '2.7'


### PR DESCRIPTION
See commit message for details.

We did not add any tests for this because I could not work out a way to execute the completer code in test mode.  The logical test is to execute partial commands in interactive mode (ex. "class get "). The completer would then initiate but that does not work when commands are entered through stdin.

The manual test consisted of entering interactive mode and then step through the various options of command group and command followed by a space to initiate the completion logic.   That works manually.