### PR TITLE
Fixes issue# 935,  Confusing exception display from server add_mof and remove_mof()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -70,6 +70,9 @@ Released: not yet
   and displaying of PYWBEMCLI environment variables during testing in verbose
   mode.
 
+* Change add_mof() to only display exceptions received if not MOFCompileError
+  since the MOF compiler logs all MOFCompileError exceptions. (see issue #395)
+
 **Enhancements:**
 
 * Increased the minimum pywbem version to 1.2.0.

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -29,7 +29,7 @@ import sys
 import click
 
 from pywbem import Error, MOFCompiler
-from pywbem._mof_compiler import MOFWBEMConnection
+from pywbem._mof_compiler import MOFWBEMConnection, MOFCompileError
 
 from .pywbemcli import cli
 from ._common import format_table, pywbem_error_exception, \
@@ -333,6 +333,11 @@ def cmd_server_add_mof(context, options):
                 # inside of the MOF compiler.
                 mofcomp.compile_file(moffile, options['namespace'])
 
+    # If MOFCompileError, exception already logged by compile_string().
+    except MOFCompileError:
+        raise click.ClickException("Compile failed.")
+
+    # Otherwise display the exception itself
     except Error as exc:
         raise pywbem_error_exception(exc)
 
@@ -392,6 +397,7 @@ def cmd_server_remove_mof(context, options):
                 # inside of the MOF compiler.
                 mofcomp.compile_file(moffile, options['namespace'])
 
+        # rollback the compiled objects to remove them from the target.
         if not options['dry_run']:
             if context.verbose:
                 print('Deleting CIM objects found in MOF...')
@@ -399,6 +405,8 @@ def cmd_server_remove_mof(context, options):
         else:
             if context.verbose:
                 print('No deletions will be shown in dry-run mode')
-
+    # If MOFCompileError, exception already logged by compile_string().
+    except MOFCompileError:
+        raise click.ClickException("Compile failed.")
     except Error as exc:
         raise pywbem_error_exception(exc)

--- a/tests/unit/test_server_cmds.py
+++ b/tests/unit/test_server_cmds.py
@@ -259,8 +259,8 @@ TEST_CASES = [
     ['Verify server command add-mof of same mock file fails',
      {'args': ['add-mof', SIMPLE_MOCK_MODEL_FILEPATH],
       'general': []},
-     {'stdout': ['Error modifying class root/cimv2:CIM_BaseRef:.* cannot be '
-                 'modified because it has subclasses'],
+     {'stdout': ["Class 'CIM_BaseRef' namespace 'root/cimv2' cannot be "
+                 "modified because it has subclasses"],
       'rc': 1,
       'test': 'regex'},
      SIMPLE_MOCK_MODEL, OK],


### PR DESCRIPTION
Proposal to fix the pywbemcli component of issue #395.

Modified server add_mof and remove_mofto only display the exception received from the call to
the compiler compile_string() exception if it is NOT MOFCompileError
exception.  The compile_string() method creates a log entry with any exception from calling the compiler and then raises the exception again so we were duplicating the exception display