### PR TITLE
Fixed incorrect property order in instance table output

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -62,6 +62,10 @@ Released: not yet
 
 * Test: Added checking for no expected warning. (see issue #774)
 
+* Fixed incorrect property order in instance table output, where key properties
+  were not ordered before non-key properties but ordered along with them.
+  (see issue #782)
+
 **Enhancements:**
 
 * Introduced caching of the mock environment used by connection definitions in

--- a/pywbemtools/pywbemcli/_display_cimobjects.py
+++ b/pywbemtools/pywbemcli/_display_cimobjects.py
@@ -575,25 +575,22 @@ def sorted_prop_names(insts):
     and if instances of subclasses have additional keys.
     """
 
-    all_props = NocaseDict()  # key: org prop name, value
-    key_props = NocaseDict()  # key: org prop name, value
+    all_props = NocaseDict()  # key: org prop name, value: lower prop name
+    key_props = NocaseDict()  # key: org prop name, value: lower prop name
     for inst in insts:
-        inst_props = inst.keys()
-        for pn in inst_props:
+        for pn in inst.properties:
             all_props[pn] = pn.lower()
-        if inst.path:
-            key_prop_names = inst.path.keys()
-            for pn in inst_props:
-                if pn in key_prop_names:
-                    key_props[pn] = pn.lower()
+            if inst.path and pn in inst.path.keybindings:
+                key_props[pn] = pn.lower()
 
-    nonkey_props = NocaseDict()  # key: org prop name, value
+    nonkey_props = NocaseDict()  # key: org prop name, value: lower prop name
     for pn in all_props:
         if pn not in key_props:
             nonkey_props[pn] = all_props[pn]
 
-    key_prop_list = sorted(key_props.keys(), key=lambda p: p.lower())
-    nonkey_prop_list = sorted(nonkey_props.keys(), key=lambda p: p.lower())
+    key_prop_list = sorted(key_props.keys(), key=lambda pn: key_props[pn])
+    nonkey_prop_list = sorted(
+        nonkey_props.keys(), key=lambda pn: nonkey_props[pn])
     key_prop_list.extend(nonkey_prop_list)
     return key_prop_list
 


### PR DESCRIPTION
See commit message.
It is not clear why the issue did not surface earlier (see comments in #782), but the issue itself is understood as well as the fix.