### PR TITLE
0.7: Pinned prompt-toolkit to <3.0 on Python 3.8 on Windows to avoid WinError 995

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Pinned prompt-toolkit to <3.0 on Python 3.8 on Windows to avoid WinError 995.
+  (See issue #690)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,13 +19,22 @@ click-spinner>=0.1.8
 click-repl>=0.1.6
 asciitree>=0.3.3
 tabulate>=0.8.2
-prompt-toolkit>=2.0.1; python_version >= '3.4'
-# See pywbemtools issue # 192. The repl mode fails with unexpected Exception
+
+# prompt-toolkit>=2.0 failed on py27 (issue #192), so it was pinned to <2.0.
+#   Later, the fix for issue #224 allowed to lift that pinning.
+# prompt-toolkit>=3.0 does not support py27.
+# prompt-toolkit>=3.0 may cause WinError 995 on py38 on Windows (issue #690).
 prompt-toolkit>=1.0.15,<3.0.0; python_version == '2.7'
+prompt-toolkit>=2.0.1; python_version >= '3.4' and python_version < '3.8'
+prompt-toolkit>=2.0.1; python_version >= '3.8' and sys_platform != 'win32'
+prompt-toolkit>=2.0.1,<3.0.0; python_version >= '3.8' and sys_platform == 'win32'
+
 pydicti>=1.1.3
+
 # PyYAML 5.3 has removed support for Python 3.4
 PyYAML>=5.1; python_version == '2.7'
 PyYAML>=5.1,<5.3; python_version == '3.4'
 PyYAML>=5.1; python_version > '3.4'
+
 yamlloader>=0.5.5
 packaging>=17.0


### PR DESCRIPTION
Rolls back PR #696 into 0.7.1