### PR TITLE
Add verbose mode displays for connection file load and save and fix one isse

### DIFF
--- a/pywbemtools/pywbemcli/_connection_repository.py
+++ b/pywbemtools/pywbemcli/_connection_repository.py
@@ -94,8 +94,8 @@ class ConnectionsFileLoadError(ConnectionsFileError):
           message (:term:`string`): Text describing just the error
             (without text like 'Cannot load connection file {file}').
         """
-        msg = 'Cannot load connections file "{0}": {1}'. \
-            format(connections_file, message)
+        msg = 'Cannot load connections file "{0}": {1}'.format(connections_file,
+                                                               message)
         super(ConnectionsFileLoadError, self).__init__(msg)
 
 
@@ -124,7 +124,7 @@ class ConnectionRepository(object):
     example that defines a mock connection named 'mock1', a server connection
     named 'server1', and defines 'mock1' as the default connection. The
     properties of each connection definition are the attributes of PywbemServer
-    objects::
+    objects:
 
         connection_definitions:
             mock1:
@@ -168,7 +168,7 @@ class ConnectionRepository(object):
     # default connection name
     default_connection_grp_name = 'default_connection_name'
 
-    def __init__(self, connections_file):
+    def __init__(self, connections_file, verbose=None):
         """
         Initialize the object. The connections file is not yet loaded.
 
@@ -176,6 +176,9 @@ class ConnectionRepository(object):
 
           connections_file (:term:`string`):
             Path name of the connections file. Must not be `None`.
+
+          verbose (:class:`py:bool`):
+            If `True` enables progress console displays.
         """
 
         # Dictionary of connection definitions.
@@ -192,6 +195,7 @@ class ConnectionRepository(object):
         # Name of the default connection definition.
         # `None`, if there is no default connection definition.
         self._default_connection_name = None
+        self._verbose = verbose
 
     @property
     def connections_file(self):
@@ -493,6 +497,9 @@ class ConnectionRepository(object):
                             'definition "{0}": {1}'.format(name, ve))
                     self._pywbemcli_servers[name] = server
                 self._loaded = True
+                if self._verbose:
+                    click.echo("Connections file loaded: {}".
+                               format(self._connections_file))
 
         except (OSError, IOError) as exc:
             raise ConnectionsFileLoadError(
@@ -659,3 +666,6 @@ class ConnectionRepository(object):
                 self._connections_file,
                 'Error renaming temporary file "{0}" to connections file '
                 '"{1}": {2}'.format(tmpfile, self._connections_file, exc))
+        if self._verbose:
+            click.echo("Connections file saved: {}".
+                       format(self._connections_file))

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -678,9 +678,7 @@ def cli(ctx, server, connection_name, default_namespace, user, password,
         # for the connection defined by the cmd line input)
 
         connections_repo = ConnectionRepository(
-            connections_file or DEFAULT_CONNECTIONS_FILE)
-        if verbose:
-            click.echo(str(connections_repo))
+            connections_file or DEFAULT_CONNECTIONS_FILE, verbose)
 
         pywbem_server = _create_server_instance(server, connection_name,
                                                 resolved_default_namespace,
@@ -705,11 +703,11 @@ def cli(ctx, server, connection_name, default_namespace, user, password,
     # decorators that define them.
 
     else:  # ctx.obj exists. Processing an interactive command.
-        # Issue # 920Imposed this limit to avoid confusion at least for current
-        # release of pywbemcli.  Consider relaxing this in the future.
+        # Issue # 920Imposed this limit to avoid confusion of changing
+        # connections file in interactive mode
         if connections_file:
-            click.ClickException("--connections-file general option not "
-                                 "allowed in interactive mode.")
+            raise click.ClickException('General option "--connections-file" '
+                                       'not allowed in interactive mode.')
         connections_repo = ctx.obj.connections_repo
         # Apply the general options from the command line options
         # or from the context object to modify the PywbemServer object and

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -919,6 +919,22 @@ TEST_CASES = [
       'test': 'regex'},
      None, OK],
 
+    ['Verify --connection-file general option not allowed in interactive mode.',
+     {'general': ['--server', 'http://blah', ],
+      'stdin': ['--connections-file blah.yaml connection list']},
+     {'stderr': ['General option "--connections-file" not allowed in '
+                 'interactive mode'],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify -C general option not allowed in interactive mode.',
+     {'general': ['--server', 'http://blah', ],
+      'stdin': ['-C blah.yaml connection list']},
+     {'stderr': ['General option "--connections-file" not allowed in '
+                 'interactive mode'],
+      'test': 'innows'},
+     None, OK],
+
     #
     #  Test setting general options in interactive mode
     #


### PR DESCRIPTION
1. Added verbose mode display for connection file load and save. Removed another display when conneciton file used that displayed too much information.
2.  Fixed issue where raise was missing on a click.ClickException
3. Added ttests for the case of connection file general option in interactive mode.