### PR TITLE
fix issue #678-add-class-filters

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -37,6 +37,12 @@ Released: not yet
 * Move the commands associated with WBEM management profiles from the server
   group to a new profile group. (See issue #612). See also Incompatible changes.
 
+* Add --deprecated/-no-deprecated as a new qualifier filter for the class
+  enumerate, class find, and instance count commands. Extend the behavior so
+  that for each of the possible filters it looks for the qualifier on all
+  of the elements (property, method, parameter) in addition to the class
+  itself.  See issue #678)
+
 
 **Known issues:**
 

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -345,6 +345,10 @@ Help text for ``pywbemcli class enumerate`` (see :ref:`class enumerate command`)
                                       classes that are not experimental (--no-iexperimental). If the option is not defined
                                       no filtering occurs
 
+      --deprecated / --no-deprecated  Filter the returned classes to return only deprecated classes (--deprecated) or
+                                      classes that are not deprecated (--no-deprecated). If the option is not defined no
+                                      filtering occurs
+
       -h, --help                      Show this help message.
 
 
@@ -402,6 +406,10 @@ Help text for ``pywbemcli class find`` (see :ref:`class find command`):
                                       Filter the returned classes to return only experimental classes (--experimental) or
                                       classes that are not experimental (--no-iexperimental). If the option is not defined
                                       no filtering occurs
+
+      --deprecated / --no-deprecated  Filter the returned classes to return only deprecated classes (--deprecated) or
+                                      classes that are not deprecated (--no-deprecated). If the option is not defined no
+                                      filtering occurs
 
       -h, --help                      Show this help message.
 
@@ -1043,6 +1051,7 @@ Help text for ``pywbemcli instance count`` (see :ref:`instance count command`):
       -n, --namespace NAMESPACE       Add a namespace to the search scope. May be specified multiple times. Default: Search
                                       in all namespaces of the server.
 
+      -s, --sort                      Sort by instance count. Otherwise sorted by class name.
       --association / --no-association
                                       Filter the returned classes to return only indication classes (--association) or
                                       classes that are not associations(--no-association). If the option is not defined no
@@ -1057,7 +1066,10 @@ Help text for ``pywbemcli instance count`` (see :ref:`instance count command`):
                                       classes that are not experimental (--no-iexperimental). If the option is not defined
                                       no filtering occurs
 
-      -s, --sort                      Sort by instance count. Otherwise sorted by class name.
+      --deprecated / --no-deprecated  Filter the returned classes to return only deprecated classes (--deprecated) or
+                                      classes that are not deprecated (--no-deprecated). If the option is not defined no
+                                      filtering occurs
+
       -h, --help                      Show this help message.
 
 

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -146,13 +146,14 @@ If the ``--deep-inheritance``/``--di`` command option is set, all direct and
 indirect subclasses are included in the result. Otherwise, only one level of
 the class hierarchy is in the result.
 
-.. index:: single: qualifier filters
+.. index:: single: qualifier filters; class enumerate command
 
-The ``--association``/``--no-association``, ``--indication``/``--no-indication``,
-and ``--experimental``/``--no-experimental`` options filter the returned
-classes or classnames to include or exclude classes with the corresponding
-qualifiers.  Thus the ``--association`` option returns only classes or
-classnames that are association classes.
+The ``--association``/``--no-association``,
+``--indication``/``--no-indication``, ,``--experimental``/``--no-experimental``
+and ``--deprecated``/``--no-deprecated`` options filter the returned classes or
+classnames to include or exclude classes with the corresponding qualifiers.
+Thus the ``--association`` option returns only classes or classnames that are
+association classes.
 
 The following example enumerates the class names of the root classes in the
 default namespace:
@@ -183,11 +184,12 @@ times.
 
 .. index:: pair: qualifier filters; class find command
 
-The ``--association``/``--no-association``, ``--indication``/``--no-indication``,
-and ``--experimental``/``--no-experimental`` options filter the returned
-classes or classnames to include or exclude classes with the corresponding
-qualifiers.  Thus the ``--association`` option returns only classes or
-classnames that are association classes.
+The ``--association``/``--no-association``,
+``--indication``/``--no-indication``, ,``--experimental``/``--no-experimental``
+and ``--deprecated``/``--no-deprecated`` options filter the returned classes or
+classnames to include or exclude classes with the corresponding qualifiers.
+Thus the ``--association`` option returns only classes or classnames that are
+association classes.
 
 The command displays the namespaces and class names of the result using the
 ``txt`` output format (default), or using :term:`Table output formats`.
@@ -492,11 +494,12 @@ the target namespaces are counted.
 
 .. index:: pair: qualifier filters; instance count command
 
-The ``--association``/``--no-association``, ``--indication``/``--no-indication``,
-and ``--experimental``/``--no-experimental`` options filter the returned
-classes or classnames to include or exclude classes with the corresponding
-qualifiers.  Thus the ``--association`` option returns only classes or
-classnames that are association classes.
+The ``--association``/``--no-association``,
+``--indication``/``--no-indication``, ,``--experimental``/``--no-experimental``
+and ``--deprecated``/``--no-deprecated`` options filter the returned classes or
+classnames to include or exclude classes with the corresponding qualifiers.
+Thus the ``--association`` option returns only classes or classnames that are
+association classes.
 
 Results for classes that have no instances are not displayed.
 

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -38,8 +38,7 @@ from ._common import display_cim_objects, \
 from ._common_options import add_options, propertylist_option, \
     names_only_option, include_classorigin_instance_option, namespace_option, \
     summary_option, verify_option, multiple_namespaces_option, \
-    association_filter_option, indication_filter_option, \
-    experimental_filter_option, help_option
+    class_filter_options, help_option
 
 from ._cimvalueformatter import mof_escaped
 
@@ -565,11 +564,9 @@ def instance_query(context, query, **options):
 @click.argument('classname', type=str, metavar='CLASSNAME-GLOB',
                 required=False)
 @add_options(multiple_namespaces_option)
-@add_options(association_filter_option)
-@add_options(indication_filter_option)
-@add_options(experimental_filter_option)
 @click.option('-s', '--sort', is_flag=True, required=False,
               help=u'Sort by instance count. Otherwise sorted by class name.')
+@add_options(class_filter_options)
 @add_options(help_option)
 @click.pass_obj
 def instance_count(context, classname, **options):

--- a/pywbemtools/pywbemcli/_common_options.py
+++ b/pywbemtools/pywbemcli/_common_options.py
@@ -113,6 +113,23 @@ experimental_filter_option = [              # pylint: disable=invalid-name
                       u'are not experimental (--no-iexperimental). If the '
                       u'option is not defined no filtering occurs')]
 
