### PR TITLE
Fixes #912: Refactor pywbemcli to issue disconnect part2

### DIFF
--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -681,17 +681,18 @@ def cmd_connection_select(context, name, options):
                          context.verbose,
                          context.pdb,
                          context.warn,
-                         context.connections_repo)
+                         context.connections_repo,
+                         context.interactive_mode,
+                         False)
 
     # Update the root context making this context the basis for future
     # commands in the current interactive session
     ContextObj.update_root_click_context(new_ctx)
 
-    # close any existing connection.
-    # TODO/KS: Validate that the first test is required.
-    if context.pywbem_server_exists():
-        if context.is_connected:
-            context.pywbem_server.disconnect()
+    # Close any existing connection.
+    if context.is_connected():
+        context.pywbem_server.disconnect()
+
     context.spinner_stop()
     if options['default']:
         connections_repo.default_connection_name = name

--- a/pywbemtools/pywbemcli/_cmd_statistics.py
+++ b/pywbemtools/pywbemcli/_cmd_statistics.py
@@ -215,23 +215,6 @@ OBJMGR_STAT_PROPERTY_NAME = "GatherStatisticalData"
 CIMOM_STATISTICAL_DATA_CLASS = "CIM_CIMOMStatisticalData"
 
 
-def test_conn_exists(context):
-    """
-    Test if server defined.
-
-    Returns if server defined
-
-    Exception:
-       click.Exception if no current server.
-    """
-    # TODO/KS: Is this necessary since we should be protecting with classes
-    #          or does the pywbem_server access provide same protection??
-    conn = context.pywbem_server.conn
-    if not conn:
-        raise click.ClickException(
-            'No server defined in current context.')
-
-
 def get_objmgr_inst(context):
     """
     Return the state of statistics gathering on the server.
@@ -342,7 +325,6 @@ def cmd_statistics_server_on(context):
     Attempt to enable the statistics gathering on the current server if there
     is a current server defined.
     """
-    test_conn_exists(context)
     set_server_statistics(context, True)
 
 
@@ -351,7 +333,6 @@ def cmd_statistics_server_off(context):
     Attempt to disable the statistics gathering on the current server if there
     is a current server defined.
     """
-    test_conn_exists(context)
     set_server_statistics(context, False)
 
 
@@ -370,10 +351,8 @@ def cmd_statistics_status(context):
     """
 
     # validate output format with default of table
-    output_format = validate_output_format(context.output_format, ['TABLE',
-                                                                   'TEXT'])
-
-    test_conn_exists(context)
+    output_format = validate_output_format(context.output_format,
+                                           ['TABLE', 'TEXT'])
 
     # Display server status as on/off
     try:
@@ -410,7 +389,6 @@ def cmd_statistics_reset(context):
     It does reset the statistics kept in the pywbem client for server
     response time.
     """
-    test_conn_exists(context)
 
     conn = context.pywbem_server.conn
     conn.statistics.reset()
@@ -424,11 +402,10 @@ def cmd_statistics_show(context):
     If the statistics are enabled for the client and the connection exits,
     display the statistics
     """
-    test_conn_exists(context)
+
     conn = context.pywbem_server.conn
 
     context.spinner_stop()
-
     click.echo(context.format_statistics(conn.statistics, context))
 
 
@@ -576,9 +553,6 @@ def cmd_statistics_server_show(context):
             #       Since we want to be able to relate that to the server time
             #       in the client statistics, we calculate the server time
             #       as CIMOM time plus provider time.
-            # TODO: Clarify for OpenPegasus whether CimomElapsedTime is just
-            #       CIMOM time as described, or is already the total server
-            #       time.
             avg_server_time_ms = avg_cimom_time_ms + avg_provider_time_ms
 
             avg_request_size = avg_value(inst['RequestSize'],

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -848,7 +848,7 @@ def test_pick_one_from_list(testcase, options, choices, exp_rtn):
     # test option with only one choice bypasses user request
     if not choices:
         context = ContextObj(None, None, None, None, None, None, None, None,
-                             None, None)
+                             None, None, False, False)
 
         # The code to be tested
         act_rtn = pick_one_from_list(context, options, title)
@@ -867,7 +867,7 @@ def test_pick_one_from_list(testcase, options, choices, exp_rtn):
             with patch(mock_echo_func):
                 # Fake context object
                 context = ContextObj(None, None, None, None, None, None, None,
-                                     None, None, None)
+                                     None, None, None, False, False)
 
                 # The code to be tested
                 act_rtn = pick_one_from_list(context, options, title)

--- a/tests/unit/test_context_obj.py
+++ b/tests/unit/test_context_obj.py
@@ -44,6 +44,8 @@ def test_ContextObj_init():
     pdb = False
     warn = False
     connections_repo = None
