### PR TITLE
Refactor pywbemcli to separate code that sets up prompt mock.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -113,6 +113,10 @@ Released: not yet
   Connections File and created a unit test and function error test.
   (see issue #661)
 
+* Separate code to execute test files (ex. setup up mock of prompt) from
+  the process of executing files defined by the --mock-server general option.
+  The new capability is controled by an environment variable
+  "PYWBEMCLI_STARTUP_SCRIPT" that is considered intenal to pywbemcli testing.
 
 **Known issues:**
 

--- a/tests/unit/mock_confirm_n.py
+++ b/tests/unit/mock_confirm_n.py
@@ -1,4 +1,3 @@
-# !PROCESS!AT!STARTUP!
 # The previous statement is used by pywbemcli to force this script to be
 # run at pywbemcli startup and not included in the list of --mock-server
 # files that are used to build the repository.  This is a development
@@ -22,7 +21,10 @@
     Python code to mock click.click_prompt. Returns the
     value defined in RETURN_VALUE
 
-    Used to mock response from commmon_verify_operation
+    Used to mock response from commmon_verify_operation.
+
+    This file is enabled during testing through the PYWBEMCLI_STARTUP_SCRIPT
+    environment variable.
 """
 from mock import Mock
 import pywbemtools

--- a/tests/unit/mock_confirm_y.py
+++ b/tests/unit/mock_confirm_y.py
@@ -1,4 +1,3 @@
-# !PROCESS!AT!STARTUP!
 # The previous statement is used by pywbemcli to force this script to be
 # run at pywbemcli startup and not included in the list of --mock-server
 # files that are used to build the repository.  This is a development
@@ -23,6 +22,9 @@
     value defined in RETURN_VALUE
 
     Used to mock response from commmon_verify_operation
+
+    This file is enabled during testing through the PYWBEMCLI_STARTUP_SCRIPT
+    environment variable.
 """
 from mock import Mock
 import pywbemtools

--- a/tests/unit/mock_password_prompt.py
+++ b/tests/unit/mock_password_prompt.py
@@ -1,4 +1,3 @@
-# !PROCESS!AT!STARTUP!
 # The previous statement is used by pywbemcli to force this script to be
 # run at pywbemcli startup and not included in the list of --mock-server
 # files that are used to build the repository.  This is a development
@@ -23,6 +22,9 @@ Python code to mock click.click_prompt. Returns the
 value defined in RETURN_VALUE
 
 Used to mock response from commmon_verify_operation
+
+    This file is enabled during testing through the PYWBEMCLI_STARTUP_SCRIPT
+    environment variable.
 """
 
 from mock import Mock

--- a/tests/unit/mock_prompt_0.py
+++ b/tests/unit/mock_prompt_0.py
@@ -1,4 +1,3 @@
-# !PROCESS!AT!STARTUP!
 # The previous statement is used by pywbemcli to force this script to be
 # run at pywbemcli startup and not included in the list of --mock-server
 # files that are used to build the repository.  This is a development
@@ -29,6 +28,9 @@
     Add this file to the set of mock options and the prompt for picking
     the instance will be output but the prompt for a response from the
     user will be bypassed and the value defined in RETURN_VALUE returned.
+
+    This file is enabled during testing through the PYWBEMCLI_STARTUP_SCRIPT
+    environment variable.
 """
 from mock import Mock
 

--- a/tests/unit/mock_prompt_pick_response_11.py
+++ b/tests/unit/mock_prompt_pick_response_11.py
@@ -1,4 +1,3 @@
-# !PROCESS!AT!STARTUP!
 # The previous statement is used by pywbemcli to force this script to be
 # run at pywbemcli startup and not included in the list of --mock-server
 # files that are used to build the repository.  This is a development
@@ -29,6 +28,9 @@
     Add this file to the set of mock options and the prompt for picking
     the instance will be output but the prompt for a response from the
     user will be bypassed and the value defined in RETURN_VALUE returned.
+
+    This file is enabled during testing through the PYWBEMCLI_STARTUP_SCRIPT
+    environment variable.
 """
 from mock import Mock
 

--- a/tests/unit/mock_prompt_pick_response_3.py
+++ b/tests/unit/mock_prompt_pick_response_3.py
@@ -1,4 +1,3 @@
-# !PROCESS!AT!STARTUP!
 # The previous statement is used by pywbemcli to force this script to be
 # run at pywbemcli startup and not included in the list of --mock-server
 # files that are used to build the repository.  This is a development
@@ -29,6 +28,9 @@
     Add this file to the set of mock options and the prompt for picking
     the instance will be output but the prompt for a response from the
     user will be bypassed and the value defined in RETURN_VALUE returned.
+
+    This file is enabled during testing through the PYWBEMCLI_STARTUP_SCRIPT
+    environment variable.
 """
 from mock import Mock
 

--- a/tests/unit/test_connection_cmds.py
+++ b/tests/unit/test_connection_cmds.py
@@ -37,13 +37,23 @@ SCRIPT_DIR = os.path.dirname(__file__)
 SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
 ONE_CLASS_MOCK_FILE = 'one_class_mock.mof'
 INVOKE_METHOD_MOCK_FILE = 'simple_mock_invokemethod.py'
-MOCK_PROMPT_0_FILE = "mock_prompt_0.py"
 
 TEST_DIR = os.path.dirname(__file__)
+TEST_DIR_REL = os.path.relpath(TEST_DIR)
+
+
+def GET_TEST_PATH_STR(filename):  # pylint: disable=invalid-name
+    """
+    Return the string representing the relative path of the file name provided.
+    """
+    return (str(os.path.join(TEST_DIR_REL, filename)))
+
+
+MOCK_DEFINITION_ENVVAR = 'PYWBEMCLI_STARTUP_SCRIPT'
+MOCK_PROMPT_0_FILE = "mock_prompt_0.py"
 
 # Get the relative path to the current directory.  This presumes that the
 # test was run from the pywbemtools directory
-TEST_DIR_REL = os.path.relpath(TEST_DIR)
 MOCK_FILE_PATH = os.path.join(TEST_DIR_REL, SIMPLE_MOCK_FILE)
 
 CONNECTION_HELP_LINES = [
@@ -784,29 +794,34 @@ ca-certs
       'file': {'before': 'exists', 'after': 'exists'}},
      None, OK],
 
