### PR TITLE
Mitigates #822: causing test failure because of mock version update

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -25,6 +25,9 @@ Released: not yet
   b) incompatibility between click 8.0 and clicl-repl.
   (see issues #816 and #817)
 
+* Limit mock package to lt 4.0.3 to avoid issue issue that causes test failure.
+  (see #822)
+
 **Enhancements:**
 
 * Add new option to class find command (--summary) to display a summary of

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,9 @@ PyYAML>=5.3.1; python_version > '3.4'
 
 yamlloader>=0.5.5
 packaging>=17.0
-mock>=3.0.0
+
+# See issue #822 about issue in mock 4.0.3.
+mock>=3.0.0,<4.0.3
 
 # Mock requires funcsigs>1;python_version<"3.3" but for unknown reasons
 # Pip 9.0.1 (with minimum package levels) does not install it on MacOs on Python


### PR DESCRIPTION
The update to mock 4.0.3 causes at least one test to fail.  This pr limits the version of the mock package to lless than version 4.0.3