### PR TITLE
Limit click to versions LT 8.0

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,10 @@ Released: not yet
 * Fixed a ValueError on Windows that was raised when the connections file was
   not on the home drive.
 
+* Limit click package to < 8.0 because of a) incompatibility with python 2.7,
+  b) incompatibility between click 8.0 and clicl-repl.
+  (see issues #816 and #817)
+
 **Enhancements:**
 
 * Add new option to class find command (--summary) to display a summary of

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,9 @@ nocaselist>=1.0.3
 nocasedict>=1.0.1
 six>=1.14.0
 # Click 7.1 has a bug with output capturing
-Click>=7.0,!=7.1
+# Click 8.0 is incompatible with pywbemcli. See issues #816 (python 2.7 not
+#     supported) and #819 (click-repl incompatible)
+Click>=7.0,!=7.1,<8.0
 click-spinner>=0.1.8
 click-repl>=0.1.6
 asciitree>=0.3.3
@@ -31,6 +33,7 @@ tabulate>=0.8.2
 prompt-toolkit>=1.0.15,<3.0.0; python_version == '2.7'
 prompt-toolkit>=2.0.1; python_version >= '3.4' and python_version < '3.8'
 prompt-toolkit>=2.0.1; python_version >= '3.8' and sys_platform != 'win32'
+# See issue #690
 prompt-toolkit>=2.0.1,<3.0.0; python_version >= '3.8' and sys_platform == 'win32'
 
 # PyYAML is also pulled in by dparse and python-coveralls


### PR DESCRIPTION
While 8.0 has not yet been released it is clearly incompatible with
pywbemcli in at least the following two areas:

1. It is the first click version to drop support for python 2.7 and
pywbemcli continues to support python 2.7, See issue #816

2. The click-repl tool as of version 0.1.6 is incompatibile with click
8.0. See issue #817.

Note that this pr is preventative in nature in that click 8.0 has not been released but since releases of many packages are often surprise dates it will keep pywbemcli users out of trouble until the issues between click-repl and click are fixed, since the indication of the issues is that pywbemcli startup fails with unknown function in click from call in click-repl