### PR TITLE
Fixes #766: Pywbemcli tests fail, assertion mof_compiler

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -54,6 +54,9 @@ Released: not yet
 
 * Upgraded nocasedict and nocaselist packages to pick up fixes.
 
+* Error in test defintion for qualdecl Indication causes failure with pywbem
+  i.1.0 where mocker validates qualifiers scopes. (see issue #766)
+
 **Enhancements:**
 
 * Introduced caching of the mock environment used by connection definitions in

--- a/tests/unit/qualifier_filter_model.mof
+++ b/tests/unit/qualifier_filter_model.mof
@@ -21,7 +21,7 @@ Qualifier Experimental : boolean = true,
     Flavor(DisableOverride, ToSubclass);
 
 Qualifier Indication : boolean = true,
-    Scope(class),
+    Scope(class, indication),
     Flavor(DisableOverride, ToSubclass);
 
 Qualifier Key : boolean = false,


### PR DESCRIPTION
The tests actually fail because of a badly defined qualifier declaration
in the model qualifier_filter_model.mof.  The Indication qualifier
declaration is invalid it this test (scope should be class, indication).

Changes in pywbem PR 2456, issue #2455 added the scope validity test to class resolution and caught the error

Fixed.

The secondary issue of an assertion error is an issue in pywbem, not
pywbemcli

NOTE: cmdshelp.rst was also modified because we must have missed that
change in earlier commit.   Build doc made the changes seen.