+    # The following 3 tests use a file defined to pywbemcli through an
+    # environment variable to mock the select prompt.
     ['Verify connection command select mocktest with prompt',
      {'general': [],
-      'args': ['select']},
+      'args': ['select'],
+      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)}},
      {'stdout': "",
       'test': 'in',
       'file': {'before': 'exists', 'after': 'exists'}},
-     MOCK_PROMPT_0_FILE, OK],
+     None, OK],
 
     ['Verify connection command show with prompt',
      {'general': [],
-      'args': ['show', '?']},
+      'args': ['show', '?'],
+      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)}},
      {'stdout': ['name mocktest'],
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'exists'}},
-     MOCK_PROMPT_0_FILE, OK],
+     None, OK],
 
     ['Verify connection command delete last one that deletes w/o prompt',
      {'general': [],
-      'args': ['delete']},
+      'args': ['delete'],
+      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)}},
      {'stdout': ['Deleted connection "mocktest"'],
       'test': 'innows',
       'file': {'before': 'exists', 'after': 'none'}},
-     MOCK_PROMPT_0_FILE, OK],
+     None, OK],
 
     ['Verify Add mock server to empty connections file.',
      {'general': ['--mock-server', MOCK_FILE_PATH],

--- a/tests/unit/test_instance_cmds.py
+++ b/tests/unit/test_instance_cmds.py
@@ -47,6 +47,7 @@ _PYWBEM_VERSION = parse_version(pywbem_version)
 PYWBEM_1_0_0 = _PYWBEM_VERSION.release >= (1, 0, 0)
 
 TEST_DIR = os.path.dirname(__file__)
+TEST_DIR_REL = os.path.relpath(TEST_DIR)
 
 SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
 ASSOC_MOCK_FILE = 'simple_assoc_mock_model.mof'
@@ -60,10 +61,25 @@ INVOKE_METHOD_MOCK_FILE = INVOKE_METHOD_MOCK_FILE_0 if PYWBEM_0 else \
 
 
 COMPLEX_ASSOC_MODEL = "complex_assoc_model.mof"
+
+
+#
+# Definition of files that mock selected pywbemcli calls for tests
+# These are installed in pywbemcli through a special env variable set
+# before the test that is NOT one of the externally defined environment
+# variables
+#
+def GET_TEST_PATH_STR(filename):  # pylint: disable=invalid-name
+    """
+    Return the string representing the relative path of the file name provided.
+    """
+    return (str(os.path.join(TEST_DIR_REL, filename)))
+
+
+MOCK_DEFINITION_ENVVAR = 'PYWBEMCLI_STARTUP_SCRIPT'
 MOCK_PROMPT_0_FILE = "mock_prompt_0.py"
 MOCK_PROMPT_PICK_RESPONSE_3_FILE = 'mock_prompt_pick_response_3.py'
 MOCK_PROMPT_PICK_RESPONSE_11_FILE = 'mock_prompt_pick_response_11.py'
-
 MOCK_CONFIRM_Y_FILE = "mock_confirm_y.py"
 MOCK_CONFIRM_N_FILE = "mock_confirm_n.py"
 
@@ -1398,29 +1414,35 @@ Instances: TST_Person
      SIMPLE_MOCK_FILE, OK],
 
     ['INSTANCENAME with wildcard keybinding, no options',
-     ['get', 'TST_Person.?'],
+     {'general': [],
+      'args': ['get', 'TST_Person.?'],
+      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)}},
      {'stdout':
       ['Input integer between 0 and 7',
        'root/cimv2:TST_Person',
        'instance of TST_Person'],
       'rc': 0,
       'test': 'regex'},
