### PR TITLE
Removed --no-warn from tools/click_help_capture.py

### DIFF
--- a/tools/click_help_capture.py
+++ b/tools/click_help_capture.py
@@ -126,7 +126,7 @@ def get_subcmd_group_names(script_cmd, script_name, cmd):
 
     returns list of command groups/commands
     """
-    command = '{} --no-warn {} --help'.format(script_cmd, cmd)
+    command = '{} {} --help'.format(script_cmd, cmd)
     # Disable python warnings for script call.
     if sys.platform != 'win32':
         command = 'export PYTHONWARNINGS="" && {}'.format(command)


### PR DESCRIPTION
See commit message.