### PR TITLE
Fixes issue #751, [ylint errors when pdb++ is in the local python environment

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -128,6 +128,9 @@ Released: not yet
 
 * Remove use of pydicti dictionary package in favor of NocaseDict.
 
+* set pylint disable on all uses of pdb.set_trace(). This is an issue between
+  the add-on package pdbpp and lint, not pdb.  (see issue # 751)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/pywbemtools/pywbemcli/_context_obj.py
+++ b/pywbemtools/pywbemcli/_context_obj.py
@@ -281,7 +281,7 @@ class ContextObj(object):  # pylint: disable=useless-object-inheritance
             self.spinner_start()
         if self.pdb:
             import pdb  # pylint: disable=import-outside-toplevel
-            pdb.set_trace()
+            pdb.set_trace()  # pylint: disable=no-member
         try:
             cmd()
         finally:

--- a/tests/unit/pytest_extensions.py
+++ b/tests/unit/pytest_extensions.py
@@ -136,7 +136,7 @@ def simplified_test_function(test_func):
                 if exp_exc_types:
                     with pytest.raises(exp_exc_types):
                         if condition == 'pdb':
-                            pdb.set_trace()
+                            pdb.set_trace()  # pylint: disable=no-member
 
                         test_func(testcase, **kwargs)  # expecting an exception
 
@@ -146,7 +146,7 @@ def simplified_test_function(test_func):
                     # exception).
                 else:
                     if condition == 'pdb':
-                        pdb.set_trace()
+                        pdb.set_trace()  # pylint: disable=no-member
 
                     test_func(testcase, **kwargs)  # not expecting an exception
 
@@ -156,14 +156,14 @@ def simplified_test_function(test_func):
             if exp_exc_types:
                 with pytest.raises(exp_exc_types):
                     if condition == 'pdb':
-                        pdb.set_trace()
+                        pdb.set_trace()  # pylint: disable=no-member
 
                     test_func(testcase, **kwargs)  # expecting an exception
 
                 ret = None  # Debugging hint
             else:
                 if condition == 'pdb':
-                    pdb.set_trace()
+                    pdb.set_trace()  # pylint: disable=no-member
 
                 test_func(testcase, **kwargs)  # not expecting an exception
 

--- a/tests/unit/test_connection_cmds.py
+++ b/tests/unit/test_connection_cmds.py
@@ -1265,7 +1265,7 @@ class TestSubcmdClass(CLITestsBase):
 
         if condition == 'pdb':
             import pdb  # pylint: disable=import-outside-toplevel
-            pdb.set_trace()
+            pdb.set_trace()  # pylint: disable=no-member
 
         if 'file' in exp_response:
             if 'before' in exp_response['file']:
@@ -1480,7 +1480,7 @@ class TestSubcmdClassError(CLITestsBase):
 
         if condition == 'pdb':
             import pdb  # pylint: disable=import-outside-toplevel
-            pdb.set_trace()
+            pdb.set_trace()  # pylint: disable=no-member
 
         if 'file' in exp_response:
             if 'before' in exp_response['file']:


### PR DESCRIPTION
Add pyline warning to all uses of set_trace() to eliminate the
warning that appears if pdbpp is used in place of pdb.  Since
pdbpp is supposed to be a direct replacement for pdb (at least in
linux environments), this seems logical. Note that this is not
a requirement since there is no required use of pdbpp but since it
does simplify debugging its use is logical.