### PR TITLE
Multiple fixes to make tests succeed again with pywbem 1.0 and 0.x

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -42,6 +42,9 @@ Released: not yet
   some cases for pywbem 1 vs previous versions(inclusion of "/:" prefix).
   (see issue #704)
 
+* Test: Fixed attempt in test_class_cmds.py to invoke a non-static method on a
+  class object. (see issue #707)
+
 **Enhancements:**
 
 * Modify general help to display the full path of the default connections file.

--- a/pywbemtools/pywbemcli/_association_shrub.py
+++ b/pywbemtools/pywbemcli/_association_shrub.py
@@ -663,7 +663,7 @@ class AssociationShrub(object):
 
         ret.append('.\n')
 
-        for key in case_sorted(path.keybindings.iterkeys()):
+        for key in case_sorted(six.iterkeys(path.keybindings)):
             value = path.keybindings[key]
 
             ret.append(key)

--- a/tests/unit/all_types_method_mock_v1.py
+++ b/tests/unit/all_types_method_mock_v1.py
@@ -1,10 +1,8 @@
 """
 mock_pywbem test script that installs a method callback to be executed. This is
 based on the CIM_Foo class in the simple_mock_model.mof test file
-
 """
 
-import six
 from pywbem_mock import MethodProvider
 
 from pywbem import CIM_ERR_METHOD_NOT_AVAILABLE, CIMError, CIM_ERR_NOT_FOUND
@@ -31,26 +29,21 @@ class CIM_AllTypesMethodProvider(MethodProvider):
     def __init__(self, cimrepository):
         super(CIM_AllTypesMethodProvider, self).__init__(cimrepository)
 
-    def InvokeMethod(self, namespace, MethodName, ObjectName, Params):
+    def InvokeMethod(self, methodname, localobject, params):
         """
-        Simplistic test method. Validates methodname, objectname, Params
-        and returns rtn value 0 and one parameter
+        Simplistic test method. Validates methodname, localobject,
+        and returns return value 0 and the input parameters.
 
         The parameters and return for Invoke method are defined in
         :meth:`~pywbem_mock.MethodProvider.InvokeMethod`
         """
-        # validate namespace using method in BaseProvider
-        self.validate_namespace(namespace)
+        namespace = localobject.namespace
 
         # get classname and validate. This provider uses only one class
-        if isinstance(ObjectName, six.string_types):
-            classname = ObjectName
-        else:
-            classname = ObjectName.classname
-
+        classname = localobject.classname
         assert classname.lower() == self.provider_classnames.lower()
 
-        if MethodName != 'AllTypesMethod':
+        if methodname != 'AllTypesMethod':
             raise CIMError(CIM_ERR_METHOD_NOT_AVAILABLE)
 
         # Test if class exists.
@@ -61,7 +54,7 @@ class CIM_AllTypesMethodProvider(MethodProvider):
                 "namespace {1}".format(classname, namespace))
 
         # Return the input parameters and returnvalue == 0
-        return (0, Params)
+        return (0, params)
 
 
 # Add the the callback to the mock repository

--- a/tests/unit/all_types_method_mock_v1.py
+++ b/tests/unit/all_types_method_mock_v1.py
@@ -52,9 +52,10 @@ class CIM_AllTypesMethodProvider(MethodProvider):
                 CIM_ERR_NOT_FOUND,
                 "class {0} does not exist in CIM repository, "
                 "namespace {1}".format(classname, namespace))
-
+        # Map input params to list of params for response.
+        out_params = [p for p in params.values()]
         # Return the input parameters and returnvalue == 0
-        return (0, params)
+        return (0, out_params)
 
 
 # Add the the callback to the mock repository

--- a/tests/unit/simple_mock_invokemethod_v0.py
+++ b/tests/unit/simple_mock_invokemethod_v0.py
@@ -36,3 +36,4 @@ def fuzzy_callback(conn, object_name, methodname, **params):
 # Add the the callback to the mock repository
 # pylint: disable=undefined-variable
 CONN.add_method_callback('CIM_Foo', 'Fuzzy', fuzzy_callback)  # noqa: F821
