### PR TITLE
0.8: Mitigated the coveralls HTTP status 422

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -36,7 +36,7 @@ coverage>=5.0; python_version == '2.7' or python_version >= '3.5'
 pytest-cov>=2.7.0; python_version == '2.7' or python_version >= '3.5'
 # coveralls 2.0 has removed support for Python 2.7 and 3.4
 git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
-coveralls>=2.1.2; python_version >= '3.5'
+coveralls>=2.1.2,<3.0.0; python_version >= '3.5'
 
 # Safety CI by pyup.io
 # safety 1.9.0 removed support for Python 2.7 and 3.4 (and now also enforces that)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,9 @@ Released: not yet
 * Docs: Fixed incorrect removal of 'off' value for the --log option that was
   done in version 0.8.1.
 
+* Mitigated the coveralls HTTP status 422 by pinning coveralls-python to
+  <3.0.0.
+
 **Enhancements:**
 
 **Cleanup:**


### PR DESCRIPTION
Rolls back PR #874 into 0.8.2.