### PR TITLE
0.7: Test: Preventively fixed potential issue with virtualenv on py34

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,7 +23,8 @@ colorama>=0.4.0; python_version >= '3.5'
 
 # Virtualenv
 # Virtualenv 20.0.19 has an issue where it does not install pip on Python 3.4.
-virtualenv>=14.0.0,!=20.0.19; python_version < '3.5'
+# Virtualenv 20.0.32 has an issue where it raises AttributeError on Python 3.4.
+virtualenv>=14.0.0,!=20.0.19,!=20.0.32; python_version < '3.5'
 virtualenv>=16.1.0; python_version >= '3.5' and python_version < '3.8'
 virtualenv>=20.0.0; python_version >= '3.8'
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,9 @@ Released: not yet
 * Test: Fixed attempt in test_class_cmds.py to invoke a non-static method on a
   class object. (see issue #707)
 
+* Test: Preventive fix for potential issue with virtualenv raising
+  AttributeError during installtest on Python 3.4. (see issue #775)
+
 **Enhancements:**
 
 **Known issues:**


### PR DESCRIPTION
Rolls back PR #776 into 0.7.2.