### PR TITLE
Added end2end tests using Pegasus container image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,15 @@ on:
   pull_request:
     branches: [ master, stable_0.8 ]
 
+env:
+  # WBEM server image on Docker Hub as repository:tag.
+  # Keep the version in sync with the Makefile.
+  TEST_SERVER_IMAGE: keyporttech/smi-server:0.1.2
+  # Base file name of local tarball created from WBEM server image
+  TEST_SERVER_IMAGE_TAR: smi-server-0.1.2.tar.gz
+  # Local Docker image cache directory
+  DOCKER_CACHE_DIR: ~/docker-cache
+
 jobs:
 
   set_matrix:
@@ -94,6 +103,30 @@ jobs:
       matrix: ${{ fromJson(needs.set_matrix.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Create local cache directory for Docker images
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        mkdir -p ${{ env.DOCKER_CACHE_DIR }}
+    - name: Set up caching for local Docker image cache directory
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      uses: actions/cache@v1
+      with:
+        path: ${{ env.DOCKER_CACHE_DIR }}
+        key: docker-cache-{hash}
+        restore-keys: |
+          docker-cache-
+    - name: Get WBEM server image from Docker Hub or local Docker image cache
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        if [[ ! -f ${{ env.DOCKER_CACHE_DIR }}/${{ env.TEST_SERVER_IMAGE_TAR }} ]]; then \
+          echo "Pulling image from Docker Hub"; \
+          docker pull ${{ env.TEST_SERVER_IMAGE }}; \
+          echo "Saving image in local Docker image cache"; \
+          docker save -o ${{ env.DOCKER_CACHE_DIR }}/${{ env.TEST_SERVER_IMAGE_TAR }} ${{ env.TEST_SERVER_IMAGE }}; \
+        else \
+          echo "Loading image from local Docker image cache"; \
+          docker load -i ${{ env.DOCKER_CACHE_DIR }}/${{ env.TEST_SERVER_IMAGE_TAR }}; \
+        fi
     - name: Checkout repo
       uses: actions/checkout@v2
       with:
@@ -151,6 +184,13 @@ jobs:
         # TESTCASES: test_cim_obj.py
       run: |
         make test
+    - name: Run end2end test with WBEM server Docker image
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      env:
+        PACKAGE_LEVEL: ${{ matrix.package_level }}
+        # Uses TEST_SERVER_IMAGE variable
+      run: |
+        make end2endtest
     - name: Send coverage result to coveralls.io
       shell: bash -l {0}
       env:

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -91,6 +91,9 @@ Released: not yet
 * Added commands 'add-mof' and 'remove-mof' for compiling MOF to the 'server'
   command group. (issue #886)
 
+* Test: Added end2end test capability using the OpenPegasus container image
+  on Docker Hub.
+
 **Cleanup:**
 
 * Cleaned up the circumvention for Click issue #1231 by upgrading the minimum

--- a/tests/end2endtest/test_server.py
+++ b/tests/end2endtest/test_server.py
@@ -1,0 +1,81 @@
+# Copyright 2021 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Basic server tests.
+"""
+
+from __future__ import absolute_import, print_function
+
+import re
+
+# pylint: disable=unused-import
+from .utils import server_url  # noqa: F401
+# pylint: enable=unused-import
+from ..unit.utils import execute_pywbemcli
+
+
+def test_server_is_pegasus(server_url):
+    # pylint: disable=redefined-outer-name
+    """
+    Test that this WBEM server is OpenPegasus and that it provides the
+    expected Interop namespace, and the namespaces and profiles we want to test
+    against.
+
+    This container-packaged version of OpenPegasus is provided by the
+    OpenPegasus project on GitHub (https://github.com/OpenPegasus/OpenPegasus).
+    It includes OpenPegasus 2.14.2, the CIM Schema version 2.41.0, and a number
+    of providers including a namespace provider.
+    """
+
+    # Check the server brand
+    rc, stdout, stderr = execute_pywbemcli(
+        ['-s', server_url, '--no-verify', 'server', 'brand'])
+    assert rc == 0
+    assert stderr == ''
+    brand = stdout.strip('\n')
+    assert brand == 'OpenPegasus'
+
+    # Check the expected Interop namespace
+    rc, stdout, stderr = execute_pywbemcli(
+        ['-s', server_url, '--no-verify', 'namespace', 'interop'])
+    assert rc == 0
+    assert stderr == ''
+    interop = stdout.strip('\n')
+    assert interop == 'root/interop'
+
+    # Check the namespaces our tests will use
+    rc, stdout, stderr = execute_pywbemcli(
+        ['-s', server_url, '--no-verify', 'namespace', 'list'])
+    assert rc == 0
+    assert stderr == ''
+    namespaces = stdout.strip('\n').split('\n')[2:]
+    assert 'root/interop' in namespaces
+    assert 'test/TestProvider' in namespaces
+
+    # Check the profiles our tests will use
+    rc, stdout, stderr = execute_pywbemcli(
+        ['-s', server_url, '--no-verify', 'profile', 'list'])
+    assert rc == 0
+    assert stderr == ''
+    profile_lines = stdout.strip('\n').split('\n')[3:]
+    profiles = []
+    for line in profile_lines:
+        m = re.match(r'^(.+?) {2,}(.+?) {2,}(.+)$', line)
+        assert m, "Cannot parse 'profile list' output line: {!r}".format(line)
+        profiles.append(m.groups())
+    assert ('SNIA', 'Array', '1.1.0') in profiles
+    assert ('SNIA', 'Indication', '1.2.0') in profiles
+    assert ('SNIA', 'Profile Registration', '1.0.0') in profiles
+    assert ('SNIA', 'SMI-S', '1.2.0') in profiles

--- a/tests/end2endtest/utils.py
+++ b/tests/end2endtest/utils.py
@@ -1,0 +1,71 @@
+# Copyright 2021 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Utilities for end2end testing.
+"""
+
+from __future__ import absolute_import, print_function
+
+import os
+from subprocess import call, check_call
+try:
+    from subprocess import DEVNULL  # Python 3
+except ImportError:
+    DEVNULL = open(os.devnull, 'wb')
+
+import pytest
+
+# Server nickname or server group nickname in WBEM server definition file
+TEST_SERVER_IMAGE = os.getenv('TEST_SERVER_IMAGE', None)
+
+
+@pytest.fixture(
+    params=[TEST_SERVER_IMAGE],
+    scope='module'
+)
+def server_url(request):
+    """
+    Fixture that starts a WBEM server in a Docker image and returns its URL.
+
+    The TCP ports used on the host side are 15988 and 15989 so that they do
+    not conflict with a WBEM server the user may have set up manually, which
+    typically would use the standard ports 5988 and 5989.
+    """
+    image = request.param
+    if image is None:
+        raise ValueError("TEST_SERVER_IMAGE variable not specified")
+
+    # The container name and ports are chosen to minimize the potential of
+    # conflicts. They are fixed so multiple instances of the test cannot run
+    # in parallel on the same system.
+    container = 'pywbemtools_test_server'
+    host_port_http = '15988'
+    host_port_https = '15989'
+
+    call(['docker', 'rm', container, '--force'],
+         stdout=DEVNULL, stderr=DEVNULL)
+
+    check_call(['docker', 'create',
+                '--name', container,
+                '--publish', '{}:5988'.format(host_port_http),
+                '--publish', '{}:5989'.format(host_port_https),
+                image],
+               stdout=DEVNULL)
+
+    check_call(['docker', 'start', container], stdout=DEVNULL)
+
+    yield 'https://localhost:15989'
+
+    check_call(['docker', 'rm', container, '--force'], stdout=DEVNULL)


### PR DESCRIPTION
See commit message.
Ready for review.
It now has a first end2end test function that just checks that the server is OpenPegasus and provides the expected namespaces and profiles.

**DISCUSSION (RESOLVED):**
* This PR adds the capability to have end2end test cases, but does not define any actual end2end test cases yet. I suggest that the end2end test cases are added in subsequent PRs.
* We have an infrastructure for defining end2end server environments in the pywbem project, but not in pywbemtools. The end2end tests here currently implement a very small scale version of that by means of defining a single environment variable for a single target server. Good enough?
* Right now, the container is created just once in the test workflow. Should we create it new for each end2end testcase, e.g. in a fixture? (takes about 7 sec)