### PR TITLE
0.7: Fixed incorrect property order in instance table output

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,10 @@ Released: not yet
 * Docs/Test: Fixed failing install of Jinja2 on Python 3.4 by adding it
   to dev-requirements.txt and pinning it to <2.11 for Python 3.4.
 
+* Fixed incorrect property order in instance table output, where key properties
+  were not ordered before non-key properties but ordered along with them.
+  (see issue #782)
+
 **Enhancements:**
 
 **Known issues:**

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -1578,22 +1578,19 @@ def sorted_prop_names(insts):
     all_props = odicti()  # key: org prop name, value: lower cased prop name
     key_props = odicti()  # key: org prop name, value: lower cased prop name
     for inst in insts:
-        inst_props = inst.keys()
-        for pn in inst_props:
+        for pn in inst.properties:
             all_props[pn] = pn.lower()
-        if inst.path:
-            key_prop_names = inst.path.keys()
-            for pn in inst_props:
-                if pn in key_prop_names:
-                    key_props[pn] = pn.lower()
+            if inst.path and pn in inst.path.keybindings:
+                key_props[pn] = pn.lower()
 
     nonkey_props = odicti()  # key: org prop name, value: lower cased prop name
     for pn in all_props:
         if pn not in key_props:
             nonkey_props[pn] = all_props[pn]
 
-    key_prop_list = sorted(key_props.keys(), key=lambda p: p.lower())
-    nonkey_prop_list = sorted(nonkey_props.keys(), key=lambda p: p.lower())
+    key_prop_list = sorted(key_props.keys(), key=lambda pn: key_props[pn])
+    nonkey_prop_list = sorted(
+        nonkey_props.keys(), key=lambda pn: nonkey_props[pn])
     key_prop_list.extend(nonkey_prop_list)
     return key_prop_list
 


### PR DESCRIPTION
Rolls back PR #785 into 0.7.2.