### PR TITLE
[WIP] Fixes #761: Add comment field to connection definition

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -53,6 +53,10 @@ Released: not yet
 * Migrated from Travis and Appveyor to GitHub Actions. This required several
   changes in package dependencies for development.
 
+* Add comment field to connection definition and command "connection comment"
+  to edit this field for any defined connection definition. (see
+  issue #761)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -1317,6 +1317,9 @@ The attributes of each connection definition in the :term:`connections file` are
 
 The commands in this group are:
 
+* :ref:`Connection comment command` - Create/modify a comment for a WBEM connection definition.
+
+* :ref:`Connection comment command` - Edit comment in WBEM connection definition.
 * :ref:`Connection delete command` - Delete a WBEM connection definition.
 * :ref:`Connection export command` - Export the current connection.
 * :ref:`Connection list command` - List the WBEM connection definitions.
@@ -1324,6 +1327,43 @@ The commands in this group are:
 * :ref:`Connection select command` - Select a WBEM connection definition as current or default.
 * :ref:`Connection show command` - Show connection info of a WBEM connection definition.
 * :ref:`Connection test command` - Test the current connection with a predefined WBEM request.
+
+
+.. index:: pair: connection commands; connection comment
+
+.. _`Connection comment command`:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `connection comment` command adds or modifies comments mainained in the
+connection definition file for each connection.
+
+The comments are created and formatted by the user and created or modified
+by a multiline editor called by this command.
+
+The comments may be viewed with the ``connection list`` command using the
+``--full`` option.
+
+.. code-block:: text
+
+    $ pywbemcli connection comment mock1
+    Edit/create comment. Enter creates new line, arrow keys and mouse move cursor,
+    [Meta+Enter] or [Esc] followed by [Enter] accept edit. Ctrl-C aborts edit.
+
+    > This is first line of comment
+    > Second line of comment
+
+In the edit mode, the arrow keys, [Enter], and other editing keys are honored
+so that the multiline text can be created or modified.
+
+The edit mode is terminated and the changes accepted with either [Meta+Enter]
+or [Esc] keys where the [Meta] is normally the key to the left of the space bar
+[Alt] or by [Esc] followed by [Enter]. The comment will be saved in the
+server definition file.
+
+The edit can be aborted with[Ctrl-C].
+
+``connection delete`` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. index:: pair: connection commands; connection delete
 

--- a/pywbemtools/pywbemcli/_connection_repository.py
+++ b/pywbemtools/pywbemcli/_connection_repository.py
@@ -140,6 +140,7 @@ class ConnectionRepository(object):
                 certfile: null
                 keyfile: null
                 ca-certs: null
+                comment: null
                 mock-server:
                 - tests/unit/simple_mock_model.mof
                 - tests/unit/simple_mock_invokemethod_v1old.py
@@ -156,6 +157,7 @@ class ConnectionRepository(object):
                 certfile: null
                 keyfile: null
                 ca-certs: null
+                comment: null
                 mock-server: []
         default_connection_name: mock1
     """
@@ -317,6 +319,9 @@ class ConnectionRepository(object):
         Parameters:
 
           name (:term:`string`): Name of the connection definition.
+
+        Returns:
+            PywbemcliServer object defined by name
 
         Raises:
           ConnectionsFileLoadError

--- a/pywbemtools/pywbemcli/_pywbem_server.py
+++ b/pywbemtools/pywbemcli/_pywbem_server.py
@@ -125,7 +125,8 @@ class PywbemServer(object):
                  name='default', user=None, password=None,
                  timeout=DEFAULT_CONNECTION_TIMEOUT, verify=None, use_pull=None,
                  pull_max_cnt=None, certfile=None, keyfile=None,
-                 ca_certs=None, mock_server=None, connections_file=None):
+                 ca_certs=None, mock_server=None, connections_file=None,
+                 comment=None):
         """
         Create  a PywbemServer object. This contains the configuration
         and operation information to create a connection to the server
@@ -153,6 +154,7 @@ class PywbemServer(object):
         self.certfile = certfile
         self.keyfile = keyfile
         self.ca_certs = ca_certs
+        self.comment = comment
 
         # May be None in case of not-saved connection (e.g. connection save)
         self._connections_file = connections_file
@@ -169,7 +171,8 @@ class PywbemServer(object):
                'password={s.password} timeout={s.timeout} ' \
                'use_pull={s.use_pull} pull_max_cnt={s.pull_max_cnt} ' \
                'verify={s.verify} certfile={s.certfile} keyfile={s.keyfile} ' \
-               'ca_certs={s.ca_certs} mock_server={s.mock_server!r} ' \
+               'ca_certs={s.ca_certs} comment="{s.comment}" ' \
+               'mock_server={s.mock_server!r} ' \
                'wbem_server={s.wbem_server!r})'.format(s=self)
 
     @property
@@ -412,6 +415,22 @@ class PywbemServer(object):
         """
         return self.wbem_server.conn if self.wbem_server else None
 
+    def comment(self):
+        """
+        :term:`string`: String that defines comment for server validation"
+        """
+        if self._comment:
+            assert isinstance(self._comment, six.string_types)
+        return self._comment
+
+    @ca_certs.setter
+    def _comment(self, comment):
+        """Setter method; for a description see the getter method."""
+        if comment and not isinstance(comment, six.string_types):
+            _raise_typeerror("comment", comment, 'string')
+        # pylint: disable=attribute-defined-outside-init
+        self._comment = comment
+
     @property
     def wbem_server(self):
         """
@@ -467,6 +486,7 @@ class PywbemServer(object):
                             "certfile": self.certfile,
                             "keyfile": self.keyfile,
                             "ca-certs": self.ca_certs,
+                            "comment": self.comment,    # added ver 0.9
                             "mock-server": self.mock_server})
 
     @staticmethod


