### PR TITLE
[DROP] Added listener command group to pywbemcli

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,16 @@ jobs:
                 \"os\": \"macos-latest\", \
                 \"python-version\": \"3.4\", \
                 \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"windows-latest\", \
+                \"python-version\": \"3.4\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"windows-latest\", \
+                \"python-version\": \"3.4\", \
+                \"package_level\": \"latest\" \
               } \
             ], \
             \"include\": [ \
@@ -113,12 +123,12 @@ jobs:
               }, \
               { \
                 \"os\": \"windows-latest\", \
-                \"python-version\": \"3.4\", \
+                \"python-version\": \"3.5\", \
                 \"package_level\": \"minimum\" \
               }, \
               { \
                 \"os\": \"windows-latest\", \
-                \"python-version\": \"3.4\", \
+                \"python-version\": \"3.5\", \
                 \"package_level\": \"latest\" \
               } \
             ] \

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,9 @@ Released: not yet
 
 **Enhancements:**
 
+* Added support for managing WBEM indication listeners by adding a command
+  group 'listener'. (issue #430)
+
 **Cleanup:**
 
 **Known issues:**

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -146,6 +146,7 @@ Help text for ``pywbemcli``:
     Commands:
       class       Command group for CIM classes.
       instance    Command group for CIM instances.
+      listener    Command group for WBEM indication listeners.
       namespace   Command group for CIM namespaces.
       profile     Command group for WBEM management profiles.
       qualifier   Command group for CIM qualifier declarations.
@@ -1598,6 +1599,201 @@ Help text for ``pywbemcli instance shrub`` (see :ref:`instance shrub command`):
                                       --namespace options.
 
       -h, --help                      Show this help message.
+
+
+.. _`pywbemcli listener --help`:
+
+pywbemcli listener --help
+-------------------------
+
+
+
+Help text for ``pywbemcli listener`` (see :ref:`listener command group`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] listener COMMAND [ARGS] [COMMAND-OPTIONS]
+
+      Command group for WBEM indication listeners.
+
+      This command group defines commands to manage WBEM indication listeners. Each listener is a process that executes
+      the `pywbemcli listener run` command to receive WBEM indications sent from a WBEM server.
+
+      A listener process can be started with the `pywbemcli listener start` command and stopped with the `pywbemcli
+      listener stop` command.
+
+      There is no central registration of the currently running listeners. Instead, the currently running processes
+      executing the `pywbemcli listener run` command are by definition the currently running listeners. Because of this,
+      there is no notion of a stopped listener nor does a listener have an operational status.
+
+      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help')
+      can also be specified before the 'connection' keyword.
+
+    Command Options:
+      -h, --help  Show this help message.
+
+    Commands:
+      run    Run as a named WBEM indication listener.
+      start  Start a named WBEM indication listener in the background.
+      stop   Stop a named WBEM indication listener.
+      show   Show a named WBEM indication listener.
+      list   List the currently running named WBEM indication listeners.
+
+
+.. _`pywbemcli listener list --help`:
+
+pywbemcli listener list --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli listener list`` (see :ref:`listener list command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] listener list [COMMAND-OPTIONS]
+
+      List the currently running named WBEM indication listeners.
+
+      This is done by listing the currently running `pywbemcli listener run` commands.
+
+    Command Options:
+      -h, --help  Show this help message.
+
+
+.. _`pywbemcli listener run --help`:
+
+pywbemcli listener run --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli listener run`` (see :ref:`listener run command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] listener run NAME [COMMAND-OPTIONS]
+
+      Run as a named WBEM indication listener.
+
+      Run this command as a named WBEM indication listener until it gets terminated, e.g. by a keyboard interrupt, break
+      signal (e.g. kill), or the `pywbemcli listener stop` command.
+
+      A listener with that name must not be running, otherwise the command fails.
+
+      Examples:
+
+        pywbemcli listener run lis1
+
+    Command Options:
+      --port PORT          The port number the listener will open to receive indications. This can be any available port.
+                           Default: 25989
+
+      --protocol PROTOCOL  The protocol used by the listener (http, https). Default: https
+      --certfile FILE      Path name of a PEM file containing the certificate that will be presented as a server certificate
+                           during SSL/TLS handshake. Required when using https. The file may in addition contain the private
+                           key of the certificate.
+
+      --keyfile FILE       Path name of a PEM file containing the private key of the server certificate. Required when using
+                           https and when the certificate file does not contain the private key. Default: Certificate file.
+
+      -h, --help           Show this help message.
+
+
+.. _`pywbemcli listener show --help`:
+
+pywbemcli listener show --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli listener show`` (see :ref:`listener show command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] listener show NAME [COMMAND-OPTIONS]
+
+      Show a named WBEM indication listener.
+
+      A listener with that name must be running, otherwise the command fails.
+
+      Examples:
+
+        pywbemcli listener stop lis1
+
+    Command Options:
+      -h, --help  Show this help message.
+
+
+.. _`pywbemcli listener start --help`:
+
+pywbemcli listener start --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli listener start`` (see :ref:`listener start command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] listener start NAME [COMMAND-OPTIONS]
+
+      Start a named WBEM indication listener in the background.
+
+      A listener with that name must not be running, otherwise the command fails.
+
+      A listener is identified by its hostname or IP address and a port number. It can be started with any free port.
+
+      Examples:
+
+        pywbemcli listener start lis1
+
+    Command Options:
+      --port PORT          The port number the listener will open to receive indications. This can be any available port.
+                           Default: 25989
+
+      --protocol PROTOCOL  The protocol used by the listener (http, https). Default: https
+      --certfile FILE      Path name of a PEM file containing the certificate that will be presented as a server certificate
+                           during SSL/TLS handshake. Required when using https. The file may in addition contain the private
+                           key of the certificate.
+
+      --keyfile FILE       Path name of a PEM file containing the private key of the server certificate. Required when using
+                           https and when the certificate file does not contain the private key. Default: Certificate file.
+
+      -h, --help           Show this help message.
+
+
+.. _`pywbemcli listener stop --help`:
+
+pywbemcli listener stop --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli listener stop`` (see :ref:`listener stop command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] listener stop NAME [COMMAND-OPTIONS]
+
+      Stop a named WBEM indication listener.
+
+      The listener will shut down gracefully.
+
+      A listener with that name must be running, otherwise the command fails.
+
+      Examples:
+
+        pywbemcli listener stop lis1
+
+    Command Options:
+      -h, --help  Show this help message.
 
 
 .. _`pywbemcli namespace --help`:

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -20,7 +20,9 @@
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
-pywbem==1.2.0
+
+# TODO: Enable pywbem 1.3.0 once released, before releasing pywbemtools
+# pywbem==1.3.0
 # When using the GitHub master branch of pywbem, simply comment out the line
 # above, since links are not allowed in constraint files - the minimum will be
 # ensured by requirements.txt then.
@@ -44,6 +46,7 @@ PyYAML==5.3.1; python_version >= '3.5'
 yamlloader==0.5.5
 mock==3.0.0
 toposort==1.6
+psutil==5.5.0
 
 # Virtualenv
 virtualenv==14.0.0; python_version < '3.5'

--- a/pywbemtools/pywbemcli/__init__.py
+++ b/pywbemtools/pywbemcli/__init__.py
@@ -32,6 +32,7 @@ from ._cmd_server import *          # noqa: F403,F401
 from ._cmd_connection import *      # noqa: F403,F401
 from ._cmd_profile import *         # noqa: F403,F401
 from ._cmd_statistics import *      # noqa: F403,F401
+from ._cmd_listener import *        # noqa: F403,F401
 from ._context_obj import *         # noqa: F403,F401
 from ._connection_repository import *   # noqa: F403,F401
 from .pywbemcli import *            # noqa: F403,F401

--- a/pywbemtools/pywbemcli/_cmd_listener.py
+++ b/pywbemtools/pywbemcli/_cmd_listener.py
@@ -1,0 +1,833 @@
+# (C) Copyright 2021 Inova Development Inc.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Click Command definition for the listener command group which includes
+cmds to manage indication listeners that are separate invocations of
+pywbemcli representing a listener.
+
+NOTE: Commands are ordered in help display by their order in this file.
+"""
+
+from __future__ import absolute_import, print_function
+
+import os
+import subprocess
+import signal
+import atexit
+import threading
+import argparse
+from time import sleep
+from datetime import datetime
+import click
+import psutil
+import six
+
+from pywbem import WBEMListener, ListenerError
+
+from .pywbemcli import cli
+from ._common import CMD_OPTS_TXT, GENERAL_OPTS_TXT, SUBCMD_HELP_TXT, \
+    format_table
+from ._common_options import add_options, help_option
+from ._click_extensions import PywbemcliGroup, PywbemcliCommand
+
+# Print debug messages related to process handling
+DEBUG_PROCESS = False
+
+# Signals used for having the 'listener run' command signal startup completion
+# back to its parent 'listener start' process.
+# The default handlers for these signals are replaced.
+# The success signal can be any signal that can be handled.
+# In order to handle keyboard interrupts during password prompt correctly,
+# the failure signal must be SIGINT.
+try:
+    # Unix/Linux/macOS
+    # pylint: disable=no-member
+    SIGNAL_RUN_STARTUP_SUCCESS = signal.SIGUSR1
+except AttributeError:
+    # native Windows
+    # pylint: disable=no-member
+    SIGNAL_RUN_STARTUP_SUCCESS = signal.SIGBREAK
+SIGNAL_RUN_STARTUP_FAILURE = signal.SIGINT
+
+# Status and condition used to communicate the startup completion status of the
+# 'listener run' process between the signal handlers and other functions in the
+# 'listener start' process.
+RUN_STARTUP_STATUS = None
+RUN_STARTUP_COND = threading.Condition()
+
+# Timeout in seconds for the 'listener run' command starting up. This timeout
+# also ends a possible prompt for the password of the private key file.
+RUN_STARTUP_TIMEOUT = 60
+
+DEFAULT_LISTENER_PORT = 25989
+DEFAULT_LISTENER_PROTOCOL = 'https'
+
+LISTEN_OPTIONS = [
+    click.option('--port', type=int, metavar='PORT',
+                 required=False, default=DEFAULT_LISTENER_PORT,
+                 help=u'The port number the listener will open to receive '
+                 'indications. This can be any available port. '
+                 'Default: {}'.format(DEFAULT_LISTENER_PORT)),
+    click.option('--protocol', type=click.Choice(['http', 'https']),
+                 metavar='PROTOCOL',
+                 required=False, default=DEFAULT_LISTENER_PROTOCOL,
+                 help=u'The protocol used by the listener (http, https). '
+                 'Default: {}'.format(DEFAULT_LISTENER_PROTOCOL)),
+    click.option('--certfile', type=str, metavar='FILE',
+                 required=False, default=None,
+                 help=u'Path name of a PEM file containing the certificate '
+                 'that will be presented as a server certificate during '
+                 'SSL/TLS handshake. Required when using https. '
+                 'The file may in addition contain the private key of the '
+                 'certificate.'),
+    click.option('--keyfile', type=str, metavar='FILE',
+                 required=False, default=None,
+                 help=u'Path name of a PEM file containing the private key '
+                 'of the server certificate. '
+                 'Required when using https and when the certificate file '
+                 'does not contain the private key. '
+                 'Default: Certificate file.'),
+]
+
+
+class ListenerProperties(object):
+    """
+    The properties of a running named listener.
+    """
+
+    def __init__(self, name, port, protocol, certfile, keyfile, pid, created):
+        self._name = name
+        self._port = port
+        self._protocol = protocol
+        self._certfile = certfile
+        self._keyfile = keyfile
+        self._pid = pid
+        self._created = created
+
+    def show_row(self):
+        """Return a tuple of the properties for 'listener show' command"""
+        return (
+            self.name,
+            str(self.port),
+            self.protocol,
+            self.certfile,
+            self.keyfile,
+            str(self.pid),
+            self.created.strftime("%Y-%m-%d %H:%M:%S"),
+        )
+
+    @staticmethod
+    def show_headers():
+        """Return a tuple of the header labels for 'listener show' command"""
+        return (
+            'Name',
+            'Port',
+            'Protocol',
+            'Certificate file',
+            'Key file',
+            'PID',
+            'Created',
+        )
+
+    def list_row(self):
+        """Return a tuple of the properties for 'listener list' command"""
+        return (
+            self.name,
+            str(self.port),
+            self.protocol,
+            str(self.pid),
+            self.created.strftime("%Y-%m-%d %H:%M:%S"),
+        )
+
+    @staticmethod
+    def list_headers():
+        """Return a tuple of the header labels for 'listener list' command"""
+        return (
+            'Name',
+            'Port',
+            'Protocol',
+            'PID',
+            'Created',
+        )
+
+    @property
+    def name(self):
+        """string: Name of the listener"""
+        return self._name
+
+    @property
+    def port(self):
+        """int: Port number of the listener"""
+        return self._port
+
+    @property
+    def protocol(self):
+        """string: Protocol of the listener"""
+        return self._protocol
+
+    @property
+    def certfile(self):
+        """string: Path name of certificate file of the listener"""
+        return self._certfile
+
+    @property
+    def keyfile(self):
+        """string: Path name of key file of the listener"""
+        return self._keyfile
+
+    @property
+    def pid(self):
+        """int: Process ID of the listener"""
+        return self._pid
+
+    @property
+    def created(self):
+        """datetime: Point in time when the listener process was created"""
+        return self._created
+
+
+@cli.group('listener', cls=PywbemcliGroup, options_metavar=GENERAL_OPTS_TXT,
+           subcommand_metavar=SUBCMD_HELP_TXT)
+@add_options(help_option)
+def listener_group():
+    """
+    Command group for WBEM indication listeners.
+
+    This command group defines commands to manage WBEM indication listeners.
+    Each listener is a process that executes the `pywbemcli listener run`
+    command to receive WBEM indications sent from a WBEM server.
+
+    A listener process can be started with the `pywbemcli listener start`
+    command and stopped with the `pywbemcli listener stop` command.
+
+    There is no central registration of the currently running listeners.
+    Instead, the currently running processes executing the
+    `pywbemcli listener run` command are by definition the currently running
+    listeners. Because of this, there is no notion of a stopped listener nor
+    does a listener have an operational status.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'pywbemcli --help') can also be specified before the
+    'connection' keyword.
+    """
+    pass  # pylint: disable=unnecessary-pass
+
+
+@listener_group.command('run', cls=PywbemcliCommand,
+                        options_metavar=CMD_OPTS_TXT)
+@click.argument('name', type=str, metavar='NAME', required=True)
+@add_options(LISTEN_OPTIONS)
+@add_options(help_option)
+@click.pass_obj
+def listener_run(context, **options):
+    """
+    Run as a named WBEM indication listener.
+
+    Run this command as a named WBEM indication listener until it gets
+    terminated, e.g. by a keyboard interrupt, break signal (e.g. kill), or the
+    `pywbemcli listener stop` command.
+
+    A listener with that name must not be running, otherwise the command fails.
+
+    Examples:
+
+      pywbemcli listener run lis1
+    """
+    context.execute_cmd(lambda: cmd_listener_run(context, options))
+
+
+@listener_group.command('start', cls=PywbemcliCommand,
+                        options_metavar=CMD_OPTS_TXT)
+@click.argument('name', type=str, metavar='NAME', required=True)
+@add_options(LISTEN_OPTIONS)
+@add_options(help_option)
+@click.pass_obj
+def listener_start(context, **options):
+    """
+    Start a named WBEM indication listener in the background.
+
+    A listener with that name must not be running, otherwise the command fails.
+
+    A listener is identified by its hostname or IP address and a port number.
+    It can be started with any free port.
+
+    Examples:
+
+      pywbemcli listener start lis1
+    """
+    context.execute_cmd(lambda: cmd_listener_start(context, options))
+
+
+@listener_group.command('stop', cls=PywbemcliCommand,
+                        options_metavar=CMD_OPTS_TXT)
+@click.argument('name', type=str, metavar='NAME', required=True)
+@add_options(help_option)
+@click.pass_obj
+def listener_stop(context, name):
+    """
+    Stop a named WBEM indication listener.
+
+    The listener will shut down gracefully.
+
+    A listener with that name must be running, otherwise the command fails.
+
+    Examples:
+
+      pywbemcli listener stop lis1
+    """
+    context.execute_cmd(lambda: cmd_listener_stop(context, name))
+
+
+@listener_group.command('show', cls=PywbemcliCommand,
+                        options_metavar=CMD_OPTS_TXT)
+@click.argument('name', type=str, metavar='NAME', required=True)
+@add_options(help_option)
+@click.pass_obj
+def listener_show(context, name):
+    """
+    Show a named WBEM indication listener.
+
+    A listener with that name must be running, otherwise the command fails.
+
+    Examples:
+
+      pywbemcli listener stop lis1
+    """
+    context.execute_cmd(lambda: cmd_listener_show(context, name))
+
+
+@listener_group.command('list', cls=PywbemcliCommand,
+                        options_metavar=CMD_OPTS_TXT)
+@add_options(help_option)
+@click.pass_obj
+def listener_list(context):
+    """
+    List the currently running named WBEM indication listeners.
+
+    This is done by listing the currently running `pywbemcli listener run`
+    commands.
+    """
+    context.execute_cmd(lambda: cmd_listener_list(context))
+
+
+################################################################
+#
+#   Common methods for The action functions for the listener click group
+#
+###############################################################
+
+def get_listeners(name=None):
+    """
+    List the running listener processes, or the running listener process(es)
+    with the specified name.
+
+    Note that in case of the 'listener run' command, it is possible that this
+    function is called with a name and finds two listener processes with that
+    name: A previosly started one, and the one that is about to run now.
+    Both will be returned so this situation can be handled by the caller.
+
+    Returns:
+      list of ListenerProperties
+    """
+    ret = []
+    for p in psutil.process_iter():
+        try:
+            cmdline = p.cmdline()
+        except (psutil.AccessDenied, psutil.ZombieProcess):
+            # Ignore processes we cannot access
+            continue
+        seen_pywbemcli = False
+        for i, item in enumerate(cmdline):
+            if item.endswith('pywbemcli'):
+                seen_pywbemcli = True
+                continue
+            if seen_pywbemcli and item == 'listener':
+                listener_index = i
+                break
+        else:
+            # Ignore processes that are not 'pywbemcli [opts] listener'
+            continue
+        listener_args = cmdline[listener_index + 1:]  # After 'listener'
+        args = parse_listener_args(listener_args)
+        if args:
+            if name is None or args.name == name:
+                listener = ListenerProperties(
+                    name=args.name, port=args.port, protocol=args.protocol,
+                    certfile=args.certfile, keyfile=args.keyfile,
+                    pid=p.pid, created=datetime.fromtimestamp(p.create_time()))
+                ret.append(listener)
+    return ret
+
+
+def is_parent_start():
+    """
+    Determine whether the parent process is a 'listener start' command, and
+    return its PID if so. Otherwise, return None.
+
+    This is used by the 'listener run' command to find out whether it is
+    executed directly by a user, vs. launched by the 'listener start' command,
+    so it can signal startup completion to the 'listener start' command.
+
+    Returns:
+      int: PID of parent process, if it is 'listener start', otherwise None.
+    """
+    ppid = os.getppid()
+    pps = psutil.Process(ppid)
+
+    try:
+        cmdline = pps.cmdline()
+    except (psutil.AccessDenied, psutil.ZombieProcess):
+        # Ignore processes we cannot access
+        return None
+
+    seen_pywbemcli = False
+    seen_listener = False
+    for item in cmdline:
+        if item.endswith('pywbemcli'):
+            seen_pywbemcli = True
+            continue
+        if seen_pywbemcli and item == 'listener':
+            seen_listener = True
+            continue
+        if seen_listener and item == 'start':
+            break
+    else:
+        # Ignore processes that are not 'pywbemcli [opts] listener [opts] start'
+        return None
+
+    return ppid
+
+
+def prepare_startup_completion():
+    """
+    In the 'listener start' command, prepare for a later use of
+    wait_startup_completion() by setting up the necessary signal handlers.
+    """
+    signal.signal(SIGNAL_RUN_STARTUP_SUCCESS, success_signal_handler)
+    signal.signal(SIGNAL_RUN_STARTUP_FAILURE, failure_signal_handler)
+
+
+def success_signal_handler(sig, frame):
+    # pylint: disable=unused-argument
+    """
+    Signal handler in 'listener start' process for the signal indicating
+    success of startup completion of the 'listener run' child process.
+    """
+    # pylint: disable=global-statement
+    global RUN_STARTUP_STATUS, RUN_STARTUP_COND
+
+    if DEBUG_PROCESS:
+        print("Debug: start: Handling success signal {}".format(sig))
+
+    RUN_STARTUP_STATUS = 'success'
+    with RUN_STARTUP_COND:
+        RUN_STARTUP_COND.notify()
+
+
+def failure_signal_handler(sig, frame):
+    # pylint: disable=unused-argument
+    """
+    Signal handler in 'listener start' process for the signal indicating
+    failure of startup completion of the 'listener run' child process.
+    """
+    # pylint: disable=global-statement
+    global RUN_STARTUP_STATUS, RUN_STARTUP_COND
+
+    if DEBUG_PROCESS:
+        print("Debug: start: Handling failure signal {}".format(sig))
+
+    RUN_STARTUP_STATUS = 'failure'
+    with RUN_STARTUP_COND:
+        RUN_STARTUP_COND.notify()
+
+
+def wait_startup_completion(child_pid):
+    """
+    In the 'listener start' command, wait for the 'listener run' child process
+    to either successfully complete its startup or to fail its startup.
+
+    Returns:
+      int: Return code indicating whether the child started up successfully (0)
+        or failed its startup (1).
+    """
+    # pylint: disable=global-statement
+    global RUN_STARTUP_STATUS, RUN_STARTUP_COND
+
+    if DEBUG_PROCESS:
+        print("Debug: start: Waiting for run process {} to "
+              "complete startup".format(child_pid))
+
+    RUN_STARTUP_STATUS = 'failure'
+    with RUN_STARTUP_COND:
+        rc = RUN_STARTUP_COND.wait(RUN_STARTUP_TIMEOUT)
+
+    # Before Python 3.2, wait() always returns None. Since 3.2, it returns
+    # a boolean indicating whether the timeout expired (False) or the
+    # condition was triggered (True).
+    if rc is None or rc is True:
+        status = RUN_STARTUP_STATUS
+    else:
+        # Only since Python 3.2
+        status = 'timeout'
+
+    if status == 'success':
+        if DEBUG_PROCESS:
+            print("Debug: start: Startup of run process {} succeeded".
+                  format(child_pid))
+        return 0
+
+    if status == 'timeout':
+        click.echo("Timeout")
+
+    # The 'listener run' child process may still be running, or already a
+    # zombie, or no longer exist. If it still is running, the likely cause is
+    # that it was in a password prompt for the keyfile password that was not
+    # entered.
+
+    sleep(0.5)  # Give it some time to finish by itself before we clean it up
+
+    if DEBUG_PROCESS:
+        print("Debug: start: Startup of run process {} failed".
+              format(child_pid))
+    child_exists = False
+    try:
+        child_ps = psutil.Process(child_pid)
+        child_status = child_ps.status()
+        if child_status != psutil.STATUS_ZOMBIE:
+            child_exists = True
+    except (psutil.NoSuchProcess, psutil.ZombieProcess):
+        # No need to clean up anything in these cases.
+        pass
+
+    if child_exists:
+        if DEBUG_PROCESS:
+            print("Debug: start: Cleaning up run process {} and status {}".
+                  format(child_pid, child_status))
+        try:
+            child_ps.terminate()
+            child_ps.wait()
+        except (IOError, OSError) as exc:
+            raise click.ClickException(
+                "Cannot clean up 'listener run' child process with PID {}: "
+                "{}: {}".format(child_pid, type(exc), exc))
+    return 1
+
+
+def run_exit_handler(start_pid):
+    """
+    Exit handler that gets etablished for the 'listener run' command.
+
+    This exit handler signals a failed startup of the 'listener run' command
+    to the 'listener start' process, if it still exists. If the 'listener start'
+    process no longer exists, this means that the startup of the 'listener run'
+    command succeeded earlier, and it is now terminated by some means.
+    """
+    if DEBUG_PROCESS:
+        print("Debug: run: Exit handler sends failure signal {} to "
+              "start process {}".
+              format(SIGNAL_RUN_STARTUP_FAILURE, start_pid))
+    try:
+        os.kill(start_pid, SIGNAL_RUN_STARTUP_FAILURE)  # Sends the signal
+    except OSError:
+        # The original start parent no longer exists -> the earlier startup
+        # succeeded.
+        pass
+
+
+class SilentArgumentParser(argparse.ArgumentParser):
+    """
+    argparse.ArgumentParser subclass that silences any errors and exit and
+    just raises them as SystemExit.
+    """
+
+    def error(self, message=None):
+        """Called for usage errors detected by the parser"""
+        raise SystemExit(2)
+
+    def exit(self, status=0, message=None):
+        """Not sure when this is called"""
+        raise SystemExit(status)
+
+
+def parse_listener_args(listener_args):
+    """
+    Parse the command line arguments of a process. If it is a listener process
+    return its parsed arguments (after the 'listener' command); otherwise
+    return None.
+    """
+
+    parser = SilentArgumentParser()
+    parser.add_argument('run', type=str, default=None)
+    parser.add_argument('name', type=str, default=None)
+    parser.add_argument('--port', type=int, default=DEFAULT_LISTENER_PORT)
+    parser.add_argument('--protocol', type=str,
+                        default=DEFAULT_LISTENER_PROTOCOL)
+    parser.add_argument('--certfile', type=str, default=None)
+    parser.add_argument('--keyfile', type=str, default=None)
+
+    try:
+        parsed_args = parser.parse_args(listener_args)
+    except SystemExit:
+        # Invalid arguments
+        return None
+
+    if parsed_args.run != 'run':
+        return None
+
+    return parsed_args
+
+
+def run_term_signal_handler(sig, frame):
+    # pylint: disable=unused-argument
+    """
+    Signal handler for the 'listener run' command that gets called for the
+    SIGTERM signal, i.e. when the 'listener run' process gets terminated by
+    some means.
+
+    Ths handler ensures that the main loop of the the 'listener run' command
+    gets control and can gracefully stop the listener.
+    """
+    if DEBUG_PROCESS:
+        print("Debug: run: Received SIGTERM signal {}".format(sig))
+    raise SystemExit(1)
+
+
+def display_show_listener(listener, table_format):
+    """
+    Display a listener for the 'listener show' command.
+    """
+    headers = ListenerProperties.show_headers()
+    rows = [listener.show_row()]
+    table = format_table(
+        rows, headers, table_format=table_format,
+        sort_columns=None, hide_empty_cols=None, float_fmt=None)
+    click.echo(table)
+
+
+def display_list_listeners(listeners, table_format):
+    """
+    Display listeners for the 'listener list' command.
+    """
+    headers = ListenerProperties.list_headers()
+    rows = []
+    for listener in listeners:
+        rows.append(listener.list_row())
+    table = format_table(
+        rows, headers, table_format=table_format,
+        sort_columns=None, hide_empty_cols=None, float_fmt=None)
+    click.echo(table)
+
+
+################################################################
+#
+#   Common methods for The action functions for the listener click group
+#
+###############################################################
+
+
+def cmd_listener_run(context, options):
+    """
+    Run as a listener.
+    """
+    name = options['name']
+    port = options['port']
+    protocol = options['protocol']
+    host = 'localhost'
+
+    # Register a termination signal handler that causes the loop further down
+    # to get control via SystemExit.
+    signal.signal(signal.SIGTERM, run_term_signal_handler)
+
+    # If this run process is started from a start process, register a Python
+    # atexit handler to make sure we get control when Click exceptions terminate
+    # the process. The exit handler signals a failed startup to the start
+    # process.
+    start_pid = is_parent_start()
+    if start_pid:
+        atexit.register(run_exit_handler, start_pid)
+
+    listeners = get_listeners(name)
+    if len(listeners) > 1:  # This upcoming listener and a previous one
+        lis = listeners[0]
+        url = '{}://{}:{}'.format(lis.protocol, host, lis.port)
+        raise click.ClickException(
+            "Listener {} already runs at {}".format(name, url))
+
+    if protocol == 'http':
+        http_port = port
+        https_port = None
+        certfile = None
+        keyfile = None
+    else:
+        assert protocol == 'https'
+        https_port = port
+        http_port = None
+        certfile = options['certfile']
+        keyfile = options['keyfile'] or certfile
+    url = '{}://{}:{}'.format(protocol, host, port)
+
+    context.spinner_stop()
+
+    try:
+        listener = WBEMListener(
+            host=host, http_port=http_port, https_port=https_port,
+            certfile=certfile, keyfile=keyfile)
+    except ValueError as exc:
+        raise click.ClickException(
+            "Cannot create listener {}: {}".format(name, exc))
+    try:
+        listener.start()
+    except (IOError, OSError, ListenerError) as exc:
+        raise click.ClickException(
+            "Cannot start listener {}: {}".format(name, exc))
+
+    click.echo("Running listener {} at {}".format(name, url))
+
+    # Signal successful startup completion to the parent 'listener start'
+    # process.
+    start_pid = is_parent_start()
+    if start_pid:
+        if DEBUG_PROCESS:
+            print("Debug: run: Sending success signal {} to start "
+                  "process {}".
+                  format(SIGNAL_RUN_STARTUP_SUCCESS, start_pid))
+        os.kill(start_pid, SIGNAL_RUN_STARTUP_SUCCESS)  # Sends the signal
+
+    try:
+        while True:
+            sleep(60)
+    except (KeyboardInterrupt, SystemExit) as exc:
+        if DEBUG_PROCESS:
+            print("Debug: run: Caught exception {}: {}".
+                  format(type(exc), exc))
+        # SystemExit occurs only due to being raised in the signal handler
+        # that was registered.
+        listener.stop()
+        click.echo("Shut down listener {} running at {}".format(name, url))
+
+        # Signal failure to the parent 'listener start' process if it still
+        # exists.
+        start_pid = is_parent_start()
+        if start_pid:
+            if DEBUG_PROCESS:
+                print("Debug: run: Sending failure signal {} to start "
+                      "process {}".
+                      format(SIGNAL_RUN_STARTUP_FAILURE, start_pid))
+            os.kill(start_pid, SIGNAL_RUN_STARTUP_FAILURE)  # Sends the signal
+
+
+def cmd_listener_start(context, options):
+    """
+    Start a named listener.
+    """
+    name = options['name']
+    port = options['port']
+    protocol = options['protocol']
+    certfile = options['certfile']
+    keyfile = options['keyfile']
+    host = 'localhost'
+
+    listeners = get_listeners(name)
+    if listeners:
+        lis = listeners[0]
+        url = '{}://{}:{}'.format(lis.protocol, host, lis.port)
+        raise click.ClickException(
+            "Listener {} already runs at {}".format(name, url))
+
+    run_args = [
+        'pywbemcli', 'listener', 'run', name,
+        '--port', str(port),
+        '--protocol', protocol,
+    ]
+    if certfile:
+        run_args.extend(['--certfile', certfile])
+    if keyfile:
+        run_args.extend(['--keyfile', keyfile])
+
+    # While we stop the spinner of this 'start' command, the spinner of the
+    # invoked 'run' command will still be spinning until its startup/exit
+    # completion is detected. When the output of the 'start'command is
+    # redirected, the spinner of the child process will also be suppressed,
+    # so this behavior is consistent and should be fine.
+    context.spinner_stop()
+
+    prepare_startup_completion()
+
+    if six.PY2:
+        popen_kwargs = {}
+    else:
+        popen_kwargs = dict(start_new_session=True)
+
+    # pylint: disable=consider-using-with
+    p = subprocess.Popen(run_args, **popen_kwargs)
+
+    # Wait for startup completion or for error exit
+    try:
+        rc = wait_startup_completion(p.pid)
+    except KeyboardInterrupt:
+        raise click.ClickException(
+            "Keyboard interrupt while waiting for listener to start up")
+    if rc != 0:
+        # Error has already been displayed
+        raise SystemExit(rc)
+
+    # A message about the successful startup has already been displayed by
+    # the child process.
+
+
+def cmd_listener_stop(context, name):
+    """
+    Stop a named listener.
+    """
+    listeners = get_listeners(name)
+    if not listeners:
+        raise click.ClickException(
+            "No running listener found with name {}".format(name))
+    listener = listeners[0]
+
+    context.spinner_stop()
+
+    p = psutil.Process(listener.pid)
+    p.terminate()
+    p.wait()
+
+    # A message about the successful shutdown has already been displayed by
+    # the child process.
+
+
+def cmd_listener_show(context, name):
+    """
+    Show a named listener.
+    """
+    listeners = get_listeners(name)
+    if not listeners:
+        raise click.ClickException(
+            "No running listener found with name {}".format(name))
+
+    context.spinner_stop()
+    display_show_listener(listeners[0], table_format=context.output_format)
+
+
+def cmd_listener_list(context):
+    """
+    List all named listeners.
+    """
+    listeners = get_listeners()
+    context.spinner_stop()
+    if not listeners:
+        click.echo("No running listeners")
+    else:
+        display_list_listeners(listeners, table_format=context.output_format)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,12 +8,13 @@
 
 # Direct dependencies (except pip, setuptools, wheel):
 
-pywbem>=1.2.0
+# TODO: Enable pywbem 1.3.0 once released, before releasing pywbemtools
+# pywbem>=1.3.0
 # When using the GitHub master branch of pywbem, comment out the line above,
 # activate the GitHub link based dependency below.
 # In that case, some of the install tests need to be disabled by setting
 # the 'PYWBEM_FROM_REPO' variable in in tests/install/test_install.sh.
-# git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
+git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
 
 nocaselist>=1.0.3
 nocasedict>=1.0.1
@@ -31,6 +32,7 @@ click-repl>=0.1.6
 asciitree>=0.3.3
 tabulate>=0.8.2
 toposort>=1.6
+psutil>=5.5.0
 
 # prompt-toolkit>=2.0 failed on py27 (issue #192), so it was pinned to <2.0.
 #   Later, the fix for issue #224 allowed to lift that pinning.

--- a/tests/unit/test_general_options.py
+++ b/tests/unit/test_general_options.py
@@ -141,6 +141,7 @@ GENERAL_HELP_LINES = [
     """Commands:
       class       Command group for CIM classes.
       instance    Command group for CIM instances.
+      listener    Command group for WBEM indication listeners.
       namespace   Command group for CIM namespaces.
       profile     Command group for WBEM management profiles.
       qualifier   Command group for CIM qualifier declarations.


### PR DESCRIPTION
**DROP:** This PR has been abandoned in favor of PR #971, but we keep it around until that PR is merged.


Initial stab at listener support. This PR adds a 'listener' command group to pywbemcli. At this point, the listener does nothing with any received indications.

Ready for a concept review and early test.

TODO:

* Add documentation
* Add tests
* Add support for using the general logging options to log the output of 'listener run'. (see discussion item, below)
* Change --certfile and --keyfile to use the corresponding global options instead. (see discussion item, below)
* Add support for processing indications: display (subject to being logged), log to file (separate from logging), call Python function. (see discussion item, below)

**DISCUSSION:**

* How to treat stdout/stderr of the running listeners. Should they log to a file?
  KS/COMMENT: I think we have a real discussion about how we log/display/count, etc. received indications.
  Result: We go with the general logging options, for now.
  Status: **OPEN**

* The general options --certfile, --keyfile and --ca-certs could be used instead of adding similar options at the level of the listener run/start commands.
  Status: **OPEN**

* What types of indication processing would we support: display, log to file, call Python function, execute command?
  Result: For now, we do: display (subject to being logged), log to file (separate from logging), call Python function.
  Status: **OPEN**

* Default listener protocol? (currently http)
  KS/COMMENT: This one does not really bother me other than the default for the server is https so this is "different".
  Andy: Changed the default to https for security by default and for consistency.
  Result: Agreed to https as a default.
  Status: DONE

* Default listener port? (currently 5988)
  KS/COMMENT: I think that Jim did set it up that way and certainly we did not claim any standard port. However 5988 always bothered me because there was always the real chance that the server was on the same system. That is why I always pick some high number like 50000.
  Andy: Changed to 25989 to have a more unique value with less chance of collisions.
  Result: Agreed to that port as a default.
  Status: DONE

* Need for a certificate trust store: Somehow the single (!) server certificate to be presented during SSL/TLS handshake needs to be determined. How would that be done with multiple certificates in a trust store? The underlying WBEMListener class takes certfile and keyfile and it passes them on to `ssl.SSLContext.load_cert_chain()`. That is straight forward. What would a trust store improve?
  KS/COMMENTS: Our listener may be more primitive but the listener should be capable of handling certs from a CA tree, possibly even multiple  CAs since, in all probably the same cert store as the server(s) with which it is defining subscriptions. For our listener we need to determine how much of that we want to do since we do not have an implemented multiple certificate store that we can simply attach to.  I should have recognized this much earlier in the project but (to be honest) I tried to avoid the whole certificate subject as long as possible (i.e. until I had to fix pegasus).
  Andy: This does not answer the question why a *server* would need more than one server certificate?
  Result: We agree that for the server certificate presented by the listener, only one certificate is needed. However, when supporting mutual TLS, a set of CA certs is needed, which Karl meant with "trust store". This item is now about adding support for mutual TLS verification.
  Status: DEFERRED to issue #965

* Do we want a `send` or `test` command?  KS: I like the idea of an indication sender that we can use in tests but is part of pywbemcli.
  Result: For now, we do only "send". It is not clear what the addiitonal value of test would be given that we cannot really test the indication was processed.
  Status: DEFERRED to issue #966

* Do we want to show the general options in the 'show' command? They are not generically available but are properties on the context object.
  Result: We want to show them. We have to, if we use the general options --certfile etc. It is also easier than I thought because they come from parsing the command line of the run commands, not from the context of the currently running list/show command.
  Status: DEFERRED to issue #967

* Does the WBEMListener class need to be extended with:
  - support for keyfile password? (see [ssl.SSLContext.load_cert_chain()](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain))
    Result: Yes
    Status: DONE - it already did that, by letting OpenSSL perform the prompt. PR https://github.com/pywbem/pywbem/pull/2695 improves that a little.
  - support for restricting version of TLS protocol? (see [Protocol versions](https://docs.python.org/3/library/ssl.html#protocol-versions))
    Result: Yes
    Status: DEFERRED to issue #964
  - support for setting the ciphers? (see [Cipher selection](https://docs.python.org/3/library/ssl.html#cipher-selection))
    Result: Yes
    Status: DEFERRED to issue #964
 
* Idea: During startup of the "run" command, have its stdout/err/in redirected to/from the parent process, in order to get success and error messages in the parent process, and also the potential prompt for keyfile password. Needs investigation.
  Status: DONE - all messages of the run process are now displayed on the correct stream before the start process terminates, and the start process exit code is also correct (i.e. shows error if the child process had an error). The password prompt is also properly displayed and is not subject to redirection.
