### PR TITLE
Fixes #183: Create a test that uses multiple namespaces

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -190,6 +190,11 @@ Released: not yet
 
 * Docs: Changed Sphinx theme to sphinx_rtd_theme. (see issue #792)
 
+* Modified the class WbemServerMock in tests/unit/testmock to define a
+  WBEM server configuration that includes multiple namespaces, a user and
+  an interop namespace to test cross-namespace mock. (see issue #183)
+
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -1600,10 +1600,10 @@ Help text for ``pywbemcli profile centralinsts`` (see :ref:`profile centralinsts
       -o, --organization ORG-NAME     Filter by the defined organization. (ex. -o DMTF
       -p, --profile PROFILE-NAME      Filter by the profile name. (ex. -p Array
       --cc, --central-class CLASSNAME
-                                      Optional. Required only if profiles supports only scopig methodology
+                                      Optional. Required only if profiles supports only scoping methodology
       --sc, --scoping-class CLASSNAME
-                                      Optional. Required only if profiles supports only scopig methodology
-      --sp, --scoping-path CLASSLIST  Optional. Required only if profiles supports only scopig methodology. Multiples
+                                      Optional. Required only if profiles supports only scoping methodology
+      --sp, --scoping-path CLASSLIST  Optional. Required only if profiles supports only scoping methodology. Multiples
                                       allowed
 
       --rd, --reference-direction [snia|dmtf]

--- a/pywbemtools/pywbemcli/_cmd_profile.py
+++ b/pywbemtools/pywbemcli/_cmd_profile.py
@@ -103,15 +103,15 @@ def profile_list(context, **options):
 @click.option('--cc', '--central-class', 'central_class', type=str,
               metavar='CLASSNAME', required=False,
               help=u'Optional. Required only if profiles supports only '
-              u'scopig methodology')
+              u'scoping methodology')
 @click.option('--sc', '--scoping-class', 'scoping_class', type=str,
               metavar='CLASSNAME', required=False,
               help=u'Optional. Required only if profiles supports only '
-              u'scopig methodology')
+              u'scoping methodology')
 @click.option('--sp', '--scoping-path', 'scoping_path', type=str,
               metavar='CLASSLIST', required=False, multiple=True,
               help=u'Optional. Required only if profiles supports only '
-              u'scopig methodology. Multiples allowed')
+              u'scoping methodology. Multiples allowed')
 @click.option('--rd', '--reference-direction', 'reference_direction',
               type=click.Choice(['snia', 'dmtf']),
               default='dmtf',

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -192,17 +192,14 @@ def cmd_server_info(context):
         # execute the namespaces to force contact with server before
         # turning off the spinner.
         server = context.wbem_server
-        server.namespaces  # pylint: disable=pointless-statement
+        namespaces = sorted(server.namespaces)
         context.spinner_stop()
-
-        server = context.wbem_server
 
         rows = []
         headers = ['Brand', 'Version', 'Interop Namespace', 'Namespaces']
-        if len(server.namespaces) > 3:
-            namespaces = '\n'.join(server.namespaces)
-        else:
-            namespaces = ', '.join(server.namespaces)
+        sep = '\n' if namespaces and len(namespaces) > 3 else ', '
+        namespaces = sep.join(namespaces)
+
         rows.append([server.brand, server.version,
                      server.interop_ns,
                      namespaces])

--- a/tests/unit/pytest_extensions.py
+++ b/tests/unit/pytest_extensions.py
@@ -157,14 +157,14 @@ def simplified_test_function(test_func):
                 if exp_exc_types:
                     with pytest.raises(exp_exc_types):
                         if condition == 'pdb':
-                            pdb.set_trace()
+                            pdb.set_trace()  # pylint: disable=no-member
 
                         test_func(testcase, **kwargs)  # expecting an exception
 
                     ret = None  # Debugging hint
                 else:
                     if condition == 'pdb':
-                        pdb.set_trace()
+                        pdb.set_trace()  # pylint: disable=no-member
 
                     test_func(testcase, **kwargs)  # not expecting an exception
 

--- a/tests/unit/test_profile_cmds.py
+++ b/tests/unit/test_profile_cmds.py
@@ -31,6 +31,7 @@ TEST_DIR = os.path.dirname(__file__)
 # but not tied to the DMTF classes.
 SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
 INVOKE_METHOD_MOCK_FILE = 'simple_mock_invokemethod.py'
+
 MOCK_SERVER_MODEL = os.path.join('testmock', 'wbemserver_mock.py')
 
 # The following lists define the help for each command in terms of particular
@@ -135,7 +136,7 @@ TEST_CASES = [
 
     ['Verify server command profiles',
      {'args': ['list'],
-      'general': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-o', 'simple']},
      {'stdout': ['Advertised management profiles:',
                  'Organization    Registered Name       Version',
                  '--------------  --------------------  ---------',
@@ -153,7 +154,7 @@ TEST_CASES = [
 
     ['Verify server command profiles, filtered by org',
      {'args': ['list', '-o', 'DMTF'],
-      'general': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-o', 'simple']},
      {'stdout': ['Advertised management profiles: org=DMTF',
                  'Organization    Registered Name       Version',
                  '--------------  --------------------  ---------',
@@ -166,7 +167,7 @@ TEST_CASES = [
 
     ['Verify server command profiles, filtered by org, long',
      {'args': ['list', '--organization', 'DMTF'],
-      'general': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-o', 'simple']},
      {'stdout': ['Advertised management profiles: org=DMTF',
                  'Organization    Registered Name       Version',
                  '--------------  --------------------  ---------',
@@ -179,7 +180,7 @@ TEST_CASES = [
 
     ['Verify server command profiles, filtered by org, and name',
      {'args': ['list', '--organization', 'DMTF', '--profile', 'Component'],
-      'general': ['-d', 'interop', '-o', 'plain']},
+      'general': ['-o', 'plain']},
      {'stdout': ['Advertised management profiles: org=DMTF name=Component',
                  'Organization    Registered Name       Version',
                  'DMTF            Component             1.4.0'],
@@ -189,7 +190,7 @@ TEST_CASES = [
 
     ['Verify server command profiles, filtered by name',
      {'args': ['list', '-p', 'Profile Registration'],
-      'general': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-o', 'simple']},
      {'stdout': ['Advertised management profiles:',
                  'Organization    Registered Name       Version',
                  '--------------  --------------------  ---------',
@@ -200,7 +201,7 @@ TEST_CASES = [
 
     ['Verify server command profiles, filtered by org, long',
      {'args': ['list', '--profile', 'Profile Registration'],
-      'general': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-o', 'simple']},
      {'stdout': ['Advertised management profiles:',
                  'Organization    Registered Name       Version',
                  '--------------  --------------------  ---------',
@@ -212,13 +213,13 @@ TEST_CASES = [
     ['Verify server command centralinsts based on wbem server mock.',
      {'args': ['centralinsts', '-o', 'SNIA',
                '-p', 'Server'],
-      'general': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-o', 'simple']},
      {'stdout': ['Advertised Central Instances:',
                  'Profile',
                  'Central Instance paths',
                  'SNIA:Server:1.1.0',
                  'SNIA:Server:1.2.0',
-                 'interop:MCK_StorageComputerSystem'],
+                 'root/cimv2:MCK_StorageComputerSystem'],
       'rc': 0,
       'test': 'innows'},
      MOCK_SERVER_MODEL, OK],

--- a/tests/unit/test_server_cmds.py
+++ b/tests/unit/test_server_cmds.py
@@ -30,6 +30,7 @@ TEST_DIR = os.path.dirname(__file__)
 # but not tied to the DMTF classes.
 SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
 INVOKE_METHOD_MOCK_FILE = 'simple_mock_invokemethod.py'
+
 MOCK_SERVER_MODEL = os.path.join('testmock', 'wbemserver_mock.py')
 
 # The following lists define the help for each command in terms of particular
@@ -169,16 +170,15 @@ TEST_CASES = [
     #   Verify the individual commands returning data
     #
     ['Verify server command interop default output',
-     {'args': ['interop'],
-      'general': ['-d', 'interop']},
+     {'args': ['interop'], },
      {'stdout': ['interop'],
       'rc': 0,
       'test': 'innows'},
-     MOCK_SERVER_MODEL, OK],
+     MOCK_SERVER_MODEL, RUN],
 
     ['Verify server command interop',
      {'args': ['interop'],
-      'general': ['-d', 'interop', '-o', 'text']},
+      'general': ['-o', 'text']},
      {'stdout': ['interop'],
       'rc': 0,
       'test': 'innows'},
@@ -186,34 +186,33 @@ TEST_CASES = [
 
     ['Verify server command namespaces',
      {'args': ['namespaces'],
-      'general': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-o', 'simple']},
      {'stdout': ['Server Namespaces:',
                  'Namespace Name',
                  '----------------',
-                 'interop'],
+                 'interop',
+                 'root/cimv2'],
       'rc': 0,
       'test': 'lines'},
      MOCK_SERVER_MODEL, OK],
 
     ['Verify server command namespaces, text output',
      {'args': ['namespaces'],
-      'general': ['-d', 'interop', '-o', 'text']},
-     {'stdout': ['interop'],
+      'general': ['-o', 'text']},
+     {'stdout': ['interop, root/cimv2'],
       'rc': 0,
       'test': 'lines'},
      MOCK_SERVER_MODEL, OK],
 
     ['Verify server command namespaces with sort option',
-     {'args': ['namespaces'],
-      'general': ['-d', 'interop']},
+     {'args': ['namespaces'], },
      {'stdout': ['interop'],
       'rc': 0,
       'test': 'innows'},
      MOCK_SERVER_MODEL, OK],
 
     ['Verify server command brand',
-     {'args': ['brand'],
-      'general': ['-d', 'interop']},
+     {'args': ['brand'], },
      {'stdout': ['OpenPegasus'],
       'rc': 0,
       'test': 'innows'},
@@ -222,7 +221,7 @@ TEST_CASES = [
 
     ['Verify server command brand with --output table fails',
      {'args': ['brand'],
-      'general': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-o', 'simple']},
      {'stderr': ['Output format "simple" not allowed for this command'],
       'rc': 1,
       'test': 'innows'},
@@ -230,14 +229,14 @@ TEST_CASES = [
 
     ['Verify server command info with mock server',
      {'args': ['info'],
-      'general': ['-d', 'interop', '-o', 'simple']},
+      'general': ['-o', 'simple']},
      {'stdout':
       ['Server General Information',
        'Brand        Version    Interop Namespace    Namespaces',
-       '-----------  ---------  -------------------  ------------',
-       'OpenPegasus  2.15.0     interop              interop'],
+       '-----------  ---------  -------------------  -------------------',
+       'OpenPegasus  2.15.0     interop              interop, root/cimv2'],
       'rc': 0,
-      'test': 'lines'},
+      'test': 'linesnows'},
      MOCK_SERVER_MODEL, OK],
 
     #

--- a/tests/unit/testmock/wbemserver_mock.py
+++ b/tests/unit/testmock/wbemserver_mock.py
@@ -1,8 +1,16 @@
 """
     Define the classes and instances to mock a WEMServer as the basis for
-    other test mocks
+    test mocks
+
+    This model is defined in a single multi-level dictionary and the
+    WbemServerMock class uses that dictionary to populate the mock
+    cim_repository with qualifiers, classes, and instances for the model
 
     This was modified from an equivalent test tool in pywbem
+
+    NOTE: There is a version of this functionality wbemserver_mock_v0.py
+    that is used to run tests against python versions < 3 because the
+    mock script using setup does not exist for these version of python.
 """
 
 from __future__ import print_function, absolute_import
@@ -11,16 +19,10 @@ import os
 
 from pywbem import ValueMapping, CIMInstance, CIMInstanceName, CIMError, \
     CIM_ERR_ALREADY_EXISTS
-from pywbem_mock import FakedWBEMConnection, DMTFCIMSchema
-
-# from .dmtf_mof_schema_def import DMTF_TEST_SCHEMA_VER
+from pywbem_mock import FakedWBEMConnection, DMTFCIMSchema, \
+    CIMNamespaceProvider
 
 DMTF_TEST_SCHEMA_VER = (2, 49, 0)
-
-# test that GLOBALS exist. They should be provided by pywbemcli
-assert "CONN" in globals()
-assert 'SERVER' in globals()
-assert 'VERBOSE' in globals()
 
 
 # Location of DMTF schema directory used by all tests.
@@ -43,37 +45,70 @@ TESTSUITE_SCHEMA_DIR = os.path.join('tests', 'schema')
 #  namespace is defined in the WbemServerMock init method that overrides any
 #  value in this dictionary
 #
-#  other_namespaces: Any other namespaces that the users wants to be defined
-#  in the mock repository
+#  class-names: Lists of leaf classes origanized by namespace that are to
+#  be used as the basis to build classes in the mock CIM repository
+#
+#  class_mof: element that defines specific classes that are to be included
+#  in the model.  This is largely to allow building trivial sublcasses for
+#  components of profiles
 #
 #  registered_profiles: The Organization, profile name, profile version for any
-#  registered profiles
+#  registered profiles that are to be built
 #
 #  referenced_profiles: Definition of CIM_ReferencedProfile associations
 #  between CIM_RegisteredProfiles. This is used to test get_central_instances
 #
+#  central-instances: Specific central intances that are built
+#
+#  element-conforms-to: Set of relations that define the associations between
+#  the registered profiles and central classes.#
 #
 DEFAULT_WBEM_SERVER_MOCK_DICT = {
+    # Defines the DMTF schema from which qualifier declarations and classes
+    # are to be retrieved.
     'dmtf_schema': {'version': DMTF_TEST_SCHEMA_VER,
                     'dir': TESTSUITE_SCHEMA_DIR},
-    'pg_schema': {
-        'dir': os.path.join(TESTSUITE_SCHEMA_DIR, 'OpenPegasus'),
-        'files': ['PG_Namespace.mof']},
 
-    'class_names': ['CIM_Namespace',
-                    'CIM_ObjectManager',
-                    'CIM_RegisteredProfile',
-                    'CIM_ElementConformsToProfile',
-                    'CIM_ReferencedProfile',
-                    'CIM_ComputerSystem'],
-    'class-mof': ["class MCK_StorageComputerSystem : CIM_ComputerSystem{};", ],
+    # TODO: Relook at this since it is just a class compile based on a mof file
+    # Other schema definitions and the mof from them to be inserted.
+    # This is used just to intall one piece of mof today.
+    'pg_schema': {'interop':
+                  {'dir': os.path.join(TESTSUITE_SCHEMA_DIR, 'OpenPegasus'),
+                   'files': ['PG_Namespace.mof']}},
+
+    # Definition of the interop namespace name.
+    'interop-namspace': 'interop',
+
+    # Class names for leaf classes from the dmtf_schema to be installed in the
+    # mockserver organized by namespace. The namespaces will be built if they
+    # do not already exist before the build_class method is called.
+    'class-names': {'interop': ['CIM_Namespace',
+                                'CIM_ObjectManager',
+                                'CIM_RegisteredProfile',
+                                'CIM_ElementConformsToProfile',
+                                'CIM_ReferencedProfile',
+                                'CIM_ComputerSystem'],
+
+                    'root/cimv2': ['CIM_ElementConformsToProfile',
+                                   'CIM_ComputerSystem']},
+
+    # class MOF that must be compiled the environment by namespace
+    'class-mof': {'root/cimv2': ["class MCK_StorageComputerSystem: "
+                                 "CIM_ComputerSystem{};", ]},
+
+    # A name for the system and properties for the object namager that
+    # will be used to build the object manager instance
     'system_name': 'Mock_WBEMServerTest',
     'object_manager': {'Name': 'FakeObjectManager',
                        'ElementName': 'Pegasus',
                        'Description': 'Pegasus CIM Server Version 2.15.0'
                                       ' Released', },
-    'interop_namspace': 'interop',
-    'other_namespaces': [],
+
+    # TODO/FUTURE: WbemServerMock currently only builds the pywbem supplied
+    # CIM namespace provider.
+    # User providers that are to be registered.
+    # 'user_providers': [CIMNamespaceProvider(conn.cimrepository)],
+
     'registered_profiles': [('DMTF', 'Indications', '1.1.0'),
                             ('DMTF', 'Profile Registration', '1.0.0'),
                             ('SNIA', 'Server', '1.2.0'),
@@ -90,27 +125,40 @@ DEFAULT_WBEM_SERVER_MOCK_DICT = {
         (('SNIA', 'Array', '1.4.0'), ('SNIA', 'Software', '1.4.0')),
 
     ],
-    # define profile relation to central class instance
-    # First element is a profile, second is name and keybindings of a
-    # CIMInstanceName
-    'element_conforms_to_profile': [
-        (('SNIA', 'Server', '1.2.0'),
-         ("MCK_StorageComputerSystem", {'Name': "10.1.2.3",
-                                        'CreationClassName':
-                                            "MCK_StorageComputerSystem"})), ],
-    # List of CIMInstances. Each entry is a CIM instance with classname,
-    # and properties. All properties required to build the path must be
-    # defined. No other properties are required for this test.
-    # TODO: We may expand this for more scoping tests.
-    'central-instances': [
-        CIMInstance(
-            'MCK_StorageComputerSystem',
-            properties={
-                'Name': "10.1.2.3",
-                'CreationClassName': "MCK_StorageComputerSystem",
-                'NameFormat': "IP"}),
-    ],
-    'scoping-instances': []
+
+    # List of CIMInstances to install by namespace. Each entry is a CIM
+    # instance with classname,and properties. All properties required to build
+    # the path must be defined. No other properties are required for this test.
+    # (namespace, instance)
+    'central-instances': {
+        'interop': [],  # TODO add CIMComputerSystem profile
+        'root/cimv2':
+            [CIMInstance(
+                'MCK_StorageComputerSystem',
+                properties={'Name': "10.1.2.3",
+                            'CreationClassName': "MCK_StorageComputerSystem",
+                            'NameFormat': "IP"})]},
+
+    # TODO/Future: Add definition of scoping instance path
+    'scoping-instances': [],
+
+
+    # Define the relationships between a central instance and a specific
+    # profile by namespace where the namespace is the location of the
+    # central instance.
+    # Two elements in list for each element conforms to definition.
+    # 1. a specific profile including org, name, and version
+    # 2. Components to define an instance including:
+    #    Classname,
+    #    Keybindings of CIMInstance name
+    'element_conforms_to_profile':
+        {'interop': [],
+         'root/cimv2': [
+             (('SNIA', 'Server', '1.2.0'),
+              ("MCK_StorageComputerSystem", {'Name': "10.1.2.3",
+                                             'CreationClassName':
+                                             "MCK_StorageComputerSystem"})), ],
+         },
 }
 
 
@@ -131,7 +179,9 @@ class WbemServerMock(object):
     tests
     """
 
-    def __init__(self, interop_ns=None, server_mock_data=None, verbose=None):
+    def __init__(self, conn, server, interop_ns=None, server_mock_data=None,
+                 verbose=None):
+        # pylint: disable=too-many-arguments, too-many-locals
         """
         Build the class repository for with the classes defined for
         the WBEMSERVER.  This is built either from a dictionary of data
@@ -140,35 +190,87 @@ class WbemServerMock(object):
         the DEFAULT_WBEM_SERVER_MOCK_DICT dictionary.
         """
         self.verbose = verbose
-        if server_mock_data is None:
-            self.server_mock_data = DEFAULT_WBEM_SERVER_MOCK_DICT
-        else:
-            self.server_mock_data = server_mock_data
+        self.conn = conn
+        self.server = server
+        self.wbem_server = server
+
+        self.server_mock_data = server_mock_data or \
+            DEFAULT_WBEM_SERVER_MOCK_DICT
+
+        FakedWBEMConnection._reset_logging_config()
 
         self.system_name = self.server_mock_data['system_name']
         self.object_manager_name = \
             self.server_mock_data['object_manager']['Name']
 
-        # override dictionary interop namespace with init parameter
-        if interop_ns:
-            self.interop_ns = interop_ns
-        else:
-            self.interop_ns = self.server_mock_data['interop_ns']
+        self.interop_ns = interop_ns or \
+            self.server_mock_data['interop-namspace']
 
         self.dmtf_schema_ver = self.server_mock_data['dmtf_schema']['version']
         self.schema_dir = self.server_mock_data['dmtf_schema']['dir']
-        self.pg_schema_dir = self.server_mock_data['pg_schema']['dir']
-        self.pg_schema_files = self.server_mock_data['pg_schema']['files']
         self.registered_profiles = self.server_mock_data['registered_profiles']
-        # Retrieved from globals setup by pywbemcli for
-        #  WBEMConnection object
-        #  WBEMServer object
-        global CONN  # pylint: disable=global-variable-not-assigned
-        self.conn = CONN  # pylint: disable=undefined-variable
-        global SERVER  # pylint: disable=global-variable-not-assigned
-        self.wbem_server = SERVER  # pylint: disable=undefined-variable
 
-        self.build_mock()
+        # Step 1: build classes for all namespaces based on class-names dict
+        class_names = self.server_mock_data['class-names']
+        for namespace, clns in class_names.items():
+            self.build_classes(clns, namespace)
+
+        self.display("Built classes")
+
+        # Step 2: install user providers
+        # TODO/Future: Install user providers from configuration definition
+        # For now, install the Namespace provider. The issue is knowing
+        # exactly what input parameters are required for each user provider.
+        ns_provider = CIMNamespaceProvider(conn.cimrepository)
+        conn.register_provider(ns_provider, namespaces=self.interop_ns)
+
+        # NOTE: The wbemserver is not usable until the instances for at
+        # least object manager and namespaces have been inserted. Any attempt
+        # to display the instance objects before that will fail because the
+        # enumerate namespaces will be inconsistent.
+
+        # Step 3: build the object manager.
+        # Build CIM_ObjectManager instance into the interop namespace since
+        # this is required to build namespace instances
+        self.build_obj_mgr_inst(
+            self.system_name,
+            self.object_manager_name,
+            self.server_mock_data['object_manager']['ElementName'],
+            self.server_mock_data['object_manager']['Description'])
+
+        self.display("Built object manager object")
+
+        # Step 4: Build the registered profile and referenced_profile instances
+        self.build_reg_profile_insts(self.registered_profiles)
+        self.build_referenced_profile_insts(
+            self.server_mock_data['referenced_profiles'])
+
+        self.display("Built profile instances")
+
+        # Step 5: build the defined central instances
+        for ns, insts in self.server_mock_data['central-instances'].items():
+            self.build_central_instances(ns, insts)
+
+        # Step 6: build the defined element-conforms-to-profile associations
+        # build element_conforms_to_profile insts from dictionary
+        for ns, items in self.server_mock_data[
+                'element_conforms_to_profile'].items():
+            for item in items:
+                profile_name = item[0]
+                central_inst_path = CIMInstanceName(
+                    item[1][0],
+                    keybindings=item[1][1],
+                    host=conn.host,
+                    namespace=ns)
+                prof_insts = self.wbem_server.get_selected_profiles(
+                    registered_org=profile_name[0],
+                    registered_name=profile_name[1],
+                    registered_version=profile_name[2])
+                assert len(prof_insts) == 1
+
+                self.build_ECTP_inst(prof_insts[0].path, central_inst_path)
+
+        self.display("Built central instances and element_conforms_to_Profile")
 
     def __str__(self):
         return 'object_manager_name={!r}, interop_ns={!r}, system_name=' \
@@ -184,37 +286,36 @@ class WbemServerMock(object):
         """
         return 'WBEMServerMock(object_manager_name={!r}, interop_ns={!r}, ' \
             'system_name={!r}, dmtf_schema_ver={!r}, schema_dir={!r}, ' \
-            'pg_schema_dir={!r}, pg_schema_files={}, wbem_server={!r}, ' \
-            'registered_profiles={!r})' \
+            'wbem_server={!r}, registered_profiles={!r})' \
             .format(self.object_manager_name, self.interop_ns, self.system_name,
-                    self.dmtf_schema_ver, self.schema_dir, self.pg_schema_dir,
-                    self.pg_schema_files,
+                    self.dmtf_schema_ver, self.schema_dir,
                     getattr(self, 'wbem_server', None),
                     self.registered_profiles)
 
-    def build_classes(self, namespace):
+    def display(self, txt):
+        """Display the txt and current repository. Diagnostic only"""
+        if self.verbose:
+            print(txt)
+            self.conn.display_repository()
+
+    def build_classes(self, classes, namespace):
         """
         Build the schema qualifier declarations, and the class objects in the
-        repository from a DMTF schema.
+        defined namespace of the CIM repository from a DMTF schema.
         This requires only that the leaf objects be defined in a mof
         include file since the compiler finds the files for qualifiers
         and dependent classes.
-
-        Returns:
-            Instance of FakedWBEMConnection object.
         """
-        # pylint: disable=protected-access
-
-        FakedWBEMConnection._reset_logging_config()
-
-        # Note: During tests, not needed.  When you run direct from
-        # pywbemcli it fails
         try:
             self.conn.add_namespace(namespace)
         except CIMError as er:
             if er.status_code != CIM_ERR_ALREADY_EXISTS:
-                raise
+                pass
 
+        # Compile the leaf classes into the CIM repositor
+        # This test not required to use the class in the test environment.
+        # However, if it is ever used as template for code that could
+        # execute on pywbem version 0.x, this test is required.
         if hasattr(self.conn, 'compile_schema_classes'):
             # Using pywbem 1.x
             schema = DMTFCIMSchema(self.dmtf_schema_ver, self.schema_dir,
@@ -222,7 +323,7 @@ class WbemServerMock(object):
                                    verbose=self.verbose)
             # pylint: disable=no-member
             self.conn.compile_schema_classes(
-                self.server_mock_data['class_names'],
+                classes,
                 schema.schema_pragma_file,
                 namespace=namespace,
                 verbose=self.verbose)
@@ -230,20 +331,29 @@ class WbemServerMock(object):
             # Using pywbem 0.x
             self.conn.compile_dmtf_schema(
                 self.dmtf_schema_ver, self.schema_dir,
-                class_names=self.server_mock_data['class_names'],
+                class_names=classes,
                 namespace=namespace,
                 verbose=self.verbose)
 
-        for filename in self.pg_schema_files:
-            filepath = os.path.join(self.pg_schema_dir, filename)
-            self.conn.compile_mof_file(filepath, namespace=namespace,
-                                       search_paths=[self.pg_schema_dir],
-                                       verbose=self.verbose)
+        # Build the pg_schema elements
+        # TODO: This should be separate method.
+        if namespace in self.server_mock_data['pg_schema']:
+            pg_schema_ns = self.server_mock_data['pg_schema'][namespace]
+            filenames = pg_schema_ns['files']
+            pg_dir = pg_schema_ns['dir']
+            for fn in filenames:
+                filepath = os.path.join(pg_dir, fn)
+                self.conn.compile_mof_file(
+                    filepath, namespace=namespace,
+                    search_paths=[pg_dir],
+                    verbose=self.verbose)
 
-        # compile the mof defined in the 'class-mof definitions
-        for mof in self.server_mock_data['class-mof']:
-            self.conn.compile_mof_string(mof, namespace=namespace,
-                                         verbose=self.verbose)
+        # Compile the mof defined in the 'class-mof definitions
+        if namespace in self.server_mock_data['class-mof']:
+            mofs = self.server_mock_data['class-mof'][namespace]
+            for mof in mofs:
+                self.conn.compile_mof_string(mof, namespace=namespace,
+                                             verbose=self.verbose)
 
     def inst_from_classname(self, class_name, namespace=None,
                             property_list=None,
@@ -263,10 +373,32 @@ class WbemServerMock(object):
                                  PropertyList=property_list)
 
         return CIMInstance.from_class(
-            cls, namespace=namespace,
+            cls,
+            namespace=namespace,
             property_values=property_values,
             include_missing_properties=include_missing_properties,
             include_path=include_path)
+
+    def add_inst_from_def(self, class_name, namespace=None,
+                          property_values=None,
+                          include_missing_properties=True,
+                          include_path=True):
+        """
+        Build and insert into the environment a complete instance given the
+        classname and a dictionary defining the properties of the instance.
+
+        """
+        # pylint: disable=too-many-arguments
+        new_inst = self.inst_from_classname(
+            class_name,
+            namespace=namespace,
+            property_values=property_values,
+            include_missing_properties=include_missing_properties,
+            include_path=include_path)
+
+        self.conn.CreateInstance(new_inst, namespace=namespace)
+
+        return new_inst
 
     def build_obj_mgr_inst(self, system_name, object_manager_name,
                            object_manager_element_name,
@@ -274,7 +406,7 @@ class WbemServerMock(object):
         """
         Build a CIMObjectManager instance for the mock wbem server using
         fixed data defined in this method and data from the init parameter
-        mock data. Build into interop namespace always
+        mock data. Add this instance to the repository
         """
         omdict = {"SystemCreationClassName": "CIM_ComputerSystem",
                   "CreationClassName": "CIM_ObjectManager",
@@ -283,13 +415,11 @@ class WbemServerMock(object):
                   "ElementName": object_manager_element_name,
                   "Description": object_manager_description}
 
-        ominst = self.inst_from_classname("CIM_ObjectManager",
-                                          namespace=self.interop_ns,
-                                          property_values=omdict,
-                                          include_missing_properties=False,
-                                          include_path=True)
-
-        self.conn.add_cimobjects(ominst, namespace=self.interop_ns)
+        ominst = self.add_inst_from_def("CIM_ObjectManager",
+                                        namespace=self.interop_ns,
+                                        property_values=omdict,
+                                        include_missing_properties=False,
+                                        include_path=True)
 
         rtn_ominsts = self.conn.EnumerateInstances("CIM_ObjectManager",
                                                    namespace=self.interop_ns)
@@ -297,33 +427,6 @@ class WbemServerMock(object):
             "Expected 1 ObjetManager instance, got {!r}".format(rtn_ominsts)
 
         return ominst
-
-    def build_cimnamespace_insts(self, namespaces=None):
-        """
-        Build instances of CIM_Namespace defined by namespaces list parameter.
-        These instances are built into the interop namespace. They allow the
-        standard WBEM tools for getting and creating namespaces to work.
-        """
-        for namespace in namespaces:
-            nsdict = {"SystemName": self.system_name,
-                      "ObjectManagerName": self.object_manager_name,
-                      'Name': namespace,
-                      'CreationClassName': 'PG_Namespace',
-                      'ObjectManagerCreationClassName': 'CIM_ObjectManager',
-                      'SystemCreationClassName': 'CIM_ComputerSystem'}
-
-            nsinst = self.inst_from_classname("PG_Namespace",
-                                              namespace=self.interop_ns,
-                                              property_values=nsdict,
-                                              include_missing_properties=False,
-                                              include_path=True)
-            self.conn.add_cimobjects(nsinst, namespace=self.interop_ns)
-
-        rtn_namespaces = self.conn.EnumerateInstances("CIM_Namespace",
-                                                      namespace=self.interop_ns)
-        assert len(rtn_namespaces) == len(namespaces), \
-            "Expected namespaces: {!r}, got {}".format(namespaces,
-                                                       rtn_namespaces)
 
     def build_reg_profile_insts(self, profiles):
         """
@@ -352,13 +455,12 @@ class WbemServerMock(object):
                              'RegisteredName': profile[1],
                              'RegisteredVersion': profile[2],
                              'InstanceID': instance_id}
-            rpinst = self.inst_from_classname("CIM_RegisteredProfile",
-                                              namespace=self.interop_ns,
-                                              property_values=reg_prof_dict,
-                                              include_missing_properties=False,
-                                              include_path=True)
 
-            self.conn.add_cimobjects(rpinst, namespace=self.interop_ns)
+            self.add_inst_from_def("CIM_RegisteredProfile",
+                                   namespace=self.interop_ns,
+                                   property_values=reg_prof_dict,
+                                   include_missing_properties=False,
+                                   include_path=True)
 
         rtn_rpinsts = self.conn.EnumerateInstances("CIM_RegisteredProfile",
                                                    namespace=self.interop_ns)
@@ -374,13 +476,11 @@ class WbemServerMock(object):
         element_conforms_dict = {'ConformantStandard': profile_path,
                                  'ManagedElement': element_path}
 
-        inst = self.inst_from_classname(class_name,
-                                        namespace=self.interop_ns,
-                                        property_values=element_conforms_dict,
-                                        include_missing_properties=False,
-                                        include_path=True)
-
-        self.conn.add_cimobjects(inst, namespace=self.interop_ns)
+        inst = self.add_inst_from_def(class_name,
+                                      namespace=self.interop_ns,
+                                      property_values=element_conforms_dict,
+                                      include_missing_properties=False,
+                                      include_path=True)
 
         assert self.conn.EnumerateInstances(class_name,
                                             namespace=self.interop_ns)
@@ -418,120 +518,43 @@ class WbemServerMock(object):
             ref_profile_dict = {'Antecedent': antecedent_inst[0].path,
                                 'Dependent': dependent_inst[0].path}
 
-            inst = self.inst_from_classname(class_name,
-                                            namespace=self.interop_ns,
-                                            property_values=ref_profile_dict,
-                                            include_missing_properties=False,
-                                            include_path=True)
-
-            self.conn.add_cimobjects(inst, namespace=self.interop_ns)
+            inst = self.add_inst_from_def(class_name,
+                                          namespace=self.interop_ns,
+                                          property_values=ref_profile_dict,
+                                          include_missing_properties=False,
+                                          include_path=True)
 
             assert self.conn.EnumerateInstances(class_name,
                                                 namespace=self.interop_ns)
             assert self.conn.GetInstance(inst.path)
 
-    def build_central_instances(self, central_instances):
+    def build_central_instances(self, namespace, central_instances):
         """
         Build the central_instances from the definitions provided in the list
         central_instance where each definition is a python CIMInstance object
         and add them to the repository. This method adds the path to each
         """
         for inst in central_instances:
-            cls = self.conn.GetClass(inst.classname, namespace=self.interop_ns,
+            cls = self.conn.GetClass(inst.classname, namespace=namespace,
                                      LocalOnly=False, IncludeQualifiers=True,
                                      IncludeClassOrigin=True)
             inst.path = CIMInstanceName.from_instance(
-                cls, inst, namespace=self.interop_ns, strict=True)
+                cls, inst, namespace=namespace, strict=True)
 
-            self.conn.add_cimobjects(inst, namespace=self.interop_ns)
-
-    def build_mock(self):
-        """
-            Builds the classes and instances for a mock WBEMServer from data
-            in the init parameter. This calls the builder for:
-              the object manager
-              the namespaces
-              the profiles
-        """
-
-        self.build_classes(self.interop_ns)
-
-        if self.verbose:
-            print("Built classes")
-            self.conn.display_repository()
-
-        # NOTE: The wbemserver is not complete until the instances for at
-        # least object manager and namespaces have been inserted. Any attempt
-        # to display the instance object before that will fail because the
-        # enumerate namespaces will be inconsistent
-
-        # Build CIM_ObjectManager instance into the interop namespace since
-        # this is required to build namespace instances
-        om_inst = self.build_obj_mgr_inst(
-            self.system_name,
-            self.object_manager_name,
-            self.server_mock_data['object_manager']['ElementName'],
-            self.server_mock_data['object_manager']['Description'])
-
-        if self.verbose:
-            print("Built object manager object")
-            self.conn.display_repository()
-
-        # build CIM_Namespace instances based on the init parameters
-        namespaces = [self.interop_ns]
-        if self.server_mock_data['other_namespaces']:
-            namespaces.extend(self.server_mock_data['other_namespaces'])
-        self.build_cimnamespace_insts(namespaces)
-
-        if self.verbose:
-            print("Built namespace instances")
-            self.conn.display_repository()
-
-        self.build_reg_profile_insts(self.registered_profiles)
-
-        self.build_referenced_profile_insts(
-            self.server_mock_data['referenced_profiles'])
-
-        if self.verbose:
-            print("Built profile instances")
-            self.conn.display_repository()
-
-        self.build_central_instances(self.server_mock_data['central-instances'])
-
-        # Get element conforms for SNIA server to object manager
-        # TODO this should be driven by the input dictionary
-        prof_inst = self.wbem_server.get_selected_profiles(
-            registered_org='SNIA',
-            registered_name='Server',
-            registered_version='1.1.0')
-        # TODO this is simplistic form and only builds one instance of
-        # conforms to.  Should expand but need better way to define instance
-        # at other end.
-
-        self.build_ECTP_inst(prof_inst[0].path, om_inst.path)
-
-        # build element_conforms_to_profile insts from dictionary
-        for item in self.server_mock_data['element_conforms_to_profile']:
-            profile_name = item[0]
-            # TODO we are fixing the host name here.  should get from conn
-            central_inst_path = CIMInstanceName(
-                item[1][0],
-                keybindings=item[1][1],
-                host='FakedUrl',
-                namespace=self.wbem_server.interop_ns)
-            prof_insts = self.wbem_server.get_selected_profiles(
-                registered_org=profile_name[0],
-                registered_name=profile_name[1],
-                registered_version=profile_name[2])
-            assert len(prof_insts) == 1
-
-            self.build_ECTP_inst(prof_insts[0].path, central_inst_path)
-
-        if self.verbose:
-            print("Built central instances and element_conforms_to_Profile")
-            self.conn.display_repository()
+            self.conn.CreateInstance(inst, namespace=namespace)
 
 
-# Execute the WBEM Server configuration build
-MOCK_WBEMSERVER = WbemServerMock(interop_ns="interop",
-                                 verbose=False)  # noqa: F821
+# TODO: Future. switch to this mock script setup
+# def setup(conn, server, verbose):
+#    """
+#    Setup function to initiate the setup of the mock environment.
+#    """
+#    WbemServerMock(conn, server, interop_ns='interop', verbose=verbose)
+
+# Execute the WBEM Server configuration build using the old mock script
+# interface
+
+# pylint: disable=undefined-variable
+WbemServerMock(CONN, SERVER,  # noqa: F821
+               interop_ns=None,
+               verbose=VERBOSE)  # noqa: F821


### PR DESCRIPTION
This pr modifies the WbemServerMock test class to create a mocker model that:

1. Includes two namespaces, an interop and a user namespace.
2. Inserts the classes defined for each namespace in the proper namespace.
3. Creates a set of registered profile definitions, corresponding profile classes, and the instances and association instances to represent a single profile (to the level of the central instance) in the user namespace.

This model is used by the server and profile tests as validation.

Note that it makes changes for a couple of spelling errors in other comments.