+deprecated_filter_option = [              # pylint: disable=invalid-name
+    click.option('--deprecated/--no-deprecated',
+                 default=None,
+                 help='Filter the returned classes to return only deprecated '
+                      'classes (--deprecated) or classes that are not '
+                      'deprecated (--no-deprecated). If the option is not '
+                      'defined no filtering occurs')]
+
+# List of the class filter options that are common to multiple class commands
+# Since the filters are in a list to allow them to be used individually, the
+# first item of each list must be used for the combined defintion that can
+# be use with add_options
+class_filter_options = [association_filter_option[0],
+                        indication_filter_option[0],
+                        experimental_filter_option[0],
+                        deprecated_filter_option[0]]
+
 help_option = [              # pylint: disable=invalid-name
     click.help_option('-h', '--help', help=u'Show this help message.')]
 
@@ -120,7 +137,7 @@ help_option = [              # pylint: disable=invalid-name
 def add_options(options):
     """
     Accumulate multiple options into a list. This list can be referenced as
-    a click decorator @att_options(name_of_list)
+    a click decorator @add_options(name_of_list)
 
     The list is reversed because of the way click processes options
 
@@ -134,6 +151,8 @@ def add_options(options):
     """
     def _add_options(func):
         """ Reverse options list"""
+        # TODO: Future.  This should account for a single option not
+        # in a list.
         for option in reversed(options):
             func = option(func)
         return func

--- a/tests/unit/qualifier_filter_model.mof
+++ b/tests/unit/qualifier_filter_model.mof
@@ -1,6 +1,6 @@
 /*
     Model with associations, Indication class, and Experimental
-    qualifier declarations to test the --association, 
+    qualifier declarations to test the --association,
     --indication, and --experimental options
 */
 
@@ -12,10 +12,13 @@ Qualifier Description : string = null,
     Scope(any),
     Flavor(EnableOverride, ToSubclass, Translatable);
 
-Qualifier Experimental : boolean = true,
-    Scope(class),
+Qualifier Deprecated : boolean = true,
+    Scope(class, association, indication, property, reference, method, parameter),
     Flavor(DisableOverride, ToSubclass);
 
+Qualifier Experimental : boolean = true,
+    Scope(class, association, indication, property, reference, method, parameter),
+    Flavor(DisableOverride, ToSubclass);
 
 Qualifier Indication : boolean = true,
     Scope(class),
@@ -26,14 +29,34 @@ Qualifier Key : boolean = false,
     Flavor(DisableOverride, ToSubclass);
 
 class TST_Person{
-        [Key, Description ("This is key prop")]
+        [Key, Description ("This is key prop") ]
     string name;
     string extraProperty = "defaultvalue";
 };
 
-[Experimental]
-class TST_Personsub : TST_Person{
+[Experimental, Description("TST_Person subclass, experimental") ]
+class TST_PersonExp : TST_Person{
     string secondProperty = "empty";
+    uint32 counter;
+};
+
+[Description(" TST_Person subclass")]
+class TST_PersonSub : TST_Person{
+    string secondProperty = "empty";
+    uint32 counter;
+    string ExperimentalProperty;
+};
+
+[Deprecated, Description(" TST_Person subclass deprecated ") ]
+class TST_PersonDep : TST_Person{
+    string secondProperty = "empty";
+    uint32 counter;
+};
+
+[Deprecated, Description(" TST_Person subclass experimental property ") ]
+class TST_PersonExpProperty : TST_Person{
+    string secondProperty = "empty";
+    [experimental]
     uint32 counter;
 };
 
@@ -52,12 +75,17 @@ class TST_MemberOfFamilyCollection {
 };
 
 
-[Association, Experimental, Description(" Family gathers person to family.") ]
-class TST_MemberOfFamilyCollectionSub {
+[Association, Experimental, Description(" Family gathers person to family. Experimental") ]
+class TST_MemberOfFamilyCollectionExp {
    [key] TST_Person ref family;
    [key] TST_Person ref member;
 };
 
+[Association, Deprecated, Description(" Family gathers person to family. Deprecated") ]
+class TST_MemberOfFamilyCollectionDep {
+   [key] TST_Person ref family;
+   [key] TST_Person ref member;
+};
 [ Description("Collection of Persons into a Family") ]
 class TST_FamilyCollection {
         [Key, Description ("This is key prop and family name")]
@@ -69,29 +97,38 @@ class TST_Indication {
     string IndicationName;
 };
 
-[Indication, Experimental, Description("Indicaiton class experimental")]
+[Indication, Experimental, Description("Indication class; experimental")]
 class TST_IndicationExperimental {
     string IndicationName;
 };
+
+[Indication, Deprecated, Description("Indication class; deprecated")]
+class TST_IndicationDeprecated {
+    string IndicationName;
+};
+
+//
+//  Define instances of the various classes
+//
 
 instance of TST_Person as $Mike { name = "Mike"; };
 instance of TST_Person as $Saara { name = "Saara"; };
 instance of TST_Person as $Sofi { name = "Sofi"; };
 instance of TST_Person as $Gabi{ name = "Gabi"; };
 
-instance of TST_PersonSub as $Mikesub{ name = "Mikesub";
+instance of TST_PersonExp as $Mikesub{ name = "Mikesub";
                             secondProperty = "one" ;
                             counter = 1; };
 
-instance of TST_PersonSub as $Saarasub { name = "Saarasub";
+instance of TST_PersonExp as $Saarasub { name = "Saarasub";
                             secondProperty = "two" ;
                             counter = 2; };
 
-instance of TST_PersonSub as $Sofisub{ name = "Sofisub";
+instance of TST_PersonExp as $Sofisub{ name = "Sofisub";
                             secondProperty = "three" ;
                             counter = 3; };
 
-instance of TST_PersonSub as $Gabisub{ name = "Gabisub";
+instance of TST_PersonExp as $Gabisub{ name = "Gabisub";
                             secondProperty = "four" ;
                             counter = 4; };
 
@@ -142,5 +179,11 @@ instance of TST_MemberOfFamilyCollection as $GabiMember
 instance of TST_MemberOfFamilyCollection as $MikeMember
 {
     family = $Family2;
+    member = $Mike;
+};
+
+instance of TST_MemberOfFamilyCollectionExp as $MikeMemberExp
+{
+    family = $Family1;
     member = $Mike;
 };

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -584,7 +584,7 @@ TEST_CASES = [
      {'stdout': ['TST_FamilyCollection',
                  'TST_Lineage',
                  'TST_MemberOfFamilyCollection',
-                 'TST_MemberOfFamilyCollectionSub',
+                 'TST_MemberOfFamilyCollectionExp',
                  'TST_Person'],
       'test': 'innows'},
      QUALIFIER_FILTER_MODEL, OK],
@@ -607,7 +607,7 @@ TEST_CASES = [
 
     ['Verify class command enumerate with --experimental and --association.',
      ['enumerate', '--experimental', '--association', '--names-only'],
-     {'stdout': ['TST_MemberOfFamilyCollectionSub'],
+     {'stdout': ['TST_MemberOfFamilyCollectionExp'],
       'test': 'innows'},
      QUALIFIER_FILTER_MODEL, OK],
 
@@ -990,7 +990,7 @@ TEST_CASES = [
      ['find', '*TST_*', '-n', 'root/cimv2', '--association'],
      {'stdout': ['TST_Lineage',
                  'TST_MemberOfFamilyCollection',
-                 'TST_MemberOfFamilyCollectionSub'],
+                 'TST_MemberOfFamilyCollectionExp'],
       'test': 'innows'},
      QUALIFIER_FILTER_MODEL, OK],
 
@@ -1009,7 +1009,7 @@ TEST_CASES = [
 
     ['Verify class command find with --association & --experimental filters',
      ['find', '*TST_*', '-n', 'root/cimv2', '--association', '--experimental'],
-     {'stdout': ['TST_MemberOfFamilyCollectionSub'],
+     {'stdout': ['TST_MemberOfFamilyCollectionExp'],
       'test': 'innows'},
      QUALIFIER_FILTER_MODEL, OK],
 

--- a/tests/unit/test_instance_cmds.py
+++ b/tests/unit/test_instance_cmds.py
@@ -2588,6 +2588,7 @@ interop      TST_Personsub        4
 Namespace    Class            count
 interop      TST_Lineage          3
 interop      TST_MemberOfFamilyCollection  3
+interop      TST_MemberOfFamilyCollectionExp 1
 """,
       'rc': 0,
       'test': 'linesnows'},
@@ -2599,7 +2600,8 @@ interop      TST_MemberOfFamilyCollection  3
                   'plain']},
      {'stdout': """Count of instances per class
 Namespace    Class            count
-interop      TST_Personsub        4
+interop      TST_MemberOfFamilyCollectionExp 1
+interop      TST_PersonExp        4
 """,
       'rc': 0,
       'test': 'linesnows'},
@@ -2613,6 +2615,7 @@ interop      TST_Personsub        4
 Namespace    Class            count
 interop      TST_Lineage          3
 interop      TST_MemberOfFamilyCollection  3
+interop      TST_MemberOfFamilyCollectionExp        1
 """,
       'rc': 0,
       'test': 'linesnows'},
@@ -2780,7 +2783,7 @@ interop      TST_MemberOfFamilyCollection  3
      {'stdout': SIMPLE_SHRUB_TREE,
       'rc': 0,
       'test': 'innows'},
-     ASSOC_MOCK_FILE, RUN],
+     ASSOC_MOCK_FILE, OK],
 
     ['Verify instance command shrub, simple tree, namespace in INSTNAME',
      ['shrub', 'root/cimv2:TST_Person.name="Mike"', '--fullpath'],
@@ -2892,7 +2895,7 @@ interop      TST_MemberOfFamilyCollection  3
      {'stdout': SIMPLE_SHRUB_TABLE1,
       'rc': 0,
       'test': 'innows'},
-     ASSOC_MOCK_FILE, RUN],
+     ASSOC_MOCK_FILE, OK],
 
     ['Verify instance command shrub, simple tree with namespace',
      ['shrub', 'TST_Person.name="Mike"', '--fullpath'],


### PR DESCRIPTION
Adds the --deprecated filter to the same commands as the other filters
and extends the filter search to that the qualifiers are inspected
for all class elements defined in the scope for the defined filter.
Thus, an experimental qualifier on a property, method, or parameter
will now be equal to the same qualifier at the class level.

NOTE: The logic for multiple filters is effectively anding of
the conditions so that --association and --indication is for both
the association and indication filter and --association --no-indication
finds classes that have the association qualifier but not the
indication qualifier.

The code was refactored to make extension to other filters easier in
the future.

Added more options to the test mof qualifierfilters.mof and extended
the tests.