### PR TITLE
Add units to property names for table output of instances

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -65,6 +65,13 @@ Released: not yet
 * Test: Enabled coveralls to run on all Python versions in the Travis CI,
   resulting in a combined coverage for all Python versions.
 
+* For instance display in table format, added the display of
+  the units of properties to the table headers. If a property
+  in the class has a PUnit or Units qualifier set, the unit
+  is translated to a human readable SI unit using the pywbem.siunit_obj()
+  function, and appended to the property name in square brackets.
+  (See issue #727)
+
 **Cleanup**
 
 * Remove unused NocaseList from __common.py

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -81,7 +81,10 @@ wheel==0.33.5; python_version >= '3.8'
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
-pywbem==0.17.0
+# pywbem==0.17.0
+# Alternative to test against current github master pywbem
+git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
+# TODO: Upgrade to pywbem 1.1.0 once released.
 
 six==1.10.0
 Click==7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,10 @@
 
 # Direct dependencies (except pip, setuptools, wheel):
 
-pywbem>=0.17.0
+# pywbem>=0.17.0
 # Alternative to test against current github master pywbem
-#git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
+git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
+# TODO: Upgrade to pywbem 1.1.0 once released.
 
 six>=1.10.0
 # Click 7.1 has a bug with output capturing

--- a/tests/unit/simple_assoc_mock_model.mof
+++ b/tests/unit/simple_assoc_mock_model.mof
@@ -29,6 +29,9 @@ Qualifier Values : string[],
     Scope(property, method, parameter),
     Flavor(EnableOverride, ToSubclass, Translatable);
 
+Qualifier PUnit : string = null,
+    Scope(property, method, parameter);
+
 class TST_Person{
         [Key, Description ("This is key prop")]
     string name;
@@ -43,6 +46,7 @@ class TST_Person{
 // This is good test of case insensitivity for class names.
 class TST_Personsub : TST_Person{
     string secondProperty = "empty";
+        [PUnit ("byte * 10^3")]
     uint32 counter;
 };
 


### PR DESCRIPTION
See commit message.

**Note: This PR requires the master branch of pywbem, until pywben 1.1.0 is released.**

Example (property `counter` has `PUnit("byte * 10^3")`):
```
$ pywbemcli -m tests/unit/simple_assoc_mock_model.mof -o table instance enumerate TST_Person
Instances: TST_Person
+------------+----------------+------------+-----------------------+------------------+
| name       | counter [kB]   | gender     | likes                 | secondProperty   |
|------------+----------------+------------+-----------------------+------------------|
| "Gabi"     |                | 1 (female) | 2 (movies)            |                  |
| "Mike"     |                | 2 (male)   | 1 (books), 2 (movies) |                  |
| "Saara"    |                | 1 (female) | 1 (books)             |                  |
| "Sofi"     |                | 1 (female) |                       |                  |
| "Gabisub"  | 4              | 1 (female) |                       | "four"           |
| "Mikesub"  | 1              | 2 (male)   |                       | "one"            |
| "Saarasub" | 2              | 1 (female) |                       | "two"            |
| "Sofisub"  | 3              | 1 (female) |                       | "three"          |
+------------+----------------+------------+-----------------------+------------------+
```