### PR TITLE
Added dependency checks to class delete (non-empty ns delete, pt.2)

### DIFF
--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -272,10 +272,12 @@ Help text for ``pywbemcli class delete`` (see :ref:`class delete command`):
       Delete a CIM class (CLASSNAME argument) in a CIM namespace (--namespace option). If no namespace was specified, the
       default namespace of the connection is used.
 
-      If the class has subclasses, the command is rejected.
-
       If the class has instances, the command is rejected, unless the --include-instances option is specified, in which
       case the instances are also deleted.
+
+      If other classes in that namespace depend on the class to be deleted, the command is rejected. Dependencies that are
+      considered for this purpose are subclasses, referencing classes and embedding classes (EmbeddedInstance qualifier
+      only).
 
       WARNING: Deletion of instances will cause the removal of corresponding resources in the managed environment (i.e. in
       the real world). Some instances may not be deletable.
@@ -294,9 +296,9 @@ Help text for ``pywbemcli class delete`` (see :ref:`class delete command`):
       -f, --force                Same as --include-instances. The -f / --force option has been deprecated and will be
                                  removed in a future version.
 
-      --include-instances        Delete any instances of the class as well. WARNING: Deletion of instances will cause all
-                                 implemented side-effects to happen, such as the removal of resources in the managed
-                                 environment. Default: Reject command if the class has any instances.
+      --include-instances        Delete any instances of the class as well. WARNING: Deletion of instances will cause the
+                                 removal of corresponding resources in the managed environment (i.e. in the real
+                                 world).Default: Reject command if the class has any instances.
 
       -n, --namespace NAMESPACE  Namespace to use for this command, instead of the default namespace of the connection.
       -h, --help                 Show this help message.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -44,6 +44,7 @@ PyYAML==5.2; python_version == '3.4'
 PyYAML==5.3.1; python_version >= '3.5'
 yamlloader==0.5.5
 mock==3.0.0
+toposort==1.6
 
 # Virtualenv
 virtualenv==14.0.0; python_version < '3.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ click-spinner>=0.1.8
 click-repl>=0.1.6
 asciitree>=0.3.3
 tabulate>=0.8.2
+toposort>=1.6
 
 # prompt-toolkit>=2.0 failed on py27 (issue #192), so it was pinned to <2.0.
 #   Later, the fix for issue #224 allowed to lift that pinning.

--- a/tests/unit/cli_test_extensions.py
+++ b/tests/unit/cli_test_extensions.py
@@ -13,6 +13,7 @@ import six
 # import pkgs to determine pywbem version
 import packaging.version
 import pywbem
+from pywbem_mock import FakedWBEMConnection
 
 from .utils import execute_pywbemcli, assert_rc, assert_patterns, assert_lines
 
@@ -449,3 +450,36 @@ def remove_ws(inputs, join=False):
     if join:
         ret_lines = ''.join(ret_lines)
     return ret_lines
+
+
+def setup_mock_connection(mock_items, namespace):
+    """
+    Return FakedWBEMConnection with the specified mock items in the specified
+    namespace.
+
+    Parameters:
+
+      mock_items (iterable of mock items): List of mock items to be added
+        to the mock environment.
+
+        A mock item can be:
+        * string: path name of MOF file to be compiled
+        * string: MOF string to be compiled
+        * list/tuple: List of CIM objects to be added
+
+      namespace (string): CIM namespace
+
+    Returns:
+      FakedWBEMConnection: Mock environment that has been set up.
+    """
+    conn = FakedWBEMConnection()
+    conn.add_namespace(namespace)
+    for mock_item in mock_items:
+        if isinstance(mock_item, six.string_types):
+            if mock_item.endswith('.mof'):
+                conn.compile_mof_file(mock_item, namespace=namespace)
+            else:
+                conn.compile_mof_string(mock_item, namespace=namespace)
+        elif isinstance(mock_item, (list, tuple)):
+            conn.add_cimobjects(mock_item, namespace=namespace)
+    return conn