+    interactive_mode = True
+    close_interactive_server = True
 
     ctxobj = ContextObj(
         pywbem_server=svr,
@@ -55,6 +57,9 @@ def test_ContextObj_init():
         verbose=verbose,
         pdb=pdb,
         warn=warn,
-        connections_repo=connections_repo)
+        connections_repo=connections_repo,
+        interactive_mode=interactive_mode,
+        close_interactive_server=close_interactive_server)
 
     assert ctxobj.pywbem_server == svr
+    assert ctxobj.interactive_mode is True

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -33,6 +33,9 @@ from .cli_test_extensions import CLITestsBase, PYWBEM_0, PYWBEM_1
 from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
 
 TEST_DIR = os.path.dirname(__file__)
+CONNECTION_REPO_TEST_FILE_PATH = os.path.join(TEST_DIR,
+                                              'tst_general_options.yaml')
+CONN_REPO_FP_STR = str(CONNECTION_REPO_TEST_FILE_PATH)
 
 
 def GET_TEST_PATH_STR(filename):  # pylint: disable=invalid-name
@@ -51,6 +54,8 @@ SIMPLE_MOCK_FILE_PATH = os.path.join(TEST_DIR, SIMPLE_MOCK_MODEL_FILE)
 PYTHON_MOCK_FILE_PATH = os.path.join(TEST_DIR, 'simple_python_mock_script.py')
 BAD_MOF_FILE_PATH = os.path.join(TEST_DIR, 'mof_with_error.mof')
 BAD_PY_FILE_PATH = os.path.join(TEST_DIR, 'py_with_error.py')
+
+MOCK_SERVER_MODEL = os.path.join(TEST_DIR, 'testmock', 'wbemserver_mock.py')
 
 GENERAL_HELP_LINES = [
     """
@@ -1287,7 +1292,6 @@ TEST_CASES = [
       'test': 'innows'},
      None, FAIL],
 
-
     ['Verify operation that makes request to WBEM server fails with no server.',
      {'args': ['enumerate'],
       'cmdgrp': 'class', },
@@ -1298,7 +1302,7 @@ TEST_CASES = [
 
     #
     #  Verify operation that tries interactive general options for name
-    #  and server/mock server fails
+    #  and server/mock server fails.
     #
 
     ['Test conflicting server defintions interactive mode.',
@@ -1307,6 +1311,57 @@ TEST_CASES = [
       'rc': 0,
       'test': 'innows'},
      None, OK],
+
+    #
+    # Test of 3 ways to execute same simple command. Creates a mock
+    # and tests combination of single comman. Uses -v to test for
+    # Connect and disconnect
+
+    ['Verify new config file with defined data is created and saved.',
+     {'general': ['-v', '-C', CONN_REPO_FP_STR],
+      'stdin': ['connection save blah',
+                'connection show']},
+     {'stdout': ['default-namespace root/cimv2'],
+      'test': 'innows'},
+     SIMPLE_MOCK_MODEL_FILE, OK],
+
+    ['Verify simple pywbem command against file works and verbose connect and '
+     'disconnect work.',
+     {'general': ['-n', 'blah', '-v', '-C', CONN_REPO_FP_STR],
+      'args': ['enumerate', '--di', '--no', '--subclass-of', 'CIM_Foo_sub'],
+      'cmdgrp': 'class'},
+     {'stdout': ["Connecting to mock environment",
+                 'CIM_Foo_sub_sub',
+                 "Disconnecting from mock environment"],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify simple pywbem command with stdin on same connection name.',
+     {'general': ['-n', 'blah', '-v', '-C', CONN_REPO_FP_STR],
+      'stdin': ['class enumerate --di --no --subclass-of CIM_Foo_sub']},
+     {'stdout': ["Connecting to mock environment",
+                 'CIM_Foo_sub_sub',
+                 "Disconnecting from mock environment"],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify cmd with -n option in stdin.',
+     {'general': ['-n', 'blah', '-v', '-C', CONN_REPO_FP_STR],
+      'stdin': ['-n blah -v class enumerate --di --no '
+                '--subclass-of CIM_Foo_sub']},
+     {'stdout': ["Connecting to mock environment",
+                 'CIM_Foo_sub_sub',
+                 "Disconnecting from mock environment"],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify interactive create mock with bad file name does not fail.',
+     {'general': ['-v', '-C', CONN_REPO_FP_STR],
+      'stdin': ['connection delete blah']},
+     {'stdout': ['Deleted connection "blah"'],
+      'test': 'innows', },
+     None, OK],
+
 ]
 
 # TODO add test for pull operations with pull ops max size variations


### PR DESCRIPTION
See commit message

NOTE: This PR also removes the temporary PR900 flagged code/comments and actually does the close, etc. and corrects the
issue where the disconnect was not issued under all circmstances of the combination of general options and use of stdin