-     [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
+     ASSOC_MOCK_FILE, OK],
 
     ['INSTANCENAME with wildcard keybinding, --key option (error)',
-     ['get', 'TST_Person.?', '--key', 'name=Saara'],
+     {'general': [],
+      'args': ['get', 'TST_Person.?', '--key', 'name=Saara'],
+      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)}},
      {'stderr': "Using the --key option conflicts with specifying a "
                 "wildcard keybinding",
       'rc': 1,
       'test': 'regex'},
-     [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
+     ASSOC_MOCK_FILE, OK],
 
     ['INSTANCENAME with wildcard keybinding, invalid class path (error)',
-     ['get', 'TST_Person.name=1.?'],
+     {'general': [],
+      'args': ['get', 'TST_Person.name=1.?'],
+      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)}},
      {'stderr': "Invalid format for a class path in WBEM URI",
       'rc': 1,
       'test': 'regex'},
-     [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
+     ASSOC_MOCK_FILE, OK],
 
     ['INSTANCENAME with namespace and with wildcard keybinding, '
      'option --namespace with same ns (error)',
@@ -1589,14 +1611,16 @@ Instances: TST_Person
     # Cannot insure order of the pick and we are using an integer to
     # pick so result is very general
     ['Verify instance command get with wildcard keybinding',
-     ['get', 'TST_Person.?'],
+     {'general': [],
+      'args': ['get', 'TST_Person.?'],
+      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)}},
      {'stdout':
       ['Input integer between 0 and 7',
        'root/cimv2:TST_Person',
        'instance of TST_Person'],
       'rc': 0,
       'test': 'regex'},
-     [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
+     ASSOC_MOCK_FILE, OK],
 
     #
     #  instance get command errors
@@ -1676,7 +1700,9 @@ Instances: TST_Person
 
     ['Verify instance command create, new instance of CIM_Foo one '
      'property and verify yes',
-     ['create', 'CIM_Foo', '-p', 'InstanceID=blah', '--verify'],
+     {'general': [],
+      'args': ['create', 'CIM_Foo', '-p', 'InstanceID=blah', '--verify'],
+      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_CONFIRM_Y_FILE)}},
      {'stdout': ['instance of CIM_Foo {',
                  'InstanceID = "blah";',
                  '};',
@@ -1684,11 +1710,13 @@ Instances: TST_Person
                  'root/cimv2:CIM_Foo.InstanceID="blah"'],
       'rc': 0,
       'test': 'in'},
-     [SIMPLE_MOCK_FILE, MOCK_CONFIRM_Y_FILE], OK],
+     SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance command create, new instance of CIM_Foo one '
      'property and verify no',
-     ['create', 'CIM_Foo', '-p', 'InstanceID=blah', '--verify'],
+     {'general': [],
+      'args': ['create', 'CIM_Foo', '-p', 'InstanceID=blah', '--verify'],
+      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_CONFIRM_N_FILE)}},
      {'stdout': ['instance of CIM_Foo {',
                  'InstanceID = "blah";',
                  '};',
@@ -1696,7 +1724,7 @@ Instances: TST_Person
                  'Request aborted'],
       'rc': 0,
       'test': 'in'},
-     [SIMPLE_MOCK_FILE, MOCK_CONFIRM_N_FILE], OK],
+     SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance command create, new instance of CIM_Foo, '
      'one property, explicit namespace definition',
