### PR TITLE
Fixes #912: Refactor ContextObj and PywbemServer classes - Part1

### DIFF
--- a/pywbemtools/pywbemcli/_cmd_profile.py
+++ b/pywbemtools/pywbemcli/_cmd_profile.py
@@ -186,17 +186,17 @@ def cmd_profile_list(context, options):
     """
     output_format = validate_output_format(context.output_format, 'TABLE')
 
-    server = context.wbem_server
+    wbem_server = context.pywbem_server.wbem_server
 
     organization = options['organization']
     profile_name = options['profile']
     try:
-        found_server_profiles = server.get_selected_profiles(
+        found_server_profiles = wbem_server.get_selected_profiles(
             registered_org=organization,
             registered_name=profile_name)
 
-        org_vm = ValueMapping.for_property(server,
-                                           server.interop_ns,
+        org_vm = ValueMapping.for_property(wbem_server,
+                                           wbem_server.interop_ns,
                                            'CIM_RegisteredProfile',
                                            'RegisteredOrganization')
         rows = []
@@ -229,16 +229,16 @@ def cmd_profile_centralinsts(context, options):
     output_format = validate_output_format(context.output_format, ['CIM',
                                                                    'TABLE'])
 
-    server = context.wbem_server
+    wbem_server = context.pywbem_server.wbem_server
     organization = options['organization']
     profile_name = options['profile']
     try:
-        found_server_profiles = server.get_selected_profiles(
+        found_server_profiles = wbem_server.get_selected_profiles(
             registered_org=organization,
             registered_name=profile_name)
 
-        org_vm = ValueMapping.for_property(server,
-                                           server.interop_ns,
+        org_vm = ValueMapping.for_property(wbem_server,
+                                           wbem_server.interop_ns,
                                            'CIM_RegisteredProfile',
                                            'RegisteredOrganization')
         rows = []
@@ -246,7 +246,7 @@ def cmd_profile_centralinsts(context, options):
             pi = get_profile_info(org_vm, inst)
             row = [":".join(pi)]
             try:
-                ci = server.get_central_instances(
+                ci = wbem_server.get_central_instances(
                     inst.path,
                     central_class=options['central_class'],
                     scoping_class=options['scoping_class'],

--- a/pywbemtools/pywbemcli/_cmd_qualifier.py
+++ b/pywbemtools/pywbemcli/_cmd_qualifier.py
@@ -136,12 +136,13 @@ def cmd_qualifier_get(context, qualifiername, options):
     """
     Execute the command for get qualifier and display result
     """
+    conn = context.pywbem_server.conn
     output_format = validate_output_format(context.output_format, ['CIM',
                                                                    'TABLE'])
 
     try:
-        qual_decl = context.conn.GetQualifier(qualifiername,
-                                              namespace=options['namespace'])
+        qual_decl = conn.GetQualifier(qualifiername,
+                                      namespace=options['namespace'])
 
         display_cim_objects(context, qual_decl, output_format)
 
@@ -153,9 +154,9 @@ def cmd_qualifier_delete(context, qualifiername, options):
     """
     Execute the command for delete qualifier and display result
     """
+    conn = context.pywbem_server.conn
     try:
-        context.conn.DeleteQualifier(qualifiername,
-                                     namespace=options['namespace'])
+        conn.DeleteQualifier(qualifiername, namespace=options['namespace'])
         if context.verbose:
             context.spinner_stop()
             click.echo('Deleted qualifier type {}.'.format(qualifiername))
@@ -167,11 +168,12 @@ def cmd_qualifier_enumerate(context, options):
     """
     Execute the command for enumerate qualifiers and desplay the result.
     """
+    conn = context.pywbem_server.conn
     output_format = validate_output_format(context.output_format, ['CIM',
                                                                    'TABLE'])
 
     try:
-        qual_decls = sort_cimobjects(context.conn.EnumerateQualifiers(
+        qual_decls = sort_cimobjects(conn.EnumerateQualifiers(
             namespace=options['namespace']))
 
         display_cim_objects(context, qual_decls, output_format,

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -234,10 +234,11 @@ def cmd_server_brand(context):
     """
     Display product and version info of the current WBEM server
     """
+    wbem_server = context.pywbem_server.wbem_server
     output_format = validate_output_format(context.output_format, 'TEXT')
 
     try:
-        brand = context.wbem_server.brand
+        brand = wbem_server.brand
         context.spinner_stop()
 
         display_text(brand, output_format)
@@ -250,13 +251,13 @@ def cmd_server_info(context):
     """
     Display general overview of info from current WBEM server
     """
+    wbem_server = context.pywbem_server.wbem_server
     output_format = validate_output_format(context.output_format, 'TABLE')
 
     try:
-        # execute the namespaces to force contact with server before
+        # Execute the namespaces to force contact with server before
         # turning off the spinner.
-        server = context.wbem_server
-        namespaces = sorted(server.namespaces)
+        namespaces = sorted(wbem_server.namespaces)
         context.spinner_stop()
 
         rows = []
@@ -264,8 +265,8 @@ def cmd_server_info(context):
         sep = '\n' if namespaces and len(namespaces) > 3 else ', '
         namespaces = sep.join(namespaces)
 
-        rows.append([server.brand, server.version,
-                     server.interop_ns,
+        rows.append([wbem_server.brand, wbem_server.version,
+                     wbem_server.interop_ns,
                      namespaces])
         click.echo(format_table(rows, headers,
                                 title='Server General Information',
@@ -279,6 +280,7 @@ def cmd_server_add_mof(context, options):
     """
     Compile MOF and add/update CIM objects in the server.
     """
+    conn = context.pywbem_server.conn
 
     try:
 
@@ -288,9 +290,9 @@ def cmd_server_add_mof(context, options):
         # MOFWBEMConnection writes resulting CIM objects to a local store
         # but reads from the connection.
         if options['dry_run']:
-            comp_handle = MOFWBEMConnection(conn=context.conn)
+            comp_handle = MOFWBEMConnection(conn=conn)
         else:
-            comp_handle = context.conn
+            comp_handle = conn
 
         if options['dry_run']:
             print('Executing in dry-run mode')
@@ -339,6 +341,7 @@ def cmd_server_remove_mof(context, options):
     """
     Compile MOF and remove CIM objects from the server.
     """
+    conn = context.pywbem_server.conn
 
     try:
 
@@ -347,7 +350,7 @@ def cmd_server_remove_mof(context, options):
         # Define the connection to be used by the MOF compiler.
         # MOFWBEMConnection writes resulting CIM objects to a local store
         # but reads from the connection.
-        comp_handle = MOFWBEMConnection(conn=context.conn)
+        comp_handle = MOFWBEMConnection(conn=conn)
 
         if options['dry_run']:
             print('Executing in dry-run mode')

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -356,10 +356,11 @@ def pick_instance(context, objectname, namespace=None):
     Raises:
         ClickException if user choses to terminate the selection process
     """