+CONN.add_method_callback('CIM_Foo', 'FuzzyStatic', fuzzy_callback)  # noqa: F821

--- a/tests/unit/simple_mock_invokemethod_v1.py
+++ b/tests/unit/simple_mock_invokemethod_v1.py
@@ -1,10 +1,8 @@
 """
 mock_pywbem test script that installs a a method provider for the class
 CIM_Foo
-
 """
 
-import six
 from pywbem_mock import MethodProvider
 
 from pywbem import CIM_ERR_METHOD_NOT_AVAILABLE, CIMError, CIM_ERR_NOT_FOUND, \
@@ -32,22 +30,17 @@ class CIM_FooMethodProvider(MethodProvider):
     def __init__(self, cimrepository):
         super(CIM_FooMethodProvider, self).__init__(cimrepository)
 
-    def InvokeMethod(self, namespace, MethodName, ObjectName, Params):
+    def InvokeMethod(self, methodname, localobject, params):
         """
-        Simplistic test method. Validates methodname, objectname, Params
+        Simplistic test method. Validates methodname, localobject, params
         and returns rtn value 0 and one parameter
 
         The parameters and return for Invoke method are defined in
         :meth:`~pywbem_mock.MethodProvider.InvokeMethod`
         """
-        # validate namespace using method in BaseProvider
-        self.validate_namespace(namespace)
+        namespace = localobject.namespace
+        classname = localobject.classname
 
-        # get classname and validate. This provider uses only one class
-        if isinstance(ObjectName, six.string_types):
-            classname = ObjectName
-        else:
-            classname = ObjectName.classname
         assert classname.lower() == 'cim_foo'
 
         # Test if class exists.
@@ -57,25 +50,25 @@ class CIM_FooMethodProvider(MethodProvider):
                 "class {0} does not exist in CIM repository, "
                 "namespace {1}".format(classname, namespace))
 
-        if isinstance(ObjectName, CIMInstanceName):
+        if isinstance(localobject, CIMInstanceName):
             instance_store = self.cimrepository.get_instance_store(namespace)
-            if not instance_store.object_exists(ObjectName):
+            if not instance_store.object_exists(localobject):
                 raise CIMError(
                     CIM_ERR_NOT_FOUND,
                     "Instance {0} does not exist in CIM repository",
-                    format(ObjectName))
+                    format(localobject))
 
         # This method expects a single parameter input
         return_params = []
-        if MethodName.lower() == 'fuzzy':
-            if Params:
-                if 'TestInOutParameter' in Params:
-                    return_params.append(Params['TestInOutParameter'])
+        if methodname.lower() in ('fuzzy', 'fuzzystatic'):
+            if params:
+                if 'TestInOutParameter' in params:
+                    return_params.append(params['TestInOutParameter'])
 
-            if 'TestRef' in Params:
-                return_params.append(Params['TestRef'])
+            if 'TestRef' in params:
+                return_params.append(params['TestRef'])
 
-            return_value = Params.get('OutputRtnValue', 0)
+            return_value = params.get('OutputRtnValue', 0)
 
             return (return_value, return_params)
 

--- a/tests/unit/simple_mock_model.mof
+++ b/tests/unit/simple_mock_model.mof
@@ -39,6 +39,10 @@ Qualifier Override : string = null,
     Scope(property, reference, method),
     Flavor(EnableOverride, Restricted);
 
