### PR TITLE
Cleaned up the circumvention for Click issue #1231 by using Click 7.1.1

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -84,6 +84,12 @@ Released: not yet
   and 'server interop' commands that provide a subset of that functionality
   have been deprecated. (issue #877)
 
+**Cleanup:**
+
+* Cleaned up the circumvention for Click issue #1231 by upgrading the minimum
+  Click version to 7.1.1, where possible. The circumvention is still required
+  on Python 2.7 and 3.4 on Windows.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -29,7 +29,9 @@
 nocaselist==1.0.3
 nocasedict==1.0.1
 six==1.14.0
-Click==7.0
+Click==7.1.1; python_version == '2.7'
+Click==7.0; python_version == '3.4'
+Click==7.1.1; python_version >= '3.5'
 click-spinner==0.1.8
 click-repl==0.1.6
 asciitree==0.3.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,10 +19,14 @@ git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
 nocaselist>=1.0.3
 nocasedict>=1.0.1
 six>=1.14.0
+# Click 7.0 has issue #1231 on Windows which we circumvent in the test code
 # Click 7.1 has a bug with output capturing
+# Click 7.1 removed support for Python 3.4
 # Click 8.0 is incompatible with pywbemcli. See issues #816 (python 2.7 not
 #     supported) and #819 (click-repl incompatible)
-Click>=7.0,!=7.1,<8.0
+Click>=7.1.1,<8.0; python_version == '2.7'
+Click>=7.0,<7.1; python_version == '3.4'
+Click>=7.1.1,<8.0; python_version >= '3.5'
 click-spinner>=0.1.8
 click-repl>=0.1.6
 asciitree>=0.3.3


### PR DESCRIPTION
See commit message.

This issue came up during the tests in an old version of PR #888, but meanwhile the PR no longer depends on this.