### PR DESCRIPTION
**WIP incomplete. See below for discussion items.**

Adds a new field to connection definitions and a new command to the
connection group to edit data into the field.

connection edit allows editing the comment of any defined connection and
allows re-editing the text at will.

The editor  used is built into prompt-toolkit and allows multiline
editing including adding and deleting lines, moving the cursor with
arrow keys or the mouse, and saving the resulting comment.

This enhances the server definition with an additional field, comment, where the user can include comments on the server definition and a command "connection comment" that allows editing a multiline comment.

An editing session might look as follows with instructions on how to control the edit process.  This allows the string to be created and edited.  It is automatically saved in the svr definition at the end of each edit session.:```

```

pywbemcli > connection comment

0: mock1
1: mock2
Input integer between 0 and 1 or Ctrl-C to exit selection: 1
Edit/create comment connection: "mock2".
Enter creates new line, arrow keys and mouse move cursor,
[Meta+Enter] or [Esc] followed by [Enter] accept edit. Ctrl-C aborts the edit.
Comment: Hi There. This is more comment
       : Added more comment. Line 3.
       : Now added line 4 again

```

`**`LIMITATIONS/DISCUSSION**

the following are a number of the unresolved issues.

1. In retrospect I would prefer to call this notes rather than comment.  a) you could have multiple notes, b) This implies that things could be added.
2. There is no general option to manipulate a comment (i.e. you cannot add a comment on the command line).  That gets messy because it would probably only be used to completely replace a comment or to append to one and therefore is limited compared to the multiline editor.
3. There is no max width to the lines of edit text at this point and the connection list does not reformat other than width in which the user edits the text. You can make the comments as wide as you want and that is how they show up in the display.  It would be logical to set a maximum of some sort and to clean up the relation between NLs  by the editor and a max width.
4. The comment only shows up in the connection list --full option. To me it would be logical to include it in the connection list default (brief mode) since if used, this information could be important in selecting/understanding connections..
5. No tests written because of the number of outstanding decisions to be made.
6. We have only two modes of selecting the connection to be edited "connection comment": presents pick list as shown in example above and 2) "connection comment NAME" that edits the  NAME connection.  There is no selection mode to select the current connection at this point.  This is because:
  a. Wanted to be sure this worked first.
  b. This is consistend with delete where you have choice of select on NAME but no option to delete current connection.
7. Currently the comment is tied to an already saved server definition. 

```
WBEM server connections(full): (#: default, *: current)
file: test_connections.yaml
name     server    namespace    user      timeout  use-pull    pull-max-cnt    verify    certfile    keyfile    mock-server                       comment
-------  --------  -----------  ------  ---------  ----------  --------------  --------  ----------  ---------  --------------------------------  -------------------------------
*#mock1            root/cimv2                  30                              True                             tests/unit/simple_mock_model.mof  Hi There.
                                                                                                                                                  Line 2
                                                                                                                                                  line 3,
                                                                                                                                                  line 4 added.
mock2              root/cimv2                  30                              True                             tests/unit/simple_mock_model.mof  Hi There. This is more comment
                                                                                                                                                  Added more comment. Line 3.
                                                                                                                                                  Now added line 4 again


       :