+Qualifier Static : boolean = false,
+    Scope(property, method),
+    Flavor(DisableOverride, ToSubclass);
+
      [Description ("Simple CIM Class")]
 class CIM_Foo {
         [Key, Description ("This is key property.")]
@@ -51,13 +55,21 @@ class CIM_Foo {
     uint32 Fuzzy(
         [IN, OUT, Description("Define data to be returned in output parameter")]
       string TestInOutParameter,
-
         [IN, OUT, Description ( "Test of ref in/out parameter")]
       CIM_Foo REF TestRef,
-
         [IN ( false ), OUT, Description("Rtns method name if exists on input")]
       string OutputParam,
+        [IN , Description("Defines return value if provided.")]
+      uint32 OutputRtnValue);
 
+        [Description ("Static method with in and out parameters"), Static]
+    uint32 FuzzyStatic(
+        [IN, OUT, Description("Define data to be returned in output parameter")]
+      string TestInOutParameter,
+        [IN, OUT, Description ( "Test of ref in/out parameter")]
+      CIM_Foo REF TestRef,
+        [IN ( false ), OUT, Description("Rtns method name if exists on input")]
+      string OutputParam,
         [IN , Description("Defines return value if provided.")]
       uint32 OutputRtnValue);
 

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -19,7 +19,9 @@ Tests the class command
 from __future__ import absolute_import, print_function
 
 import os
+from packaging.version import parse as parse_version
 import pytest
+from pywbem import __version__ as pywbem_version
 
 from .cli_test_extensions import CLITestsBase, PYWBEM_0, \
     FAKEURL_STR
@@ -32,6 +34,10 @@ from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
     CMD_OPTION_ASSOCIATION_FILTER_HELP_LINE, \
     CMD_OPTION_INDICATION_FILTER_HELP_LINE, \
     CMD_OPTION_EXPERIMENTAL_FILTER_HELP_LINE
+
+_PYWBEM_VERSION = parse_version(pywbem_version)
+# pywbem 1.0.0 or later
+PYWBEM_1_0_0 = _PYWBEM_VERSION.release >= (1, 0, 0)
 
 TEST_DIR = os.path.dirname(__file__)
 
@@ -46,7 +52,6 @@ INVOKE_METHOD_MOCK_FILE = INVOKE_METHOD_MOCK_FILE_0 if PYWBEM_0 else \
 
 SIMPLE_ASSOC_MOCK_FILE = 'simple_assoc_mock_model.mof'
 QUALIFIER_FILTER_MODEL = 'qualifier_filter_model.mof'
-
 
 #
 # The following list defines the help for each command in terms of particular
@@ -1620,12 +1625,19 @@ TEST_CASES = [
       'test': 'innows'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
-    ['Verify class command invokemethod fails non-static method',
+    ['Verify class command invokemethod fails non-static method, pywbem 1.0',
      ['invokemethod', 'CIM_Foo', 'Fuzzy'],
      {'stderr': ["Non-static method 'Fuzzy' in class 'CIM_Foo'"],
       'rc': 1,
       'test': 'innows'},
-     [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
+     [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], PYWBEM_1_0_0],
+
+    ['Verify class command invokemethod succeeds non-static method, pywbem 0.x',
+     ['invokemethod', 'CIM_Foo', 'Fuzzy'],
+     {'stdout': ['ReturnValue=0'],
+      'rc': 0,
+      'test': 'innows'},
+     [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], not PYWBEM_1_0_0],
 
     ['Verify class command invokemethod fails Method not registered',
      ['invokemethod', 'CIM_Foo', 'Fuzzy'],

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -168,6 +168,7 @@ CLASS_TREE_HELP_LINES = [
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
+# pylint: disable=line-too-long
 CIMFOO_SUB_SUB = """
    [Description ( "Subclass of CIM_Foo_sub" )]
 class CIM_Foo_sub_sub : CIM_Foo_sub {
@@ -208,12 +209,32 @@ class CIM_Foo_sub_sub : CIM_Foo_sub {
           Description ( "Defines return value if provided." )]
       uint32 OutputRtnValue);
 
+      [Description ( "Static method with in and out parameters" ),
+       Static ( true )]
+   uint32 FuzzyStatic(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_Foo REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue);
+
       [Description ( "Method with no Parameters" )]
    uint32 DeleteNothing();
 
 };
 
-"""
+"""  # noqa: E501
+# pylint: enable=line-too-long
 
 CIMFOO_SUB_SUB_NO_QUALS = """
 class CIM_Foo_sub_sub : CIM_Foo_sub {
@@ -230,6 +251,12 @@ class CIM_Foo_sub_sub : CIM_Foo_sub {
       string OutputParam2);
 
    uint32 Fuzzy(
+      string TestInOutParameter,
+      CIM_Foo REF TestRef,
+      string OutputParam,
+      uint32 OutputRtnValue);
+
+   uint32 FuzzyStatic(
       string TestInOutParameter,
       CIM_Foo REF TestRef,
       string OutputParam,
@@ -292,7 +319,6 @@ RUN = True    # Mark OK = False and current test case being created RUN
 FAIL = False  # Any test currently FAILING or not tested yet
 
 
-# pylint: enable=line-too-long
 TEST_CASES = [
 
     # List of testcases.
@@ -563,6 +589,11 @@ TEST_CASES = [
                  'CIM_Foo REF TestRef,',
                  'string OutputParam,',
                  'uint32 OutputRtnValue);',
+                 'uint32 FuzzyStatic(',
+                 'string TestInOutParameter,',
+                 'CIM_Foo REF TestRef,',
+                 'string OutputParam,',
+                 'uint32 OutputRtnValue);',
                  'uint32 DeleteNothing();', '};'],
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
@@ -725,6 +756,12 @@ TEST_CASES = [
                  '      string OutputParam,',
                  '      uint32 OutputRtnValue);',
                  '',
+                 '   uint32 FuzzyStatic(',
+                 '      string TestInOutParameter,',
+                 '      CIM_Foo REF TestRef,',
+                 '      string OutputParam,',
+                 '      uint32 OutputRtnValue);',
+                 '',
                  '   uint32 DeleteNothing();',
                  '',
                  '};',
@@ -748,6 +785,12 @@ TEST_CASES = [
                  '      string OutputParam,',
                  '      uint32 OutputRtnValue);',
                  '',
+                 '   uint32 FuzzyStatic(',
+                 '      string TestInOutParameter,',
+                 '      CIM_Foo REF TestRef,',
+                 '      string OutputParam,',
+                 '      uint32 OutputRtnValue);',
+                 '',
                  '   uint32 DeleteNothing();',
                  '',
                  '};',
@@ -758,13 +801,33 @@ TEST_CASES = [
     # pylint: disable=line-too-long
     ['Verify class command get with propertylist. Tests whole response',
      ['get', 'CIM_Foo_sub2', '--pl', 'InstanceID'],
-     {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {', '',
+     {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
+                 '',
                  '      [Key ( true ),',
-                 '       Description ( "This is key property." )]', ''
-                 '   string InstanceID;', '',
-                 '      [Description ( "Method with in and out parameters" )'
-                 ']',
+                 '       Description ( "This is key property." )]',
+                 '   string InstanceID;',
+                 '',
+                 '      [Description ( "Method with in and out parameters" )]',
                  '   uint32 Fuzzy(',
+                 '         [IN ( true ),',
+                 '          OUT ( true ),',
+                 '          Description ( "Define data to be returned in output parameter" )]',  # noqa: E501
+                 '      string TestInOutParameter,',
+                 '         [IN ( true ),',
+                 '          OUT ( true ),',
+                 '          Description ( "Test of ref in/out parameter" )]',
+                 '      CIM_Foo REF TestRef,',
+                 '         [IN ( false ),',
+                 '          OUT ( true ),',
+                 '          Description ( "Rtns method name if exists on input" )]',  # noqa: E501
+                 '      string OutputParam,',
+                 '         [IN ( true ),',
+                 '          Description ( "Defines return value if provided." )]',  # noqa: E501
+                 '      uint32 OutputRtnValue);',
+                 '',
+                 '      [Description ( "Static method with in and out parameters" ),',  # noqa: E501
+                 '       Static ( true )]',
+                 '   uint32 FuzzyStatic(',
                  '         [IN ( true ),',
                  '          OUT ( true ),',
                  '          Description ( "Define data to be returned in output parameter" )]',  # noqa: E501
@@ -792,10 +855,29 @@ TEST_CASES = [
     ['Verify class command get with empty propertylist. Tests whole '
      'response',
      ['get', 'CIM_Foo_sub2', '--pl', '""'],
-     {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {', '',
-                 '      [Description ( "Method with in and out parameters" )'
-                 ']',
+     {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
+                 '',
+                 '      [Description ( "Method with in and out parameters" )]',
                  '   uint32 Fuzzy(',
+                 '         [IN ( true ),',
+                 '          OUT ( true ),',
+                 '          Description ( "Define data to be returned in output parameter" )]',  # noqa: E501
+                 '      string TestInOutParameter,',
+                 '         [IN ( true ),',
+                 '          OUT ( true ),',
+                 '          Description ( "Test of ref in/out parameter" )]',
+                 '      CIM_Foo REF TestRef,',
+                 '         [IN ( false ),',
+                 '          OUT ( true ),',
+                 '          Description ( "Rtns method name if exists on input" )]',  # noqa: E501
+                 '      string OutputParam,',
+                 '         [IN ( true ),',
+                 '          Description ( "Defines return value if provided." )]',  # noqa: E501
+                 '      uint32 OutputRtnValue);',
+                 '',
+                 '      [Description ( "Static method with in and out parameters" ),',  # noqa: E501
+                 '       Static ( true )]',
+                 '   uint32 FuzzyStatic(',
                  '         [IN ( true ),',
                  '          OUT ( true ),',
                  '          Description ( "Define data to be returned in output parameter" )]',  # noqa: E501
@@ -819,6 +901,7 @@ TEST_CASES = [
                  ''],
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
+    # pylint: enable=line-too-long
 
     ['Verify class command get with xml output format).',
      {'args': ['get', 'CIM_Foo'],
@@ -845,7 +928,6 @@ TEST_CASES = [
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
 
-    # pylint: enable=line-too-long
     ['Verify class command get with propertylist and classorigin,',
      ['get', 'CIM_Foo_sub2', '--pl', 'InstanceID', '--ico'],
      {'stdout': ['class CIM_Foo_sub2 : CIM_Foo {',
@@ -854,6 +936,28 @@ TEST_CASES = [
                  '   string InstanceID;',
                  '      [Description ( "Method with in and out parameters" )]',
                  '   uint32 Fuzzy(',
+                 '         [IN ( true ),',
+                 '          OUT ( true ),',
+                 '          Description ( "Define data to be returned in '
+                 'output parameter" )]',
+                 '      string TestInOutParameter,',
+                 '         [IN ( true ),',
+                 '          OUT ( true ),',
+                 '          Description ( "Test of ref in/out parameter" )]',
+                 '      CIM_Foo REF TestRef,',
+                 '         [IN ( false ),',
+                 '          OUT ( true ),',
+                 '          Description ( "Rtns method name if exists on '
+                 'input" )]',
+                 '      string OutputParam,',
+                 '         [IN ( true ),',
+                 '          Description ( "Defines return value if '
+                 'provided." )]',
+                 '      uint32 OutputRtnValue);',
+                 '      [Description ( "Static method with in and out '
+                 'parameters" ),',
+                 '       Static ( true )]',
+                 '   uint32 FuzzyStatic(',
                  '         [IN ( true ),',
                  '          OUT ( true ),',
                  '          Description ( "Define data to be returned in '
@@ -1486,22 +1590,16 @@ TEST_CASES = [
     #
     #  class invokemethod command without parameters
     #
-    ['Verify class command invokemethod. Class CIM_Foo, method Fuzzy',
-     ['invokemethod', 'CIM_Foo', 'Fuzzy'],
+    ['Verify class command invokemethod CIM_Foo.FuzzyStatic() - no in parms',
+     ['invokemethod', 'CIM_Foo', 'FuzzyStatic'],
      {'stdout': ["ReturnValue=0"],
       'rc': 0,
       'test': 'lines'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
-    ['Verify class command invokemethod. Class CIM_Foo, method Fuzzy',
-     ['invokemethod', 'CIM_Foo', 'Fuzzy'],
-     {'stdout': ["ReturnValue=0"],
-      'rc': 0,
-      'test': 'lines'},
-     [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
-
-    ['Verify class command invokemethod',
-     ['invokemethod', 'CIM_Foo', 'Fuzzy', '-p', 'TestInOutParameter="blah"'],
+    ['Verify class command invokemethod CIM_Foo.FuzzyStatic() - one in parm',
+     ['invokemethod', 'CIM_Foo', 'FuzzyStatic',
+      '-p', 'TestInOutParameter="blah"'],
      {'stdout': ['ReturnValue=0',
                  'TestInOutParameter=', 'blah'],
       'rc': 0,
@@ -1509,15 +1607,22 @@ TEST_CASES = [
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
     ['Verify class command invokemethod fails Invalid Class',
-     ['invokemethod', 'CIM_Foox', 'Fuzzy', '-p', 'TestInOutParameter="blah"'],
+     ['invokemethod', 'CIM_Foox', 'FuzzyStatic'],
      {'stderr': ['CIMError', '6'],
       'rc': 1,
       'test': 'innows'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
     ['Verify class command invokemethod fails Invalid Method',
-     ['invokemethod', 'CIM_Foo', 'Fuzzyx', '-p', 'TestInOutParameter=blah'],
+     ['invokemethod', 'CIM_Foo', 'Fuzzyx'],
      {'stderr': ['Class CIM_Foo does not have a method Fuzzyx'],
+      'rc': 1,
+      'test': 'innows'},
+     [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
+
+    ['Verify class command invokemethod fails non-static method',
+     ['invokemethod', 'CIM_Foo', 'Fuzzy'],
+     {'stderr': ["Non-static method 'Fuzzy' in class 'CIM_Foo'"],
       'rc': 1,
       'test': 'innows'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -311,6 +311,25 @@ TEST_CASES = [
                  'blah is not a valid integer'],
       'rc': 2,
       'test': 'innows'},
+     None, OK],  # Only tests that the option is accepted
+
+    ['Verify --no-deprecation-warnings general option.',
+     {'general': ['-s', 'http://blah', '--no-deprecation-warnings'],
+      'cmdgrp': 'connection',
+      'args': ['show']},
+     {'stdout': [''],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],  # Only tests that the option is accepted
+
+
+    ['Verify --deprecation-warnings general option.',
+     {'general': ['-s', 'http://blah', '--deprecation-warnings'],
+      'cmdgrp': 'connection',
+      'args': ['show']},
+     {'stdout': [''],
+      'rc': 0,
+      'test': 'innows'},
      None, OK],
 
     ['Verify --version general option.',

--- a/tests/unit/test_instance_cmds.py
+++ b/tests/unit/test_instance_cmds.py
@@ -19,7 +19,9 @@ Tests the commands in the server command group.
 from __future__ import absolute_import, print_function
 
 import os
+from packaging.version import parse as parse_version
 import pytest
+from pywbem import __version__ as pywbem_version
 
 from .cli_test_extensions import CLITestsBase, FAKEURL_STR, PYWBEM_0
 
@@ -39,6 +41,10 @@ from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
     CMD_OPTION_INDICATION_FILTER_HELP_LINE, \
     CMD_OPTION_EXPERIMENTAL_FILTER_HELP_LINE, \
     CMD_OPTION_HELP_INSTANCENAME_HELP_LINE
+
+_PYWBEM_VERSION = parse_version(pywbem_version)
+# pywbem 1.0.0 or later
+PYWBEM_1_0_0 = _PYWBEM_VERSION.release >= (1, 0, 0)
 
 TEST_DIR = os.path.dirname(__file__)
 
@@ -1017,12 +1023,25 @@ Instances: TST_Person
     #
     # instance enumerate error returns
     #
-    ['Verify instance command enumerate error, invalid classname fails',
+
+    # Note: In pywbem 1.0, the returned status for this test changed from
+    #       NOT_FOUND to INVALID_CLASS because that is the correct one for
+    #       instance operations that do not find their class.
+    ['Verify instance command enumerate error, invalid classname fails, '
+     'pywbem 1.0',
      ['enumerate', 'CIM_Foox'],
      {'stderr': ["CIMError:", "CIM_ERR_INVALID_CLASS"],
       'rc': 1,
-      'test': 'innows'},  # NOTE: For some reason this changed from NOT_FOUND
-     SIMPLE_MOCK_FILE, OK],
+      'test': 'innows'},
+     SIMPLE_MOCK_FILE, PYWBEM_1_0_0],
+
+    ['Verify instance command enumerate error, invalid classname fails, '
+     'pywbem 0.x',
+     ['enumerate', 'CIM_Foox'],
+     {'stderr': ["CIMError:", "CIM_ERR_NOT_FOUND"],
+      'rc': 1,
+      'test': 'innows'},
+     SIMPLE_MOCK_FILE, not PYWBEM_1_0_0],
 
     ['Verify instance command enumerate error, no classname fails',
      ['enumerate'],

--- a/tests/unit/test_instance_cmds.py
+++ b/tests/unit/test_instance_cmds.py
@@ -1019,9 +1019,9 @@ Instances: TST_Person
     #
     ['Verify instance command enumerate error, invalid classname fails',
      ['enumerate', 'CIM_Foox'],
-     {'stderr': ["Error: CIMError: 6"],
+     {'stderr': ["CIMError:", "CIM_ERR_INVALID_CLASS"],
       'rc': 1,
-      'test': 'in'},
+      'test': 'innows'},  # NOTE: For some reason this changed from NOT_FOUND
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance command enumerate error, no classname fails',
@@ -1769,8 +1769,8 @@ Instances: TST_Person
       'test': 'lines'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance command create, new instance Error in Property Type'
-     " with array values",
+    ['Verify instance command create, new instance Error in Property Type with'
+     " array values",
      ['create', 'PyWBEM_AllTypes', '-p', 'InstanceID=blah',
       '-p', 'arrayBool=8,9',
       '-p', 'arrayUint8=1,2,3',
@@ -1783,7 +1783,7 @@ Instances: TST_Person
                 "type='boolean', array=True and input value='8,9'. "
                 'Exception: Invalid boolean value: "8"',
       'rc': 1,
-      'test': 'lines'},
+      'test': 'innows'},
      ALLTYPES_MOCK_FILE, OK],
 
     ['Verify instance command create, new instance already exists',
@@ -1939,7 +1939,7 @@ Instances: TST_Person
                 "type='boolean', array=False and input value='9'. "
                 'Exception: Invalid boolean value: "9"',
       'rc': 1,
-      'test': 'lines'},
+      'test': 'innows'},
      ALLTYPES_MOCK_FILE, OK],
 
     ['Verify instance command modify, single property, Fail modifies key',
@@ -1972,7 +1972,7 @@ Instances: TST_Person
                 "type='boolean', array=False and input value='False,True'. "
                 'Exception: Invalid boolean value: "False,True"',
       'rc': 1,
-      'test': 'lines'},
+      'test': 'innows'},
      ALLTYPES_MOCK_FILE, OK],
 
     ['Verify instance command modify, Error value types mismatch with array',
@@ -1982,7 +1982,7 @@ Instances: TST_Person
                 "type='boolean', array=True and input value='9,8'. "
                 'Exception: Invalid boolean value: "9"',
       'rc': 1,
-      'test': 'lines'},
+      'test': 'innows'},
      ALLTYPES_MOCK_FILE, OK],
 
     ['Verify instance command modify, Error different value types',
@@ -1992,7 +1992,7 @@ Instances: TST_Person
                 "type='boolean', array=True and input value='true,8'. "
                 'Exception: Invalid boolean value: "8"',
       'rc': 1,
-      'test': 'lines'},
+      'test': 'innows'},
      ALLTYPES_MOCK_FILE, OK],
 
     ['Verify instance command modify, Error integer out of range',
@@ -2004,7 +2004,7 @@ Instances: TST_Person
                 "Exception: Integer value 99999999999999999999999 is out of "
                 "range for CIM datatype uint32",
       'rc': 1,
-      'test': 'lines'},
+      'test': 'innows'},
      ALLTYPES_MOCK_FILE, OK],
 
     ['Verify instance command modify, Error property not in class',
@@ -2012,7 +2012,7 @@ Instances: TST_Person
       '-p', 'blah=9'],
      {'stderr': 'Error: Property name "blah" not in class "PyWBEM_AllTypes".',
       'rc': 1,
-      'test': 'lines'},
+      'test': 'innows'},
      ALLTYPES_MOCK_FILE, OK],
 
     # TODO additional modify error tests required
@@ -2701,7 +2701,7 @@ interop      TST_MemberOfFamilyCollectionExp        1
                  'scalRef=', 'PyWBEM_AllTypes.InstanceID='],
       'rc': 0,
       'test': 'innows'},
-     [ALLTYPES_MOCK_FILE, ALLTYPES_INVOKEMETHOD_MOCK_FILE], OK],
+     [ALLTYPES_MOCK_FILE, ALLTYPES_INVOKEMETHOD_MOCK_FILE], RUN],
 
     ['Verify instance command invokemethod fails Invalid Class',
      ['invokemethod', 'CIM_Foox.InstanceID="CIM_Foo1"', 'Fuzzy', '-p',
@@ -2953,7 +2953,6 @@ class TestSubcmd(CLITestsBase):  # pylint: disable=too-few-public-methods
     Test all of the instance command variations.
     """
     command_group = 'instance'
-    # mock_mof_file = 'simple_mock_model.mof'
 
     @pytest.mark.parametrize(
         "desc, inputs, exp_response, mock, condition", TEST_CASES)

--- a/tests/unit/test_qualdecl_cmds.py
+++ b/tests/unit/test_qualdecl_cmds.py
@@ -92,6 +92,10 @@ Qualifier Override : string,
     Scope(property, reference, method),
     Flavor(EnableOverride, Restricted);
 
+Qualifier Static : boolean = false,
+    Scope(property, method),
+    Flavor(DisableOverride, ToSubclass);
+
 """
 
 
@@ -204,19 +208,19 @@ TEST_CASES = [
     ['Verify qualifier command enumerate returns qual decls.',
      ['enumerate'],
      {'stdout': QD_ENUM_MOCK,
-      'test': 'lines'},
+      'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify qualifier command enumerate with namespace returns qual decls.',
      ['enumerate', '--namespace', 'root/cimv2'],
      {'stdout': QD_ENUM_MOCK,
-      'test': 'lines'},
+      'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify qualifier command enumerate summary returns qual decls.',
      ['enumerate', '--summary'],
-     {'stdout': ['9', 'CIMQualifierDeclaration'],
-      'test': 'in'},
+     {'stdout': ['10', 'CIMQualifierDeclaration'],
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify qualifier command enumerate summary returns qual decls table',
@@ -226,7 +230,7 @@ TEST_CASES = [
 +---------+-------------------------+
 |   Count | CIM Type                |
 |---------+-------------------------|
-|       9 | CIMQualifierDeclaration |
+|      10 | CIMQualifierDeclaration |
 +---------+-------------------------+
 """],
       'test': 'linesnows'},
@@ -281,7 +285,7 @@ TEST_CASES = [
       'general': ['-o', 'grid']},
      {'stdout': QD_TBL_OUT,
       'rc': 0,
-      'test': 'lines'},
+      'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify qualifier command -o grid get Abstract table out',


### PR DESCRIPTION
Fixes a number of issues that appeared at the last minute in testing with pywbem 1.0.0 including:

This PR is built on top of PR #711m the invokemethod changes.

NOTE: This will fail until pr #711 passes.

1. The tests added a new qualifier decl to the simple_mock_model causing the displays of quallifiers to change.

2. There are several cases where tests fail (primarily in instance) becuase the UserWarning  for NocaseDict and ordering is now  possibly included in the output.  Changed these to use innows rather than lines or linesnows

3. For some reason that I have not sorted out, the CIMError for instance enumerate CIM_F00x returns INVSLID_CLASS where it prevously returned NOT_FOUND.   I assume something changed in pywbem_mock.

NOTE: This has been tested with pywbem PR #2414 and now appears to pass all t ests.

