### PR TITLE
0.8: Limit mock package version to avoid test failure.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,9 @@ Released: not yet
   b) incompatibility between click 8.0 and clicl-repl.
   (see issues #816 and #817)
 
+* Limit mock package to lt 4.0.3 to avoid issue issue that causes test failure.
+  (see #822)
+
 **Enhancements:**
 
 **Known issues:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,9 @@ PyYAML>=5.1; python_version > '3.4'
 
 yamlloader>=0.5.5
 packaging>=17.0
-mock>=3.0.0
+
+# See issue #822 about issue in mock 4.0.3.
+mock>=3.0.0,<4.0.3
 
 # Mock requires funcsigs>1;python_version<"3.3" but for unknown reasons
 # Pip 9.0.1 (with minimum package levels) does not install it on MacOs on Python


### PR DESCRIPTION
Rolls back PR #823 into 0.8.1.