### PR TITLE
Fixes #868: Document index missing from generated documentation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -44,6 +44,9 @@ Released: not yet
 * Mitigated the coveralls HTTP status 422 by pinning coveralls-python to
   <3.0.0.
 
+* Fix issue where documentation index disappeared when we changed the
+  documentation theme (see issue #868)
+
 **Enhancements:**
 
 * Add new option to class find command (--summary) to display a summary of

--- a/docs/genindex.rst
+++ b/docs/genindex.rst
@@ -1,0 +1,6 @@
+Document Index
+##############
+
+.. This is effectively an empty file that is required to generate
+.. the document index. It is overlayed in html with the generated
+.. index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,3 +18,5 @@ The pywbemtools github page is: `https://github.com/pywbem/pywbemtools <https://
    development.rst
    appendix.rst
    changes.rst
+   genindex.rst
+.. The genindex.rst and a corresponding file required to include index


### PR DESCRIPTION
Fixes the issue where the document index was being built but did not show up in the displayed document.

The document index pages disappeared when we moved to the readthedocs theme.  To fix it I added a dummy file genindex.rst and added genindex.rst to the index.rst file.

This is clearly a hack but it works and others use it.

Note that whereas in the old theme there was a hyperlink to the document index in the upper right of each page, this generates a new section to the TOC sidebar named Document Index.  Since this is clearly visible and leads the user directly to the document index page this seems satisfactory.