--- a/tests/unit/reject_deleteinstance_provider.py
+++ b/tests/unit/reject_deleteinstance_provider.py
@@ -1,0 +1,53 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+This module implements a user-defined provider that rejects the deletion
+of instances, for test purposes.
+"""
+
+from pywbem import CIMError, CIM_ERR_FAILED
+from pywbem_mock import InstanceWriteProvider
+
+
+class CIM_Foo_sub_sub_RejectDeleteProvider(InstanceWriteProvider):
+    """
+    Implements a user defined provider for the class CIM_Foo_sub_sub where
+    DeleteInstance is rejected with CIM_ERR_FAILED.
+    """
+
+    provider_classnames = 'CIM_Foo_sub_sub'
+
+    def DeleteInstance(self, InstanceName):
+        """
+        Reject the deletion of an instance of the class.
+        """
+        raise CIMError(
+            CIM_ERR_FAILED,
+            "Deletion of {} instances is rejected".
+            format(self.provider_classnames))
+
+
+def setup(conn, server, verbose):
+    # pylint: disable=unused-argument
+    """
+    Setup for this mock script.
+
+    Parameters:
+      conn (FakedWBEMConnection): Connection
+      server (PywbemServer): Server
+      verbose (bool): Verbose flag
+    """
+    provider = CIM_Foo_sub_sub_RejectDeleteProvider(conn.cimrepository)
+    conn.register_provider(provider, 'root/cimv2', verbose=verbose)

--- a/tests/unit/simple_mock_model.mof
+++ b/tests/unit/simple_mock_model.mof
@@ -19,6 +19,13 @@ Qualifier Aggregate : boolean = false,
     Scope(reference),
     Flavor(DisableOverride, ToSubclass);
 
+Qualifier EmbeddedInstance : string = null,
+    Scope(property, method, parameter);
+
+Qualifier EmbeddedObject : boolean = false,
+    Scope(property, method, parameter),
+    Flavor(DisableOverride, ToSubclass);
+
 Qualifier Description : string = null,
     Scope(any),
     Flavor(EnableOverride, ToSubclass, Translatable);
@@ -43,6 +50,40 @@ Qualifier Static : boolean = false,
     Scope(property, method),
     Flavor(DisableOverride, ToSubclass);
 
+     [Abstract, Description ("Base class for classes that are referenced")]
+class CIM_BaseRef {
+        [Key, Description ("This is key property.")]
+    string InstanceID;
+};
+
+     [Description ("Class 1 that is referenced")]
+class CIM_FooRef1 : CIM_BaseRef {};
+
+     [Description ("Class 2 that is referenced")]
+class CIM_FooRef2 : CIM_BaseRef {};
+
+     [Association, Description ("Simple CIM Association")]
+class CIM_FooAssoc {
+
+        [Key, Description ("This is key property.")]
+    CIM_FooRef1 REF Ref1;
+
+        [Key, Description ("This is key property.")]
+    CIM_FooRef2 REF Ref2;
+};
+
+     [Abstract, Description ("Base class for classes having embedded instances")]
+class CIM_BaseEmb {};
+
+     [Description ("Class 1 that has embedded instances")]
+class CIM_FooEmb1 : CIM_BaseEmb {};
+
+     [Description ("Class 2 that has embedded instances")]
+class CIM_FooEmb2 : CIM_BaseEmb {};
+
+     [Description ("Class 3 that has embedded instances")]
+class CIM_FooEmb3 : CIM_BaseEmb {};
+
      [Description ("Simple CIM Class")]
 class CIM_Foo {
         [Key, Description ("This is key property.")]
@@ -51,12 +92,15 @@ class CIM_Foo {
         [Description ("This is Uint32 property.")]
     uint32 IntegerProp;
 
+        [Description("Embedded instance property"), EmbeddedInstance("CIM_FooEmb3")]
+    string cimfoo_emb3;
+
         [Description ("Method with in and out parameters")]
     uint32 Fuzzy(
         [IN, OUT, Description("Define data to be returned in output parameter")]
       string TestInOutParameter,
         [IN, OUT, Description ( "Test of ref in/out parameter")]
-      CIM_Foo REF TestRef,
+      CIM_FooRef1 REF TestRef,
         [IN ( false ), OUT, Description("Rtns method name if exists on input")]
       string OutputParam,
         [IN , Description("Defines return value if provided.")]
@@ -71,10 +115,13 @@ class CIM_Foo {
         [IN ( false ), OUT, Description("Rtns method name if exists on input")]
       string OutputParam,
         [IN , Description("Defines return value if provided.")]
-      uint32 OutputRtnValue);
+      uint32 OutputRtnValue,
+        [IN, Description("Embedded instance parameter"), EmbeddedInstance("CIM_FooEmb1")]
+      string cimfoo_emb1);
 
-        [ Description("Method with no Parameters") ]
-    uint32 DeleteNothing();
+        [ Description("Method with no parameters but embedded instance return"),
+          EmbeddedInstance("CIM_FooEmb2") ]
+    string DeleteNothing();
 };
 
     [Description ("Subclass of CIM_Foo")]
@@ -91,11 +138,31 @@ class CIM_Foo_sub_sub : CIM_Foo_sub {
       string OutputParam2);
 };
 
-// 5 instances of CIM_Foo class
-
 class CIM_Foo_sub2 : CIM_Foo {
     string cimfoo_sub2;
 };
+
+
+// 1 instance of each CIM_FooRef* class
+
+instance of CIM_FooRef1 as $fooref11 {
+    InstanceID = "CIM_FooRef11";
+};
+
+instance of CIM_FooRef2 as $fooref21 {
+    InstanceID = "CIM_FooRef21";
+};
+
+
+// 1 instance of CIM_FooAssoc
+
+instance of CIM_FooAssoc as $fooassoc1 {
+    Ref1 = $fooref11;
+    Ref2 = $fooref21;
+};
+
+
+// 5 instances of CIM_Foo class
 
 instance of CIM_Foo as $foo1 {
     InstanceID = "CIM_Foo1";

--- a/tests/unit/test_instance_cmds.py
+++ b/tests/unit/test_instance_cmds.py
@@ -2679,6 +2679,9 @@ Instances: TST_Person
 +-------------+-----------------+---------+
 | Namespace   | Class           |   count |
 |-------------+-----------------+---------|
+| interop     | CIM_FooAssoc    |       1 |
+| interop     | CIM_FooRef1     |       1 |
+| interop     | CIM_FooRef2     |       1 |
 | interop     | CIM_Foo_sub_sub |       3 |
 | interop     | CIM_Foo_sub     |       4 |
 | interop     | CIM_Foo         |       5 |
@@ -2697,6 +2700,9 @@ Instances: TST_Person
 | Namespace   | Class           |   count |
 |-------------+-----------------+---------|
 | interop     | CIM_Foo         |       5 |
+| interop     | CIM_FooAssoc    |       1 |
+| interop     | CIM_FooRef1     |       1 |
+| interop     | CIM_FooRef2     |       1 |
 | interop     | CIM_Foo_sub     |       4 |
 | interop     | CIM_Foo_sub_sub |       3 |
 +-------------+-----------------+---------+

--- a/tests/unit/test_qualdecl_cmds.py
+++ b/tests/unit/test_qualdecl_cmds.py
@@ -72,6 +72,13 @@ Qualifier Description : string,
     Scope(any),
     Flavor(EnableOverride, ToSubclass, Translatable);
 
+Qualifier EmbeddedInstance : string,
+    Scope(property, method, parameter);
+
+Qualifier EmbeddedObject : boolean = false,
+    Scope(property, method, parameter),
+    Flavor(DisableOverride, ToSubclass);
+
 Qualifier In : boolean = true,
     Scope(parameter),
     Flavor(DisableOverride, ToSubclass);
@@ -99,41 +106,54 @@ Qualifier Static : boolean = false,
 """
 
 
