### PR TITLE
Fixed failing install of indirect dependency Jinja2 on Python 3.4

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -116,3 +116,10 @@ readme-renderer>=23.0; python_version >= '3.5'
 PyYAML>=5.1; python_version == '2.7'
 PyYAML>=5.1,<5.3; python_version == '3.4'
 PyYAML>=5.1; python_version > '3.4'
+
+# Jinja2 is used by Sphinx, and pip needs explicit versions for this
+# otherwise indirect dependency.
+# Jinja2 2.11 has removed support for Python 3.4
+Jinja2>=2.8; python_version == '2.7'
+Jinja2>=2.8,<2.11; python_version == '3.4'
+Jinja2>=2.8; python_version > '3.4'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -66,6 +66,9 @@ Released: not yet
   were not ordered before non-key properties but ordered along with them.
   (see issue #782)
 
+* Docs/Test: Fixed failing install of Jinja2 on Python 3.4 by adding it
+  to dev-requirements.txt and pinning it to <2.11 for Python 3.4.
+
 **Enhancements:**
 
 * Introduced caching of the mock environment used by connection definitions in


### PR DESCRIPTION
See commit message.
No review needed.