### PR TITLE
0.8: Fixed change log by adding GitHub Actions change

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,9 @@ Released: not yet
 
 **Enhancements:**
 
+* Migrated from Travis and Appveyor to GitHub Actions. This required several
+  changes in package dependencies for development.
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
Rolls back PR #849 into 0.8.1.