### PR TITLE
0.9: Extended the pinning of Click to <8.0.0 to dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -47,6 +47,11 @@ safety>=1.9.0; python_version >= '3.5'
 dparse>=0.4.1,<0.5.0; python_version == '2.7'
 dparse>=0.4.1; python_version == '3.4'
 dparse>=0.5.1; python_version >= '3.5'
+# Safety requires Click>6.0 and the upgrade strategy 'eager' causes Click to be
+# upgraded to 8.0.0, unless we repeat the Click requirements from requirements.txt.
+Click>=7.1.1,<8.0; python_version == '2.7'
+Click>=7.0,<7.1; python_version == '3.4'
+Click>=7.1.1,<8.0; python_version >= '3.5'
 
 # PyYAML is also pulled in by dparse and python-coveralls
 # PyYAML 5.3 has removed support for Python 3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,8 @@ six>=1.14.0
 # Click 7.1 removed support for Python 3.4
 # Click 8.0 is incompatible with pywbemcli. See issues #816 (python 2.7 not
 #     supported) and #819 (click-repl incompatible)
+# The Click requirements were copied into dev-requirements.txt in order not to
+# have the safety package upgrade it. Keep them in sync.
 Click>=7.1.1,<8.0; python_version == '2.7'
 Click>=7.0,<7.1; python_version == '3.4'
 Click>=7.1.1,<8.0; python_version >= '3.5'


### PR DESCRIPTION
Rolls back PR #972 into 0.9.1.