### PR TITLE
Test: Support for simple interop mock script for py27

### DIFF
--- a/tests/unit/simple_interop_mock_script.py
+++ b/tests/unit/simple_interop_mock_script.py
@@ -2,8 +2,14 @@
 Test mock script that installs the pywbem provided namespace provider
 CIMNamespaceProvider and the simple Interop and user namespace model
 defined in simple_interop_mock_model.mof.
+
+This mock script uses 'new-style' setup for Python >=3.5 and 'old-style' setup
+otherwise, and is therefore useable for all supported Python versions.
+On Python <3.5, the tests using this script must be run from the repo main
+directory.
 """
 
+import sys
 import os
 import pywbem_mock
 
@@ -11,7 +17,7 @@ import pywbem_mock
 INTEROP_NAMESPACE = 'interop'
 
 
-def setup(conn, server, verbose):
+def _setup(conn, server, verbose):
     # pylint: disable=unused-argument
     """
     Setup for this mock script.
@@ -25,17 +31,52 @@ def setup(conn, server, verbose):
     if INTEROP_NAMESPACE not in conn.cimrepository.namespaces:
         conn.add_namespace(INTEROP_NAMESPACE)
 
-    # This MOF file sets pragma namespace to 'interop' and 'root/cimv2'
-    mof_file = os.path.join(os.path.dirname(__file__),
+    if sys.version_info >= (3, 5):
+        this_file_path = __file__
+    else:
+        # Unfortunately, it does not seem to be possible to find the file path
+        # of the current script when it is executed using exec(), so we hard
+        # code the file path. This requires that the tests are run from the
+        # repo main directory.
+        this_file_path = 'tests/unit/simple_interop_mock_script.py'
+        assert os.path.exists(this_file_path)
+
+    mof_file = os.path.join(os.path.dirname(this_file_path),
                             'simple_interop_mock_model.mof')
-    mof_inc1_file = os.path.join(os.path.dirname(__file__),
+    mof_inc1_file = os.path.join(os.path.dirname(this_file_path),
                                  'mock_interop.mof')
-    mof_inc2_file = os.path.join(os.path.dirname(__file__),
+    mof_inc2_file = os.path.join(os.path.dirname(this_file_path),
                                  'simple_mock_model.mof')
     conn.compile_mof_file(mof_file, namespace=None)
-    conn.provider_dependent_registry.add_dependents(__file__, mof_file)
-    conn.provider_dependent_registry.add_dependents(__file__, mof_inc1_file)
-    conn.provider_dependent_registry.add_dependents(__file__, mof_inc2_file)
+    conn.provider_dependent_registry.add_dependents(
+        this_file_path, mof_file)
+    conn.provider_dependent_registry.add_dependents(
+        this_file_path, mof_inc1_file)
+    conn.provider_dependent_registry.add_dependents(
+        this_file_path, mof_inc2_file)
 
     ns_provider = pywbem_mock.CIMNamespaceProvider(conn.cimrepository)
     conn.register_provider(ns_provider, INTEROP_NAMESPACE, verbose=verbose)
+
+
+if sys.version_info >= (3, 5):
+    # New-style setup
+
+    # If the function is defined directly, it will be detected and refused
+    # by the check for setup() functions on Python <3.5, despite being defined
+    # only conditionally. The indirect approach with exec() addresses that.
+    # pylint: disable=exec-used
+    exec("""
+def setup(conn, server, verbose):
+    _setup(conn, server, verbose)
+""")
+
+else:
+    # Old-style setup
+
+    global CONN  # pylint: disable=global-at-module-level
+    global SERVER  # pylint: disable=global-at-module-level
+    global VERBOSE  # pylint: disable=global-at-module-level
+
+    # pylint: disable=undefined-variable
+    _setup(CONN, SERVER, VERBOSE)  # noqa: F821

--- a/tests/unit/test_namespace_cmds.py
+++ b/tests/unit/test_namespace_cmds.py
@@ -18,15 +18,11 @@ Tests the 'namespace' command group.
 
 from __future__ import absolute_import, print_function
 
-import sys
 import pytest
 
 from .cli_test_extensions import CLITestsBase
 from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
 
-
-# Condition to run testcases with mock scripts that have the new setup() func
-PY_MOCK = sys.version_info[0:2] >= (3, 5)
 
 # The mock files used for testing
 TEST_INTEROP_MOCK_FILE = 'simple_interop_mock_script.py'
@@ -166,7 +162,7 @@ TEST_CASES = [
             ],
             test='innows'
         ),
-        TEST_INTEROP_MOCK_FILE, PY_MOCK
+        TEST_INTEROP_MOCK_FILE, True
     ),
     (
         "Verify that command 'namespace list' fails when there is no "
@@ -211,7 +207,7 @@ TEST_CASES = [
             stdout=['Created namespace foo'],
             test='innows'
         ),
-        TEST_INTEROP_MOCK_FILE, PY_MOCK
+        TEST_INTEROP_MOCK_FILE, True
     ),
     (
         "Verify that command 'namespace create foo' creates the namespace "
@@ -230,7 +226,7 @@ TEST_CASES = [
             ],
             test='innows'
         ),
-        TEST_INTEROP_MOCK_FILE, PY_MOCK
+        TEST_INTEROP_MOCK_FILE, True
     ),
     (
         "Verify that command 'namespace create root/cimv2' fails because it "
@@ -241,7 +237,7 @@ TEST_CASES = [
             stderr=['CIMError.*CIM_ERR_ALREADY_EXISTS.*already exists'],
             test='regex'
         ),
-        TEST_INTEROP_MOCK_FILE, PY_MOCK
+        TEST_INTEROP_MOCK_FILE, True
     ),
     (
         "Verify that command 'namespace create interop' fails when there is no "
@@ -287,7 +283,7 @@ TEST_CASES = [
             stderr=['CIMError.*CIM_ERR_NOT_FOUND.*namespace does not exist'],
             test='regex'
         ),
-        TEST_INTEROP_MOCK_FILE, PY_MOCK
+        TEST_INTEROP_MOCK_FILE, True
     ),
     (
         "Verify that command 'namespace delete root/cimv2' fails because it "
@@ -299,7 +295,7 @@ TEST_CASES = [
                     'empty'],
             test='regex'
         ),
-        TEST_INTEROP_MOCK_FILE, PY_MOCK
+        TEST_INTEROP_MOCK_FILE, True
     ),
     (
         "Verify that command 'namespace delete foo' succeeds when foo exists "
@@ -319,7 +315,7 @@ TEST_CASES = [
             ],
             test='innows'
         ),
-        TEST_INTEROP_MOCK_FILE, PY_MOCK
+        TEST_INTEROP_MOCK_FILE, True
     ),
 
     #
@@ -355,7 +351,7 @@ TEST_CASES = [
             ],
             test='innows'
         ),
-        TEST_INTEROP_MOCK_FILE, PY_MOCK
+        TEST_INTEROP_MOCK_FILE, True
     ),
     (
         "Verify that command 'namespace interop' fails when there is no "


### PR DESCRIPTION
See commit message.
Set to priority because it is expected to address the <90% coverage issue for other PRs.