+# pylint: disable=line-too-long
 QD_TBL_OUT = """Qualifier Declarations
-+-------------+---------+---------+---------+-------------+-----------------+
-| Name        | Type    | Value   | Array   | Scopes      | Flavors         |
-+=============+=========+=========+=========+=============+=================+
-| Abstract    | boolean | False   | False   | CLASS       | EnableOverride  |
-|             |         |         |         | ASSOCIATION | Restricted      |
-|             |         |         |         | INDICATION  |                 |
-+-------------+---------+---------+---------+-------------+-----------------+
-| Aggregate   | boolean | False   | False   | REFERENCE   | DisableOverride |
-|             |         |         |         |             | ToSubclass      |
-+-------------+---------+---------+---------+-------------+-----------------+
-| Association | boolean | False   | False   | ASSOCIATION | DisableOverride |
-|             |         |         |         |             | ToSubclass      |
-+-------------+---------+---------+---------+-------------+-----------------+
-| Description | string  |         | False   | ANY         | EnableOverride  |
-|             |         |         |         |             | ToSubclass      |
-|             |         |         |         |             | Translatable    |
-+-------------+---------+---------+---------+-------------+-----------------+
-| In          | boolean | True    | False   | PARAMETER   | DisableOverride |
-|             |         |         |         |             | ToSubclass      |
-+-------------+---------+---------+---------+-------------+-----------------+
-| Indication  | boolean | False   | False   | CLASS       | DisableOverride |
-|             |         |         |         | INDICATION  | ToSubclass      |
-+-------------+---------+---------+---------+-------------+-----------------+
-| Key         | boolean | False   | False   | PROPERTY    | DisableOverride |
-|             |         |         |         | REFERENCE   | ToSubclass      |
-+-------------+---------+---------+---------+-------------+-----------------+
-| Out         | boolean | False   | False   | PARAMETER   | DisableOverride |
-|             |         |         |         |             | ToSubclass      |
-+-------------+---------+---------+---------+-------------+-----------------+
-| Override    | string  |         | False   | PROPERTY    | EnableOverride  |
-|             |         |         |         | REFERENCE   | Restricted      |
-|             |         |         |         | METHOD      |                 |
-+-------------+---------+---------+---------+-------------+-----------------+
-"""
++------------------+---------+---------+---------+-------------+-----------------+
+| Name             | Type    | Value   | Array   | Scopes      | Flavors         |
++==================+=========+=========+=========+=============+=================+
+| Abstract         | boolean | False   | False   | CLASS       | EnableOverride  |
+|                  |         |         |         | ASSOCIATION | Restricted      |
+|                  |         |         |         | INDICATION  |                 |
++------------------+---------+---------+---------+-------------+-----------------+
+| Aggregate        | boolean | False   | False   | REFERENCE   | DisableOverride |
+|                  |         |         |         |             | ToSubclass      |
++------------------+---------+---------+---------+-------------+-----------------+
+| Association      | boolean | False   | False   | ASSOCIATION | DisableOverride |
+|                  |         |         |         |             | ToSubclass      |
++------------------+---------+---------+---------+-------------+-----------------+
+| Description      | string  |         | False   | ANY         | EnableOverride  |
+|                  |         |         |         |             | ToSubclass      |
+|                  |         |         |         |             | Translatable    |
++------------------+---------+---------+---------+-------------+-----------------+
+| EmbeddedInstance | string  |         | False   | PROPERTY    | DisableOverride |
+|                  |         |         |         | METHOD      | Restricted      |
+|                  |         |         |         | PARAMETER   |                 |
++------------------+---------+---------+---------+-------------+-----------------+
+| EmbeddedObject   | boolean | False   | False   | PROPERTY    | DisableOverride |
+|                  |         |         |         | METHOD      | ToSubclass      |
+|                  |         |         |         | PARAMETER   |                 |
++------------------+---------+---------+---------+-------------+-----------------+
+| In               | boolean | True    | False   | PARAMETER   | DisableOverride |
+|                  |         |         |         |             | ToSubclass      |
++------------------+---------+---------+---------+-------------+-----------------+
+| Indication       | boolean | False   | False   | CLASS       | DisableOverride |
+|                  |         |         |         | INDICATION  | ToSubclass      |
++------------------+---------+---------+---------+-------------+-----------------+
+| Key              | boolean | False   | False   | PROPERTY    | DisableOverride |
+|                  |         |         |         | REFERENCE   | ToSubclass      |
++------------------+---------+---------+---------+-------------+-----------------+
+| Out              | boolean | False   | False   | PARAMETER   | DisableOverride |
+|                  |         |         |         |             | ToSubclass      |
++------------------+---------+---------+---------+-------------+-----------------+
+| Override         | string  |         | False   | PROPERTY    | EnableOverride  |
+|                  |         |         |         | REFERENCE   | Restricted      |
+|                  |         |         |         | METHOD      |                 |
++------------------+---------+---------+---------+-------------+-----------------+
+| Static           | boolean | False   | False   | PROPERTY    | DisableOverride |
+|                  |         |         |         | METHOD      | ToSubclass      |
++------------------+---------+---------+---------+-------------+-----------------+
+"""  # noqa: E501
+# pylint: enable=line-too-long
 
 QD_TBL_GET_OUT = """Qualifier Declarations
 +----------+---------+---------+---------+-------------+----------------+
@@ -219,7 +239,7 @@ TEST_CASES = [
 
     ['Verify qualifier command enumerate summary returns qual decls.',
      ['enumerate', '--summary'],
-     {'stdout': ['10', 'CIMQualifierDeclaration'],
+     {'stdout': ['12', 'CIMQualifierDeclaration'],
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
@@ -230,7 +250,7 @@ TEST_CASES = [
 +---------+-------------------------+
 |   Count | CIM Type                |
 |---------+-------------------------|
-|      10 | CIMQualifierDeclaration |
+|      12 | CIMQualifierDeclaration |
 +---------+-------------------------+
 """],
       'test': 'linesnows'},


### PR DESCRIPTION
This is part 2 of delete namespaces with content, in which the dependency checks for "class delete" are completed.
For details, see commit message.
See the description of dependent_classes() in _common.py for details on which dependencies are considered.