### PR TITLE
Renamed common functions pywbemcliwarn* to pywbemtools_warn*

### DIFF
--- a/pywbemtools/_utils.py
+++ b/pywbemtools/_utils.py
@@ -111,19 +111,19 @@ def _formatwarning(message, category, filename, lineno, line=None):
     return "{}: {}\n".format(category.__name__, message)
 
 
-def pywbemcliwarn(*args, **kwargs):
+def pywbemtools_warn(*args, **kwargs):
     """
-    Pywbemcli monkey patch for the warnings.warn function; substitutes our
-    own formatter.
+    Pywbemtools version of the warnings.warn() function,
+    with replaced formatting.
     """
     with mock.patch.object(warnings, 'formatwarning', _formatwarning):
         warnings.warn(*args, **kwargs)
 
 
-def pywbemcliwarn_explicit(*args, **kwargs):
+def pywbemtools_warn_explicit(*args, **kwargs):
     """
-    Pywbemcli monkey patch for the warnings.warn_explicit function;
-    substitutes our own formatter
+    Pywbemtools version of the warnings.warn_explicit() function,
+    with replaced formatting.
     """
     with mock.patch.object(warnings, 'formatwarning', _formatwarning):
         warnings.warn_explicit(*args, **kwargs)

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -43,7 +43,7 @@ from ._common_options import propertylist_option, names_only_option, \
 from ._displaytree import display_class_tree
 from .._click_extensions import PywbemtoolsGroup, PywbemtoolsCommand, \
     CMD_OPTS_TXT, GENERAL_OPTS_TXT, SUBCMD_HELP_TXT
-from .._utils import pywbemcliwarn
+from .._utils import pywbemtools_warn
 from .._options import add_options, help_option
 from .._output_formatting import output_format_is_table, \
     validate_output_format, format_table, warning_msg
@@ -1177,9 +1177,10 @@ def cmd_class_delete(context, classname, options):
     include_instances = options['include_instances']
     if options['force']:
         include_instances = options['force']
-        pywbemcliwarn("The --force / -f option has been deprecated and "
-                      "will be removed in a future version. Use "
-                      "--include-instances instead.", DeprecationWarning)
+        pywbemtools_warn(
+            "The --force / -f option has been deprecated and will be removed "
+            "in a future version. Use --include-instances instead.",
+            DeprecationWarning)
     dry_run = options['dry_run']
     dry_run_prefix = "Dry run: " if dry_run else ""
 

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -35,7 +35,7 @@ from .pywbemcli import cli
 from ._common import pywbem_error_exception
 from ._common_options import namespace_option
 from ._cmd_namespace import cmd_namespace_list, cmd_namespace_interop
-from .._utils import pywbemcliwarn
+from .._utils import pywbemtools_warn
 from .._click_extensions import PywbemtoolsGroup, PywbemtoolsCommand, \
     CMD_OPTS_TXT, GENERAL_OPTS_TXT, SUBCMD_HELP_TXT
 from .._options import add_options, help_option
@@ -101,7 +101,7 @@ def server_namespaces(context):
     Deprecated: The 'server namespaces' command is deprecated and will be
     removed in a future version. Use the 'namespace list' command instead.
     """
-    pywbemcliwarn(
+    pywbemtools_warn(
         "The 'server namespaces' command is deprecated and will be removed in "
         "a future version. Use the 'namespace list' command instead.",
         DeprecationWarning)
@@ -121,7 +121,7 @@ def server_interop(context):
     Deprecated: The 'server interop' command is deprecated and will be removed
     in a future version. Use the 'namespace interop' command instead.
     """
-    pywbemcliwarn(
+    pywbemtools_warn(
         "The 'server interop' command is deprecated and will be removed in "
         "a future version. Use the 'namespace interop' command instead.",
         DeprecationWarning)

--- a/pywbemtools/pywbemcli/mockscripts/__init__.py
+++ b/pywbemtools/pywbemcli/mockscripts/__init__.py
@@ -27,7 +27,7 @@ import importlib
 import traceback
 import pywbem
 
-from ..._utils import pywbemcliwarn_explicit
+from ..._utils import pywbemtools_warn_explicit
 
 
 class MockError(Exception):
@@ -122,7 +122,7 @@ def setup_script(file_path, conn, server, verbose):
             except Exception as exc:
                 raise script_error(file_path, exc)
         else:
-            pywbemcliwarn_explicit(
+            pywbemtools_warn_explicit(
                 "The support of mock scripts without setup() function is "
                 "deprecated and will be removed in a future version.",
                 DeprecatedSetupWarning, file_path, 0)
@@ -145,7 +145,7 @@ def setup_script(file_path, conn, server, verbose):
                 "On Python <3.5, mock scripts with setup() function are not "
                 "supported")
 
-        pywbemcliwarn_explicit(
+        pywbemtools_warn_explicit(
             "The support of mock scripts without setup() function is "
             "deprecated and will be removed in a future version.",
             DeprecatedSetupWarning, file_path, 0)

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -44,8 +44,8 @@ from ._connection_repository import ConnectionRepository, \
     ConnectionsFileError
 from .._click_extensions import PywbemtoolsTopGroup, GENERAL_OPTS_TXT, \
     SUBCMD_HELP_TXT
-from .._utils import pywbemcliwarn, get_terminal_width, CONNECTIONS_FILENAME, \
-    DEFAULT_CONNECTIONS_FILE
+from .._utils import pywbemtools_warn, get_terminal_width, \
+    CONNECTIONS_FILENAME, DEFAULT_CONNECTIONS_FILE
 from .._options import add_options, help_option
 from .._output_formatting import OUTPUT_FORMAT_GROUPS
 
@@ -872,7 +872,7 @@ def cli(ctx, server, connection_name, default_namespace, user, password,
 
     _python_nm = sys.version_info[0:2]
     if _python_nm in ((2, 7), (3, 4)):
-        pywbemcliwarn(
+        pywbemtools_warn(
             "Pywbemcli support for Python {}.{} is deprecated and will be "
             "removed in a future version".
             format(_python_nm[0], _python_nm[1]),

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -507,7 +507,7 @@ def test_get_terminal_width(
             os.environ[termwidth_envvar] = saved_termwidth
 
 
-# The pywbemcliwarn() and pywbemcliwarn_explicit() functions are not tested
-# directly because the pytest capturing of warnings nullifies their patching of
-# warnings.formatwarning(). These functions are tested indirectly though, by
-# the tests that invoke the pywbemcli command.
+# The pywbemtools_warn() and pywbemtools_warn_explicit() functions are not
+# tested directly because the pytest capturing of warnings nullifies their
+# patching of warnings.formatwarning(). These functions are tested indirectly
+# though, by the tests that invoke the pywbemtools commands.


### PR DESCRIPTION
For details, see the commit message.

Note: An update to the change log is not needed, because there is already a general statement in the Cleanup section that covers this change.