### PR TITLE
0.8: In normal test envs, added py27 and removed minimum levels on Win/macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,18 +62,18 @@ jobs:
             \"include\": [ \
               { \
                 \"os\": \"macos-latest\", \
+                \"python-version\": \"2.7\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
                 \"python-version\": \"3.9\", \
                 \"package_level\": \"latest\" \
               }, \
               { \
                 \"os\": \"windows-latest\", \
-                \"python-version\": \"3.8\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"windows-latest\", \
-                \"python-version\": \"3.9\", \
-                \"package_level\": \"minimum\" \
+                \"python-version\": \"2.7\", \
+                \"package_level\": \"latest\" \
               }, \
               { \
                 \"os\": \"windows-latest\", \


### PR DESCRIPTION
Rolls back PR #842 into 0.8.1.