### PR TITLE
0.8: Added TODOs for using pywbem 1.1.3 once released; Fixed dependency of pywbemcli_operations testcase to pywbem version

### DIFF
--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -81,10 +81,11 @@ wheel==0.33.5; python_version >= '3.8'
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
-# pywbem==1.1.1
-# Alternative to test against current github master pywbem
-# Links are not allowed in constraint files - minimum ensured by requirements.txt:
-# git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
+# TODO: Enable the following line once pywbem 1.1.3 is released.
+# pywbem==1.1.3
+# When using the GitHub master branch of pywbem, simply comment out the line
+# above, since links are not allowed in constraint files - the minimum will be
+# ensured by requirements.txt then.
 
 nocaselist==1.0.3
 nocasedict==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,13 @@
 
 # Direct dependencies (except pip, setuptools, wheel):
 
-# pywbem>=1.1.1
-# Alternative to test against current github master pywbem
-# If this is enabled, some of the install tests need to be disabled by setting
-# the 'pywbem_from_repo' variable in in test_install.sh - keep this in sync.
-git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
+# TODO: Enable the following line and disable the link line once pywbem 1.1.3 is released.
+# pywbem>=1.1.3
+# When using the GitHub master branch of pywbem, comment out the line above,
+# activate the GitHub link based dependency below.
+# In that case, some of the install tests need to be disabled by setting
+# the 'PYWBEM_FROM_REPO' variable in in tests/install/test_install.sh.
+git+https://github.com/pywbem/pywbem.git@stable_1.1#egg=pywbem
 
 nocaselist>=1.0.3
 nocasedict>=1.0.1

--- a/tests/install/test_install.sh
+++ b/tests/install/test_install.sh
@@ -34,6 +34,7 @@ VERBOSE="true"
 # Indicates that pywbem is installed from a repository. This will disable
 # some install tests because they don't support this. Keep in sync with
 # the installation of pywbem from repo vs package in requirements.txt.
+# TODO: Set to false once pywbem 1.1.3 is released.
 PYWBEM_FROM_REPO="true"
 
 MYNAME=$(basename "$0")

--- a/tests/unit/test_pywbemcli_operations.py
+++ b/tests/unit/test_pywbemcli_operations.py
@@ -62,18 +62,18 @@ DEFAULT_CONNECTIONS_FILE_BAK = DEFAULT_CONNECTIONS_FILE + \
 # is supported.
 NEWSTYLE_SUPPORTED = sys.version_info[0:2] >= (3, 5)
 
-# RETRY_DEPRECATION_ Flag indicating that pywbem raises a DeprecationWarning
+# RETRY_DEPRECATION: Flag indicating that pywbem raises a DeprecationWarning
 # for urllib3.Retry.
 # urllib3 1.26.0 started issuing a DeprecationWarning for using the
 # 'method_whitelist' init parameter of Retry and announced its removal in
 # version 2.0. The replacement parameter is 'allowed_methods'.
-# pywbem >=1.2.0 avoids the warning, but pywbem <1.2.0 issues it.
+# pywbem >=1.1.0 avoids the warning, but pywbem <1.1.0 issues it.
 with warnings.catch_warnings():
     warnings.filterwarnings('error')
     try:
         urllib3.Retry(method_whitelist={})
     except (DeprecationWarning, TypeError):
-        RETRY_DEPRECATION = PYWBEM_VERSION.release <= (1, 2)
+        RETRY_DEPRECATION = PYWBEM_VERSION.release < (1, 1)
     else:
         RETRY_DEPRECATION = False
 


### PR DESCRIPTION
Rolls back PR #844 into 0.8.1.