### PR TITLE
Fixes issue #725 - Exception python 2.7

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -45,6 +45,9 @@ Released: not yet
 * Test: Fixed attempt in test_class_cmds.py to invoke a non-static method on a
   class object. (see issue #707)
 
+* Fix help message for "--deprecated" to be unicode so python 2.7 help does not
+  fail. (see issue #725). This error was added with issue #678
+
 **Enhancements:**
 
 * Modify general help to display the full path of the default connections file.

--- a/pywbemtools/pywbemcli/_common_options.py
+++ b/pywbemtools/pywbemcli/_common_options.py
@@ -116,10 +116,10 @@ experimental_filter_option = [              # pylint: disable=invalid-name
 deprecated_filter_option = [              # pylint: disable=invalid-name
     click.option('--deprecated/--no-deprecated',
                  default=None,
-                 help='Filter the returned classes to return only deprecated '
-                      'classes (--deprecated) or classes that are not '
-                      'deprecated (--no-deprecated). If the option is not '
-                      'defined no filtering occurs')]
+                 help=u'Filter the returned classes to return only deprecated '
+                      u'classes (--deprecated) or classes that are not '
+                      u'deprecated (--no-deprecated). If the option is not '
+                      u'defined no filtering occurs')]
 
 # List of the class filter options that are common to multiple class commands
 # Since the filters are in a list to allow them to be used individually, the

--- a/tests/unit/common_options_help_lines.py
+++ b/tests/unit/common_options_help_lines.py
@@ -82,6 +82,8 @@ CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE = \
 CMD_OPTION_KEYS_HELP_LINE = \
     '-k, --key KEYNAME=VALUE         Value for a key in keybinding of'
 
+# NOTE: The FILTER help lines should exist as a group wherever used.
+
 CMD_OPTION_ASSOCIATION_FILTER_HELP_LINE = \
     '--association / --no-association'
 
@@ -90,6 +92,9 @@ CMD_OPTION_INDICATION_FILTER_HELP_LINE = \
 
 CMD_OPTION_EXPERIMENTAL_FILTER_HELP_LINE = \
     '--experimental / --no-experimental'
+
+CMD_OPTION_DEPRECATED_FILTER_HELP_LINE = \
+    '--deprecated / --no-deprecated'
 
 CMD_OPTION_HELP_INSTANCENAME_HELP_LINE = \
     '--hi, --help-instancename Show help message for specifying INSTANCENAME'

--- a/tests/unit/test_class_cmds.py
+++ b/tests/unit/test_class_cmds.py
@@ -33,7 +33,9 @@ from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
     CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE, \
     CMD_OPTION_ASSOCIATION_FILTER_HELP_LINE, \
     CMD_OPTION_INDICATION_FILTER_HELP_LINE, \
-    CMD_OPTION_EXPERIMENTAL_FILTER_HELP_LINE
+    CMD_OPTION_EXPERIMENTAL_FILTER_HELP_LINE, \
+    CMD_OPTION_DEPRECATED_FILTER_HELP_LINE
+
 
 _PYWBEM_VERSION = parse_version(pywbem_version)
 # pywbem 1.0.0 or later
@@ -112,9 +114,12 @@ CLASS_ENUMERATE_HELP_LINES = [
     CMD_OPTION_NAMES_ONLY_HELP_LINE,
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
+    # NOTE: The FILTER options are a group. Define all of them.
     CMD_OPTION_ASSOCIATION_FILTER_HELP_LINE,
     CMD_OPTION_INDICATION_FILTER_HELP_LINE,
     CMD_OPTION_EXPERIMENTAL_FILTER_HELP_LINE,
+    CMD_OPTION_DEPRECATED_FILTER_HELP_LINE,
+
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
@@ -124,9 +129,12 @@ CLASS_FIND_HELP_LINES = [
     'List the classes with matching class names on the server.',
     '-s, --sort                 Sort by namespace. Default is to sort by',
     CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE,
+    # FILTER OPTIONS
     CMD_OPTION_ASSOCIATION_FILTER_HELP_LINE,
     CMD_OPTION_INDICATION_FILTER_HELP_LINE,
     CMD_OPTION_EXPERIMENTAL_FILTER_HELP_LINE,
+    CMD_OPTION_DEPRECATED_FILTER_HELP_LINE,
+
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
@@ -672,6 +680,25 @@ TEST_CASES = [
       '--names-only'],
      {'stdout': ['TST_FamilyCollection',
                  'TST_Person'],
+      'test': 'innows'},
+     QUALIFIER_FILTER_MODEL, OK],
+
+    ['Verify class command enumerate with --deprecated,'
+     '--no-association',
+     ['enumerate', '--deprecated',
+      '--names-only'],
+     {'stdout': ['TST_IndicationDeprecated',
+                 'TST_MemberOfFamilyCollectionDep'],
+      'test': 'innows'},
+     QUALIFIER_FILTER_MODEL, OK],
+
+    ['Verify class command enumerate with --no-deprecated, --association'
+     '--no-association',
+     ['enumerate', '--no-deprecated', '--association',
+      '--names-only'],
+     {'stdout': ['TST_Lineage',
+                 'TST_MemberOfFamilyCollection',
+                 'TST_MemberOfFamilyCollectionExp'],
       'test': 'innows'},
      QUALIFIER_FILTER_MODEL, OK],
 


### PR DESCRIPTION
Fixed issue where the help for the --deprecated command is not unicode.

Adds test for this option.