+    conn = context.pywbem_server.conn
     if not is_classname(objectname):
         raise click.ClickException('{} must be a classname'.format(objectname))
-    instance_names = context.conn.PyWbemcliEnumerateInstancePaths(objectname,
-                                                                  namespace)
+    instance_names = conn.PyWbemcliEnumerateInstancePaths(objectname,
+                                                          namespace)
 
     if not instance_names:
         click.echo('No instance paths found for {}'.format(objectname))
@@ -837,11 +838,12 @@ def process_invokemethod(context, objectname, methodname, options):
             params.append((name, cim_value))
         return params
 
+    conn = context.pywbem_server.conn
     classname = objectname.classname \
         if isinstance(objectname, (CIMClassName, CIMInstanceName)) \
         else objectname
 
-    cim_class = context.conn.GetClass(
+    cim_class = conn.GetClass(
         classname,
         namespace=options['namespace'], LocalOnly=False)
 
@@ -854,7 +856,7 @@ def process_invokemethod(context, objectname, methodname, options):
 
     params = create_params(classname, cim_method, options['parameter'])
 
-    rtn = context.conn.InvokeMethod(methodname, objectname, params)
+    rtn = conn.InvokeMethod(methodname, objectname, params)
 
     # Output results, both ReturnValue and all output parameters
     click.echo('ReturnValue={}'.format(rtn[0]))

--- a/pywbemtools/pywbemcli/_display_cimobjects.py
+++ b/pywbemtools/pywbemcli/_display_cimobjects.py
@@ -382,6 +382,7 @@ def _format_instances_as_rows(insts, max_cell_width=DEFAULT_MAX_CELL_WIDTH,
         list of strings where each string is a row in the table and each
         item in a row is a cell entry
     """
+    conn = context.pywbem_server.conn if context else None
     # Avoid crash deeper in code if max_cell_width is None.
     if max_cell_width is None:
         max_cell_width = DEFAULT_MAX_CELL_WIDTH
@@ -424,8 +425,8 @@ def _format_instances_as_rows(insts, max_cell_width=DEFAULT_MAX_CELL_WIDTH,
                     except KeyError:
                         try:
                             valuemapping = ValueMapping.for_property(
-                                context.conn,
-                                context.conn.default_namespace,
+                                conn,
+                                conn.default_namespace,
                                 inst.classname,
                                 name)
                         except ValueError:
@@ -465,6 +466,7 @@ def _display_instances_as_table(insts, table_width, table_format,
     instance) are shown with both the actual property value and the mapped
     value in parenthesis.
     """
+    conn = context.pywbem_server.conn if context else None
 
     if table_width is None:
         table_width = get_terminal_width()
@@ -488,7 +490,8 @@ def _display_instances_as_table(insts, table_width, table_format,
     else:
         max_cell_width = table_width
 
-    # TODO: Decide whether and how the showing of units should be controlled.
+    # TODO Future: Decide whether and how the showing of units should be
+    #              controlled.
     show_units = True
 
     # Retrieve all creation classes of the instances in order to get
@@ -508,7 +511,7 @@ def _display_instances_as_table(insts, table_width, table_format,
                 break
             namespace = inst.path.namespace
             try:
-                class_obj = context.conn.GetClass(
+                class_obj = conn.GetClass(
                     classname, namespace=namespace,
                     IncludeQualifiers=True, LocalOnly=False)
             except CIMError as exc:

--- a/tests/unit/test_connection_cmds.py
+++ b/tests/unit/test_connection_cmds.py
@@ -431,7 +431,7 @@ ca-certs
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection command select test2.. SEQ 0,9',
+    ['Verify connection command select test2 and set default.. SEQ 0.9.1',
      {'general': [],
       'args': ['select', 'test2', '--default']},
      {'stdout': ['test2', 'default'],
@@ -701,7 +701,8 @@ ca-certs
     ['Verify connection command export no current conection. SEQ 1.7',
      {'general': [],
       'args': ['export']},
-     {'stderr': ['No server currently defined as current'],
+     {'stderr': ['No current server for command "connection export" that '
+                 'requires a WBEM server'],
       'rc': 1,
       'test': 'innows',
       'file': {'before': 'none', 'after': 'none'}},
@@ -973,7 +974,7 @@ ca-certs
       'rc': 1,
       'test': 'innows',
       'file': {'before': 'none', 'after': 'none'}},
-     None, RUN],
+     None, OK],
 
 
     ['Verify connection show with just current server defined by --server. '
@@ -1071,24 +1072,19 @@ ca-certs
 
     # Begin of sequence - repository is empty.
 
-    # NOTE: This works because we insert the first command into the first
-    #       line of the stdin. If the connection save fred is not in the
-    #       first line, the test fails.
-
     ['Verify Create new connection in interactive mode and delete - single, '
      'SEQ 8.1',
-     {'general': [],
-      'stdin': ['--server http://blah --user fred --password fred '
-                '--certfile cert1.pem --keyfile keys1.pem '
-                ' connection save fred',
+     {'general': ['--server', 'http://blah', '--user', 'fred',
+                  '--password', 'fred',
+                  '--certfile', 'cert1.pem', '--keyfile', 'keys1.pem'],
+      'stdin': ['connection save fred',
                 'connection select fred',
                 'connection show fred',
                 'connection delete fred']},
      {'stdout': ['name', 'fred',
                  'server', 'http://blah',
                  'default-namespace', 'root/cimv2',
-                 'user',
-                 'fred',
+                 'user', 'fred',
                  'password',
                  'timeout', '30',
                  'verify', 'True',
@@ -1137,10 +1133,9 @@ ca-certs
     # Begin of sequence - repository is empty.
 
     ['Verify Create new connection in interactive mode and delete. SEQ 9.1',
-     {'general': [],
-      'stdin': ['--server http://blah --user fred --password fred '
-                '--certfile cert1.pem --keyfile keys1.pem',
-                'connection save fred',
+     {'general': ['--server', 'http://blah', '--user', 'fred', '--password',
+                  'fred', '--certfile', 'cert1.pem', '--keyfile', 'keys1.pem'],
+      'stdin': ['connection save fred',
                 'connection show fred']},
      {'stdout': ['name', 'fred',
                  'server', 'http://blah',
@@ -1270,6 +1265,8 @@ class TestSubcmdClass(CLITestsBase):
         if 'file' in exp_response:
             if 'before' in exp_response['file']:
                 test_file_existence(exp_response['file']['before'])
+
+        # add connections file if the general list exists.
         if 'general' in inputs:
             inputs['general'].extend(['--connections-file', connections_file])
         else:

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -229,7 +229,7 @@ TEST_CASES = [
      {'general': ['-s', 'httpx://blah'],
       'cmdgrp': 'class',
       'args': ['get', 'blah']},
-     {'stderr': ['Error: Invalid scheme on server argument. httpx://blah Use '
+     {'stderr': ['Error: Invalid scheme on server argument: httpx://blah. Use '
                  '"http" or "https"'],
       'rc': 1,
       'test': 'in'},
@@ -686,15 +686,12 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-    ['Verify connection without server definition and command that '
-     ' requires a connection actually fails.',
+    ['Verify connection without server definition and command that requires a '
+     'connection actually fails.',
      {'cmdgrp': 'class',
       'args': ['enumerate']},
-     {'stderr': ['No server specified for a command that requires a WBEM '
-                 'server. To specify a server, use the "--server", '
-                 '"--mock-server", or "--name" general options, or set the '
-                 'corresponding environment variables, or in interactive mode '
-                 'use "connection select"'],
+     {'stderr': ['No current server for command "class enumerate" that '
+                 'requires a WBEM server.'],
       'rc': 1,
       'test': 'innows'},
      None, OK],
@@ -973,7 +970,8 @@ TEST_CASES = [
       'test': 'innows'},
      None, FAIL],  # TODO: this test fails on windows. Outputs don't compare'
 
-    ['Verify Change --name in interactive mode, name invalid. command',
+    ['Verify Change --name invalid in interactive mode. command no connections '
+     'file',
      {'general': ['--name', 'NAMEDOESNOTEXIST'],
       'args': ['show'],
       'cmdgrp': 'connection',
@@ -985,10 +983,13 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-    ['Verify Change --name in interactive mode, name invalid. stdin',
+    ['Verify Change --name invalid in interactive mode . stdin. Connection '
+     'file exists and we delete',
      {'general': ['--server', 'http://blah'],
       # args not allowed in interactive mode
-      'stdin': ['--name NAMEDOESNOTEXIST connection show'],
+      'stdin': ['connection save argh',
+                '--name NAMEDOESNOTEXIST connection show',
+                'connection delete argh'],
       'cmdgrp': None,
       },
      {'stderr': ['Connection definition',
@@ -1236,11 +1237,11 @@ TEST_CASES = [
     #  Test that bad mock_error file names do not cause Abort but bad MOF
     #  or python script do cause Abort
     #
-
+    # TODO: This may leave connection file behind or use existing one
     ['Verify interactive create mock with bad file name does not fail.',
-     {'general': [],
-      'stdin': ['--server http://blah --user fred --password fred '
-                ' connection save connectiontoprovestdincontinues',
+     {'general': ['--server', 'http://blah', '--user', 'fred', '--password',
+                  'fred', '-C', 'tmpconfig.yaml'],
+      'stdin': ['connection save connectiontoprovestdincontinues',
                 '--mock-server DoesNotExist.mof class enumerate',
                 '-m DoesNotExist.py class enumerate',
                 'connection select connectiontoprovestdincontinues',
@@ -1262,9 +1263,9 @@ TEST_CASES = [
     # --mock-server ... class enumerate inserts the filepath without
     # the backslashes. This is a windows issue, and problem occurs for both
     # python 2 and 3
-    ['Verify interactive MOF or PY failures causes Abort.',
+    ['Verify interactive MOF or PY failures don"t cause Abort.',
      {'general': [],
-      'stdin': ['--server http://blah --user fred --password fred ',
+      'stdin': ['--server http://blah --user fred --password fred '
                 'connection save fred',
                 '--mock-server {} class enumerate'.format(BAD_MOF_FILE_PATH),
                 'connection select fred',
@@ -1272,7 +1273,7 @@ TEST_CASES = [
                 'connection delete fred'],
       'platform': 'win32'},  # ignore this platform.  See comments above
      {'stdout': ['Deleted connection "fred"'],
-      'rc': 1,
+      'rc': 0,
       'test': 'not-innows'},
      None, OK],
 
@@ -1290,7 +1291,7 @@ TEST_CASES = [
     ['Verify operation that makes request to WBEM server fails with no server.',
      {'args': ['enumerate'],
       'cmdgrp': 'class', },
-     {'stderr': "No server specified for a command that requires a WBEM server",
+     {'stderr': "No current server for command ",
       'rc': 1,
       'test': 'innows'},
      None, OK],


### PR DESCRIPTION
1. Separate out the use of conn and wbem_server from their context.

2. Remove conn and wbem_server from ContextObj and define them in
PywbemServer.

3. Modify several tests that no longer worked.

4. Cleaned uo the code in the DIAGNOSTIC display of ctx and ctx.obj
as part of a diagnostics displayzzzmerged .

5. Merged in pywbemserver connect and disconnect

6. Extended select to disconnect any currently connected PywbemServer object.

Part 2 - fix disconnect

Part 3 - SeparatePR Refactor the code that modifies PywbemServer for interactive command that modifies PyebemServer object

1. Test all variables and do not modify if no changes.
2. Move entire functionality to separate function
3. . Review under what conditions we must reconnect.