### PR TITLE
Added end2end testcase for ResourceWarning about unclosed sockets

### DIFF
--- a/tests/end2endtest/test_errors.py
+++ b/tests/end2endtest/test_errors.py
@@ -1,0 +1,69 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test some errors with real servers.
+"""
+
+from __future__ import absolute_import, print_function
+
+import re
+
+# pylint: disable=unused-import
+from .utils import server_url  # noqa: F401
+# pylint: enable=unused-import
+from ..unit.utils import execute_pywbemcli
+
+
+def test_resourcewarning_interactive(server_url):
+    # pylint: disable=redefined-outer-name
+    """
+    Test that ending an interactive session to a real WBEM server does not
+    cause any ResourceWarnings (e.g. about unclosed sockets).
+    """
+
+    def details(what, expected=None):
+        "Return a string with details about the unexpected command result"
+        msg = """
+Unexpected {} (expected: {}):
+rc={}
+stdout:
+{}
+stderr:
+{}
+""".format(what, expected, rc, stdout, stderr)
+        return msg
+
+    # Note: We want to see ResourceWarning but not other warnings, particularly
+    # not DeprecationWarning which is issued on Python 2.7. Using the 'env'
+    # parameter to set PYTHONWARNINGS does not work because PYTHONWARNINGS is
+    # disabled in execute_pywbemcli(). So we use '--warn' and manually process
+    # the warnings that are issued.
+    rc, stdout, stderr = execute_pywbemcli(
+        ['-s', server_url, '--no-verify', '--warn'],
+        stdin='server brand')
+
+    out_lines = stdout.strip('\n')
+    out_lines = [] if out_lines == '' else out_lines.split('\n')
+    err_lines = stderr.strip('\n')
+    err_lines = [] if err_lines == '' else err_lines.split('\n')
+    reswarn_lines = []
+    for line in err_lines:
+        if 'ResourceWarning:' in line:
+            reswarn_lines.append(line)
+
+    assert rc == 0, details('rc')
+    assert len(reswarn_lines) == 0, details('stderr', '0 ResourceWarning lines')
+    assert len(out_lines) == 2, details('stdout', '2 stdout lines')
+    assert re.match(r"Enter 'help' for help", out_lines[0]), details('stdout')
+    assert re.match(r"OpenPegasus", out_lines[1]), details('stdout')


### PR DESCRIPTION
This PR is now ready to be reviewed.
For details, see commit message.

**Old description:**

This is to investigate and reproduce issue #883, without having it fixed. Note that PR #900 which now got merged only prepares the fix, but does not fix it yet.

The test can be run locally with `make end2endtest` as long as the target WBEM server is in a docker container. The docker image name is by default the pegasus image name, and can be set with the env var TEST_SERVER_IMAGE. See `make help`.

**DISCUSSION: (resolved)**
* Why does the new testcase not reproduce the warning in GitHub Actions? Answer: Did not use `--warn`. It does reproduce them with `--warn`.
* Does the new testcase succeed in the environments that produced the original ResourceWarning? Answer: After using `--warn`, the `make end2endtest` reproduced it on macos. See issue #883 for details.