### PR TITLE
Remove use of pydicti package in favor of NocaseDict.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -126,6 +126,8 @@ Released: not yet
 * Refactor connections show command and clean up its documentation.  (see
   issue #732)
 
+* Remove use of pydicti dictionary package in favor of NocaseDict.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -826,13 +826,13 @@ Help text for ``pywbemcli connection show`` (see :ref:`connection show command`)
 
       Show the name and attributes of a WBEM connection definition or the current connection, as follows:
 
-      * If the NAME argument is specified, display the connection information with that   name from the connections file
-      or the current connection   if it is the same name.
+      * If the NAME argument is specified, display the connection information   with that name from the connections file
+      or the current connection if it   is the same name.
 
       * If the NAME argument is '?', the command presents a list of connection   definitions from the connections file and
       prompts the user to   select one, which is then displayed.
 
-      * If the NAME argument is omitted, displays the current connection information   if there is a current connection.
+      * If the NAME argument is omitted, displays the current connection   information if there is a current connection.
 
       Example showing a named connection definition:
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -98,7 +98,6 @@ tabulate==0.8.2
 prompt-toolkit==1.0.15; python_version == '2.7'
 prompt-toolkit==2.0.1; python_version >= '3.4'
 PyYAML==5.1
-pydicti==1.1.3
 yamlloader==0.5.5
 mock==3.0.0
 

--- a/pywbemtools/pywbemcli/_association_shrub.py
+++ b/pywbemtools/pywbemcli/_association_shrub.py
@@ -43,9 +43,9 @@ import six
 import click
 # TODO: Future Could we combine this tree into tree file???
 from asciitree import LeftAligned
-from pydicti import dicti
 from pywbem import CIMInstanceName, CIMClassName, CIMFloat, CIMInt, CIMError, \
     CIMDateTime
+from pywbem._nocasedict import NocaseDict
 
 from ._common import output_format_is_table, format_table, shorten_path_str, \
     warning_msg, sort_cimobjects
@@ -432,8 +432,8 @@ class AssociationShrub(object):
         assoctree = OrderedDict()
         # Create dictionary of standard instance keys to potentially hide.
         # For now we always hide the following independent of key value
-        replacements = dicti((("SystemCreationClassName", None),
-                              ("SystemName", None)))
+        replacements = NocaseDict((("SystemCreationClassName", None),
+                                   ("SystemName", None)))
         for role, ref_clns in six.iteritems(self.instance_shrub):
             elementstree = OrderedDict()
             for ref_cln in ref_clns:
@@ -767,7 +767,7 @@ class AssociationShrub(object):
         assert isinstance(inst_names_tuple, list)
         assert isinstance(inst_names_tuple[0], tuple)
         assert len(inst_names_tuple[0]) == 2
-        assert isinstance(replacements, dicti)
+        assert isinstance(replacements, NocaseDict)
 
         # If path shortening specified, determine which keys can be shortened
         # based on keys with the same value in all instance names

--- a/pywbemtools/pywbemcli/_display_cimobjects.py
+++ b/pywbemtools/pywbemcli/_display_cimobjects.py
@@ -23,14 +23,13 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import re
 
-from pydicti import odicti
 import six
 import click
-from nocasedict import NocaseDict
 
 from pywbem import CIMInstanceName, CIMInstance, CIMClass, \
     CIMQualifierDeclaration, CIMClassName, ValueMapping, siunit_obj, \
     CIMError, CIM_ERR_NOT_SUPPORTED
+from pywbem._nocasedict import NocaseDict
 
 from ._common import format_table, fold_strings, DEFAULT_MAX_CELL_WIDTH, \
     output_format_is_table, sort_cimobjects, format_keys
@@ -565,8 +564,8 @@ def sorted_prop_names(insts):
     and if instances of subclasses have additional keys.
     """
 
-    all_props = odicti()  # key: org prop name, value: lower cased prop name
-    key_props = odicti()  # key: org prop name, value: lower cased prop name
+    all_props = NocaseDict()  # key: org prop name, value
+    key_props = NocaseDict()  # key: org prop name, value
     for inst in insts:
         inst_props = inst.keys()
         for pn in inst_props:
@@ -577,7 +576,7 @@ def sorted_prop_names(insts):
                 if pn in key_prop_names:
                     key_props[pn] = pn.lower()
 
-    nonkey_props = odicti()  # key: org prop name, value: lower cased prop name
+    nonkey_props = NocaseDict()  # key: org prop name, value
     for pn in all_props:
         if pn not in key_props:
             nonkey_props[pn] = all_props[pn]

--- a/pywbemtools/pywbemcli/_displaytree.py
+++ b/pywbemtools/pywbemcli/_displaytree.py
@@ -26,7 +26,7 @@ import click
 
 # Use an ordered Nocase dictionary for the tree. Ordered dictionary creates
 # tree output that has the same order in multiple versions of python.
-from pydicti import odicti
+from pywbem._nocasedict import NocaseDict
 
 
 def build_tree(class_subclass_dict, top_class):
@@ -58,7 +58,7 @@ def build_tree(class_subclass_dict, top_class):
         Returns:
           Structure of nested dictionaries defining the class/subclass structure
         """
-        node_dict = odicti()
+        node_dict = NocaseDict()
         # If there is no subclass, the class will not exist in this dictionary
         if cln in class_to_subclass_dict:
             cln_list = class_to_subclass_dict[cln]
@@ -68,7 +68,7 @@ def build_tree(class_subclass_dict, top_class):
                     node_dict[key] = _tree_node(class_to_subclass_dict, key)
         return node_dict
 
-    rtn_dict = odicti()
+    rtn_dict = NocaseDict()
     # _tree_node generates dictionary node for elements in class-subclass
     # dictionary and returns complete node structure. This is recursive,
     # with _tree_node recursively calling until there are no subclasses.
@@ -97,7 +97,7 @@ def build_class_tree_dict(classes, top_class=None):
     cln_to_supercln = {cln.classname: cln.superclass for cln in classes}
 
     # Sort so there is a fixed order to the resulting tree.
-    cln_supercln_sorted = odicti()
+    cln_supercln_sorted = NocaseDict()
     for key in sorted(cln_to_supercln.keys()):
         cln_supercln_sorted[key] = cln_to_supercln[key]
     cln_to_supercln = cln_supercln_sorted
@@ -112,7 +112,7 @@ def build_class_tree_dict(classes, top_class=None):
     # Build the class to subclass dictionary from the
     # superclass to class dictionary by reversing the dictionary.
     # Built within a comprehension but comprehension not assigned.
-    subcln_in_cln = odicti()
+    subcln_in_cln = NocaseDict()
     # pylint: disable=bad-continuation, expression-not-assigned
     [subcln_in_cln.setdefault(v, []).append(k) for (k, v) in
         six.iteritems(cln_to_supercln)]  # noqa: F841

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,8 +33,6 @@ prompt-toolkit>=2.0.1; python_version >= '3.4' and python_version < '3.8'
 prompt-toolkit>=2.0.1; python_version >= '3.8' and sys_platform != 'win32'
 prompt-toolkit>=2.0.1,<3.0.0; python_version >= '3.8' and sys_platform == 'win32'
 
-pydicti>=1.1.3
-
 # PyYAML 5.3 has removed support for Python 3.4
 PyYAML>=5.1; python_version == '2.7'
 PyYAML>=5.1,<5.3; python_version == '3.4'


### PR DESCRIPTION
Change all use of the pydicti package in favor of the pywbem NocaseDict
package.  For the moment this uses the pywbem internal NocaseDict. See
issue # 754 that documents this issue.