### PR TITLE
Fixes issue #704, association shrub instance output format

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -38,6 +38,10 @@ Released: not yet
 * Test: Default connection file does not get restored in some cases during test.
   (See issue #680)
 
+* AssociationShrub produces instancename slightly different table output in
+  some cases for pywbem 1 vs previous versions(inclusion of "/:" prefix).
+  (see issue #704)
+
 **Enhancements:**
 
 * Modify general help to display the full path of the default connections file.

--- a/pywbemtools/pywbemcli/_association_shrub.py
+++ b/pywbemtools/pywbemcli/_association_shrub.py
@@ -616,10 +616,16 @@ class AssociationShrub(object):
           TypeError: Invalid type in keybindings
           ValueError: Invalid format
         """
+        # Remove host and namespace if same as source instance
         path = self.simplify_path(path)
-        path_str = "{}".format(path)
+
+        path_str = path.to_wbem_uri(format=format)
         if len(path_str) <= max_len:
             return path_str
+
+        # Otherwise reproduce complete wbemuri method except fold the
+        # keybindings.  TODO, FUTURE: Is there a better way to fold based
+        # on the string output.
 
         ret = []
 


### PR DESCRIPTION
Under some circumstances the display is different for pywbem 1 vs
previous versions because we were using a different and simplistic
formatter depending on the length of the resulting instance name string.

This change simply fixies the issue and does not add any tests.