### PR TITLE
Ks/#810 class find summary

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -23,6 +23,11 @@ Released: not yet
 
 **Enhancements:**
 
+* Add new option to class find command (--summary) to display a summary of
+  the counts of classes found instead of the full list of the classes to make
+  the command more useful for real servers that may return many classes for
+  a class find. (see issue #810)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -402,7 +402,8 @@ Help text for ``pywbemcli class find`` (see :ref:`class find command`):
       -n, --namespace NAMESPACE       Add a namespace to the search scope. May be specified multiple times. Default: Search
                                       in all namespaces of the server.
 
-      -s, --sort                      Sort by namespace. Default is to sort by classname
+      -s, --sort                      Sort by namespace. Default is to sort by classname or bycount if --summary set.
+      --summary                       Display only a summary count of classes per namespace
       --association / --no-association
                                       Filter the returned classes to return only indication classes (--association) or
                                       classes that are not associations(--no-association). If the option is not defined no

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -425,7 +425,7 @@ TESTCASES_FORMAT_KEYS = [
      None, None, False),
 
     # Test no keys
-    ('Verify no keys',
+    ('Verify no keys. Causes MissingKeybindingWarning',
      dict(kb=[],
           width=100,
           exp_rtn=''),

--- a/tests/unit/test_server_cmds.py
+++ b/tests/unit/test_server_cmds.py
@@ -174,7 +174,7 @@ TEST_CASES = [
      {'stdout': ['interop'],
       'rc': 0,
       'test': 'innows'},
-     MOCK_SERVER_MODEL, RUN],
+     MOCK_SERVER_MODEL, OK],
 
     ['Verify server command interop',
      {'args': ['interop'],


### PR DESCRIPTION

This pr depends on pr #812, Issues that cause failure of pywbemtools tests.

Adds a new option to the class find command --summary that simply reports the count of classes by namespace.

Thus, for the OpenPegasus image that we distributed:

```

Find class counts *
+-------------------------------+---------------+
| Namespace                     |   Class count |
|-------------------------------+---------------|
| root                          |             0 |
| root/PG_Internal              |             9 |
| root/SampleProvider           |           454 |
| root/benchmark                |           206 |
| root/cimv2                    |          1463 |
| root/interop                  |           276 |
| test/CimsubTestNS0            |           212 |
| test/CimsubTestNS1            |           212 |
| test/CimsubTestNS2            |           212 |
| test/CimsubTestNS3            |           212 |
| test/EmbeddedInstance/Dynamic |           188 |
| test/EmbeddedInstance/Static  |           188 |
| test/TestINdSrcNS2            |           209 |
| test/TestIndSrcNS1            |           209 |
| test/TestProvider             |           510 |
| test/cimv2                    |           776 |
| test/static                   |           243 |
+-------------------------------+---------------+
