### PR TITLE
Close WBEMConnection when leaving interactive mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ endif
 pytest_end2end_opts := -v --tb=short $(pytest_opts)
 
 ifeq ($(python_m_version),3)
-  pytest_warning_opts := -W default -W ignore::PendingDeprecationWarning -W ignore::ResourceWarning
+  pytest_warning_opts := -W default -W ignore::PendingDeprecationWarning
   pytest_end2end_warning_opts := $(pytest_warning_opts)
 else
   pytest_warning_opts := -W default -W ignore::PendingDeprecationWarning

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -713,7 +713,7 @@ def cli(ctx, server, connection_name, default_namespace, user, password,
                     modified_server = True
 
                 if modified_server:
-                    pywbem_server.reset()
+                    pywbem_server.disconnect()
                 else:
                     pywbem_server = ctx.obj.pywbem_server
             else:

--- a/tests/unit/test_pywbem_server.py
+++ b/tests/unit/test_pywbem_server.py
@@ -477,7 +477,7 @@ def test_pysvr_init(testcase, init_args, init_kwargs, exp_attrs):
 
 
 TESTCASES_PYSVR_CONNECT_ATTRS = [
-    # Testcases for PywbemServer.create_connection() for testing attrs
+    # Testcases for PywbemServer.connect() for testing attrs
     #
     # Each list item is a testcase tuple with these items:
     # * desc: Short testcase description.
@@ -543,7 +543,7 @@ TESTCASES_PYSVR_CONNECT_ATTRS = [
 @simplified_test_function
 def test_pysvr_connect_attrs(testcase, init_kwargs, exp_attrs):
     """
-    Test function for PywbemServer.create_connection() for testing attrs.
+    Test function for PywbemServer.connect() for testing attrs.
     """
     svr = PywbemServer(**init_kwargs)
 
@@ -554,7 +554,7 @@ def test_pysvr_connect_attrs(testcase, init_kwargs, exp_attrs):
     # connect and test connection results. Try block insures finally is
     # called.
     try:
-        svr.create_connection(False)
+        svr.connect(False)
     except Exception:  # pylint: disable=broad-except
         pass  # pass all exceptions
     finally:
@@ -573,4 +573,7 @@ def test_pysvr_connect_attrs(testcase, init_kwargs, exp_attrs):
     assert svr.certfile == exp_attrs['certfile']
     assert svr.keyfile == exp_attrs['keyfile']
 
-# TODO: Add test for get_password.
+
+# TODO: Add test for PywbemServer.disconnect().
+
+# TODO: Add test for PywbemServer.get_password().


### PR DESCRIPTION
The first commit just performs some restructuring on connection related elements in the `PywbemServer` and `ContextObj` classes.

There are two temporary flags that are used to switch between old and new behavior.
```
PR900_REQUIRE_CORRECT_CONNECTION_STATUS = False
PR900_DISCONNECT_CALLS_CLOSE = False
```

TODOs for Karl when continuing the work on this PR:
* Enable the two temporary flags to enable the new behavior. That causes some tests to now fail.
* Rework how and when `PywbemServer.connect()` and `PywbemServer.disconnect()` and `PywbemServer` objects in general are used. One major verification is is when the tests succeed again.
* Extend testcases to cover all variartions on how connection related input can be specified, inherited, overwritten in command mode and interactive mode, including setting default connections and selecting interactive connections.