@@ -1707,14 +1735,16 @@ Instances: TST_Person
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify get and delete with wildcard keybinding with stdin',
-     {'stdin': ['instance get CIM_Foo.?',
+     {'env': {MOCK_DEFINITION_ENVVAR:
+              GET_TEST_PATH_STR(MOCK_PROMPT_PICK_RESPONSE_3_FILE)},
+      'stdin': ['instance get CIM_Foo.?',
                 'instance delete CIM_Foo.?']},
      {'stdout': ['CIM_Foo',
                  'instance of CIM_Foo',
                  'InstanceID = "CIM_Foo30"'],
       'rc': 0,
       'test': 'innows'},
-     [SIMPLE_MOCK_FILE, MOCK_PROMPT_PICK_RESPONSE_3_FILE], OK],
+     SIMPLE_MOCK_FILE, 'pdb'],
 
     ['Verify multiple creates verify with enum summary with stdin',
      {'stdin': ['instance create CIM_Foo -p InstanceID=blah1',
@@ -1746,7 +1776,9 @@ Instances: TST_Person
     #      version. Test marked as failing.
     ['Verify create, get with wildcard keybinding, delete with wildcard '
      'keybinding, with stdin',
-     {'stdin': ['instance create CIM_Foo -p InstanceID=blah',
+     {'env': {MOCK_DEFINITION_ENVVAR:
+              GET_TEST_PATH_STR(MOCK_PROMPT_PICK_RESPONSE_11_FILE)},
+      'stdin': ['instance create CIM_Foo -p InstanceID=blah',
                 'instance get CIM_Foo.?',
                 'instance delete CIM_Foo.?']},
      {'stdout': ['CIM_Foo',
@@ -1754,7 +1786,7 @@ Instances: TST_Person
                  'IntegerProp = NULL'],
       'rc': 0,
       'test': 'innows'},
-     [SIMPLE_MOCK_FILE, MOCK_PROMPT_PICK_RESPONSE_11_FILE], FAIL],
+     SIMPLE_MOCK_FILE, FAIL],
 
     ['Verify instance command create, new instance of all_types '
      'with scalar types',
@@ -2104,12 +2136,14 @@ Instances: TST_Person
      SIMPLE_MOCK_FILE, OK],
 
     ['Verify instance command delete with wildcard keybinding',
-     ['delete', 'TST_Person.?'],
+     {'general': [],
+      'args': ['delete', 'TST_Person.?'],
+      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)}},
      {'stdout':
       ['root/cimv2:TST_Person.name="Mike"'],
       'rc': 0,
       'test': 'in'},
-     [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
+     ASSOC_MOCK_FILE, OK],
 
     #
     # Delete command error tests
@@ -2342,7 +2376,9 @@ Instances: TST_Person
      ASSOC_MOCK_FILE, OK],
 
     ['Verify instance command references with wildcard keybinding',
-     ['references', 'TST_Person.?'],
+     {'general': [],
+      'args': ['references', 'TST_Person.?'],
+      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)}},
      {'stdout':
       ['root/cimv2:TST_Person.name="Mike"',
        'instance of TST_Lineage {',
@@ -2350,7 +2386,7 @@ Instances: TST_Person
        'instance of TST_MemberOfFamilyCollection {'],
       'rc': 0,
       'test': 'innows'},
-     [ASSOC_MOCK_FILE, MOCK_PROMPT_0_FILE], OK],
+     ASSOC_MOCK_FILE, OK],
 
     ['Verify instance command references with query',
      ['references', 'TST_Person.name="Mike"', '--filter-query',

--- a/tests/unit/test_misc_errors.py
+++ b/tests/unit/test_misc_errors.py
@@ -22,7 +22,8 @@ import pytest
 from .cli_test_extensions import CLITestsBase
 
 SCRIPT_DIR = os.path.dirname(__file__)
-SIMPLE_MOCK_FILE_PATH = os.path.join(SCRIPT_DIR, 'simple_mock_model.mof')
+SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
+SIMPLE_MOCK_FILE_PATH = os.path.join(SCRIPT_DIR, SIMPLE_MOCK_FILE)
 
 OK = True
 RUN = True

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -73,9 +73,6 @@ def execute_pywbemcli(args, env=None, stdin=None, verbose=None):
     else:
         env = copy(env)
 
-    # TODO should we consider removing all env variables before each
-    # test???
-
     env['PYTHONPATH'] = '.'  # Use local files
     env['PYTHONWARNINGS'] = ''  # Disable for parsing output
 


### PR DESCRIPTION
Removes code that installs test scripts from the mock_serverprocessing and makes it a separate component  in pywbemcli.py

pywbemcli uses python files that are executed during the startup
process to define the mock of selected component as part of
the pywbemcli tests.  Generally we mock the prompt and
associated functions to that we can test pywbemcli commands that
use prompt and continue based on the return.

Whereas the old code used python files defined with
the --mock-server general option but with the first line with
as particular string to execute these files as part of the
startup of the server, the new code uses a separate environment
variable that should be considered private to pywbemcli to define
the python file to be executed as part of the pywbemcli startup.

The environment variable we use is "pywbemcli_startup_script".