### PR TITLE
Add new pywbemcli command group subscriptions

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -73,6 +73,16 @@ This documentation uses a few special terms to refer to Python types:
       non-embedded instances of the class (not including subclasses) within the
       namespace.
 
+   Interop namespace
+      The Interop namespace is a :term:`CIM namespace` that exists in a WBEM
+      server as a point of interoperatbility with WBEM clients because it has a
+      well known name. A WBEM server may have only a single Interop namespace
+      and the names are limited normally to ``interop``, ``root/interop``.
+      Pywbemcli adds ``root/PG_Interop`` as a third alternative when it looks
+      for any Interop namespaces on a WBEM server.  The object manager,
+      profile, namespace information and indication subscription is available
+      through the interop namespace.
+
    connections file
       A file maintained by pywbemcli and managed by the
       :ref:`Connection command group`.
@@ -208,11 +218,47 @@ This documentation uses a few special terms to refer to Python types:
       if a :term:`default connection`) has been defined. The current connection can be
       changed in the interactive mode with the :ref:`connection select command`.
 
+   default namespace
+      The :term:`CIM namespace` set as the current namespace for CIM operations
+      if pywbemcli is started with a connection defined but without a specific
+      namespace defined.  Pywbemcli uses ``root/cimv2`` as the default
+      namespace.
+
    CQL
       CQL (CIM Query Language) is a query language defined by DMTF for use
       by query operations against WBEM servers. In operation parameters that
       define the use of a query language, it is specified with the string
-      ``DMTF:QCL``. CQL is described in DMTF standard :term:`DSP0202`.
+      ``DMTF:CQL``. CQL is described in DMTF standard :term:`DSP0202`.
+
+   WQL
+      WQL (WBEM Query Language) is a query language defined by Microsoft for use
+      by query operations against WBEM servers. In operation parameters that
+      define the use of a query language, it is specified with the string
+      ``WCL``. CQL is described in informal specifications generally available
+      on the internet. WQL is not a DMTF standard and there are differences
+      in implementations partly because of different versions of the WQL specification.
+      A number of WBEM servers implement WQL query processors because WQL was
+      the first query language defined for CIM query operations.
+
+   query language
+      A language defined to support query operations against WBEM servers
+      specifically the ``ExecuteQuery`` operation and its corresponding pull
+      operation. A WBEM server may implement any desired query language but the
+      DMTF specifies the characteristics of the :term:`CQL` the :term:`WQL`
+      query language is specified by Microsoft documents.
+
+   filter query language
+      A query language defined to support the DMTF pull instance enumeration
+      operation (ex. OpenEnumerateInstances, PullEnumerateInstances) specifically
+      so that filtering of responses based on a query statement can be integrated
+      into the enumeration of the instances.  The DMTF defined the filter query
+      language ``FQL`` (defined in DMTF specification (:term:`DSP0212`))as one
+      possible filter query language
+
+      See :term:query languages for query languages that support the ``ExecuteQuery``
+      operation and its corresponding pull  operation.
+
+      Query languages and filter query languages are not interchangable.
 
    schema
       A schema (named CIM schema in the DMTF specification :term:`DSP0004`) in
@@ -229,6 +275,37 @@ This documentation uses a few special terms to refer to Python types:
       number (ex. version 2.41.0). The DMTF CIM Schemas can be retrieved from
       the DMTF web site at: `<https://www.dmtf.org/standards/cim>`_ .
 
+   CIM indication subscription
+   indication subscription
+      A CIM indication subscription is the definition of :term:`listener destination`
+      and :term:`indication filter` contained within an association class
+      (``CIM_IndicationSubscription`` class) that defines for a WBEM server the
+      characteristics of indications to be generated and where they are to be
+      sent. The  listener destination is defined by the ``Handler`` reference
+      property (class name ``CIM_ListenerDestination``) and the filter is
+      defined by the ``Filter`` reference property(class name
+      ``CIM_IndicationFilter``). The DMTF indication profile and is defined in
+      :term:`DSP0154`
+
+   CIM indication destination
+   listener destination
+      A listener destination is an instance of a CIM class that maintains a
+      reference to a listener within an implementation. Specifically within
+      the scope of pywbemcli it is an instance of the class
+      ``CIM_ListenerDestinationCIMXML`` where the listener reference is the
+      ``Destination`` property which contains the URL of the target
+      indication listener.
+
+   CIM indication filter
+   indication filter
+      An indication filter is an instance of a CIM Class
+      (``CIM_IndicationFilter``) that defines characteristics of indications
+      that the WBEM server will generate. The basis for the indication
+      characteristics is the query language and query statement properties of
+      the instance.
+
+   dynamic indication filter
+      An :term: indication filter whose lifecycle is controlled by a client
 
 .. _`Profile advertisement methodologies`:
 
@@ -372,6 +449,9 @@ References
 
    DSP1033
       `DMTF DSP1033, Profile Registration Profile, Version 1.1 <https://www.dmtf.org/standards/published_documents/DSP1033_1.1.pdf>`_
+
+   DSP0154
+      `DMTF DSP1054, Indications Profile, Version 1.2.2, <https://www.dmtf.org/sites/default/files/standards/documents/DSP1054_1.2.2.pdf>`_
 
    RFC3986
       `IETF RFC3986, Uniform Resource Identifier (URI): Generic Syntax, January 2005 <https://tools.ietf.org/html/rfc3986>`_

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -102,6 +102,13 @@ Released: not yet
 * Enhanced test matrix for push-driven runs on GitHub Actions to add
   Python 3.5 on macOS, and removing Python 3.5 minimum on Windows.
 
+* Implement command group subscription that manages the creation, viewing and
+  removal of indication subscription on WBEM servers. This creates a new command
+  group 'subscription' and new commands for adding, removing, and displaying
+  (list) indication destination, filter, and subscription instances on target
+  WBEM servers. It includes the code for the new commands, a set of tests
+  and the documentation for the new commands. (see issue #4)
+
 **Cleanup:**
 
 * Prepared the development environment for having more than one pywbemtools

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -144,16 +144,17 @@ Help text for ``pywbemcli``:
       -h, --help                      Show this help message.
 
     Commands:
-      class       Command group for CIM classes.
-      instance    Command group for CIM instances.
-      namespace   Command group for CIM namespaces.
-      profile     Command group for WBEM management profiles.
-      qualifier   Command group for CIM qualifier declarations.
-      server      Command group for WBEM servers.
-      statistics  Command group for WBEM operation statistics.
-      connection  Command group for WBEM connection definitions.
-      help        Show help message for interactive mode.
-      repl        Enter interactive mode (default).
+      class         Command group for CIM classes.
+      instance      Command group for CIM instances.
+      namespace     Command group for CIM namespaces.
+      profile       Command group for WBEM management profiles.
+      qualifier     Command group for CIM qualifier declarations.
+      server        Command group for WBEM servers.
+      statistics    Command group for WBEM operation statistics.
+      subscription  Command group to manage WBEM indication subscriptions.
+      connection    Command group for WBEM connection definitions.
+      help          Show help message for interactive mode.
+      repl          Enter interactive mode (default).
 
 
 .. _`pywbemcli class --help`:
@@ -2489,4 +2490,500 @@ Help text for ``pywbemcli statistics status`` (see :ref:`statistics status comma
 
     Command Options:
       -h, --help  Show this help message.
+
+
+.. _`pywbemcli subscription --help`:
+
+pywbemcli subscription --help
+-----------------------------
+
+
+
+Help text for ``pywbemcli subscription`` (see :ref:`subscription command group`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] subscription COMMAND [ARGS] [COMMAND-OPTIONS]
+
+      Command group to manage WBEM indication subscriptions.
+
+      This group uses the pywbem subscription manager to create, view, and remove CIM Indication subscriptions for a WBEM
+      Server.
+
+      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help')
+      can also be specified before the command. These are NOT retained after the command is executed.
+
+    Command Options:
+      -h, --help  Show this help message.
+
+    Commands:
+      add-destination      Add new listener destination.
+      add-filter           Add new indication filter.
+      add-subscription     Add new indication subscription.
+      list                 Display indication subscriptions overview.
+      list-destinations    Display indication listeners on the WBEM server.
+      list-filters         Display indication filters on the WBEM server.
+      list-subscriptions   Display indication subscriptions on the WBEM server.
+      remove-destination   Remove a listener destination from the WBEM server.
+      remove-filter        Remove an indication filter from the WBEM server.
+      remove-subscription  Remove indication subscription from the WBEM server.
+      remove-server        Remove current WBEM server from the SubscriptionManager.
+
+
+.. _`pywbemcli subscription add-destination --help`:
+
+pywbemcli subscription add-destination --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli subscription add-destination`` (see :ref:`subscription add-destination command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] subscription add-destination IDENTITY [COMMAND-OPTIONS]
+
+      Add new listener destination.
+
+      This command adds a listener destination to be the target of indications sent by a WBEM server a WBEM server, by
+      adding an instance of the CIM class "CIM_ListenerDestinationCIMXML" in the Interop namespace of the WBEM server.
+
+      A listener destination defines the target of a WBEM indication listener including URI of the listener including the
+      listener port.
+
+      The required IDENTITY argument along with the --owned/--permanent option define the ``Name`` key property of the new
+      instance.  If the instance is to be owned by the current SubscriptionManager, pywbemcli creates a 'Name' property
+      value with the format: "pywbemdestination:" <SubscriptionManagerID> ":" <IDENTITY>. If the destination instance is
+      to be permanent, the value of the IDENTITY argument becomes the value of the 'Name' property.
+
+      Owned destinations are added or updated conditionally: If the destination instance to be added is already registered
+      with this subscription manager and has the same property values, it is not created or modified. If an instance with
+      this path and properties does not exist yet (the normal case), it is created on the WBEM server.
+
+      Permanent listener destinations are created unconditionally, and it is up to the user to ensure that such an
+      instance does not already exist.
+
+      If the --verbose general option is set, the created instance is displayed.
+
+    Command Options:
+      -l, --listener-url URL  Defines the URL of the target listener in the format: [SCHEME://]HOST:PORT. SCHEME must be
+                              "https" (default) or "http". HOST is a short or long hostname or literal IPV4/v6 address. PORT
+                              is a positive integer and is required
+
+      --owned / --permanent   Defines whether an owned or permanent filter, destination, or subscription is to be added.
+                              Default: owned
+
+      -h, --help              Show this help message.
+
+
+.. _`pywbemcli subscription add-filter --help`:
+
+pywbemcli subscription add-filter --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli subscription add-filter`` (see :ref:`subscription add-filter command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] subscription add-filter IDENTITY [COMMAND-OPTIONS]
+
+      Add new indication filter.
+
+      This command adds an indication filter to a WBEM server, by creating an indication filter instance (CIM class
+      "CIM_IndicationFilter") in the Interop namespace of the server.
+
+      A indication listener defines the query and query language to be used by the WBEM server to create indications for
+      an indication subscription.
+
+      The required IDENTITY argument of the command and the --owned/--permanent option defines the 'Name' key property of
+      the the created instance.  If the the instance is to be owned by the current SubscriptionManager, pywbemcli
+      indirectly specifies the 'Name' property value with the format: "pywbemfilter:" "<SubscriptionManagerID>" ":"
+      <identity>``. If the destination instance is to be permanent, the value of the IDENTITY argument directly becomes
+      the value of the Name property.
+
+      Owned indication filters are added or updated conditionally: If the indication filter instance to be added is
+      already registered with this subscription manager and has the same property values, it is not created or modified.
+      If it has the same path but different property values, it is modified to get the desired property values. If an
+      instance with this path does not exist yet (the normal case), it is created.
+
+      Permanent indication filters are created unconditionally; it is up to the user to ensure that such an instance does
+      not exist yet.
+
+      If the --verbose general option is set, the created instance is displayed.
+
+    Command Options:
+      -q, --query FILTER        Filter query definition. This is a SELECT statement in the query language defined in the
+                                filter-query-language parameter  [required]
+
+      --query-language TEXT     Filter query language for this subscription The query languages normally implemented are
+                                'DMTF:CQL' and 'WQL' .  Default: WQL
+
+      --source-namespaces TEXT  The namespace(s) for which the query is defined. If not defined, the default namespace of
+                                the server is used. Define multiple namespaces by using option multiple times or comma-
+                                separating namespaces names.
+
+      --owned / --permanent     Defines whether an owned or permanent filter, destination, or subscription is to be added.
+                                Default: owned
+
+      -h, --help                Show this help message.
+
+
+.. _`pywbemcli subscription add-subscription --help`:
+
+pywbemcli subscription add-subscription --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli subscription add-subscription`` (see :ref:`subscription add-subscription command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] subscription add-subscription DESTINATION FILTER [COMMAND-OPTIONS]
+
+      Add new indication subscription.
+
+      Adds an indication subscription to the current WBEM server for a particular DESTINATION and FILTER. The command
+      creates an instance of CIM association class "CIM_IndicationSubscription" in the Interop namespace of the server.
+
+      The destination and filter instances to be used in the subscription is based on the DESTINATION and FILTER arguments
+      which define the the 'Handler' and 'Filter' reference properties of the subscription instance to be created.
+
+      The required DESTINATION argument defines the existing destination instance that will be attached to the 'Handler'
+      reference of the association class. This argument may consist of either the value of the 'Name' property of the
+      target destination instance or the identity of that instance.  The identity is the full value of the 'Name' property
+      for permanent destinations and is a component of the 'Name' property for owned instances. If just the identity is
+      used, this will result in multiple destinations being found if the same string is defined as the identity of an
+      owned and permanent destination.
+
+      The required FILTER argument defines the existing filter instance that will be attached to the 'Filter' reference of
+      the association class. This argument may consist of either the value of the 'Name' property of the target filter
+      instance or the identity of that instance.  The identity is the full value of the 'Name' property for permanent
+      filters and is a component of the 'Name' property for owned instances. If just the identity is used, this will
+      result in multiple filters being found if the same string is defined as the identity of an owned and permanent
+      filter.
+
+      When creating permanent subscriptions, the indication filter and the listener destinations must not be owned. for
+      owned subscriptions, indication filter and listener destination may be either owned or permanent.
+
+      Owned subscriptions are added or updated conditionally: If the subscription instance to be added is already
+      registered with this subscription manager and has the same path, it is not created.
+
+      Permanent subscriptions are created unconditionally, and it is up to the user to ensure that such an instance does
+      not already exist.
+
+      Upon successful return of this method, the added subscription is active on the WBEM server, so that the specified
+      WBEM listeners may immediately receive indications.
+
+      If the --verbose general option is set, the created instance is displayed.
+
+    Command Options:
+      --owned / --permanent  Defines whether an owned or permanent filter, destination, or subscription is to be added.
+                             Default: owned
+
+      --select               Prompt user to select from multiple objects that match the IDENTITY. Otherwise, if the command
+                             finds multiple instance that match the IDENTITY, the operation fails.
+
+      -h, --help             Show this help message.
+
+
+.. _`pywbemcli subscription list --help`:
+
+pywbemcli subscription list --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli subscription list`` (see :ref:`subscription list command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] subscription list [COMMAND-OPTIONS]
+
+      Display indication subscriptions overview.
+
+      This command provides an overview of the count of subscriptions, filters, and destinations retrieved from the WBEM
+      server.
+
+    Command Options:
+      --type [owned|permanent|all]  Defines whether the command is going to filter owned ,permanent, or all objects for the
+                                    response display.  Default: all
+
+      -s, --summary                 If True, show only summary count of instances
+      -h, --help                    Show this help message.
+
+
+.. _`pywbemcli subscription list-destinations --help`:
+
+pywbemcli subscription list-destinations --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli subscription list-destinations`` (see :ref:`subscription list-destinations command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] subscription list-destinations [COMMAND-OPTIONS]
+
+      Display indication listeners on the WBEM server.
+
+      Display existing CIM indication listener destinations on the current connection. The listener destinations to be
+      displayed can be filtered by the owned choice option (owned, permanent, all).
+
+      The data display is determined by the --detail, --names_only, and --summary options and can be displayed as either a
+      table or CIM objects (ex. mof) format using the --output general option (ex. --output mof).
+
+    Command Options:
+      --type [owned|permanent|all]  Defines whether the command is going to filter owned ,permanent, or all objects for the
+                                    response display.  Default: all
+
+      -d, --detail                  Show more detailed information. Otherwise only non-null or predefined property values
+                                    are displayed. It applies to both MOF and TABLE output formats
+
+      --names-only, --no            Show the CIMInstanceName elements of the instances. This only applies when the --output-
+                                    format is one of the CIM object options (ex. mof
+
+      -s, --summary                 If True, show only summary count of instances
+      -h, --help                    Show this help message.
+
+
+.. _`pywbemcli subscription list-filters --help`:
+
+pywbemcli subscription list-filters --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli subscription list-filters`` (see :ref:`subscription list-filters command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] subscription list-filters [COMMAND-OPTIONS]
+
+      Display indication filters on the WBEM server.
+
+      Display existing CIM indication filters (CIM_IndicationFilter class) on the current connection. The indication
+      filters to be displayed can be filtered by the owned choice option (owned, permanent, all).
+
+      The data display is determined by the --detail, --names-only, and --summary options and can be displayed as either a
+      table or CIM objects (ex. mof) format using the --output general option (ex. --output mof).
+
+    Command Options:
+      --type [owned|permanent|all]  Defines whether the command is going to filter owned ,permanent, or all objects for the
+                                    response display.  Default: all
+
+      -d, --detail                  Show more detailed information. Otherwise only non-null or predefined property values
+                                    are displayed. It applies to both MOF and TABLE output formats
+
+      --names-only, --no            Show the CIMInstanceName elements of the instances. This only applies when the --output-
+                                    format is one of the CIM object options (ex. mof
+
+      -s, --summary                 If True, show only summary count of instances
+      -h, --help                    Show this help message.
+
+
+.. _`pywbemcli subscription list-subscriptions --help`:
+
+pywbemcli subscription list-subscriptions --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli subscription list-subscriptions`` (see :ref:`subscription list-subscriptions command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] subscription list-subscriptions [COMMAND-OPTIONS]
+
+      Display indication subscriptions on the WBEM server.
+
+      Displays information on indication subscriptions on the WBEM server, filtering the subscriptions to be displayed can
+      be filtered by the owned choice option (owned, permanent, all).
+
+      The default display is a table of information from the associated Filter and Handler instances
+
+      The data display is determined by the --detail, --names-only, and --summary options and can be displayed as either a
+      table or CIM objects (ex. mof) format using the --output general option (ex. --output mof).
+
+    Command Options:
+      --type [owned|permanent|all]  Defines whether the command is going to filter owned ,permanent, or all objects for the
+                                    response display.  Default: all
+
+      -d, --detail                  Show more detailed information. Otherwise only non-null or predefined property values
+                                    are displayed. It applies to both MOF and TABLE output formats
+
+      --names-only, --no            Show the CIMInstanceName elements of the instances. This only applies when the --output-
+                                    format is one of the CIM object options (ex. mof
+
+      -s, --summary                 If True, show only summary count of instances
+      -h, --help                    Show this help message.
+
+
+.. _`pywbemcli subscription remove-destination --help`:
+
+pywbemcli subscription remove-destination --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli subscription remove-destination`` (see :ref:`subscription remove-destination command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] subscription remove-destination IDENTITY [COMMAND-OPTIONS]
+
+      Remove a listener destination from the WBEM server.
+
+      Removes a listener destination instance (CIM_ListenerDestinationCIMXML) from the WBEM server where the instance to
+      be removed is identified by the IDENTITY argument and optional owned option of the command.
+
+      The required IDENTITY argument may be the value of the IDENTITY used to create the destination or may be the full
+      value of the destination 'Name' property. This is the value of the 'Name' property for permanent destinations and a
+      component of the 'Name' property for owned destinations.
+
+      If the instance is owned by the current pywbem SubscriptionManager, pywbemcli indirectly specifies the Name property
+      value with the format: "pywbemdestination:" "<SubscriptionManagerID>" ":" <IDENTITY>``. If the destination instance
+      is permanent, the value of the IDENTITY argument is the value of the Name property.
+
+      Some listener_destination instances on a server may be static in which case the server should generate an exception.
+      Pywbemcli has no way to identify these static destinations and they will appear as permanent destination instances.
+
+      The --select option can be used if, for some reason, the IDENTITY and ownership returns multiple instances. This
+      should only occur in rare cases where destination instances have been created by other tools. If the --select option
+      is not used pywbemcli displays the paths of the instances and terminates the command.
+
+    Command Options:
+      --owned / --permanent  Defines whether an owned or permanent filter, destination, or subscription is to be removed.
+                             Default: owned
+
+      --select               Prompt user to select from multiple objects that match the IDENTITY. Otherwise, if the command
+                             finds multiple instance that match the IDENTITY, the operation fails.
+
+      -h, --help             Show this help message.
+      -v, --verify           Prompt user to verify instances to be removed before request is sent to WBEM server.
+
+
+.. _`pywbemcli subscription remove-filter --help`:
+
+pywbemcli subscription remove-filter --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli subscription remove-filter`` (see :ref:`subscription remove-filter command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] subscription remove-filter IDENTITY [COMMAND-OPTIONS]
+
+      Remove an indication filter from the WBEM server.
+
+      Removes a single indication filter instance (CIM_IndicationFilter class) from the WBEM server where the instance to
+      be removed is identified by the IDENTITY argument and optional --owned option of the command.
+
+      The required IDENTITY argument may be the value of the IDENTITY used to create the filter or may be the full value
+      of the filter Name property. For permanent filters the value of the Name property is required; for owned
+      destinations the IDENTITY component of the Name property is sufficient.
+
+      If the instance is owned by the current pywbem SubscriptionManager, pywbemcli indirectly specifies the Name property
+      value with the format: "pywbemfilter:" "<SubscriptionManagerID>" ":" <IDENTITY>``. If the destination instance is
+      permanent, the value of the IDENTITY argument is the value of the Name property.
+
+      The --select option can be used if, the IDENTITY and ownership returns multiple instances. This should only occur in
+      rare cases where filter instances have been created by other tools. If the --select option is not used pywbemcli
+      displays the paths of the instances and terminates the command.
+
+    Command Options:
+      --owned / --permanent  Defines whether an owned or permanent filter, destination, or subscription is to be removed.
+                             Default: owned
+
+      --select               Prompt user to select from multiple objects that match the IDENTITY. Otherwise, if the command
+                             finds multiple instance that match the IDENTITY, the operation fails.
+
+      -v, --verify           Prompt user to verify instances to be removed before request is sent to WBEM server.
+      -h, --help             Show this help message.
+
+
+.. _`pywbemcli subscription remove-server --help`:
+
+pywbemcli subscription remove-server --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli subscription remove-server`` (see :ref:`subscription remove-server command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] subscription remove-server [COMMAND-OPTIONS]
+
+      Remove current WBEM server from the SubscriptionManager.
+
+      This command unregisters owned listeners from the WBEM server and removes all owned indication subscriptions, owned
+      indication filters, and owned listener destinations for this server-id from the WBEM server.
+
+    Command Options:
+      -h, --help  Show this help message.
+
+
+.. _`pywbemcli subscription remove-subscription --help`:
+
+pywbemcli subscription remove-subscription --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli subscription remove-subscription`` (see :ref:`subscription remove-subscription command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] subscription remove-subscription DESTINATION FILTER [COMMAND-OPTIONS]
+
+      Remove indication subscription from the WBEM server.
+
+      This command removes an indication subscription instance from the WBEM server.
+
+      The selection of subscription to be removed is defined by the DESTINATION and FILTER arguments which define the Name
+      property of the destination and filter associations of the subscription to be removed.
+
+      The required DESTINATION argument defines the existing destination instance that will be attached to the Filter
+      reference of the association class. This argument may consist of either the value of the Name property of the target
+      destination instance or the identity of that instance.  The identity is the full value of the Name property for
+      permanent destinations and is a component of the Name property for owned instances. If just the identity is used,
+      this will result in multiple destinations being found if the same string is defined as the identity of an owned and
+      permanent destination.
+
+      The required FILTER argument defines the existing filter instance that will be attached to the 'Filter' reference of
+      the association class. This argument may consist of either the value of the 'Name' property of the target filter
+      instance or the identity of that instance.  The identity is the full value of the 'Name' property for permanent
+      filters and is a component of the 'Name' property for owned instances. If just the identity is used, this may result
+      in multiple filters being found if the same string is defined as the identity of an owned and permanent filter.
+
+      This operation does not remove associated filter or destination instances unless the option --remove-associated-
+      instances is included in the command and the associated instances are not used in any other association.
+
+    Command Options:
+      -v, --verify                   Prompt user to verify instances to be removed before request is sent to WBEM server.
+      --remove-associated-instances  Attempt to remove the instances associated with this subscription. They will only be
+                                     removed if they do not participate in any other associations.
+
+      --select                       Prompt user to select from multiple objects that match the IDENTITY. Otherwise, if the
+                                     command finds multiple instance that match the IDENTITY, the operation fails.
+
+      -h, --help                     Show this help message.
 

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -37,6 +37,7 @@ The command groups are:
 * :ref:`Qualifier command group` - Command group for CIM qualifier declarations.
 * :ref:`Server command group` - Command group for WBEM servers.
 * :ref:`Statistics command group` - Command group for WBEM operation statistics.
+* :ref:`Subscription command group` - Command group for WBEM operation indication subscription management.
 * :ref:`Connection command group` - Command group for WBEM connection definitions.
 
 The individual commands (no command group) are:
@@ -56,7 +57,7 @@ The ``namespace`` command group has commands that act on CIM namespaces:
 * :ref:`Namespace list command` - List the namespaces on the server.
 * :ref:`Namespace create command` - Create a namespace on the server.
 * :ref:`Namespace delete command` - Delete a namespace on the server.
-* :ref:`Namespace interop command` - Get the Interop namespace on the server.
+* :ref:`Namespace interop command` - Get the :term:`Interop namespace` on the server.
 
 See :ref:`pywbemcli namespace --help`.
 
@@ -75,7 +76,7 @@ the :term:`current connection`.
 The result is displayed using ``txt`` output format or
 :term:`Table output formats`.
 
-The Interop namespace must exist on the server.
+The :term:`Interop namespace` must exist on the server.
 
 Example:
 
@@ -106,16 +107,16 @@ See :ref:`pywbemcli namespace list --help` for the exact help output of the comm
 ``namespace create`` command
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``namespace create`` command creates a CIM namespace on the WBEM server of
-the :term:`current connection`.
+The ``namespace create`` command creates a :term:`CIM namespace` on the WBEM
+server of the :term:`current connection`.
 
 Leading and trailing slash (``/``) characters specified in the NAMESPACE
 argument will be stripped.
 
 The namespace must not yet exist on the server.
 
-The Interop namespace must exist on the server and cannot be created using
-this command.
+The :term:`Interop namespace` must exist on the server and cannot be created
+using this command.
 
 WBEM servers may not allow this operation or may severely limit the
 conditions under which a namespace can be created on the server.
@@ -147,7 +148,7 @@ argument will be stripped.
 The namespace must exist and must be empty. That is, it must not contain
 any objects (qualifiers, classes or instances).
 
-The Interop namespace must exist on the server and cannot be deleted using
+The :term:`Interop namespace` must exist on the server and cannot be deleted using
 this command.
 
 WBEM servers may not allow this operation or may severely limit the
@@ -171,7 +172,7 @@ See :ref:`pywbemcli namespace delete --help` for the exact help output of the co
 ``namespace interop`` command
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``namespace interop`` command gets and displays the Interop namespace of
+The ``namespace interop`` command gets and displays the :term:`Interop namespace` of
 the WBEM server of the :term:`current connection`.
 
 The Interop namespace must exist on the server.
@@ -305,7 +306,7 @@ indirect subclasses are included in the result. Otherwise, only one level of
 the class hierarchy is in the result.
 
 The following example enumerates the class names of the root classes in the
-default namespace because there is no classname and the --DeepInheritance
+default namespace because there is no classname and the ``--DeepInheritance``
 option is not specified:
 
 .. code-block:: text
@@ -728,7 +729,7 @@ all namespaces in the server.
 
 This command displays the count of instances of each CIM class whose class name
 matches the specified wildcard expression (CLASSNAME-GLOB) in all CIM
-namespaces of the WBEM server, or in the specified namespaces (--namespace
+namespaces of the WBEM server, or in the specified namespaces (``--namespace``
 option).  This differs from instance enumerate, etc. in that it counts the
 instances specifically for the classname of each instance returned (the
 creation classname), not including subclasses.
@@ -848,11 +849,41 @@ The class is named with the ``CLASSNAME`` argument and is in the
 namespace specified with the ``-namespace``/``-n`` command option, or otherwise
 in the default namespace of the connection.
 
+The ``instance enumerate`` may use either the traditional operation
+(``EnumerateInstances`` or ``EnumerateInstanceNames``) or the corresponding
+pull operations depending on the :ref:`--use-pull general option`.
+
 If the ``--names-only``/``--no`` command option is set, only the instance paths
-are displayed. Otherwise, the instances are displayed.
+are displayed. Otherwise, the instances are displayed. Depending on other options,
+the either EnumerateInstances or EnumerateInstanceNames may be executed when
+pywbem is called.
 
 The ``--propertylist``/``--pl`` command option allows restricting the set of
 properties to be retrieved and displayed on the instances.
+
+The ``--namespace`` / ``n`` command option allows using a namespace other than
+the :term:`default namespace` as the target of the enumeration.
+
+Additional options allow filtering information returned  including:
+
+The ``--local-only`` / ``--lo`` option that  when allows showing only local properties
+in the instance.
+
+The ``--deep-inheritance`` / ``--di`` option that allows showing all properties or
+only properties defined in the class defined in the ``CLASSNAME`` argument
+
+The ``--include-qualifiers`` / ``iq`` option that filters out qualifiers defined in
+the instances
+
+The ``--include-classorigin`` / ``--ico``  that allows showing the classorigin attribute
+in the instances.
+
+The ``filter-query`` / ``--fq`` and ``--filter-query-language`` /
+``fql``command options allow  filtering the resulting instances if a pull
+operation is executed with a :term:`filter query language``. They are ignored
+if pywbemcli executes the traditional Enumerate operation.
+
+TODO: add the above to other instance operations
 
 Valid output formats in both cases are :term:`CIM object output formats` or
 :term:`Table output formats`.
@@ -1469,8 +1500,8 @@ See :ref:`pywbemcli server info --help` for the exact help output of the command
 ``server interop`` command
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``server interop`` command gets the name of the Interop namespace of the
-WBEM server of the :term:`current connection`.
+The ``server interop`` command gets the name of the :term:`Interop namespace`
+of the WBEM server of the :term:`current connection`.
 
 The result is displayed using :term:`Table output formats`.
 
@@ -1501,7 +1532,7 @@ the :term:`current connection`.
 The result is displayed using ``txt`` output format or
 :term:`Table output formats`.
 
-The Interop namespace must exist on the server.
+The :term:`Interop namespace` must exist on the server.
 
 Example:
 
@@ -2300,8 +2331,9 @@ as optional and some servers may not include them or all of them.
 If the server accepts the request, a simple text ``OK <server url``
 will be returned.
 
-The following example defines the connection with ``--server``, ``--user``,
-and ``--password`` and executes the test with successful result:
+The following example defines the connection with :ref:`--server general
+option`, ``--user``, and ``--password`` and executes the test with successful
+result:
 
 .. code-block:: text
 
@@ -2325,16 +2357,18 @@ The ``connection set-default`` command sets or clears the
 :term:`default-connection-name` attribute  in the currently specified
 :term:`connections file`.
 
-The :term:`default-connection-name` attribute allows a connection definition in a
-connections file to be loaded on startup without using the ``--name`` option.  If
-pywbemcli is started without ``--name``, ``--server``, or ``--mock-server`` options, the
-``default-connection-name`` attribute is retrieved from the file and, if defined,
-the name in the value of this attribute used as the name of the connection
-definition set as current connection.
+The :term:`default-connection-name` attribute allows a connection definition in
+a connections file to be loaded on startup without using the :ref:`--name general option`.
+If pywbemcli is started without :ref:`--name general option`, :ref:`--server
+general option`, or :ref:`--mock-server general option`, the
+``default-connection-name`` attribute is retrieved from the connections file if
+defined, and the value of this attribute used as the name of the
+connection definition set as current connection.
 
 Thus, for example, if the default connection definition is ``mytests`` the
 connection definition for ``mytests`` is created each time pywbemcli is started
-with no --server, --mock-server or ``--name`` option.
+with no :ref:`--server general option`, :ref:`--mock-server general option` or
+the :ref:`--name general option`.
 
 This command also allows clearing the value of the default connections file
 attribute with the ``--clear`` option.
@@ -2381,6 +2415,977 @@ The current status of the :term:`default-connection-name` can be viewed with the
 
 See :ref:`pywbemcli connection set-default --help` for the exact help output
 of the command.
+
+.. index:: pair: command groups; subscription commands
+
+.. _`subscription command group`:
+
+``subscription`` command group
+------------------------------
+
+The DMTF specification DMTF Indication Profile :term:`DSP0004` defines the
+capability for WBEM servers to generate indications (asynchronous notifications
+based on events that occur in the WBEM server managed environment) and for the
+indications to be generated to be defined by CIM indication subscriptions which may
+be created by WBEM clients.
+
+A :term:`CIM indication subscription` consists of instances of 3 separate classes:
+
+1. ``CIM_IndicationFilter`` (filter/indication filter) - Defines an
+:term:`indication filter` (using a :term:`query language`) that defines
+the characteristics of indications to be sent to a :term:`listener destination`.
+
+2. ``CIM_ListenerDestination`` (destination/listener destination) - Defines a
+:term:`listener destination` (a URL) for indications exported from a WBEM
+server. Pywbem and pywbemcli use the subclass ``CIM_ListenerDestinationCIMXML``
+specifically because that class uses the protocol supported by pywbemcli and
+the :ref:`Pywbemlistener command`.
+
+3. ``CIM_IndicationSubscription`` (subscription/indication subscription) - A
+CIM association class that relates an indication filter definition (``Filter``
+reference property) and a listener destination (``Handler`` reference
+property) to link the definition of the indication to be generated and the
+listener destination for the indication.
+
+An indication subscription defines for a WBEM server the target WBEM
+listener destination instance for indications to be generated based on the
+``Query`` and ``QueryLanguage`` properties defined in the filter instance; an indication
+subscription relates a WBEM listener destination with the definition of the
+indications that will be generated.  When a WBEM server receives a valid
+indication subscription it is expected to activate the functionality to
+generate and send indications defined by that subscription.
+
+Pywbemcli provides commands that allow creating, displaying, and removing the
+components of CIM indication subscriptions from WBEM servers. In conjunction
+with pywbemtools :ref:`Pywbemlistener command`, a user can create indication
+subscriptions on a WBEM server and view indications generated by that WBEM
+server.
+
+The ``subscription`` command group has commands that act on the CIM indication
+classes on a WBEM server including:
+
+* :ref:`subscription add-destination command` - Add a new listener destination instance to the server.
+* :ref:`subscription add-filter command` - Add a new indication filter instance to the server.
+* :ref:`subscription add-subscription command` - Add a indication subscription instance to the server.
+* :ref:`subscription list command` - list overview of indication subscriptions on the server.
+* :ref:`subscription list-destinations command` - Display destinations on the server.
+* :ref:`subscription list-filters command` - Display indication filters on the server.
+* :ref:`subscription list-subscriptions command` - Display indication subscriptions on the server.
+* :ref:`subscription remove-destination command` - Remove destinations instances from the server.
+* :ref:`subscription remove-filter command` - Remove filters from the server.
+* :ref:`subscription remove-subscription command` - Remove subscriptions from the server.
+* :ref:`subscription remove-server command` - Remove all owned subscriptions from the server.
+
+Pywbemtools groups indication subscription instances with an ownership concept
+where the instances of filters, destinations, and subscriptions can be either
+owned by the pywbemtools client or permanent.
+
+All of the instances of indication destination, indication filter and
+indication subscriptions are created by pywbemcli are created in the WBEM
+server :term:`Interop namespace`.
+
+While the definition of indication subscriptions created by pywbemcli is based
+on the DMTF Indication Profile :term:`DSP0004` there are a number of limitations
+in the pywbem implementation including:
+
+* It does not provide direct access to any of the Indication Service or Indication
+  capability functionality such as ``CIM_IndicationService``.
+
+* It requires some properties in the instances that some of the options of
+  :term:`DSP0004` consider optional including the destination URL property
+  and the filter Query property.  Thus pywbemcli does not implement what the
+  specification calls free listener destinations where the ``Destination``
+  property is left empty when the destination is created in the WBEM server.
+
+* pywbemcli creates instances of ``CIM_ListenerDestinationCIMXML`` rather than
+  ``CIM_ListenerDestination`` because pywbemcli is tied to the CIMXML protocol.
+
+* pywbemcli subscription does not provide a command to modify an existing
+  destination, filter, or subscription instance.  That must be done using
+  the ``instance`` command group.
+
+* pywbemcli subscription always uses the CIM classes to create the listener
+  destination, indication filter, and indication subscription and does not
+  provide for using subclasses (ex. vendor specific subclasses) for creating
+  instances subclasses.
+
+
+Owned destinations, filters, and subscriptions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. index:: single: owned subscriptions
+.. index:: pair: subscription owned; owned subscriptions
+.. index:: indication subscription lifecycle
+
+Owned CIM instances are created with the :ref:`subscription add-destination
+command`, :ref:`subscription add-filter command`, and :ref:`subscription
+add-subscription command` and their life cycle is bound to the life cycle of
+the registration of a WBEM server with the subscription manager.
+
+Pywbemcli registers a WBEM Server with the registration manager the first time
+a ``subscription`` command is executed if a WBEM server is currently defined
+with the :ref:`--name general option`, :ref:`--server general option` or the
+:ref:`--mock-server general option`.
+
+Owned CIM instances are deleted automatically when their WBEM server is
+deregistered from pywbemcli. See :ref:`subscription remove-server command` or
+by command with :ref:`subscription remove-destination command`,
+:ref:`subscription remove-filter command`, :ref:`subscription
+remove-subscription command`.
+
+Owned instances provide a mechanism where the life cycle of indication
+subscriptions can be easily controlled by the pywbemcli client.
+
+Permanent destinations, filters, and subscriptions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. index:: single: permanent subscriptions
+
+Permanent CIM instances are created by the :ref:`subscription add-destination
+command`, :ref:`subscription add-filter command`, and :ref:`subscription
+add-subscription command` with the command option ``--permanent`` and their
+life cycle is independent of the life cycle of the registration of that WBEM
+server with the subscription manager.
+
+Permanent CIM instances are not deleted automatically when their WBEM server is
+deregistered from the subscription manager. The user is responsible for their
+lifetime management: They can be deleted by the commands  :ref:`subscription
+remove-destination command`, :ref:`subscription remove-filter command`,
+:ref:`subscription remove-subscription command` with the option
+``--permanent``.
+
+Permanent CIM instances should be used in cases where the user needs to have
+control over the destination or filter ``Name`` property (e.g. because a DMTF
+management profile requires a particular name).
+
+Static destinations, filters, and subscriptions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. index:: single: static subscriptions
+
+Static CIM instances pre-exist in the WBEM server and cannot be deleted
+(or created) by a WBEM client.
+
+When a client creates a subscription between a filter and a listener
+destination, the types of ownership of these three CIM instances may be
+arbitrarily mixed, with one exception:
+
+* A permanent subscription cannot be created on an owned filter or an owned
+  listener destination. Allowing that would prevent the automatic life cycle
+  management of the owned filter or listener destination by the subscription
+  manager. This restriction is enforced by the
+  :class:`~pywbem.WBEMSubscriptionManager` class.
+
+Pywbemcli remembers owned subscriptions, filters, and listener destinations
+between commands in both command line and interactive mode. It does this by
+recovering instances from the current WBEM server whenever the pywbem
+SubscriptionManager object is created by a pywbemcli subscription command.
+
+Each command command execution in command mode discovers owned subscriptions,
+filters, and listener destinations for the current server. This discovery,
+is based upon the Name property. Therefore, if the Name property is set by the
+user (e.g. because a management profile requires a particular name), the filter
+must be permanent and cannot be owned.
+
+**NOTE:** Pywbem_mock used in testing does not remember any of subscription
+instances between  non-interactive commands since the mock server is created
+for each command line instantiation. Therefore most pywbemcli mock usage with
+the subscription subcommand is in interactive mode (creating, viewing, and
+deleting instances within a single interactive session).
+
+Since pywbemcli does not directly modify existing instances of filter or
+destinations or subscriptions, the user must do this directly through the
+pywbemcli ``Instance modify`` command and then updating the local owned instances
+list by executing get_all_filters(), get_all_destinations(), or
+get_all_subscriptions().
+
+Pywbemcli creates all instances of ``CIM_IndicationSubscription``,
+``CIM_ListenerDestinationCIMXML`` and ``CIM_IndicationFilter`` in the
+:term:`Interop namespace`.
+
+
+See :ref:`pywbemcli subscription --help`.
+
+
+.. index::
+    pair: subscription commands; subscription add-destination
+
+.. _`subscription add-destination command`:
+
+``subscription add-destination`` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. index::
+    single: subscription add-destination
+    pair: command; subscription add-destination
+
+This command creates a listener destination instance (CIM class
+``CIM_ListenerDestinationCIMXML``) with the identity defined by the ``IDENTITY``
+argument and the ``--owned`` | ``--permanent`` option  in the :term:`Interop
+namespace` of the specified WBEM server on the target WBEM server.
+
+A listener destination defines the location of a WBEM indication
+listener (the listener URL including port) that defines the indication listener
+for indications exported from a WBEM server and other characteristics of the
+listener.
+
+The format of this command is:
+
+.. code-block:: text
+
+    pywbemcli [GENERAL-OPTIONS] subscription add-destination IDENTITY [COMMAND-OPTIONS]
+
+The listener destination  to be added is identified by the ``IDENTITY`` argument and the
+``--owned`` / ``--permanent`` option. Together these elements define the
+``Name`` property of the destination instance.
+
+If the instance is to be owned, (``--owned``) the value of the ``Name`` property
+will be:
+
+.. code-block:: text
+
+    ``"pywbemdestination:" {submgr_id} ":" {filter_id}``
+
+where:
+
+    - ``{submgr_id}`` is the subscription manager ID
+    - ``{IDENTITY}`` is the ``IDENTITY`` argument
+
+If the instance is to be permanent, (``--permanent`` option) the ``IDENTITY``
+argument directly defines the instance ``Name`` property.
+
+If a destination instance with the specified or generated ``Name`` property
+already exists, the command returns the alternate instance if ``--owned`` or raises
+an exception if ``--permanent`` defined. Note that the behavior for permanent requests is a
+more strict behavior than what a WBEM server would do, because the 'Name'
+property is only one of four key properties. The behavior for owned add
+requests allows the alternate name to be used in subscriptions.
+
+The options that can be applied when adding a destination are:
+
+* ``--listener-url`` - the URL of the listener including its scheme, host name
+  and protocol. The host name and protocol are required and the scheme defaults
+  to ``https`` if not specified.
+* ``-- owned`` / ``--permanent`` - flag defining whether the created instance
+  will be owned or permanent where the default is owned.
+
+The following example creates an owned destination instance with the IDENTITY ``ODEST1``
+and a permanent destination with IDENTITY ``PDEST1``
+
+In this case the owned instance will be created with the Name property value:
+
+.. code-block:: text
+
+    pywbemdestination:<subscription manager id>:ODEST1
+
+
+.. code-block:: text
+
+    $ pywbemcli subscription add-destinations ODEST1 --listener-url http://my-listener:5000 --owned
+    Added owned destination: Name=pywbemdestination:defaultpywbemcliSubMgr:ODEST1
+
+    $ pywbemcli subscription add-destinations PDEST1 --listener-url http://my-listener:5000 --permanent
+    Added permanent destination: Name=PDEST1
+
+See :ref:`pywbemcli subscription add-destination --help`.
+
+
+.. index::
+    pair: subscription commands; subscription add-filter
+
+.. _`subscription add-filter command`:
+
+``subscription add-filter`` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The add-filter command creates a :term:`dynamic indication filter` to a WBEM
+server, by creating an indication filter instance (CIM class
+``CIM_IndicationFilter``) and adding this instance to the :term:`Interop namespace` of
+the current pywbemcli WBEM server (defined by the  :ref:`--name general option`,
+:ref:`--server general option`, or :ref:`--mock-server general option`).
+
+The format of this command is:
+
+.. code-block:: text
+
+    pywbemcli [GENERAL-OPTIONS] subscription add-filter IDENTITY [COMMAND-OPTIONS]
+
+The filter to be added is identified by the ``IDENTITY`` argument and the
+``--owned`` / ``--permanent`` option. Together these elements define the
+``Name`` property of the filter instance.
+
+If the instance is to be owned, (``--owned``) the value of the ``Name`` property
+will be:
+
+.. code-block:: text
+
+    "pywbemfilter:" {submgr_id} ":" {IDENTITY}``
+
+where:
+
+    - ``{submgr_id}`` is the subscription manager ID
+    - ``{IDENTITY}`` is the IDENTITY argument
+
+This should be used in cases where the user needs to have control over the
+filter name (e.g. because a DMTF management profile requires a particular
+name).
+
+If the instance is to be permanent, (``--permanent``) the the ``IDENTITY``
+argument directly defines the instance ``Name`` property.
+
+If a filter instance with the specified or generated ``Name`` property
+already exists, the command returns the alternate instance if ``--owned`` or raises
+an exception if ``--permanent`` defined. Note that the behavior for permanent requests is a
+more strict behavior than what a WBEM server would do, because the 'Name'
+property is only one of four key properties. The behavior for owned add
+requests allows the alternate name to be used in subscriptions.
+
+The command line options for this command are:
+
+* ``--query-language`` - The :term:`query language` in which the query is defined.  Normally
+  this must be either ``WQL`` a Microsoft specified query language (see
+  :term:`CQL`) or ``DMTF:CQL`` (the DMTF specified query language) (see
+  :term:`WQL`), The default language for this command is ``WQL``. The query
+  language specified must be implemented in the target server.
+* ``query`` - The query itself defined as a string using the :term:`query language`
+  defined by the ``query-language`` option.
+* ``-- owned`` / ``--permanent`` - flag defining whether the created instance
+  will be owned or permanent where the default is owned.
+
+The following example creates an owned subscription instance with the IDENTITY
+``ofilter1`` and a permanent filter with the ``Name`` property of ``pfilter1``.
+
+The owned instance ``ofilter1`` will be created with the ``Name`` property value of:
+
+    pywbemfilter:<subscription manager id>:pfilter1
+
+.. code-block:: text
+
+    $ pywbemcli subscription add-filter ofilter1 --query-language DMTF:CQL -q "SELECT * from CIM_blah" --owned
+    Added owned filter: Name=pywbemfilter:defaultpywbemcliSubMgr:pfilter1
+
+    $ pywbemcli subscription add-filter pfilter1 --listener-url http://my-listener:5000 --permanent
+    Added permanent filter: Name=filter1
+
+See :ref:`pywbemcli subscription add-filter --help`.
+
+
+.. index::
+    pair: subscription commands; subscription add-subscription
+
+
+.. _`subscription add-subscription command`:
+
+``subscription add-subscription`` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The add-subscription command creates a single indication subscription instance
+(CIM class ``CIM_IndicationSubscription``) that defines the association between
+a previously defined indication filter and destination instance.
+
+The destination and filter are defined the two required arguments of
+the command ``DESTINATION_IDENTITY`` and ``FILTER_IDENTITY``. These arguments
+may be either the complete name property value of the destination and
+filter to be associated or the ``IDENTITY`` that was the IDENTITY argument of the
+command that created each of the elements.
+
+See :ref:`subscription add-destination command`: for the definition of
+``DESTINATION_IDENTITY and :ref:_`subscription add-filter command`: for the
+definition of the ``FILTER_ARGUMENT``
+
+
+The options for add-subscription are:
+
+* ``-- owned`` / ``--permanent`` - flag defining whether the created instance
+  will be owned or permanent where the default is owned. As described above, the
+  limitation is that owned destinations and filters cannot be attached to
+  permanent subscriptions.
+
+The following is an example of the creation of the destination, filter and
+subscription.
+
+.. code-block:: text
+
+    $> pywbemcli -s https:/blah
+    pywbemcli> subscription add-destinations odest1 --listener-url http://my-listener:5000 --owned
+    Added owned destination: Name=pywbemdestination:defaultpywbemcliSubMgr:odest1
+
+    pywbemcli> subscription add-filter ofilter1 --query-language DMTF:CQL -q "SELECT * from CIM_blah" --owned
+    Added owned filter: Name=pywbemfilter:defaultpywbemcliSubMgr:ofilter1
+
+    pywbemcli> subscription list-destinations
+    Indication Destinations: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988, type=all
+    +-------------+------------+--------------------------------+-------------------+---------------+------------+----------------+
+    | Ownership   | Identity   | Name                           | Destination       |   Persistence |   Protocol |   Subscription |
+    |             |            |                                |                   |          Type |            |          Count |
+    |-------------+------------+--------------------------------+-------------------+---------------+------------+----------------|
+    | owned       | odest1     | pywbemdestination:defaultpywbe | http://blah:5000  |             3 |          2 |              0 |
+    |             |            | mcliSubMgr:odest1              |                   |               |            |                |
+    +-------------+------------+--------------------------------+-------------------+---------------+------------+----------------+
+
+    pywbemcli> subscription list-filters
+    Indication Filters: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988 type=all
+    +-------------+------------+--------------------------------+----------------+------------+--------------+----------------+
+    | Ownership   | identity   | Name                           | Query          | Query      | Source       |   Subscription |
+    |             |            |                                |                | Language   | Namespaces   |          Count |
+    |-------------+------------+--------------------------------+----------------+------------+--------------+----------------|
+    | owned       | ofilter1   | pywbemfilter:defaultpywbemcliS | SELECT * from  | WQL        | root/cimv2   |              0 |
+    |             |            | ubMgr:ofilter1                 | CIM_Indication |            |              |                |
+    +-------------+------------+--------------------------------+----------------+------------+--------------+----------------+
+
+    pywbemcli> subscription add-subscription pdest1 pfilter1 --owned
+    Added owned subscription: DestinationName=pywbemdestination:defaultpywbemcliSubMgr:odest1, FilterName=pywbemfilter:defaultpywbemcliSubMgr:ofilter1
+
+See :ref:`pywbemcli subscription add-subscription --help`.
+
+.. index::
+    pair: subscription commands; subscription list
+
+.. _`subscription list command`:
+
+``subscription list`` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``subscription list command`` provides a table with an overview of the
+subscription, filter, and destination counts organized by ownership.
+
+The options are:
+
+-  ``--type`` [ ``owned``| ``permanent`` | ``all`` ]  Defines whether the command is going to
+   filter owned ,permanent, or all objects for the response display.  The default is
+   all
+- ``-s`` / ``--summary``             If True, show only summary count of instances
+
+
+.. code-block:: text
+
+    $ subscription list
+    WBEM server instance counts: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988
+    +-------------------------------+---------+-------------+-------+
+    | CIM_class                     |   owned |   permanent |   all |
+    |-------------------------------+---------+-------------+-------|
+    | CIM_IndicationSubscription    |       1 |           0 |     1 |
+    | CIM_IndicationFilter          |       2 |           1 |     3 |
+    | CIM_ListenerDestinationCIMXML |       2 |           1 |     3 |
+    +-------------------------------+---------+-------------+-------+
+
+    $ subscription list --summary
+    1 subscriptions, 3 filters, 3 destinations
+
+
+.. index::
+    pair: subscription commands; subscription list-destinations
+
+.. _`subscription list-destinations command`:
+
+``subscription list-destinations`` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``subscription ``list-destinations`` command displays the existing
+destination instances ((CIM class ``CIM_ListenerDestinationCIMXML``)) on
+the current WBEM server.
+
+**NOTE:** pywbemcli works only with the  ``CIM_ListenerDestinationCIMXML``
+class so that any indication destination instances defined with the superclass
+``CIM_ListenerDestination`` are not visible.
+
+The set of destinations to be displayed may be all of the destinations, the
+owned destinations, or the permanent (not-owned) destinations as defined by
+the ``--type`` option where the values are ``owned`` | ``permanent`` | ``all``.
+
+The format of the output is determined by the ``--output-format`` general
+option so that the destinations may be displayed as either CIM objects ( for
+example, ``-o mof``)  or in the table format. The default is to display the
+destinations as a table.  In the table format, the most important information
+for each instance is displayed, one instance per row.
+
+The detail level of the output is determined by the ``--summary`` and the
+``detail`` options and has an effect on both the mof and table outputs. The
+``--summary`` displays counts of the number of objects and the ``--detail``
+adds more data to the normal display, in particular displaying more properties
+in the table view.
+
+The options for list-destinations are:
+
+* ``-- type [ owned | permanent | all ]`` - choice option that
+  limits the list of destinations displayed to either just owned or permanent instances
+  or displays all destinations on the current WBEM server
+
+* ``--detail`` - displays additional detail for all of the possible output formats.
+  For MOF it includes empty properties. For table, it adds more rows with  properties
+  from the instance.
+
+* ``-s``/``--summary`` limits the display to an overview
+
+* ``--no``/``names-only`` displays only the CIM instance names of the
+  instances. This option only applies if the CIM object format (ex. mof) is used
+  for output.
+
+The following is an example of the display of the destinations as a table:
+
+.. code-block:: text
+
+    Indication Destinations: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988, type=all
+    +-------------+------------+--------------------------------+-------------------+---------------+------------+----------------+
+    | Ownership   | Identity   | Name                           | Destination       |   Persistence |   Protocol |   Subscription |
+    |             |            |                                |                   |          Type |            |          Count |
+    |-------------+------------+--------------------------------+-------------------+---------------+------------+----------------|
+    | owned       | odest1     | pywbemdestination:defaultpywbe | http://blah:5000  |             3 |          2 |              2 |
+    |             |            | mcliSubMgr:odest1              |                   |               |            |                |
+    | owned       | odest2     | pywbemdestination:defaultpywbe | http://blah:5001  |             3 |          2 |              1 |
+    |             |            | mcliSubMgr:odest2              |                   |               |            |                |
+    | permanent   | pdest1     | pdest1                         | https://blah:5003 |             2 |          2 |              2 |
+    | permanent   | pdest2     | pdest2                         | https://blah:5003 |             2 |          2 |              1 |
+    | owned       | pdestdup   | pywbemdestination:defaultpywbe | https://blah:5003 |             3 |          2 |              0 |
+    |             |            | mcliSubMgr:pdestdup            |                   |               |            |                |
+    | permanent   | pdestdup   | pdestdup                       | https://blah:5003 |             2 |          2 |              0 |
+    +-------------+------------+--------------------------------+-------------------+---------------+------------+----------------+
+
+where the rows shown in the table view are:
+
+* *Ownership* - the owned/permanent definition of the destination.
+* *Identity* - The identity of the destination which should be the  ``IDENTITY``
+  used to remove the destination
+* *Name* - The value of the instance Name property
+* *Destination* - The value of the Destination property.
+* *Persistence Type* - The value of the ``PersistenceType`` property.
+* *Protocol* - The value of the ``Protocol`` property.
+* *Subscription Count* - The number of subscriptions with which this destination
+  is associated via the ``CIM_IndicationSubscription`` ``Handler`` reference.
+
+
+.. index::
+    pair: subscription commands; subscription list-filters
+
+.. _`subscription list-filters command`:
+
+``subscription list-filters`` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``subscription ``list-filters`` command displays the existing
+indication filter instances ((CIM class ``CIM_IndicationFilter``)) on
+the current WBEM server.
+
+The set of filters to be displayed may be all of the filters, the
+owned filters, or the permanent (not owned) filters as defined by
+the ``--type`` option where the values are ``owned`` | ``permanent`` | ``all``.
+
+The format of the output is determined by the ``--output-format`` general
+option so that the destinations may be displayed as either CIM objects (``-o
+mof``)  or in the table format. The default is to display the destinations as a
+table.
+
+The detail level of the output is determined by the ``--summary`` and the
+``detail`` options and has an effect on both the MOF and table outputs. The
+``--summary`` displays counts of the number of objects and the ``--detail``
+adds more data to the normal display, in particular displaying more properties
+in the table view.
+
+The options for list-destinations are:
+
+* ``-- type [ owned | permanent | all ]`` - choice option that
+  limits the list of destinations displayed to either just owned or permanent instances
+  or displays all destinations on the current WBEM server
+
+* ``--detail`` - displays additional detail for all of the possible output formats.
+  For MOF it includes empty properties. For table, it adds more rows with  properties
+  from the instance.
+
+* ``-s``/``--summary`` limits the display to an overview
+
+* ``--no``/``names-only`` displays only the CIM instance names of the instances.
+  This option only applies if the CIM object format (ex. mof) is used for output.
+
+The following is an example of table output of indication filters:
+
+.. code-block:: text
+
+    Indication Filters: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988 type=all
+    +-------------+------------+--------------------------------+----------------+------------+--------------+----------------+
+    | Ownership   | identity   | Name                           | Query          | Query      | Source       |   Subscription |
+    |             |            |                                |                | Language   | Namespaces   |          Count |
+    |-------------+------------+--------------------------------+----------------+------------+--------------+----------------|
+    | owned       | ofilter1   | pywbemfilter:defaultpywbemcliS | SELECT * from  | WQL        | root/cimv2   |              2 |
+    |             |            | ubMgr:ofilter1                 | CIM_Indication |            |              |                |
+    | owned       | ofilter2   | pywbemfilter:defaultpywbemcliS | SELECT * from  | DMTF:CQL   | root/cimv2   |              1 |
+    |             |            | ubMgr:ofilter2                 | CIM_Indication |            |              |                |
+    | permanent   | pfilter1   | pfilter1                       | SELECT * from  | WQL        | root/cimv2   |              2 |
+    |             |            |                                | CIM_Indication |            |              |                |
+    | permanent   | pfilter2   | pfilter2                       | SELECT * from  | DMTF:CQL   | root/cimv2   |              1 |
+    |             |            |                                | CIM_Indication |            |              |                |
+    +-------------+------------+--------------------------------+----------------+------------+--------------+----------------+
+
+where the rows shown in the table view are:
+
+* *Ownership* - the owned/permanent definition of the destination.
+* *Identity* - The identity of the destination which should be the ``IDENTITY``
+  used to remove the destination
+* *Name* - The value of the instance Name property
+* *Query* - The query select statement defined for this filter.
+* *QueryLanguage* - The query language defined for this filter.
+* *SourceNamespaces* - The names of the local namespaces where the Indications
+  originate. If NULL, the namespace of the Filter registration is assumed.
+  SourceNamespaces replaces the deprecated SourceNamespace property on
+  IndicationFilter to provide a means of defining the multiple
+  namespaces where indications may originate.
+* *Subscription Count* - The number of subscriptions with which this filter
+  is associated via the ``CIM_IndicationSubscription`` ``Filter`` reference.
+
+
+.. index::
+    pair: subscription commands; subscription list-subscriptions
+
+.. _`subscription list-subscriptions command`:
+
+``subscription list-subscriptions`` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``subscription ``list-filters`` command displays the existing
+indication filter instances ((CIM class ``CIM_IndicationSubscription``)) on
+the current WBEM server.
+
+The set of subscriptions to be displayed may be all of the destinations, the
+owned subscriptions, or the permanent (not owned) subscriptions as defined by
+the ``--type`` option where the values are ``owned`` | ``permanent`` | ``all``.
+
+The format of the output is determined by the ``--output-format`` general option so
+that the destinations may be displayed as either CIM objects (``-o mof``)  or
+in the table format. The default is to display the destinations as a table.
+
+The detail level of the output is determined by the ``--summary`` and the
+``detail`` options and has an effect on both the mof and table outputs. The
+``--summary`` displays counts of the number of objects and the ``--detail``
+adds more data to the normal display, in particular displaying more properties
+in the table view.
+
+The options for list-destinations are:
+
+* ``-- type [ owned | permanent | all ]`` - choice option that
+  limits the list of destinations displayed to either just owned or permanent instances
+  or displays all destinations on the current WBEM server
+
+* ``--detail`` - displays additional detail for all of the possible output formats.
+  For MOF it includes empty properties. For table, it adds more rows with  properties
+  from the instance.
+
+* ``-s``/``--summary`` limits the display to an overview
+
+* ``--no``/``names-only`` displays only the CIM instance names (paths) of the
+  instances. This option only applies if the CIM object format (ex. mof) is used
+  for output.
+
+The following is an example of table output of indication subscriptions:
+
+.. code-block:: text
+
+    pywbemcli> subscription list-subscriptions
+    Indication Subscriptions: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988, type=all
+    +-------------+-------------------+---------------------+-------------------+------------------------------+----------------+-------------------+
+    | Ownership   | Handler           | Filter              | Handler           | Filter                       | Filter Query   | Subscription      |
+    |             | Identity          | Identity            | Destination       | Query                        | language       | StartTime         |
+    |-------------+-------------------+---------------------+-------------------+------------------------------+----------------+-------------------|
+    | permanent   | pdest1(permanent) | pfilter1(permanent) | https://blah:5003 | SELECT * from CIM_Indication | WQL            | 10/22/21 14:31:30 |
+    | permanent   | pdest2(permanent) | pfilter2(permanent) | https://blah:5003 | SELECT * from CIM_Indication | DMTF:CQL       | 10/22/21 14:31:30 |
+    | owned       | odest1(owned)     | ofilter1(owned)     | http://blah:5000  | SELECT * from CIM_Indication | WQL            | 10/22/21 14:31:30 |
+    | owned       | odest2(owned)     | ofilter2(owned)     | http://blah:5001  | SELECT * from CIM_Indication | DMTF:CQL       | 10/22/21 14:31:30 |
+    | owned       | odest1(owned)     | pfilter1(permanent) | http://blah:5000  | SELECT * from CIM_Indication | WQL            | 10/22/21 14:31:31 |
+    | owned       | pdest1(permanent) | ofilter1(owned)     | https://blah:5003 | SELECT * from CIM_Indication | WQL            | 10/22/21 14:31:31 |
+    +-------------+-------------------+---------------------+-------------------+------------------------------+----------------+-------------------+
+    pywbemcli>
+
+where the rows shown in the table view are:
+
+* *Ownership* - the owned/permanent definition of the destination.
+* *HandlerIdentity* - The identity of the destination associated with this subscription.
+* *FilterIdentity* -  The identity of the filter associated with this subscription.
+* *Handler Destination* - The listener destination defined in the destination defined
+  by the HandlerIdentity
+* *FilterQuery* - The FilterQuery property from the associated filter defined by
+  the FilterIdentity
+* *FilterQueryLanguage* - The FilterQueryLanguage property from the associated
+  filter defined by the FilterIdentity
+* *Name* - The value of the instance Name property
+* *Query* - The query select statement defined for this filter.
+* *QueryLanguage* - The query language defined for this filter.
+* *SubscriptionStartTime* - The date and time that the subscription was created
+  if the WBEM server has implemented this property.
+
+.. index::
+    pair: subscription commands; subscription remove-destination
+
+.. _`subscription remove-destination command`:
+
+``subscription remove-destination`` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Removes a listener destination instance (``CIM_ListenerDestinationCIMXML``)
+from the WBEM server where the instance to be removed is identified by the
+``IDENTITY`` argument and optional ``--owned`` option of the command.
+
+The listener destination  to be removed is identified by the ``IDENTITY``
+argument and the ``--owned`` / ``--permanent`` option. Together these elements
+define the ``Name`` property of the target destination instance.
+
+If the instance is owned, (``--owned``) the ``IDENTITY`` argument will define the
+``IDENTITY`` component of the ``Name`` property as follows:
+
+.. code-block:: text
+
+    ``"pywbemdestination:" {submgr_id} ":" {IDENTITY}``
+
+where:
+
+    - ``{submgr_id}`` is the subscription manager ID
+    - ``{IDENTITY}`` is the IDENTITY argument
+
+If the instance is to be permanent, (``--permanent`` option) the ``IDENTITY``
+argument directly defines the instance ``Name`` property.
+
+Some listener_destination instances on a server may be static in which case the
+server should generate an exception if an attempt to made to remove them.
+Pywbemcli has no way to identify these static destinations and they will appear
+as permanent destination instances.
+
+The ``--select`` option can be used if, for some reason, the ``IDENTITY`` and
+ownership option returns multiple instances. This should only occur in rare
+cases where destination instances have been created by other tools. If the
+--select option is not used pywbemcli displays the paths of the instances and
+terminates the command.
+
+If the instance to be removed is part of an existing association the command
+is aborted.  The :ref:`subscription list-destinations command` shows whether
+the destination is part of an existing subscription.
+
+The following example shows a command failure when an attempt is made to
+remove a destination that is part of a subscription and a good completion
+when that subscription has been removed.
+
+.. code-block:: text
+
+    pywbemcli> subscription list-destinations
+    Indication Destinations: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988, type=all
+    +-------------+------------+--------------------------------+-------------------+---------------+------------+----------------+
+    | Ownership   | Identity   | Name                           | Destination       |   Persistence |   Protocol |   Subscription |
+    |             |            |                                |                   |          Type |            |          Count |
+    |-------------+------------+--------------------------------+-------------------+---------------+------------+----------------|
+    | owned       | odest1     | pywbemdestination:defaultpywbe | http://blah:5000  |             3 |          2 |              1 |
+    |             |            | mcliSubMgr:odest1              |                   |               |            |                |
+    +-------------+------------+--------------------------------+-------------------+---------------+------------+----------------+
+    pywbemcli> subscription remove-destination odest1
+    Error: 1 (CIM_ERR_FAILED): The listener destination is referenced by subscriptions.; remove-destination failed: Exception :CIMError. Subscription mgr id: 'WBEMSubscriptionManager(_subscription_manager_id='defaultpywbemcliSubMgr', _servers={'http://FakedUrl:5988': WBEMServer(conn.url='http://FakedUrl:5988', interop_ns='interop', namespaces=None, namespace_paths=None, namespace_classname=None, brand='OpenPegasus', version='2.15.0', profiles=[0 instances])}, _systemnames={'http://FakedUrl:5988': 'Mock_WBEMServerTest'}...)', server id: 'http://FakedUrl:5988',
+
+    pywbemcli> subscription list-subscriptions
+    Indication Subscriptions: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988, type=all
+    +-------------+-------------------+---------------------+-------------------+------------------------------+----------------+-------------------+
+    | Ownership   | Handler           | Filter              | Handler           | Filter                       | Filter Query   | Subscription      |
+    |             | Identity          | Identity            | Destination       | Query                        | language       | StartTime         |
+    |-------------+-------------------+---------------------+-------------------+------------------------------+----------------+-------------------|
+    | owned       | odest1(owned)     | ofilter1(owned)     | http://blah:5000  | SELECT * from CIM_Indication | WQL            | 10/24/21 11:36:03 |
+    +-------------+-------------------+---------------------+-------------------+------------------------------+----------------+-------------------+
+
+    pywbemcli> subscription remove-subscription odest1 ofilter1
+    Removed 1 subscription(s) for destination-id: odest1, filter-id: ofilter1.
+
+.. index::
+    pair: subscription commands; subscription remove-filters
+
+.. _`subscription remove-filter command`:
+
+``subscription remove-filter`` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Removes an indication filter instance (``CIM_IndicationFilter``) from the WBEM
+server.
+
+The filter  to be removed is identified by the ``IDENTITY`` argument and the
+``--owned`` / ``--permanent`` option. Together these elements define the
+``Name`` property of the target filter instance.
+
+If the instance is owned, (``--owned``) the ``IDENTITY`` argument will define the
+IDENTITY component of the ``Name`` property as follows:
+
+.. code-block:: text
+
+    ``"pywbemfilter:" {submgr_id} ":" {IDENTITY}``
+
+where:
+
+    - ``{submgr_id}`` is the subscription manager ID
+    - ``{IDENTITY}`` is the IDENTITY argument
+
+If the instance is to be permanent, (``--permanent`` option) the ``IDENTITY``
+argument directly defines the instance ``Name`` property.
+
+Some filter instances on a server may be static in which case the
+server should generate an exception if an attempt to made to remove them.
+Pywbemcli has no way to identify these static filters and they will appear
+as permanent filter instances.
+
+The ``--select`` option can be used if, for some reason, the ``IDENTITY``
+argument and ownership option returns multiple instances. This should only
+occur in rare cases where filter instances have been created by other tools. If
+the --select option is not used pywbemcli displays the paths of the instances
+and terminates the command.
+
+If the instance to be removed is part of an existing association the command
+is aborted.  The :ref:`subscription list-filters command` shows whether
+the filter is part of an existing subscription.
+
+.. code-block:: text
+
+    subscription list-filters
+    Indication Filters: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988 type=all
+    +-------------+------------+--------------------------------+----------------+------------+--------------+----------------+
+    | Ownership   | identity   | Name                           | Query          | Query      | Source       |   Subscription |
+    |             |            |                                |                | Language   | Namespaces   |          Count |
+    |-------------+------------+--------------------------------+----------------+------------+--------------+----------------|
+    | owned       | ofilter1   | pywbemfilter:defaultpywbemcliS | SELECT * from  | WQL        | root/cimv2   |              2 |
+    |             |            | ubMgr:ofilter1                 | CIM_Indication |            |              |                |
+    | owned       | ofilter2   | pywbemfilter:defaultpywbemcliS | SELECT * from  | DMTF:CQL   | root/cimv2   |              0 |
+    |             |            | ubMgr:ofilter2                 | CIM_Indication |            |              |                |
+    |             |            |                                | CIM_Indication |            |              |                |
+    | permanent   | pfilter2   | pfilter2                       | SELECT * from  | DMTF:CQL   | root/cimv2   |              1 |
+    |             |            |                                | CIM_Indication |            |              |                |
+    +-------------+------------+--------------------------------+----------------+------------+--------------+----------------+
+    pywbemcli> subscription remove-filter ofilter2
+    Removed owned indication filter: identity=ofilter2, Name=pywbemfilter:defaultpywbemcliSubMgr:ofilter2.
+
+.. index::
+    pair: subscription commands; subscription remove-subscriptions
+
+.. _`subscription remove-subscription command`:
+
+``subscription remove-subscription`` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This command removes an indication subscription that is identified by two
+arguments that represent the identity of the destination and filter references
+of the target indication subscription.
+
+The destination and filter are defined the two required arguments of
+the command ``DESTINATION_IDENTITY`` and ``FILTER_IDENTITY``. These arguments
+may be either the complete name property value of the destination and
+filter associated instances or the IDENTITY that was the ``IDENTITY`` argument of the
+command that created each of the elements.
+
+
+The options for this command are:
+
+* ``-v`` | ``verify`` - Prompt the user to verify the subscription to be removed
+  before the request is sent to the WBEM server.
+
+* ``--remove-associated-instances`` - Remove the associated destination and
+  filter instances before removing the subscription. They will only be removed
+  if they are not part of any other associations.
+
+* ``--select`` - Prompt user to select from multiple objects that match the
+  identity arguments provided with the command. Otherwise, if the command finds
+  multiple instances that match the IDENTITY, the operation fails.
+
+The ``--select`` option can be used if, for some reason, the
+DESTINATION_IDENTITY and FILTER_IDENTITY and return multiple instances. This
+should only occur in rare cases where filter instances have been created by
+other tools. If the --select option is not used pywbemcli displays the instance
+names  of the instances and terminates the command.
+
+.. code-block:: text
+
+    subscription list-destinations
+    Indication Destinations: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988, type=all
+    +-------------+------------+--------------------------------+-------------------+---------------+------------+----------------+
+    | Ownership   | Identity   | Name                           | Destination       |   Persistence |   Protocol |   Subscription |
+    |             |            |                                |                   |          Type |            |          Count |
+    |-------------+------------+--------------------------------+-------------------+---------------+------------+----------------|
+    | owned       | odest1     | pywbemdestination:defaultpywbe | http://blah:5000  |             3 |          2 |              2 |
+    |             |            | mcliSubMgr:odest1              |                   |               |            |                |
+    | owned       | odest2     | pywbemdestination:defaultpywbe | http://blah:5001  |             3 |          2 |              0 |
+    |             |            | mcliSubMgr:odest2              |                   |               |            |                |
+    | permanent   | pdest1     | pdest1                         | https://blah:5003 |             2 |          2 |              2 |
+    | permanent   | pdest2     | pdest2                         | https://blah:5003 |             2 |          2 |              1 |
+    +-------------+------------+--------------------------------+-------------------+---------------+------------+----------------+
+    pywbemcli> subscription list-filters
+    Indication Filters: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988 type=all
+    +-------------+------------+--------------------------------+----------------+------------+--------------+----------------+
+    | Ownership   | identity   | Name                           | Query          | Query      | Source       |   Subscription |
+    |             |            |                                |                | Language   | Namespaces   |          Count |
+    |-------------+------------+--------------------------------+----------------+------------+--------------+----------------|
+    | owned       | ofilter1   | pywbemfilter:defaultpywbemcliS | SELECT * from  | WQL        | root/cimv2   |              2 |
+    |             |            | ubMgr:ofilter1                 | CIM_Indication |            |              |                |
+    | permanent   | pfilter1   | pfilter1                       | SELECT * from  | WQL        | root/cimv2   |              2 |
+    |             |            |                                | CIM_Indication |            |              |                |
+    | permanent   | pfilter2   | pfilter2                       | SELECT * from  | DMTF:CQL   | root/cimv2   |              1 |
+    |             |            |                                | CIM_Indication |            |              |                |
+    +-------------+------------+--------------------------------+----------------+------------+--------------+----------------+
+    pywbemcli> subscription list-subscriptions
+    Indication Subscriptions: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988, type=all
+    +-------------+-------------------+---------------------+-------------------+------------------------------+----------------+-------------------+
+    | Ownership   | Handler           | Filter              | Handler           | Filter                       | Filter Query   | Subscription      |
+    |             | Identity          | Identity            | Destination       | Query                        | language       | StartTime         |
+    |-------------+-------------------+---------------------+-------------------+------------------------------+----------------+-------------------|
+    | permanent   | pdest1(permanent) | pfilter1(permanent) | https://blah:5003 | SELECT * from CIM_Indication | WQL            | 11/02/21 10:36:32 |
+    | permanent   | pdest2(permanent) | pfilter2(permanent) | https://blah:5003 | SELECT * from CIM_Indication | DMTF:CQL       | 11/02/21 10:36:33 |
+    | owned       | odest1(owned)     | ofilter1(owned)     | http://blah:5000  | SELECT * from CIM_Indication | WQL            | 11/02/21 10:36:33 |
+    | owned       | odest1(owned)     | pfilter1(permanent) | http://blah:5000  | SELECT * from CIM_Indication | WQL            | 11/02/21 10:36:33 |
+    | owned       | pdest1(permanent) | ofilter1(owned)     | https://blah:5003 | SELECT * from CIM_Indication | WQL            | 11/02/21 10:36:34 |
+    +-------------+-------------------+---------------------+-------------------+------------------------------+----------------+-------------------+
+    pywbemcli> subscription remove-subscription odest1 ofilter1
+    Removed 1 subscription(s) for destination-id: odest1, filter-id: ofilter1.
+
+
+.. index::
+    pair: subscription commands; subscription remove-server
+
+.. _`subscription remove-server command`:
+
+``Subscription remove-server`` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    This command unregisters owned listeners from the WBEM server and removes
+    all owned indication subscriptions, owned indication filters, and owned
+    listener destinations for this currently active pywbemcli WBEM server from
+    that WBEM server.
+
+    It can be used to completely clean the owned subscription entities for the
+    currently active pywbemcli WBEM server from that wbem server and local
+    caches.
+
+    The currently active WBEM server is the WBEM server to which pywbemcli is
+    currently attached; the WBEM server defined by  the :ref:`--name general option`,
+    :ref:`--server general option`, or :ref:`--mock-server general option`.
+
+    The identity of the current wbem server id visible in the title of
+    each of the subscription list table outputs.
+
+    Thus, for example current server is defined by svr_id and is actually
+    the fixed name ``http://FakedUrl:5988`` of the mock server.
+
+.. code-block:: text
+
+    pywbemcli> subscription list
+
+    WBEM server instance counts: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988
+    +-------------------------------+---------+-------------+-------+
+    | CIM_class                     |   owned |   permanent |   all |
+    |-------------------------------+---------+-------------+-------|
+    | CIM_IndicationSubscription    |       2 |           2 |     6 |
+    | CIM_IndicationFilter          |       2 |           3 |     6 |
+    | CIM_ListenerDestinationCIMXML |       2 |           3 |     6 |
+    +-------------------------------+---------+-------------+-------+
+
+    pywbemcli> subscription remove-server
+    Removing owned destinations, filters, and subscriptions for server-id http://FakedUrl:5988. Remove counts: destinations=2, filters=2, subscriptions=2
+
+    pywbemcli> subscription list
+
+    WBEM server instance counts: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988
+    +-------------------------------+---------+-------------+-------+
+    | CIM_class                     |   owned |   permanent |   all |
+    |-------------------------------+---------+-------------+-------|
+    | CIM_IndicationSubscription    |       0 |           2 |     2 |
+    | CIM_IndicationFilter          |       0 |           3 |     3 |
+    | CIM_ListenerDestinationCIMXML |       0 |           3 |     3 |
+    +-------------------------------+---------+-------------+-------+
+
 
 
 .. index:: pair: repl; command

--- a/docs/pywbemcli/generaloptions.rst
+++ b/docs/pywbemcli/generaloptions.rst
@@ -91,7 +91,7 @@ the following arguments :
    The following general options can be used for specifying additional
    information for the connection:
 
-   * The :ref:`--default-namespace general option` defines the default namespace
+   * The :ref:`--default-namespace general option` defines the :term:`default namespace`
      to be used if a command does not specify a namespace.
    * The :ref:`--user general option` defines the user name for authenticating
      with the WBEM server.
@@ -295,7 +295,7 @@ The argument value of the ``--default-namespace``/``-d`` general option is a
 string that defines the default :term:`CIM namespace` to use for the target
 WBEM server.
 
-If this option is not specified, the default namespace will be ``root/cimv2``.
+If this option is not specified, the :term:`default namespace` will be ``root/cimv2``.
 
 The default namespace will be used if the ``--namespace``/``-n`` command option
 is not used on a command.
@@ -575,14 +575,15 @@ path of a MOF file or Python script that loads a mock WBEM server in the
 pywbemcli process with mock data (i.e. CIM objects).
 This allows pywbemcli to be used without access to a real WBEM server.
 
-This option may be specified multiple times.
-
 This option may be specified multiple times to define multiple MOF and Python
 files that make up the definition of a mock server. The files must have the
 suffix ".mof" for MOF files and ".py" for Python scripts.
 
 When this option is used, the security options (ex. ``--user``) are irrelevant;
 they may be specified but are not used.
+
+See section :ref:`Mock WBEM server support` for information on the characteristics
+of the MOF and Python files that define a mock environment
 
 The following example creates a mock server with two files defining the mock
 data, shows what parameters are defined for the connection, and then saves that

--- a/pywbemtools/_output_formatting.py
+++ b/pywbemtools/_output_formatting.py
@@ -85,6 +85,21 @@ def output_format_is_table(output_format):
     return output_format in TABLE_FORMATS
 
 
+def output_format_is_cimobject(output_format):
+    """
+    Return boolean indicating whether an output format is a table format.
+
+    Parameters:
+
+      output_format (:term:`string`):
+         The output format keyword (e.g. 'mof') to be checked.
+
+    Returns:
+      bool: Boolean indicating whether the output format is a table format.
+    """
+    return output_format in CIM_OBJECT_FORMATS
+
+
 def output_format_in_groups(output_format, format_groups):
     """
     Return boolean indicating whether an output format is in a given format

--- a/pywbemtools/pywbemcli/__init__.py
+++ b/pywbemtools/pywbemcli/__init__.py
@@ -36,6 +36,7 @@ from ._cmd_server import *          # noqa: F403,F401
 from ._cmd_connection import *      # noqa: F403,F401
 from ._cmd_profile import *         # noqa: F403,F401
 from ._cmd_statistics import *      # noqa: F403,F401
+from ._cmd_subscription import *    # noqa: F403,F401
 from ._context_obj import *         # noqa: F403,F401
 from ._connection_repository import *   # noqa: F403,F401
 from .pywbemcli import *            # noqa: F403,F401

--- a/pywbemtools/pywbemcli/_cmd_subscription.py
+++ b/pywbemtools/pywbemcli/_cmd_subscription.py
@@ -1,0 +1,2071 @@
+# (C) Copyright 2021 IBM Corp.
+# (C) Copyright 2021 Inova Development Inc.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Click Command definition for the subscription command group which includes
+commands for managing subscriptions to indications on WBEM servers including
+adding, displaying, and remvoving destinations, filters, and subscriptions from
+a WBEM server.
+
+This command group is based on the  pywbem WBEMSubscriptionManager class.
+"""
+from __future__ import absolute_import
+
+import re
+
+import click
+
+from pywbem import CIMError, Error, WBEMSubscriptionManager, \
+    CIM_ERR_ALREADY_EXISTS
+
+from pywbem._subscription_manager import SUBSCRIPTION_CLASSNAME, \
+    DESTINATION_CLASSNAME, FILTER_CLASSNAME
+
+from .pywbemcli import cli
+
+from .._options import add_options, help_option
+
+from ._display_cimobjects import display_cim_objects, fold_strings
+
+from .._click_extensions import PywbemtoolsGroup, PywbemtoolsCommand, \
+    CMD_OPTS_TXT, GENERAL_OPTS_TXT, SUBCMD_HELP_TXT
+
+from ._common import pick_one_index_from_list, sort_cimobjects, \
+    verify_operation
+
+from .._output_formatting import validate_output_format, \
+    output_format_is_table, output_format_is_cimobject, format_table
+
+DEFAULT_QUERY_LANGUAGE = 'WQL'
+
+DEFAULT_SUB_MGR_ID = "defaultpywbemcliSubMgr"
+
+OWNED = True
+ALL = None
+
+# DESTINATION_CLASSNAME = 'CIM_ListenerDestinationCIMXML'
+# FILTER_CLASSNAME = 'CIM_IndicationFilter'
+# SUBSCRIPTION_CLASSNAME = 'CIM_IndicationSubscription'
+
+ownedadd_flag_option = [              # pylint: disable=invalid-name
+    click.option("--owned/--permanent", default=True,
+                 help=u"Defines whether an owned or permanent filter, "
+                      u"destination, or subscription is to be added.  "
+                      u"Default: owned"),
+]
+
+ownedremove_flag_option = [              # pylint: disable=invalid-name
+    click.option("--owned/--permanent", default=True,
+                 help=u"Defines whether an owned or permanent filter, "
+                      u"destination, or subscription is to be removed.  "
+                      u"Default: owned"),
+]
+
+ownedlist_choice_option = [              # pylint: disable=invalid-name
+    click.option("--type", default='all',
+                 type=click.Choice(['owned', 'permanent', 'all'],
+                                   case_sensitive=False),
+                 help=u"Defines whether the command is going to filter owned "
+                      u",permanent, or all objects for the response display.  "
+                      u"Default: all"),
+]
+
+names_only_option = [              # pylint: disable=invalid-name
+    click.option('--names-only', '--no', is_flag=True, required=False,
+                 help=u'Show the CIMInstanceName elements of the instances. '
+                      u'This only applies when the --output-format is one '
+                      u'of the CIM object options (ex. mof')
+]
+
+detail_option = [             # pylint: disable=invalid-name
+    click.option('-d', '--detail', is_flag=True, required=False,
+                 help=u"Show more detailed information. Otherwise only "
+                 u"non-null or predefined property values are displayed. It "
+                 u"applies to both MOF and TABLE output formats")
+]
+
+summary_option = [             # pylint: disable=invalid-name
+    click.option('-s', '--summary', is_flag=True, required=False,
+                 help=u'If True, show only summary count of instances ')
+]
+
+verify_remove_option = [       # pylint: disable=invalid-name
+    click.option('-v', '--verify', is_flag=True, default=False,
+                 help=u'Prompt user to verify instances to be removed before '
+                      u'request is sent to WBEM server.')
+]
+
+select_option = [             # pylint: disable=invalid-name
+    click.option('--select', is_flag=True, default=False,
+                 help=u'Prompt user to select from multiple objects '
+                      u'that match the IDENTITY. Otherwise, if the command '
+                      u'finds multiple instance that match the IDENTITY, the '
+                      u'operation fails.')
+]
+
+##################################################################
+#
+# Subcommand Click definitions
+#
+###################################################################
+
+
+@cli.group('subscription', cls=PywbemtoolsGroup,
+           options_metavar=GENERAL_OPTS_TXT, subcommand_metavar=SUBCMD_HELP_TXT)
+@add_options(help_option)
+def subscription_group():
+    """
+    Command group to manage WBEM indication subscriptions.
+
+    This group uses the pywbem subscription manager to create, view, and remove
+    CIM Indication subscriptions for a WBEM Server.
+
+    In addition to the command-specific options shown in this help text, the
+    general options (see 'pywbemcli --help') can also be specified before the
+    command. These are NOT retained after the command is executed.
+    """
+    pass
+
+
+@subscription_group.command('add-destination', cls=PywbemtoolsCommand,
+                            options_metavar=CMD_OPTS_TXT)
+@click.argument('identity', type=str, metavar='IDENTITY', required=True,)
+@click.option('-l', '--listener-url', type=str, metavar='URL',
+              help=u'Defines the URL of the target listener in the format: '
+                   u'[SCHEME://]HOST:PORT. SCHEME must be "https" (default) '
+                   u'or "http". HOST is a short or long hostname or literal '
+                   u'IPV4/v6 address. PORT is a positive integer and is '
+                   u'required')
+@add_options(ownedadd_flag_option)
+@add_options(help_option)
+@click.pass_obj
+def subscription_add_destination(context, identity, **options):
+    """
+    Add new listener destination.
+
+    This command adds a listener destination to be the target of indications
+    sent by a WBEM server a WBEM server, by adding an instance of the CIM class
+    "CIM_ListenerDestinationCIMXML" in the Interop namespace of the WBEM
+    server.
+
+    A listener destination defines the target of a WBEM indication
+    listener including URI of the listener including the listener port.
+
+    The required IDENTITY argument along with the --owned/--permanent option
+    define the ``Name`` key property of the new instance.  If the instance is to
+    be owned by the current SubscriptionManager, pywbemcli creates a 'Name'
+    property value with the format: "pywbemdestination:"
+    <SubscriptionManagerID> ":" <IDENTITY>. If the destination instance is to
+    be permanent, the value of the IDENTITY argument becomes the value of the
+    'Name' property.
+
+    Owned destinations are added or updated conditionally: If the destination
+    instance to be added is already registered with this subscription manager
+    and has the same property values, it is not created or modified. If an
+    instance with this path and properties does not exist yet (the normal
+    case), it is created on the WBEM server.
+
+    Permanent listener destinations are created unconditionally, and it is up to
+    the user to ensure that such an instance does not already exist.
+
+    If the --verbose general option is set, the created instance is displayed.
+    """
+    context.execute_cmd(lambda: cmd_subscription_add_destination(
+        context, identity, options))
+
+
+@subscription_group.command('add-filter', cls=PywbemtoolsCommand,
+                            options_metavar=CMD_OPTS_TXT)
+@click.argument('identity', type=str, metavar='IDENTITY', required=True,)
+@click.option('-q', '--query', type=str, metavar='FILTER',
+              required=True,
+              help=u'Filter query definition. This is a SELECT '
+                   u'statement in the query language defined in the '
+                   u'filter-query-language parameter')
+@click.option('--query-language', type=str, metavar='TEXT',
+              required=False,
+              default=DEFAULT_QUERY_LANGUAGE,
+              help=u"Filter query language for this subscription The query "
+                   u"languages normally implemented are 'DMTF:CQL' and 'WQL' . "
+                   u" Default: {0}".format(DEFAULT_QUERY_LANGUAGE))
+@click.option('--source-namespaces', type=str, metavar='TEXT',
+              required=False, default=None,
+              multiple=True,
+              help=u"The namespace(s) for which the query is defined. If not "
+                   u"defined, the default namespace of the server is used. "
+                   u"Define multiple namespaces by using option multiple times "
+                   u"or comma-separating namespaces names.")
+@add_options(ownedadd_flag_option)
+@add_options(help_option)
+@click.pass_obj
+def subscription_add_filter(context, identity, **options):
+    """
+    Add new indication filter.
+
+    This command adds an indication filter to a WBEM server, by
+    creating an indication filter instance (CIM class
+    "CIM_IndicationFilter") in the Interop namespace of the server.
+
+    A indication listener defines the query and query language to be used
+    by the WBEM server to create indications for an indication subscription.
+
+    The required IDENTITY argument of the command and the --owned/--permanent
+    option defines the 'Name' key property of the the created instance.  If the
+    the instance is to be owned by the current SubscriptionManager, pywbemcli
+    indirectly specifies the 'Name' property value with the format:
+    "pywbemfilter:" "<SubscriptionManagerID>" ":" <identity>``. If the
+    destination instance is to be permanent, the value of the IDENTITY argument
+    directly becomes the value of the Name property.
+
+    Owned indication filters are added or updated conditionally: If the
+    indication filter instance to be added is already registered with
+    this subscription manager and has the same property values, it is not
+    created or modified. If it has the same path but different property
+    values, it is modified to get the desired property values. If an
+    instance with this path does not exist yet (the normal case), it is
+    created.
+
+    Permanent indication filters are created unconditionally; it is
+    up to the user to ensure that such an instance does not exist yet.
+
+    If the --verbose general option is set, the created instance is displayed.
+    """
+    context.execute_cmd(lambda: cmd_subscription_add_filter(
+        context, identity, options))
+
+
+@subscription_group.command('add-subscription', cls=PywbemtoolsCommand,
+                            options_metavar=CMD_OPTS_TXT)
+@click.argument('destination-identity', type=str, metavar='DESTINATION',
+                required=True,)
+@click.argument('filter-identity', type=str, metavar='FILTER', required=True,)
+@add_options(ownedadd_flag_option)
+@add_options(select_option)
+@add_options(help_option)
+@click.pass_obj
+def subscription_add_subscription(context, destination_identity,
+                                  filter_identity, **options):
+    """
+    Add new indication subscription.
+
+    Adds an indication subscription to the current WBEM server for a particular
+    DESTINATION and FILTER. The command creates an instance of CIM association
+    class "CIM_IndicationSubscription" in the Interop namespace of the server.
+
+    The destination and filter instances to be used in the subscription is
+    based on the DESTINATION and FILTER arguments which define the
+    the 'Handler' and 'Filter' reference properties of the subscription
+    instance to be created.
+
+    The required DESTINATION argument defines the existing destination instance
+    that will be attached to the 'Handler' reference of the association class.
+    This argument may consist of either the value of the 'Name' property of the
+    target destination instance or the identity of that instance.  The identity
+    is the full value of the 'Name' property for permanent destinations and is
+    a component of the 'Name' property for owned instances. If just the
+    identity is used, this will result in multiple destinations being found if
+    the same string is defined as the identity of an owned and permanent
+    destination.
+
+    The required FILTER argument defines the existing filter instance that will
+    be attached to the 'Filter' reference of the association class. This
+    argument may consist of either the value of the 'Name' property of the
+    target filter instance or the identity of that instance.  The identity is
+    the full value of the 'Name' property for permanent filters and is a
+    component of the 'Name' property for owned instances. If just the identity
+    is used, this will result in multiple filters being found if the same
+    string is defined as the identity of an owned and permanent filter.
+
+    When creating permanent subscriptions, the indication filter and the
+    listener destinations must not be owned. for owned subscriptions,
+    indication filter and listener destination may be either owned or permanent.
+
+    Owned subscriptions are added or updated conditionally: If the
+    subscription instance to be added is already registered with
+    this subscription manager and has the same path, it is not
+    created.
+
+    Permanent subscriptions are created unconditionally, and it is up to
+    the user to ensure that such an instance does not already exist.
+
+    Upon successful return of this method, the added subscription is active on
+    the WBEM server, so that the specified WBEM listeners may immediately
+    receive indications.
+
+    If the --verbose general option is set, the created instance is displayed.
+    """
+    context.execute_cmd(lambda: cmd_subscription_add_subscription(
+        context, destination_identity, filter_identity, options))
+
+
+@subscription_group.command('list', cls=PywbemtoolsCommand,
+                            options_metavar=CMD_OPTS_TXT)
+@add_options(ownedlist_choice_option)
+@add_options(summary_option)
+@add_options(help_option)
+@click.pass_obj
+def subscription_list(context, **options):
+    """
+    Display indication subscriptions overview.
+
+    This command provides an overview of the count of subscriptions, filters,
+    and destinations retrieved from the WBEM server.
+    """
+    context.execute_cmd(lambda: cmd_subscription_list(context, options))
+
+
+@subscription_group.command('list-destinations', cls=PywbemtoolsCommand,
+                            options_metavar=CMD_OPTS_TXT)
+@add_options(ownedlist_choice_option)
+@add_options(detail_option)
+@add_options(names_only_option)
+@add_options(summary_option)
+@add_options(help_option)
+@click.pass_obj
+def subscription_list_destinations(context, **options):
+    """
+    Display indication listeners on the WBEM server.
+
+    Display existing CIM indication listener destinations on the current
+    connection. The listener destinations to be displayed can be filtered
+    by the owned choice option (owned, permanent, all).
+
+    The data display is determined by the --detail, --names_only, and --summary
+    options and can be displayed as either a table or CIM objects (ex. mof)
+    format using the --output general option (ex. --output mof).
+    """
+    context.execute_cmd(lambda: cmd_subscription_list_destinations(context,
+                                                                   options))
+
+
+@subscription_group.command('list-filters', cls=PywbemtoolsCommand,
+                            options_metavar=CMD_OPTS_TXT)
+@add_options(ownedlist_choice_option)
+@add_options(detail_option)
+@add_options(names_only_option)
+@add_options(summary_option)
+@add_options(help_option)
+@click.pass_obj
+def subscription_list_filters(context, **options):
+    """
+    Display indication filters on the WBEM server.
+
+    Display existing CIM indication filters (CIM_IndicationFilter class) on the
+    current connection. The indication filters to be displayed can be filtered
+    by the owned choice option (owned, permanent, all).
+
+    The data display is determined by the --detail, --names-only, and --summary
+    options and can be displayed as either a table or CIM objects (ex. mof)
+    format using the --output general option (ex. --output mof).
+
+    """
+    context.execute_cmd(lambda: cmd_subscription_list_filters(context, options))
+
+
+@subscription_group.command('list-subscriptions', cls=PywbemtoolsCommand,
+                            options_metavar=CMD_OPTS_TXT)
+@add_options(ownedlist_choice_option)
+@add_options(detail_option)
+@add_options(names_only_option)
+@add_options(summary_option)
+@add_options(help_option)
+@click.pass_obj
+def subscription_list_subscriptions(context, **options):
+    """
+    Display indication subscriptions on the WBEM server.
+
+    Displays information on indication subscriptions on the WBEM server,
+    filtering the subscriptions to be displayed can be filtered by the owned
+    choice option (owned, permanent, all).
+
+    The default display is a table of information from the associated
+    Filter and Handler instances
+
+    The data display is determined by the --detail, --names-only, and --summary
+    options and can be displayed as either a table or CIM objects (ex. mof)
+    format using the --output general option (ex. --output mof).
+
+    """
+    context.execute_cmd(lambda: cmd_subscription_list_subscriptions(
+        context, options))
+
+
+@subscription_group.command('remove-destination', cls=PywbemtoolsCommand,
+                            options_metavar=CMD_OPTS_TXT)
+@click.argument('identity', type=str, metavar='IDENTITY', required=True)
+@add_options(ownedremove_flag_option)
+@add_options(select_option)
+@add_options(help_option)
+@add_options(verify_remove_option)
+@click.pass_obj
+def subscription_remove_destination(context, identity, **options):
+    """
+    Remove a listener destination from the WBEM server.
+
+    Removes a listener destination instance (CIM_ListenerDestinationCIMXML)
+    from the WBEM server where the instance to be removed is identified by the
+    IDENTITY argument and optional owned option of the command.
+
+    The required IDENTITY argument may be the value of the IDENTITY used to
+    create the destination or may be the full value of the destination 'Name'
+    property. This is the value of the 'Name' property for permanent
+    destinations and a component of the 'Name' property for owned destinations.
+
+    If the instance is owned by the current pywbem SubscriptionManager,
+    pywbemcli indirectly specifies the Name property value with the format:
+    "pywbemdestination:" "<SubscriptionManagerID>" ":" <IDENTITY>``. If the
+    destination instance is permanent, the value of the IDENTITY argument
+    is the value of the Name property.
+
+    Some listener_destination instances on a server may be static in which
+    case the server should generate an exception. Pywbemcli has no way to
+    identify these static destinations and they will appear as permanent
+    destination instances.
+
+    The --select option can be used if, for some reason, the IDENTITY and
+    ownership returns multiple instances. This should only occur in rare cases
+    where destination instances have been created by other tools. If the
+    --select option is not used pywbemcli displays the paths of the instances
+    and terminates the
+    command.
+    """
+    context.execute_cmd(lambda: cmd_subscription_remove_destination(
+        context, identity, options))
+
+
+@subscription_group.command('remove-filter', cls=PywbemtoolsCommand,
+                            options_metavar=CMD_OPTS_TXT)
+@click.argument('identity', type=str, metavar='IDENTITY', required=True)
+@add_options(ownedremove_flag_option)
+@add_options(select_option)
+@add_options(verify_remove_option)
+@add_options(help_option)
+@click.pass_obj
+def subscription_remove_filter(context, identity, **options):
+    """
+    Remove an indication filter from the WBEM server.
+
+    Removes a single indication filter instance (CIM_IndicationFilter class)
+    from the WBEM server where the instance to be removed is identified by the
+    IDENTITY argument and optional --owned option of the command.
+
+    The required IDENTITY argument may be the value of the IDENTITY
+    used to create the filter or may be the full value of the filter Name
+    property. For permanent filters the value of the Name property is required;
+    for owned destinations the IDENTITY component of the Name property is
+    sufficient.
+
+    If the instance is owned by the current pywbem SubscriptionManager,
+    pywbemcli indirectly specifies the Name property value with the format:
+    "pywbemfilter:" "<SubscriptionManagerID>" ":" <IDENTITY>``. If the
+    destination instance is permanent, the value of the IDENTITY argument
+    is the value of the Name property.
+
+    The --select option can be used if, the IDENTITY and ownership returns
+    multiple instances. This should only occur in rare cases where filter
+    instances have been created by other tools. If the --select option is not
+    used pywbemcli displays the paths of the instances and terminates the
+    command.
+    """
+    context.execute_cmd(lambda: cmd_subscription_remove_filter(
+        context, identity, options))
+
+
+@subscription_group.command('remove-subscription', cls=PywbemtoolsCommand,
+                            options_metavar=CMD_OPTS_TXT)
+@click.argument('destination-identity', type=str, metavar='DESTINATION',
+                required=True,)
+@click.argument('filter-identity', type=str, metavar='FILTER', required=True,)
+@add_options(verify_remove_option)
+@click.option('--remove-associated-instances', is_flag=True,
+              default=False,
+              help=u'Attempt to remove the instances associated with this '
+                   u'subscription. They will only be removed if they do not '
+                   u'participate in any other associations.')
+@add_options(select_option)
+@add_options(help_option)
+@click.pass_obj
+def subscription_remove_subscription(context, destination_identity,
+                                     filter_identity, **options):
+    """
+    Remove indication subscription from the WBEM server.
+
+    This command removes an indication subscription instance from the
+    WBEM server.
+
+    The selection of subscription to be removed is defined by the
+    DESTINATION and FILTER arguments which define the Name property of the
+    destination and filter associations of the subscription to be
+    removed.
+
+    The required DESTINATION argument defines the existing destination
+    instance that will be attached to the Filter reference of the association
+    class. This argument may consist of either the value of the Name property
+    of the target destination instance or the identity of that instance.  The
+    identity is the full value of the Name property for permanent destinations
+    and is a component of the Name property for owned instances. If just the
+    identity is used, this will result in multiple destinations being found if
+    the same string is defined as the identity of an owned and permanent
+    destination.
+
+    The required FILTER argument defines the existing filter instance that will
+    be attached to the 'Filter' reference of the association class. This
+    argument may consist of either the value of the 'Name' property of the
+    target filter instance or the identity of that instance.  The identity is
+    the full value of the 'Name' property for permanent filters and is a
+    component of the 'Name' property for owned instances. If just the identity
+    is used, this may result in multiple filters being found if the same string
+    is defined as the identity of an owned and permanent filter.
+
+    This operation does not remove associated filter or destination instances
+    unless the option --remove-associated-instances is included in the command
+    and the associated instances are not used in any other association.
+    """
+    context.execute_cmd(lambda: cmd_subscription_remove_subscription(
+        context, destination_identity, filter_identity, options))
+
+
+@subscription_group.command('remove-server', cls=PywbemtoolsCommand,
+                            options_metavar=CMD_OPTS_TXT)
+@add_options(help_option)
+@click.pass_obj
+def subscription_remove_server(context, **options):
+    """
+    Remove current WBEM server from the SubscriptionManager.
+
+    This command unregisters owned listeners from the WBEM server and removes
+    all owned indication subscriptions, owned indication filters, and owned
+    listener destinations for this server-id from the WBEM server.
+    """
+    context.execute_cmd(lambda: cmd_subscription_remove_server(context,
+                                                               options))
+
+
+#####################################################################
+#
+# Class to communicate with WBEMSubscriptionManager
+#
+#####################################################################
+
+
+class CmdSubscriptionManager(object):
+    """
+    Encapsulate the initial parsing and common variables of subscriptions in
+    a single class and provide a set of methods that mirror the
+    SubscriptionManager class but for the defined subscription manager id and
+    server id.
+
+    All communication with the WBEMSubscriptionManager pass through this class
+    and exceptions from WBEMSubscriptionManager are captured in these
+    methods to simplify the command action functions.
+
+    Some of the WBEMSubscriptionManager methods have been compressed from
+    multiple (owned/all) methods into a single method with an owned parameter.
+    """
+    def __init__(self, context, options):
+        """
+        Initialize the CmdSubscriptionManager instance and the
+        WBEMSubscriptionManager instance with the subscriptionmananager_id
+        defined.  This retrieves any owned objects from the WBEMServer defined
+        by the server_id.
+        Parameters:
+
+          context(:class:`'~pywbemtools._context_obj.ContextObj`):
+            The pywbemcli context object for the current command passed to
+            the action function.
+
+          options :class:`py:dict`:
+            The options variable passes to the current command action function.
+        """
+        if not context.pywbem_server_exists():
+            raise click.ClickException("No WBEM server defined.")
+        self._context = context
+        if 'submgr_id' in options:
+            self._submgr_id = options['submgr_id']
+        else:
+            self._submgr_id = DEFAULT_SUB_MGR_ID
+
+        # ValueError and TypeError fall through. They are real programming
+        # errors in this code.
+        self._submgr = WBEMSubscriptionManager(
+            subscription_manager_id=self._submgr_id)
+
+        # Register the server in the subscription manager and get
+        # owned subscriptions, filter, and destinations from server
+        # Do not catch Value and Key exceptions. They fall through
+        self._server_id = self._submgr.add_server(
+            context.pywbem_server.wbem_server)
+
+        # Define the Name property prefix and search pattern for owned filters,
+        # etc. This is determined by a constant and the submgr_id string.
+        self.owned_destination_prefix = \
+            "pywbemdestination:{0}".format(self.submgr_id)
+        self.owned_filter_prefix = "pywbemfilter:{0}".format(self.submgr_id)
+
+        self.filter_name_pattern = re.compile(
+            r'^pywbemfilter:{0}:([^:]*)$'.format(self.submgr_id))
+        self.destination_name_pattern = re.compile(
+            r'^pywbemdestination:{0}:([^:]*)$'.format(self.submgr_id))
+
+    @property
+    def server_id(self):
+        """
+        Return the server_id init variable
+        """
+        return self._server_id
+
+    @property
+    def submgr(self):
+        """
+        Return the submger object instance
+        """
+        return self._submgr
+
+    @property
+    def submgr_id(self):
+        """
+        Return the subscription manager id string
+        """
+        return self._submgr_id
+
+    @property
+    def context(self):
+        """
+        return the Click context object supplied to command action function
+        """
+        return self._context
+
+    def get_destinations(self, owned):
+        """
+        Get the owned indication destinations or all indication
+        destinations from WBEMSubscriptionManager. This method uses
+        pywbem.SubscriptionManager APIs to return either owned or all
+        destination instances based on the owned parameter.
+
+        Parameters:
+
+          owned (:class:`py:bool`):
+            If True,return only owned destination instances. Otherwise return
+            all destination instances the match to the filter_id or name.
+
+        Returns:
+            List of CIM_ListenerDestinationCIMXML objects
+
+        Raises:
+            click.ClickException if the request encounters an error.
+        """
+        try:
+            if owned:
+                return self.submgr.get_owned_destinations(self.server_id)
+
+            return self.submgr.get_all_destinations(self.server_id)
+
+        except Error as er:
+            type_ = "owned" if owned else "all"
+            raise click.ClickException(
+                self.err_msg("Get {0} destinations failed".format(type_), er))
+
+    def get_filters(self, owned):
+        """
+        Get either the owned indication filters or all indication filters from
+        WBEMSubscriptionManager. This method uses pywbem.SubscriptionManager
+        APIs to return either owned filters or all filters based on the owned
+        parameter.
+
+        Parameters:
+
+          owned (:class:`py:bool`):
+            If True,return only owned filters. Otherwise return all filters
+            the match to the filter_id or name
+
+        Returns:
+            List of CIM_IndicationFilter objects
+
+        Raises:
+            click.ClickException if the request encounters an error.
+        """
+        try:
+            if owned:
+                return self.submgr.get_owned_filters(self.server_id)
+
+            return self.submgr.get_all_filters(self.server_id)
+
+        except Error as er:
+            type_ = "owned" if owned else "all"
+            raise click.ClickException(
+                self.err_msg("Get {0} filters failed".format(type_), er))
+
+    def get_subscriptions(self, owned):
+        """
+        Get  subscriptions from the server.  This method uses
+        pywbem.SubscriptionManager APIs to return either owned subscriptions
+        or all subscriptions based on the owned parameter.
+
+        Parameters:
+
+            owned (:class:`py:bool`):
+                True is owned, False is all subscriptions
+
+        Returns:
+            list of subscriptions either owned or all subscriptions
+
+        """
+        try:
+            if owned:
+                return self.submgr.get_owned_subscriptions(self.server_id)
+
+            return self.submgr.get_all_subscriptions(self.server_id)
+
+        except Error as er:
+            type_ = "owned" if owned else "all"
+            raise click.ClickException(
+                self.err_msg("Get {0} subscriptions failed".format(type_), er))
+
+    def add_destination(self, listener_url, owned, destination_id,
+                        destination_name, persistence_type=None):
+        """
+        Add listener destination URLs. Adds one listener destination to
+        the current WBEM server target using the Subscription Manager APIs.
+
+        Returns exception if destination already exists.
+
+        See pywbem.WBEMSubscriptionManager.add_destination for parameter
+        details.
+
+        Returns:
+          Instance created by pywbem SubscriptionManager.
+
+        Raises:
+            click.ClickException for all errors
+        """
+        # TODO: change to test this for same identity if owned
+        dest_len = self.get_destinations(True)
+        try:
+            dest = self.submgr.add_destination(
+                self.server_id, listener_url, owned,
+                destination_id, destination_name,
+                persistence_type=persistence_type)
+            # Test because SubscriptionManager tests for url equality
+            # before testing for same Name property for owned dests
+            # See issue pywbem #2782
+            if owned:
+                # TODO: Remove this when pywbem pr #2784 merged
+                if dest_len == self.get_destinations(True):
+                    if dest['Name'].endswith(destination_id):
+                        raise click.ClickException(
+                            "add-destination failed. Name property '{}' "
+                            "already exists.".format(dest['Name']))
+
+                    # Raise CIMError that pywbem should have raised
+                    raise CIMError(
+                        CIM_ERR_ALREADY_EXISTS,
+                        "Listener destination instance with Name='{0}' already "
+                        "exists: {1}".format(dest['Name'], dest.path))
+            return dest
+
+        # Invalid input parameters exception
+        except ValueError as ve:
+            raise click.ClickException(
+                "add-destination failed: {0}".format(ve))
+        except CIMError as er:
+            if er.status_code == CIM_ERR_ALREADY_EXISTS:
+                raise click.ClickException(
+                    "add-destination failed. Destination listener {0} "
+                    "already exists. Exception: {1}".format(destination_id, er))
+            raise click.ClickException(
+                self.err_msg("add-destination failed", er))
+
+    def add_filter(self, source_namespaces, query,
+                   query_language=DEFAULT_QUERY_LANGUAGE, owned=True,
+                   filter_id=None, name=None, source_namespace=None):
+        """
+        Add an indication filter calls WBEMSubscriptionManager.add_filter and
+        captures exceptions.  See WBEMSubscriptionManager for details of
+        parameters.
+
+        See pywbem.SubscriptionManager.add_filter for information on
+            parameters.
+
+        Returns:
+            The created indication filter instance created by
+            pywbwm SubscriptionManager.
+
+        Raises:
+            click.ClickException for all exceptions received from pywbem
+        """
+        try:
+            return self.submgr.add_filter(
+                self.server_id, source_namespaces, query,
+                query_language=query_language, owned=owned, filter_id=filter_id,
+                name=name, source_namespace=source_namespace)
+
+        except (TypeError, ValueError) as exc:
+            raise click.ClickException(
+                self.err_msg("add-filter failed. Pywbem parameter error", exc))
+        except CIMError as ce:
+            if ce.status_code == CIM_ERR_ALREADY_EXISTS:
+                name_value = filter_id or name
+                raise click.ClickException(
+                    "add-filter Failed. Filter name='{0}' already exists".
+                    format(name_value))
+
+            raise click.ClickException(
+                self.err_msg("add-filter failed with server exception", ce))
+        except Error as er:
+            raise click.ClickException(
+                self.err_msg("add-filter failed with server exception", er))
+
+    def add_subscriptions(self, filter_path, destination_paths=None,
+                          owned=True):
+        """
+        Add the subscription defined by filter_path and dest_path. Note that
+        if the path of the subscription already exists it is not added.
+        The ownership is defined by the ownership of the filter and
+        destination and they must match
+        """
+        try:
+            return self.submgr.add_subscriptions(
+                self.server_id, filter_path,
+                destination_paths=destination_paths,
+                owned=owned)
+
+        except ValueError as ex:
+            raise click.ClickException(
+                "add-subscription failed. pybwem SubscriptionManager "
+                "exception: {0}.".format(ex))
+        except Error as er:
+            raise click.ClickException(
+                self.err_msg("add-subscription failed", er))
+
+    def remove_destinations(self, destination_paths):
+        """
+        Remove the destination instances defined by the destination paths
+        parameter.
+
+        Parameters:
+            See pywbem.SubscriptionManager.remove_destinations
+        Raises:
+
+            Exceptions raised by :class:`~pywbem.WBEMConnection`.
+            CIMError: CIM_ERR_FAILED, if there are referencing subscriptions.
+
+        """  # noqa: E501
+        try:
+            return self.submgr.remove_destinations(self.server_id,
+                                                   destination_paths)
+        except Error as er:
+            raise click.ClickException(
+                self.err_msg("remove-destination failed", er))
+
+    def remove_filter(self, filter_path):
+        """
+        Remove the filter defined by filter_path from the WBEM Server.
+        """
+        try:
+            return self.submgr.remove_filter(self.server_id, filter_path)
+        except Error as er:
+            raise click.ClickException(
+                self.err_msg("remove-filter failed: {0} path: {1} failed".
+                             format(er, filter_path), er))
+
+    def remove_subscriptions(self, subscription_paths):
+        """
+        Remove subscriptions calls the SubscriptionManager remove_subscriptions
+
+        Raises:
+            click.ClickException if SubscriptionManager returns exception
+        """
+        try:
+            return self.submgr.remove_subscriptions(self.server_id,
+                                                    subscription_paths)
+        except Error as er:
+            raise click.ClickException(
+                self.err_msg("remove-subscriptions failed", er))
+
+    def remove_server(self):
+        """
+        Remove the WBEM server defined by the server_id from the subscription
+        manager and also unregister destinations and remove owned
+        destinations, filters, and subscriptions from the server.
+
+        Raises:
+            click.ClickException if SubscriptionManager returns exception
+        """
+        try:
+            self.submgr.remove_server(self.server_id)
+        except Error as er:
+            raise click.ClickException(self.err_msg("remove-Server failed", er))
+
+    def is_owned_destination(self, instance):
+        """
+        Test Destination instance/path Name property/key and return True
+        if it has correct prefix for owned, type-choice is owned, all, or
+        permanent.
+        """
+        return instance['Name'].startswith(self.owned_destination_prefix)
+
+    def is_owned_filter(self, instance):
+        """
+        Test Filter instance Name property or instance_path Name key and return
+        True if it has correct prefix for owned
+        """
+        return instance['Name'].startswith(self.owned_filter_prefix)
+
+    def is_owned_subscription(self, instance):
+        """
+        Test if subscription instance and instance path are owned instances.
+        """
+        hdlr = self.is_owned_destination(instance['Handler'])
+        fltr = self.is_owned_filter(instance['Filter'])
+        return fltr or hdlr
+
+    def _get_permanent_destinations(self):
+        """
+        Get just the permanent destinations
+        """
+        all_dests = self.get_destinations(False)
+        return [d for d in all_dests if not
+                d['Name'].startswith(self.owned_destination_prefix)]
+
+    def _get_permanent_filters(self):
+        """
+        Get just the permanent filters
+        """
+        all_filters = self.get_filters(False)
+        return [d for d in all_filters if not
+                d['Name'].startswith(self.owned_filter_prefix)]
+
+    def _get_permanent_subscriptions(self):
+        """
+        Get just the permanent subscriptions (all - owned)
+        """
+        all_subscriptions = self.get_subscriptions(False)
+        owned_subscriptions = self.get_subscriptions(True)
+
+        # Future: The test here is excessive. Should test only paths
+        return [s for s in all_subscriptions if s not in owned_subscriptions]
+
+    def get_destinations_for_owned_choice(self, choice):
+        """
+        Get list of destinations based on choice where choice is all, permanent,
+        or owned. type-choice is owned, all, or permanent.
+        """
+        assert choice in ('owned', 'all', 'permanent')
+        if choice == 'owned':
+            return self.get_destinations(True)
+        if choice == 'all':
+            return self.get_destinations(False)
+
+        return self._get_permanent_destinations()
+
+    def get_filters_for_owned_choice(self, choice):
+        """
+        Get list of destinations based on choice where choice is all, permanent,
+        or owned.
+        """
+        assert choice in ('owned', 'all', 'permanent')
+        if choice == 'owned':
+            return self.get_filters(True)
+        if choice == 'all':
+            return self.get_filters(False)
+
+        return self._get_permanent_filters()
+
+    def get_subscriptions_for_owned_choice(self, choice):
+        """
+        Get list of subscriptions based on choice where choice is all,
+        permanent, or owned
+        """
+        assert choice in ('owned', 'all', 'permanent')
+        if choice == 'owned':
+            return self.get_subscriptions(True)
+        if choice == 'all':
+            return self.get_subscriptions(False)
+
+        return self._get_permanent_subscriptions()
+
+    def find_destinations_for_name(self, destination_name, fail_if_none=True):
+        """
+        Find destination instances that match the identity provided
+        where the identity is the value of the Name property.
+        The identity prefix determines whether the owned or
+        all destination list is processed.
+
+          Parameters:
+            destination_names (:term:`string`):
+
+          Returns:
+            destination instances found that match destination_name
+        """
+        owned_destination_flag = destination_name.startswith(
+            self.owned_destination_prefix)
+
+        destinations = self.get_destinations(owned_destination_flag)
+
+        destination_insts = [f for f in destinations if f['Name'] ==
+                             destination_name]
+
+        if fail_if_none:
+            if not destination_insts:
+                raise click.ClickException(
+                    "No destination found with Name: '{0}'".
+                    format(destination_name))
+
+        return destination_insts
+
+    def find_filters_for_name(self, filter_name, fail_if_none=True):
+        """
+        Find filter instances that match the identity provided
+        where the identity is the value of the Name property.
+        The name prefix determines whether the owned or
+        all filters lists are searched
+        """
+        owned_filter_flag = filter_name.startswith(self.owned_filter_prefix)
+        filters = self.get_filters(owned_filter_flag)
+
+        filter_insts = [f for f in filters if f['Name'] == filter_name]
+
+        if fail_if_none:
+            if not filter_insts:
+                raise click.ClickException(
+                    "No filters found with Name: '{0}'".
+                    format(filter_name))
+
+        return filter_insts
+
+    def err_msg(self, text, er):
+        """
+        Create a text message from the inputs and return it to the caller.
+        """
+        return "{0}; {1}: Exception :{2}. Subscription mgr id: '{3}', " \
+               "server id: '{4}', " .format(er, text, er.__class__.__name__,
+                                            self.submgr, self.server_id)
+
+##########################################################################
+#
+#   Common functions/classes for this command group
+#
+##########################################################################
+
+
+class BaseIndicationObjectInstance(object):
+    """
+    Base class for the Indication Instances. Common attributes and methods.
+    These classes encapsulate the processing for a single indication
+    destination, filter, or subscription instance including parsing
+    Name property, getting property values, and building the select_id used
+    when instances are to be selected from the console.
+    """
+    def __init__(self, csm, instance):
+        """ Initialize common attributes """
+        self.csm = csm
+        self.instance = instance
+        self.owned = None
+
+    @property
+    def owned_str(self):
+        """
+        Returns boolean True if this instance is owned. Otherwise returns False
+        """
+        return 'owned' if self.owned else 'permanent'
+
+    def instance_property(self, property_name):
+        """
+        Return the value of the property_name in the filter or an empty
+        string
+        """
+        return self.instance.get(property_name, "")
+
+
+class IndicationDestination(BaseIndicationObjectInstance):
+    """
+    Process an IndicationDestination instance to create values for owned,
+    other identity characteristics.
+    """
+    def __init__(self, csm, destination_instance):
+        """
+        Initialize the object and parse the identity for components
+        """
+        super(IndicationDestination, self).__init__(csm, destination_instance)
+
+        m = re.match(csm.destination_name_pattern,
+                     self.instance.path.keybindings['Name'])
+
+        self.owned = bool(m)
+
+        self.destination_id = m.group(1) if m else ""
+        self.destination_name = "" if m else \
+            self.instance.path.keybindings['Name']
+
+        self.identity = self.destination_id if self.owned \
+            else self.destination_name
+
+    def select_id_str(self):
+        """
+        Build an identification string for use in picking destinations.
+        Consists of ownership, url, destination property and name
+        Returns path without namespace as string to use in select.
+        """
+        path = self.instance.path.copy()
+        path.namespace = None
+        return str(path)
+
+
+class IndicationFilter(BaseIndicationObjectInstance):
+    """
+    Class that contains name property parsing and other common methods for
+    procesing indication filter instances
+    """
+    def __init__(self, csm, filter_instance):
+        super(IndicationFilter, self).__init__(csm, filter_instance)
+
+        path_ = filter_instance.path
+        m = re.match(csm.filter_name_pattern, path_.keybindings['Name'])
+        self.owned = bool(m)
+
+        self.filter_id = m.group(1) if m else ""
+        self.filter_name = "" if m else path_.keybindings['Name']
+
+        self.identity = self.filter_id if self.owned else self.filter_name
+
+    def select_id_str(self):
+        """
+        Build an identification string for use in picking filters. This includes
+        properties from the instance that help to determine its uniqueness.
+        The Name property cannot always be this because the owned name is too
+        long so only the filter_id is used in this case and is not the
+        only item that can distinguish filters.
+        """
+        path = self.instance.path.copy()
+        path.namespace = None
+        return str(path)
+
+
+class IndicationSubscription(BaseIndicationObjectInstance):
+    """
+    Process an IndicationSubscription instance to create values for owned,
+    other identity characteristics.
+    """
+    def __init__(self, csm, subscription_instance):
+        super(IndicationSubscription, self).__init__(csm, subscription_instance)
+        self.owned = csm.is_owned_subscription(subscription_instance)
+
+    def select_id_str(self):
+        """
+        Build an identification string for use in picking subscriptions.  This
+        short string contains information from the associated filter
+        and destination instances.
+        """
+        conn = self.csm.context.pywbem_server.conn
+        filter_inst = conn.GetInstance(self.instance['Filter'])
+        dest_inst = conn.GetInstance(self.instance['Handler'])
+
+        # Get filter and destination select_id_str strings
+        filterinst = IndicationFilter(self.csm, filter_inst)
+        filter_str = filterinst.select_id_str()
+
+        destinst = IndicationDestination(self.csm, dest_inst)
+        dest_str = destinst.select_id_str()
+
+        return '{0} {1} {2}'.format(self.owned, dest_str, filter_str)
+
+
+def get_owned_str(owned):
+    """Return "owned" or "permanent" string depending on input boolean """
+    return "owned" if owned else "permanent"
+
+
+def display_inst_nonnull_props(context, options, instances, output_format):
+    """
+    Display the instances defined in instances after removing any properties
+    that are Null for all instances.
+    """
+    pl = None
+    # Create a dictionary of all properties that have non-null values
+    pldict = {}
+    for inst in instances:
+        for name, prop in inst.properties.items():
+            if prop.value:
+                pldict[name] = True
+    pl = list(pldict.keys())
+
+    display_cim_objects(context, instances, output_format,
+                        summary=options['summary'], sort=True,
+                        property_list=pl)
+
+
+def pick_one_inst_from_instances_list(csm, instances, pick_msg):
+    """
+    Pick one instance from list using pywbemcli pick method.
+    Presents list of paths to user and returns with picked instance
+    """
+    path = pick_one_path_from_instances_list(csm, instances, pick_msg)
+    rtn_inst = [i for i in instances if i.path == path]
+    assert len(rtn_inst) == 1
+    return rtn_inst[0]
+
+
+def pick_one_path_from_instances_list(csm, instances, pick_msg):
+    """
+    Pick one instance from list using the pywbemcli pick method.
+    This presents list of instance information to user and returns with picked
+    object path.
+
+    Returns:
+        Instance path of instance selected.
+
+    Raises:
+        click.ClickException for any error.
+    """
+    assert instances is not None
+    instances = sort_cimobjects(instances)
+    paths = [inst.path for inst in instances]
+
+    # Get the short info() string for the class defined for this instance
+    if paths[0].classname == FILTER_CLASSNAME:
+        display_list = \
+            [IndicationFilter(csm, i).select_id_str() for i in instances]
+    elif paths[0].classname == DESTINATION_CLASSNAME:
+        display_list = \
+            [IndicationDestination(csm, i).select_id_str() for i in instances]
+    elif paths[0].classname == SUBSCRIPTION_CLASSNAME:
+        display_list = \
+            [IndicationSubscription(csm, i).select_id_str() for i in instances]
+    else:
+        click.echo("Class {0} is not one of pywbem subscription mgr classes".
+                   format(paths[0].classname))
+        display_list = paths
+    try:
+        index = pick_one_index_from_list(csm.context, display_list, pick_msg)
+        return paths[index]
+    except ValueError as exc:
+        raise click.ClickException(str(exc))
+
+
+def resolve_instances(csm, instances, identity, obj_type_name,
+                      select_opt, action):
+    """
+    Resolve list of instances to a single instance or exception.
+    If select_opt, ask user to select.  Otherwise, generate
+    exception with info for each object to help user pick.
+
+      Parameters:
+        csm (csm object):
+
+        instances (list)
+            List of instances that are canidates to be used where only
+            one is allowed.
+
+        identity (:term:`string`):
+            String defining the identity that selected the instances.
+            Used in the select statement as part of the prompt.
+
+        object_type_name (:term: String):
+            either 'destination' or 'filter'. Used in exception messages.
+
+        select_opt (:class:`py:bool`):
+            The value of the select option.  If True, the the prompt for
+            the user to select one of the list of instances will be
+            presented.  If False, the command will be terminated with
+
+        action (:term:`string`)
+            The name of the command ('add' or 'remove') to be used in
+            the displays
+
+    Returns:
+        One of the instances in instances if it matches the identity
+        string
+
+    Raises:
+        click.ClickException:  This terminates the current command
+
+    """
+    # Exception, at least one instance must exist.
+    if not instances:
+        raise click.ClickException("No {0} found for identity: {1}".
+                                   format(obj_type_name, identity))
+    # Return the single item
+    if len(instances) == 1:
+        return instances[0]
+
+    # Ask user to pick one from list with prompt
+    if select_opt:
+        # FUTURE: Need better than path for prompt info.
+        inst = pick_one_inst_from_instances_list(
+            csm, instances, "Pick one {0} to use for {1}:".
+            format(obj_type_name, action))
+        return inst
+
+    # Generate an exception with summary info on the instances
+    paths_str = "\n  *".join([str(i.path) for i in instances])
+    raise click.ClickException(
+        "The identity: '{0}' returned multiple {1} instances. "
+        "Use --select option to pick one instance from:\n  * {2}".
+        format(identity, obj_type_name, paths_str))
+
+
+def get_insts_for_subscription_identities(csm, destination_identity,
+                                          filter_identity, cmd_action,
+                                          select_opt):
+    """
+    Identity resolution for add and remove subscriptions where two identites
+    are to be provided as arguments for the command. Returns the instances
+    found or an exception if no instances for the destination and filter found.
+    The identity can be either the full name as target or only the
+    id suffix of an owned element
+    """
+    # Initial and only search if destination includes owned prefix
+    destination_id_owned = destination_identity.startswith(
+        csm.owned_filter_prefix)
+
+    # Searches for match the identity value provided
+
+    destination_instances = csm.find_destinations_for_name(
+        destination_identity, fail_if_none=destination_id_owned)
+
+    # If the Identity  does not include owned prefix, search also for
+    # the full owned name
+    if not destination_id_owned:
+        d2 = csm.find_destinations_for_name(
+            "{0}:{1}".format(csm.owned_destination_prefix,
+                             destination_identity),
+            fail_if_none=False)
+        if d2:
+            destination_instances.extend(d2)
+
+    sub_destination_inst = resolve_instances(
+        csm, destination_instances, destination_identity,
+        'destination', select_opt, cmd_action)
+
+    filter_id_owned = filter_identity.startswith(csm.owned_filter_prefix)
+    filter_instances = csm.find_filters_for_name(
+        filter_identity, fail_if_none=filter_id_owned)
+
+    # If Identity not specifically owned, look also in owned with the owned
+    # prefix. This may result  in multiples that must be resolved
+    if not filter_id_owned:
+        f2 = csm.find_filters_for_name("{0}:{1}".format(
+            csm.owned_filter_prefix, filter_identity), fail_if_none=False)
+        if f2:
+            filter_instances.extend(f2)
+
+    sub_filter_inst = resolve_instances(csm, filter_instances, filter_identity,
+                                        'filter', select_opt, cmd_action)
+
+    return sub_destination_inst, sub_filter_inst
+
+
+#####################################################################
+#
+#  Command functions for each of the subcommands in the subscription group
+#
+#####################################################################
+
+
+def cmd_subscription_add_destination(context, identity, options):
+    """
+    Add indication destination CIM instance to wbem server.
+    """
+    csm = CmdSubscriptionManager(context, options)
+
+    owned_opt = options['owned']
+    destination_id = identity if owned_opt else None
+    destination_name = None if owned_opt else identity
+
+    # FUTURE: Should we make this an input parameter under some circumstances.
+    # ex. if name, we could set transient or permanent. Always transient
+    # if filter_id has value.
+    persistence_type = "transient" if destination_id else "permanent"
+
+    # For permanent destinations. test if  destination already exists before
+    # making request.
+    # We do not allow permanent destinations with same name property
+    # independent of complete path being equal to keep Name properties unique
+    if not owned_opt:
+        dests = csm.find_destinations_for_name(destination_name,
+                                               fail_if_none=False)
+        if dests:
+            dests_str = ", ".join([str(d.path) for d in dests])
+            raise click.ClickException(
+                "{0} destination: Name=[{1}] add failed. Duplicates URL of "
+                "existing destination(s): [{2}. Pywbemcli does not allow "
+                "permanent destinations with same Name property to keep Name "
+                "properties unique.".
+                format(get_owned_str(owned_opt), destination_name, dests_str))
+
+    destination_result = csm.add_destination(
+        options['listener_url'], owned_opt, destination_id, destination_name,
+        persistence_type=persistence_type)
+
+    # Success: Show resulting name and conditionally, details
+    context.spinner_stop()
+
+    # If the URL, etc. of this owned add matches an existing owned destination
+    # pywbem returns the existing destination.  Modify the  result message
+    # to indicate what was returned.
+    if owned_opt and not destination_result['Name'].endswith(destination_id):
+        click.echo(
+            "{0} destination: Name={1} Not added. Duplicates URL of "
+            "existing destination: {2}.".
+            format(get_owned_str(owned_opt), destination_name,
+                   destination_result['Name']))
+    else:
+        click.echo(
+            "Added {0} destination: Name={1}".
+            format(get_owned_str(owned_opt), destination_result['Name']))
+
+    if context.verbose:
+        click.echo("\npath={0}\n\n{1}".
+                   format(str(destination_result.path),
+                          destination_result.tomof()))
+
+
+def cmd_subscription_add_filter(context, identity, options):
+    """
+    Add a filter defined by the input argument to the target server.
+    """
+    csm = CmdSubscriptionManager(context, options)
+    owned_opt = options['owned']
+    filter_id = identity if owned_opt else None
+    filter_name = None if owned_opt else identity
+
+    # Get source namespaces, multiple strings in tuple and/or
+    # multiple namespace names comma-separated in any string in tuple
+    # NOTE: SubscriptionManager requires list as input
+    source_ns_opt = options['source_namespaces'] or \
+        [context.pywbem_server.conn.default_namespace]
+    source_namespaces = []
+    for sn in source_ns_opt:
+        if ',' in sn:
+            source_namespaces.extend(sn.split(','))
+        else:
+            source_namespaces.append(sn)
+
+    if not owned_opt:
+        filters = csm.find_filters_for_name(filter_name, fail_if_none=False)
+        if filters:
+            filters_str = ", ".join([str(f.path) for f in filters])
+            raise click.ClickException(
+                "{0} filter: Name=[{1}] add failed. Duplicates URL of "
+                "existing filters(s): [{2}. Pywbemcli does not allow "
+                "permanent filters with same Name property to keep Name "
+                "properties unique.".
+                format(get_owned_str(owned_opt), filter_name, filters_str))
+
+    result_inst = csm.add_filter(source_namespaces, options['query'],
+                                 options['query_language'],
+                                 owned_opt, filter_id,
+                                 filter_name)
+
+    # Success: Show resulting name and conditionally, details
+    context.spinner_stop()
+    click.echo("Added {0} filter: Name={1}".
+               format(get_owned_str(owned_opt), result_inst['Name']))
+
+    if context.verbose:
+        click.echo("\npath={0}\n\n{1}".
+                   format(str(result_inst.path), result_inst.tomof()))
+
+
+def cmd_subscription_add_subscription(context, destination_identity,
+                                      filter_identity, options):
+    """
+    Add a subscription based on selected a filter and destination.
+
+    The owned option defines the ownership of the resulting indication
+    subscription.
+
+    If the owned option is True, either owned or permanent filters and
+    listeners may be attached.
+
+    If the owned option is False (--permanent) only permanent filters and
+    listeners may be attached
+    """
+    csm = CmdSubscriptionManager(context, options)
+
+    owned_opt = options['owned']
+    select_opt = options['select']
+
+    # Search the existing filters and destinations to find instances
+    # that match the destination_identity and filter_identity
+    sub_dest_inst, sub_filter_inst = get_insts_for_subscription_identities(
+        csm, destination_identity, filter_identity, 'add-subscription',
+        select_opt)
+
+    # Duplicates test in SubscriptionManager but with message for parameters of
+    # the command rather than the pywbem API.
+    if (csm.is_owned_filter(sub_filter_inst) or
+            csm.is_owned_destination(sub_dest_inst)) and not owned_opt:
+        raise click.ClickException(
+            "Permanent subscriptions cannot be created with owned filters "
+            "or destinations. Create an owned subscription or use a "
+            "permanent filter and destination. Destination Name={0}, "
+            "Filter Name={1}".format(sub_dest_inst['Name'],
+                                     sub_filter_inst['Name']))
+
+    rslt = csm.add_subscriptions(sub_filter_inst.path,
+                                 sub_dest_inst.path, owned_opt)
+
+    context.spinner_stop()
+    click.echo("Added {0} subscription: DestinationName={1}, FilterName={2}".
+               format(get_owned_str(owned_opt),
+                      sub_dest_inst.path['Name'],
+                      sub_filter_inst.path["Name"]))
+    if context.verbose:
+        click.echo("\n\n{0}".format(rslt[0].tomof()))
+
+
+def cmd_subscription_list(context, options):
+    """
+    Display overview information on the subscriptions, filters and indications
+    """
+    output_format = validate_output_format(context.output_format,
+                                           ['TEXT', 'TABLE'],
+                                           default_format="table")
+    csm = CmdSubscriptionManager(context, options)
+
+    summary_opt = options['summary']
+
+    all_subscriptions = csm.get_subscriptions_for_owned_choice('all')
+    all_destinations = csm.get_destinations_for_owned_choice('all')
+    all_filters = csm.get_filters_for_owned_choice('all')
+
+    # Get info on owned objects also
+    owned_subscriptions = csm.get_subscriptions(OWNED)
+    owned_destinations = csm.get_destinations(OWNED)
+    owned_filters = csm.get_filters(OWNED)
+
+    if summary_opt:
+        headers = ['subscriptions', 'filters', 'destinations']
+        rows = [[len(all_subscriptions), len(all_filters),
+                 len(all_destinations)]]
+
+    else:
+        headers = ['CIM_class', 'owned', 'permanent', 'all']
+
+        rows = []
+        rows.append([SUBSCRIPTION_CLASSNAME,
+                     len(owned_subscriptions),
+                     len(all_subscriptions) - len(owned_subscriptions),
+                     len(all_subscriptions)])
+        rows.append([FILTER_CLASSNAME,
+                     len(owned_filters),
+                     len(all_filters) - len(owned_filters),
+                     len(all_filters)])
+        rows.append([DESTINATION_CLASSNAME,
+                     len(owned_destinations),
+                     len(all_destinations) - len(owned_destinations),
+                     len(all_destinations)])
+        rows.append(["TOTAL INSTANCES",
+                     sum([r[1] for r in rows]),
+                     sum([r[2] for r in rows]),
+                     sum([r[3] for r in rows])])
+
+    summary_str = "summary" if summary_opt else ""
+    title = "Subscription instance {0} counts: submgr-id={1}, svr-id={2}". \
+            format(summary_str, csm.submgr_id, csm.server_id)
+
+    context.spinner_stop()
+    if output_format_is_table(output_format):
+        click.echo(format_table(rows, headers, title=title,
+                                table_format=output_format))
+
+    else:  # output in TEXT format
+        if summary_opt:
+            click.echo("{0} subscriptions, {1} filters, {2} destinations".
+                       format(len(all_subscriptions), len(all_filters),
+                              len(all_destinations)))
+        else:
+            for row in rows:
+                click.echo("{0}: {1}, {2}, {3}".format(row[0], row[1], row[2],
+                                                       row[3]))
+
+
+def cmd_subscription_list_destinations(context, options):
+    """
+    List the subscription destinations objects found on the current connection.
+
+    Since these are complex objects there are a variety of display options
+    including table, CIM objects, etc.
+    """
+    output_format = validate_output_format(context.output_format,
+                                           ['CIM', 'TABLE'],
+                                           default_format="table")
+    csm = CmdSubscriptionManager(context, options)
+
+    ownedchoice_opt = (options['type']).lower()
+
+    destinations = csm.get_destinations_for_owned_choice(ownedchoice_opt)
+
+    if options['summary'] and options['detail']:
+        raise click.ClickException("The options '--summary' and '--detail' "
+                                   "conflict. Only one may be used in a "
+                                   "command")
+
+    if options['names_only']:
+        paths = [inst.path for inst in destinations]
+
+        context.spinner_stop()
+        display_cim_objects(context, paths, output_format, options['summary'])
+        return
+
+    if output_format_is_table(output_format):
+        headers = ['Ownership', 'Identity', 'Name\nProperty', 'Destination',
+                   'Persistence\nType', 'Protocol', 'Subscription\nCount']
+        if options['detail']:
+            headers.extend([
+                'CreationclassName', 'SystemCreationClassName', 'SystemName'])
+        rows = []
+
+        # FUTURE: summary with table not covered.
+        for dest in destinations:
+            conn = context.pywbem_server.conn
+            references = conn.ReferenceNames(
+                dest.path, ResultClass=SUBSCRIPTION_CLASSNAME, Role='Handler')
+
+            d = IndicationDestination(csm, dest)
+            row = [d.owned_str,
+                   d.identity,
+                   fold_strings(d.instance_property('Name'), 30,
+                                break_long_words=True),
+                   d.instance_property('Destination'),
+                   d.instance_property('PersistenceType'),
+                   d.instance_property('Protocol'),
+                   len(references)]
+            if options['detail']:
+                row.extend([d.instance_property('CreationClassName'),
+                            d.instance_property('SystemCreationClassName'),
+                            d.instance_property('SystemName')])
+
+            rows.append(row)
+
+        title = "Indication Destinations: submgr-id={0}, svr-id={1}, " \
+            "type={2}". \
+            format(csm.submgr_id, csm.server_id, ownedchoice_opt)
+
+        context.spinner_stop()
+        click.echo(format_table(rows, headers, title=title,
+                                table_format=output_format))
+
+        return
+
+    if output_format_is_cimobject(output_format):
+        context.spinner_stop()
+        if options['detail'] or options['summary']:
+            display_cim_objects(context, destinations, output_format,
+                                summary=options['summary'], sort=True)
+        else:
+            display_inst_nonnull_props(context, options, destinations,
+                                       output_format)
+
+    else:
+        raise click.ClickException("Invalid output format {0}".
+                                   format(output_format))
+
+
+def cmd_subscription_list_filters(context, options):
+    """
+    List the indication filters found in the current SubscriptionManager
+    object
+    """
+    output_format = validate_output_format(context.output_format,
+                                           ['CIM', 'TABLE'],
+                                           default_format="table")
+    csm = CmdSubscriptionManager(context, options)
+
+    # FUTURE: To be replaced when PR #1066 integrated.
+    if options['detail'] and options['summary']:
+        raise click.ClickException("The details and summary options are "
+                                   "mutually exclusive")
+
+    filterchoice_opt = options['type']
+    details_opt = options['detail']
+
+    filters = csm.get_filters_for_owned_choice(filterchoice_opt)
+
+    if filters:
+        if output_format_is_cimobject(output_format):
+            if options['detail'] or options['summary']:
+                display_cim_objects(context, filters, output_format,
+                                    summary=options['summary'])
+            else:
+                display_inst_nonnull_props(context, options, filters,
+                                           output_format)
+
+        elif output_format_is_table(output_format):
+            headers = ['Ownership', 'Identity', 'Name\nProperty', 'Query',
+                       'Query\nLanguage', 'Source\nNamespaces',
+                       'Subscription\nCount']
+            if options['detail']:
+                headers.extend(
+                    ['CreationclassName', 'SystemCreationClassName',
+                     'SystemName'])
+
+            rows = []
+            for filter_ in filters:
+                conn = context.pywbem_server.conn
+                references = conn.ReferenceNames(
+                    filter_.path, ResultClass=SUBSCRIPTION_CLASSNAME,
+                    Role='Filter')
+                f = IndicationFilter(csm, filter_)
+                row = [f.owned_str,
+                       f.identity,
+                       fold_strings(f.instance_property('Name'), 30,
+                                    break_long_words=True),
+                       fold_strings(f.instance_property('Query'), 25),
+                       f.instance_property('QueryLanguage'),
+                       "\n".join(f.instance_property('SourceNamespaces')),
+                       len(references)]
+                if details_opt:
+                    row.extend([
+                        f.instance_property('CreationClassName'),
+                        f.instance_property('SystemCreationClassName'),
+                        f.instance_property('SystemName')])
+                rows.append(row)
+            title = "Indication Filters: submgr-id={0}, svr-id={1} type={2}". \
+                format(csm.submgr_id, csm.server_id, filterchoice_opt)
+
+            context.spinner_stop()
+            click.echo(format_table(rows, headers, title=title,
+                                    table_format=output_format))
+
+        elif options['names_only']:
+            paths = [inst.path for inst in filters]
+            display_cim_objects(context, paths, output_format,
+                                options['summary'])
+        else:
+            display_inst_nonnull_props(context, options, filters, output_format)
+
+    else:
+        if context.verbose:
+            context.spinner_stop()
+            click.echo("No matching filters for server_id={0} "
+                       "type {1}".format(csm.server_id, filterchoice_opt))
+
+
+def cmd_subscription_list_subscriptions(context, options):
+    """
+    Display the list of indication subscriptions on the defined server.
+    """
+    output_format = validate_output_format(context.output_format,
+                                           ['CIM', 'TABLE'],
+                                           default_format="table")
+    csm = CmdSubscriptionManager(context, options)
+
+    # FUTURE: replace with exclusive option
+    if options['summary'] and options['detail']:
+        raise click.ClickException("The options '--summary' and '--detail' "
+                                   "conflict. Only one may be used in a "
+                                   "command")
+
+    svr_subscriptions = csm.get_subscriptions_for_owned_choice(options['type'])
+    # Get all destinations and filters
+    svr_destinations = csm.get_destinations(False)
+    svr_filters = csm.get_filters(False)
+
+    # If summary, display only summary of subscriptions.
+    if options['summary']:
+        context.spinner_stop()
+        display_cim_objects(context, svr_subscriptions,
+                            output_format='mof', summary=True)
+        return
+
+    # Otherwise display subscriptions, indications, filters.
+    inst_list = []
+    if output_format_is_cimobject(output_format):
+        for subscription in svr_subscriptions:
+            inst_list.append(subscription)
+            for filter_ in svr_filters:
+                if subscription['Filter'] == filter_.path:
+                    inst_list.append(filter_)
+            for dest in svr_destinations:
+                if subscription['Handler'] == dest.path:
+                    inst_list.append(dest)
+
+        context.spinner_stop()
+        display_cim_objects(context, inst_list,
+                            output_format=context.output_format)
+    elif output_format_is_table(output_format):
+        headers = ['Ownership', 'Handler\nIdentity', 'Filter\nIdentity',
+                   'Handler\nDestination', 'Filter\nQuery',
+                   'Filter Query\nlanguage', 'Subscription\nStartTime']
+        rows = []
+        conn = context.pywbem_server.conn
+        for subscription in svr_subscriptions:
+            is_ = IndicationSubscription(csm, subscription)
+
+            try:
+                filter_inst = conn.GetInstance(subscription['Filter'])
+                dest_inst = conn.GetInstance(subscription['Handler'])
+            except Error as er:
+                raise click.ClickException("GetInstance Failed {0}".format(er))
+
+            id_ = IndicationDestination(csm, dest_inst)
+            if_ = IndicationFilter(csm, filter_inst)
+
+            start_time = is_.instance_property('SubscriptionStartTime')
+            start_time = start_time.datetime.strftime("%x %X") if start_time \
+                else ""
+
+            row = [is_.owned_str,
+                   "{0}({1})".format(id_.identity, id_.owned_str),
+                   "{0}({1})".format(if_.identity, if_.owned_str),
+                   dest_inst['Destination'],
+                   fold_strings(if_.instance_property('query'), 30),
+                   filter_inst['QueryLanguage'],
+                   start_time]
+            rows.append(row)
+
+        title = "Indication Subscriptions: submgr-id={0}, svr-id={1}, " \
+            "type={2}".format(csm.submgr_id, csm.server_id, options['type'])
+
+        context.spinner_stop()
+        click.echo(format_table(rows, headers, title=title,
+                                table_format=output_format))
+
+    else:
+        assert False, "{0} Invalid output format for this command". \
+            format(output_format)
+
+
+def verify_instances_removal(instance_names, instance_type):
+    """Request that user verify instances to be removed."""
+
+    if isinstance(instance_names, list):
+        verify_paths = "\n".join([str(p) for p in instance_names])
+    else:
+        verify_paths = instance_names
+
+    verify_msg = "Verify {0} instance(s) to be removed:\n {1}". \
+        format(instance_type, verify_paths)
+
+    if not verify_operation(verify_msg):
+        raise click.ClickException("Instances not removed.")
+
+
+def cmd_subscription_remove_destination(context, identity, options):
+    """
+    Remove multiple destination objects from the WBEM Server.
+    """
+    csm = CmdSubscriptionManager(context, options)
+    owned_opt = options['owned']
+
+    if owned_opt and not identity.startswith(csm.owned_destination_prefix):
+        target_name = "{0}:{1}".format(csm.owned_destination_prefix, identity)
+    else:
+        target_name = identity
+
+    dest_insts = csm.get_destinations(owned_opt)
+    matching_destinations = [d for d in dest_insts if d['Name'] == target_name]
+
+    if not matching_destinations:
+        raise click.ClickException(
+            "No {0} destination found for identity={1}, Name-property={2}".
+            format(get_owned_str(owned_opt), identity, target_name))
+
+    if len(matching_destinations) == 1:
+        destination_path = matching_destinations[0].path
+
+    else:  # Multiple instances returned
+        context.spinner_stop()
+        click.echo('{0} "{1}" multiple matching destinations'.
+                   format(get_owned_str(owned_opt), identity))
+
+        if options['select']:
+            destination_path = pick_one_path_from_instances_list(
+                csm, matching_destinations,
+                "Pick indication destination to remove")
+        else:
+            inst_display = [IndicationDestination(csm, d).select_id_str() for
+                            d in matching_destinations]
+            raise click.ClickException(
+                "Remove failed. Multiple destinations meet criteria "
+                "identity={0}, owned={1}. Use --select option to pick one "
+                "destination:\n  * {2}".
+                format(identity, get_owned_str(owned_opt),
+                       "\n  * ".join(inst_display)))
+
+    if options['verify']:
+        verify_instances_removal(destination_path, 'destination')
+
+    name_property = destination_path['Name']
+    csm.remove_destinations(destination_path)
+
+    context.spinner_stop()
+    click.echo("Removed {0} indication destination: identity={1}, Name={2}..".
+               format(get_owned_str(owned_opt), identity, name_property))
+    if context.verbose:
+        click.echo("indication destination path: {0}.".format(destination_path))
+
+    return
+
+
+def cmd_subscription_remove_filter(context, identity, options):
+    """
+    Remove a single indication filter found by the get_all_filters
+    method.
+    """
+    csm = CmdSubscriptionManager(context, options)
+
+    owned_opt = options['owned']
+
+    # Determine if name should include owned identity components.
+    # Search depends on correct definition of owned option.
+    if owned_opt and not identity.startswith(csm.owned_filter_prefix):
+        target_name = "{0}:{1}".format(csm.owned_filter_prefix, identity)
+    else:
+        target_name = identity
+
+    filter_insts = csm.get_filters(owned_opt)
+    matching_filters = [f for f in filter_insts if f['Name'] == target_name]
+
+    if not matching_filters:
+        raise click.ClickException(
+            "No {0} filter found for identity={1}, Name-property={2}, ".
+            format(get_owned_str(owned_opt), identity, target_name))
+    # Multiples can only occur if outside client has added filters that match
+    # name but not other components of path. Owned flag on cmd eliminates
+    # multiples if permanent and owned ids are the same.
+    if len(matching_filters) > 1:
+        context.spinner_stop()
+        click.echo('{0} "{1}" multiple matching filters.'.
+                   format(get_owned_str(owned_opt), identity))
+
+        if options['select']:
+            filter_path = pick_one_path_from_instances_list(
+                csm, matching_filters, "Pick indication filter to remove")
+        else:
+            inst_disp = [IndicationFilter(csm, f).select_id_str()
+                         for f in matching_filters]
+            raise click.ClickException(
+                "Remove failed. Multiple filters meet criteria identity={0}, "
+                "owned={1}. Use --select option to pick one filter:\n  * {2}".
+                format(identity, get_owned_str(owned_opt),
+                       "\n  * ".join(inst_disp)))
+
+    else:  # one filter returned
+        filter_path = matching_filters[0].path
+
+    if options['verify']:
+        verify_instances_removal(filter_path, 'filter')
+
+    name_property = filter_path['Name']
+    csm.remove_filter(filter_path)
+
+    context.spinner_stop()
+    click.echo("Removed {0} indication filter: identity={1}, Name={2}.".
+               format(get_owned_str(owned_opt), identity, name_property))
+    if context.verbose:
+        click.echo("Indication filter path: {0}.".format(filter_path))
+
+    return
+
+
+def cmd_subscription_remove_subscription(context, destination_identity,
+                                         filter_identity, options):
+    """
+    Remove an indication subscription from the WBEM server. Removal is based
+    on the same parameter set as create, a destination and filter because
+    there is no identifying name on subscriptions.
+    """
+    csm = CmdSubscriptionManager(context, options)
+
+    # find instances for the associations using the input identity parameters
+    dest_inst, filter_inst = get_insts_for_subscription_identities(
+        csm, destination_identity, filter_identity, 'remove-subscription',
+        options['select'])
+
+    # FUTURE: account for multiples subscription cases.
+    # FUTURE: account for owned/not-owned from the dest and filters when that
+    # works. See pywbemtoolls issue #
+
+    subscriptions = csm.get_subscriptions(False)
+
+    # Find the subscription defined by destination_identity and filter_identity
+    remove_list = []
+    for subscription in subscriptions:
+        if subscription['Filter'] == filter_inst.path and \
+                subscription['Handler'] == dest_inst.path:
+            remove_list.append(subscription)
+
+    if not remove_list:
+        raise click.ClickException(
+            "Options destination_id={0} and filter_id={1} did "
+            "not locate any subscriptions to remove."
+            .format(destination_identity, filter_identity))
+
+    if remove_list:
+        remove_paths = [i.path for i in remove_list]
+        if options['verify']:
+            verify_instances_removal(remove_paths, 'subscription')
+
+        # Get the list of destination paths to possibly remove these
+        # associations.
+        destination_paths = [i['Handler'] for i in remove_list]
+        filter_paths = [i['Filter'] for i in remove_list]
+
+        csm.remove_subscriptions(remove_paths)
+
+        context.spinner_stop()
+        click.echo("Removed {0} subscription(s) for destination-id: {1}, "
+                   "filter-id: {2}.".
+                   format(len(remove_paths), destination_identity,
+                          filter_identity))
+
+        if context.verbose:
+            subscription_paths_str = '\n'.join([str(x) for x in remove_paths])
+            click.echo("Removed subscription(s) paths: {0}".
+                       format(subscription_paths_str))
+
+        # If option set, remove filter and destination if not used in other
+        # associations:
+        # FUTURE: should we only remove owned instances???
+        if options['remove_associated_instances']:
+            conn = context.pywbem_server.conn
+            for dest_path in destination_paths:
+                dest_refs = conn.ReferenceNames(
+                    dest_path, ResultClass=SUBSCRIPTION_CLASSNAME,
+                    Role='Handler')
+                if not dest_refs:
+                    csm.remove_destinations(dest_path)
+                    click.echo("Removed destination: {0}".
+                               format(dest_path))
+            for filter_path in filter_paths:
+                filter_refs = conn.ReferenceNames(
+                    filter_path, ResultClass=SUBSCRIPTION_CLASSNAME,
+                    Role='Filter')
+                if not filter_refs:
+                    csm.remove_filter(filter_path)
+                    click.echo("Removed filter: {0}".format(filter_path))
+
+
+def cmd_subscription_remove_server(context, options):
+    """
+    Remove the current server_id which also un-registers listener destinations
+    and removes all owned destinations, filters, and subscriptions.
+    """
+    csm = CmdSubscriptionManager(context, options)
+
+    filters = csm.get_filters(True)
+    dests = csm.get_destinations(True)
+    subscripts = csm.get_subscriptions(True)
+
+    context.spinner_stop()
+    click.echo("Removing owned destinations, filters, and subscriptions "
+               "for server-id {0}. Remove counts: destinations={1}, "
+               "filters={2}, subscriptions={3}".
+               format(csm.server_id, len(dests), len(filters), len(subscripts)))
+
+    csm.remove_server()

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 """
-Common Functions applicable across multiple components of pywbemcli
+Common functions applicable across multiple components of pywbemcli
 """
 
 from __future__ import absolute_import, print_function, unicode_literals
@@ -35,12 +35,21 @@ from toposort import toposort_flatten
 
 from pywbem import CIMInstanceName, CIMInstance, CIMClass, \
     CIMQualifierDeclaration, CIMProperty, CIMClassName, \
-    cimvalue, Error, ToleratedSchemaIssueWarning
+    cimvalue, Error, ToleratedSchemaIssueWarning, \
+    CIMFloat, CIMInt, CIMDateTime
 from pywbem._nocasedict import NocaseDict
 
 from ._cimvalueformatter import cimvalue_to_fmtd_string
 from .._output_formatting import DEFAULT_MAX_CELL_WIDTH
-from .._utils import pywbemtools_warn
+from .._utils import pywbemtools_warn, ensure_unicode, to_unicode
+
+# Same as in pwbem.cimtypes.py
+if six.PY2:
+    # pylint: disable=invalid-name,undefined-variable
+    _Longint = long  # noqa: F821
+else:
+    # pylint: disable=invalid-name
+    _Longint = int
 
 
 ######################################################################
@@ -339,9 +348,9 @@ def pick_multiple_indexes_from_list(context, options, title):
 
 def is_classname(astring):
     """
-    Test if the astring input is a classname or contains instance name
+    Test if the a string input is a classname or contains instance name
     components.  The existence of a period at the end of the name component
-    determines if it is a classname or instance name.
+    determines if it is a class name or instance name.
 
     Returns:
         True if classname. Otherwise it returns False
@@ -420,6 +429,143 @@ def verify_operation(txt, msg=None):
     if msg:
         click.echo('Request aborted')
     return False
+
+
+def to_wbem_uri_folded(path, format='standard', max_len=15):
+    # pylint: disable=redefined-builtin
+    """
+    Return the (untyped) WBEM URI string of this CIM instance path.
+    This method modifies the pywbem:CIMInstanceName.to_wbem_uri method
+    to return a reformatted string where components are on
+    separate lines if the length is longer than the max_len argument.
+
+    See :meth:`pywbem.CIMInstanceName.to_wbem_uri` for detailed
+    information. This method was derived from
+    :meth:`pywbem.CIMInstanceName.to_wbem_uri`
+
+    Parameters:
+
+      path (:class:`CIMInstanceName`):
+        The instance name to convert to a wbem uri and fold based on
+        the max_len parameter
+
+      format  (:term:`string`): Format for the generated WBEM URI string
+        using one of the formats defined in
+        :meth:`pywbem.CIMInstanceName.to_wbem_uri`
+
+      max_len (:term:`integer`):
+        Maximum length of the resulting URI before it is folded into
+        multiple lines.
+
+    Returns:
+
+      :term:`unicode string`: Untyped WBEM URI of the CIM instance path,
+      in the specified format.
+
+    Raises:
+
+      TypeError: Invalid type in keybindings
+      ValueError: Invalid format
+    """
+
+    path_str = path.to_wbem_uri(format=format)
+    if len(path_str) <= max_len:
+        return path_str
+
+    # Otherwise recreate the wbem uri and  fold the
+    # keybindings. This folds the keybindings as they are mapped back to
+    # strings. Note that this recreates the much of the pywbem wbemuri method
+    # except that it folds keybindings.
+
+    ret = []
+
+    def case(astring):
+        """Return the string in the correct lexical case for the format."""
+        if format == 'canonical':
+            astring = astring.lower()
+        return astring
+
+    def case_sorted(keys):
+        """Return the keys in the correct order for the format."""
+        if format == 'canonical':
+            case_keys = [case(k) for k in keys]
+            keys = sorted(case_keys)
+        return keys
+
+    if format not in ('standard', 'canonical', 'cimobject', 'historical'):
+        raise ValueError('Invalid format argument: {0}'.format(format))
+
+    if path.host is not None and format != 'cimobject':
+        # The CIMObject format assumes there is no host component
+        ret.append('//')
+        ret.append(case(path.host))
+
+    if path.host is not None or format not in ('cimobject', 'historical'):
+        ret.append('/')
+
+    if path.namespace is not None:
+        ret.append(case(path.namespace))
+
+    if path.namespace is not None or format != 'historical':
+        ret.append(':')
+
+    ret.append(case(path.classname))
+
+    ret.append('.\n')
+
+    for key in case_sorted(six.iterkeys(path.keybindings)):
+        value = path.keybindings[key]
+
+        ret.append(key)
+        ret.append('=')
+
+        if isinstance(value, six.binary_type):
+            value = to_unicode(value)
+
+        if isinstance(value, six.text_type):
+            # string, char16
+            ret.append('"')
+            ret.append(value.
+                       replace('\\', '\\\\').
+                       replace('"', '\\"'))
+            ret.append('"')
+        elif isinstance(value, bool):
+            # boolean
+            # Note that in Python a bool is an int, so test for bool first
+            ret.append(str(value).upper())
+        elif isinstance(value, (CIMFloat, float)):
+            # realNN
+            # Since Python 2.7 and Python 3.1, repr() prints float numbers
+            # with the shortest representation that does not change its
+            # value. When needed, it shows up to 17 significant digits,
+            # which is the precision needed to round-trip double precision
+            # IEE-754 floating point numbers between decimal and binary
+            # without loss.
+            ret.append(repr(value))
+        elif isinstance(value, (CIMInt, int, _Longint)):
+            # intNN
+            ret.append(str(value))
+        elif isinstance(value, CIMInstanceName):
+            # reference
+            ret.append('"')
+            ret.append(value.to_wbem_uri(format=format).
+                       replace('\\', '\\\\').
+                       replace('"', '\\"'))
+            ret.append('"')
+        elif isinstance(value, CIMDateTime):
+            # datetime
+            ret.append('"')
+            ret.append(str(value))
+            ret.append('"')
+        else:
+            raise TypeError(
+                "Invalid type {0} in keybinding value: {1}={2}"
+                .format(type(value), key, value))
+        ret.append(',\n')
+
+    del ret[-1]
+
+    return ensure_unicode(''.join(ret))
 
 
 def parse_wbemuri_str(wbemuri_str, namespace=None):
@@ -713,10 +859,13 @@ def process_invokemethod(context, objectname, methodname, namespace,
       methodname (:term:`string`):
         The name of the method to be executed
 
-      namespace()
-      options (:class:`py:dict`):
-        The command options dictionary.  Used to get the command namespace
-        and parameters.
+      namespace (:term:`string`):
+        String defining the current namespace used by the command or None
+        if the default namespace is to be used
+
+      parameters ():
+        The input parameters to be applied to the InvokeMethod
+
 
     """  # pylint: enable=line-too-long
 
@@ -755,9 +904,14 @@ def process_invokemethod(context, objectname, methodname, namespace,
     conn = context.pywbem_server.conn
     classname = objectname.classname
 
-    cim_class = conn.GetClass(
-        classname,
-        namespace=namespace, LocalOnly=False)
+    # if this is a string convert to a CIMClassname
+    if isinstance(objectname, six.string_types):
+        objectname = CIMClassName(objectname)
+
+    if namespace:
+        objectname.namespace = namespace
+
+    cim_class = conn.GetClass(classname, namespace=namespace, LocalOnly=False)
 
     cim_methods = cim_class.methods
     if methodname not in cim_methods:
@@ -1042,7 +1196,7 @@ def get_subclass_names(classes, classname=None, deep_inheritance=None):
     if classname not in classname_dict:
         raise ValueError("Classname {} not found in classes".format(classname))
 
-    # Recurse The classname_dict hierarchy to get subclass names
+    # Recurse the classname_dict hierarchy to get subclass names
     rtn_classnames = classname_dict[classname]
     if deep_inheritance:
         if rtn_classnames:
@@ -1063,7 +1217,7 @@ def shorten_path_str(path, replacements, fullpath):
     """
     Create a short-form path str from the input CIMInstanceName with selected
     components shortened to just a single known character.  This allows
-    modifying the path string to replace selected key/value paris with a single
+    modifying the path string to replace selected key/value pairs with a single
     character. Thus where the original string is very long and contains
     repeated key bindings (ex. CreationClassName) we can shorten the path
     string by reducing selected key/value pairs to just ~

--- a/tests/unit/pywbemcli/mock_prompt_pick_response_1.py
+++ b/tests/unit/pywbemcli/mock_prompt_pick_response_1.py
@@ -1,0 +1,48 @@
+# The previous statement is used by pywbemcli to force this script to be
+# run at pywbemcli startup and not included in the list of --mock-server
+# files that are used to build the repository.  This is a development
+# test aid.
+# (C) Copyright 2019 IBM Corp.
+# (C) Copyright 2019 Inova Development Inc.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+    Python code to mock pywbemcli._common.pywbemcli_prompt. Returns the
+    value defined in RETURN_VALUE
+
+    This file was defined to mock the return from pywbemcli instance
+    get/delete/... with the simple_assoc_mock_model and return "0" to represent
+    the first entry in the displayed output.
+
+    Add this file to the set of mock options and the prompt for picking
+    the instance will be output but the prompt for a response from the
+    user will be bypassed and the value defined in RETURN_VALUE returned.
+
+    This file is enabled during testing through the PYWBEMCLI_STARTUP_SCRIPT
+    environment variable.
+"""
+from mock import Mock
+
+import pywbemtools
+RETURN_VALUE = "1"
+
+
+def mock_prompt(msg):
+    """Mock function to replace pywbemcli_prompt and return a value"""
+    print('MOCK_CLICK_PROMPT {}'.format(msg))
+    return RETURN_VALUE
+
+
+# pylint: disable=protected-access
+pywbemtools.pywbemcli.click.prompt = Mock(side_effect=mock_prompt)

--- a/tests/unit/pywbemcli/mock_subscriptiontest.mof
+++ b/tests/unit/pywbemcli/mock_subscriptiontest.mof
@@ -1,0 +1,38 @@
+// This file extends the repository for the subscription tests to
+// add subclasses for the destination and filter classes and corresponding
+// subscriptions.  This is to allow:
+
+// * testing of add commands where the name exists already
+// * testing of the remove commands where multiple responses are being tested.
+
+// The new class and
+// instances create instances that have the same name as previously created
+// filters and destinations but different paths because some of the key
+// properties are different.
+
+# pragma namespace ("interop")
+
+class CIM_ListenerDestinationCIMXMLSub : CIM_ListenerDestinationCIMXML {
+};
+
+class CIM_IndicationFilterSub : CIM_IndicationFilter {
+};
+
+instance of CIM_ListenerDestinationCIMXMLSub  {
+    SystemCreationClassName = CIM_ComputerSystem;
+    SystemName = blah;
+    CreationClassName = CIM_ListenerDestinationCIMXMLSub;
+    Name = "duptestdest";
+    PersistenceType = 3;
+    Destination = "http://blah:5001";
+    Protocol = 2;
+};
+instance of CIM_IndicationFilterSub  {
+    SystemCreationClassName = CIM_ComputerSystem;
+    SystemName = blah;
+    CreationClassName = CIM_IndicationFilterSub;
+    Name = "duptestfilter";
+    Query = "SELECT * from CIM_Indication";
+    QueryLanguage = "DMTF:CQL";
+    IndividualSubscriptionSupported = true;
+};

--- a/tests/unit/pywbemcli/test_class_cmds.py
+++ b/tests/unit/pywbemcli/test_class_cmds.py
@@ -1707,6 +1707,9 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
 
     # Class delete errors
+    # NOTE: Missing argument tests use regex test because with Python 3.4
+    # the Missing Argument output from click uses double quotes rather than
+    # single quotes
     ['Verify class command delete no classname',
      ['delete'],
      {'stderr': ['Error: Missing argument .CLASSNAME.'],

--- a/tests/unit/pywbemcli/test_general_options.py
+++ b/tests/unit/pywbemcli/test_general_options.py
@@ -173,6 +173,7 @@ GENERAL_HELP_LINES = [
       qualifier   Command group for CIM qualifier declarations.
       server      Command group for WBEM servers.
       statistics  Command group for WBEM operation statistics.
+      subscription  Command group to manage WBEM indication subscriptions.
       connection  Command group for WBEM connection definitions.
       help        Show help message for interactive mode.
       repl        Enter interactive mode (default)."""

--- a/tests/unit/pywbemcli/test_server_cmds.py
+++ b/tests/unit/pywbemcli/test_server_cmds.py
@@ -532,8 +532,6 @@ TEST_CASES = [
       'test': 'innows'},
      QUALIFIER_FILTER_MODEL, OK],
 
-
-
 ]
 
 

--- a/tests/unit/pywbemcli/test_subscription_cmds.py
+++ b/tests/unit/pywbemcli/test_subscription_cmds.py
@@ -1,0 +1,1215 @@
+# Copyright 2018 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests the subscription command group.
+
+Many of the tests in of the subscription group use stdin because multiple
+pywbemcli commands must be used to add and test the various subscriptions.
+A single command can be used only  to test the add... commands. Since the
+requests sent to the mock server have a lifecycle of one interactive command
+session, stdin servers to test these commands.
+"""
+
+from __future__ import absolute_import, print_function
+import os
+import sys
+import pytest
+
+from .cli_test_extensions import CLITestsBase
+from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
+
+TEST_DIR = os.path.dirname(__file__)
+TEST_DIR_REL = os.path.relpath(TEST_DIR)
+
+
+def GET_TEST_PATH_STR(filename):  # pylint: disable=invalid-name
+    """
+    Return the string representing the relative path of the file name provided.
+    """
+    return (str(os.path.join(TEST_DIR_REL, filename)))
+
+#
+# Definition of files that mock selected pywbemcli calls for tests
+# These are installed in pywbemcli through a special env variable set
+# before the test that is NOT one of the externally defined environment
+# variables
+#
+
+
+TEST_INTEROP_MOCK_FILE = 'simple_interop_mock_script.py'
+TEST_USER_MOCK_FILE = 'simple_mock_model.mof'
+
+# MOF with supplementary classes/instances for some subscription tests
+SUBSCRIPTION_MOF_FILE = 'mock_subscriptiontest.mof'
+SUBSCRIPTIONTEST_MOF_FILEPATH = os.path.join(TEST_DIR, SUBSCRIPTION_MOF_FILE)
+
+MOCK_SERVER_MODEL_PATH = os.path.join(TEST_DIR, 'testmock',
+                                      'wbemserver_mock_script.py')
+
+MOCK_SERVER_MODEL_FILE = os.path.join('testmock', 'wbemserver_mock_script.py')
+
+STARTUP_SCRIPT_ENVVAR = 'PYWBEMCLI_STARTUP_SCRIPT'
+MOCK_PROMPT_0_FILE = "mock_prompt_0.py"
+MOCK_PROMPT_1_FILE = "mock_prompt_pick_response_1.py"
+
+# Test connections file used in some testcases
+TEST_SUBSCRIPTIONS_FILE_PATH = 'tmp_subscription_options.yaml'
+TEST_SUBSCRIPTIONS_FILE_DICT = {
+    'connection_definitions': {
+        'blah': {
+            'name': 'blah',
+            'server': None,
+            'user': None,
+            'password': None,
+            'default-namespace': 'root/cimv2',
+            'timeout': 30,
+            'use_pull': None,
+            'pull_max_cnt': 1000,
+            'verify': True,
+            'certfile': None,
+            'keyfile': None,
+            'ca-certs': None,
+            'mock-server': [
+                os.path.join(TEST_DIR, 'simple_mock_model.mof'),
+            ],
+        },
+    },
+    'default_connection_name': None,
+}
+
+
+SUBSCRIPTION_HELP_LINES = [
+    'Usage: pywbemcli [GENERAL-OPTIONS] subscription COMMAND [ARGS]  '
+    '[COMMAND-OPTIONS]',
+    'Command group to manage WBEM indication subscriptions.',
+    CMD_OPTION_HELP_HELP_LINE,
+    'add-destination      Add new listener destination.',
+    'add-filter           Add new indication filter.',
+    'add-subscription     Add new indication subscription.',
+    'list                 Display indication subscriptions overview.',
+    'list-destinations    Display indication listeners on the WBEM server.',
+    'list-filters         Display indication filters on the WBEM server.',
+    'list-subscriptions   Display indication subscriptions on the WBEM server.',
+    'remove-destination   Remove a listener destination from the WBEM server.',
+    'remove-filter        Remove an indication filter from the WBEM server.',
+    'remove-subscription  Remove indication subscription from the WBEM '
+    'server.',
+    'remove-server        Remove current WBEM server from the '
+    'SubscriptionManager.',
+]
+
+CMD_OPTION_OWNED_LINE = '--owned / --permanent   Defines whether an owned ' \
+    'or permanent filter, destination, or subscription is to be'
+
+OWNEDADD_FLAG_OPTION = '--owned / --permanent  Defines whether an owned or'
+
+SELECT_OPTION = '--select Prompt user to select from multiple objects that ' \
+    'match the IDENTITY'
+
+VERIFY_REMOVE_OPTION = '-v, --verify Prompt user to verify instances to be ' \
+    'removed before request is'
+
+NAMES_ONLY_OPTION = '--names-only, --no Show the CIMInstanceName elements  ' \
+    'of the'
+
+SUMMARY_OPTION = '-s, --summary If True, show only summary count of instances'
+
+TYPE_OPTION = '--type [owned|permanent|all]  Defines whether the command ' \
+    'is going to filter'
+
+SUBSCRIPTION_ADD_DESTINATION_HELP_LINES = [
+    'Usage: pywbemcli [GENERAL-OPTIONS] subscription add-destination '
+    'IDENTITY [COMMAND-OPTIONS]',
+    '-l, --listener-url URL  Defines the URL of the target listener in the '
+    'format:',
+    OWNEDADD_FLAG_OPTION,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+SUBSCRIPTION_ADD_FILTER_HELP_LINES = [
+    'Usage: pywbemcli [GENERAL-OPTIONS] subscription add-filter IDENTITY '
+    '[COMMAND-OPTIONS]',
+    '-q, --query FILTER  Filter query definition. This is a SELECT ',
+    '--source-namespaces TEXT The namespace(s) for which the query is defined',
+    '--query-language TEXT Filter query language for this subscription',
+    CMD_OPTION_HELP_HELP_LINE,
+    OWNEDADD_FLAG_OPTION,
+]
+
+SUBSCRIPTION_ADD_SUBSCRIPTION_HELP_LINES = [
+    'Usage: pywbemcli [GENERAL-OPTIONS] subscription add-subscription '
+    'DESTINATION FILTER [COMMAND-OPTIONS]',
+    CMD_OPTION_HELP_HELP_LINE,
+    OWNEDADD_FLAG_OPTION,
+    SELECT_OPTION,
+]
+
+# TODO : The list of options for each command is incomplete
+SUBSCRIPTION_LIST_DESTINATIONS_HELP_LINES = [
+    'Usage: pywbemcli [GENERAL-OPTIONS] subscription list-destinations',
+    'Display indication listeners on the WBEM server.',
+    TYPE_OPTION,
+    SUMMARY_OPTION,
+    NAMES_ONLY_OPTION,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+SUBSCRIPTION_LIST_FILTERS_HELP_LINES = [
+    'Usage: pywbemcli [GENERAL-OPTIONS] subscription list-filters',
+    'Display indication filters on the WBEM server.',
+    TYPE_OPTION,
+    SUMMARY_OPTION,
+    NAMES_ONLY_OPTION,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+SUBSCRIPTION_LIST_SUBSCRIPTIONS_HELP_LINES = [
+    'Usage: pywbemcli [GENERAL-OPTIONS] subscription list-subscriptions',
+    'Display indication subscriptions on the WBEM server.',
+    TYPE_OPTION,
+    SUMMARY_OPTION,
+    NAMES_ONLY_OPTION,
+    CMD_OPTION_HELP_HELP_LINE,
+]
+
+SUBSCRIPTION_REMOVE_DESTINATION_HELP_LINES = [
+    'Usage: pywbemcli [GENERAL-OPTIONS] subscription remove-destination',
+    'Remove a listener destination from the WBEM server.',
+    CMD_OPTION_HELP_HELP_LINE,
+    VERIFY_REMOVE_OPTION,
+    SELECT_OPTION,
+    CMD_OPTION_OWNED_LINE,
+]
+
+SUBSCRIPTION_REMOVE_FILTER_HELP_LINES = [
+    'Usage: pywbemcli [GENERAL-OPTIONS] subscription remove-filter',
+    'Remove an indication filter from the WBEM server.',
+    CMD_OPTION_HELP_HELP_LINE,
+    VERIFY_REMOVE_OPTION,
+    SELECT_OPTION,
+    CMD_OPTION_OWNED_LINE,
+]
+
+SUBSCRIPTION_REMOVE_SUBSCRIPTION_HELP_LINES = [
+    'Usage: pywbemcli [GENERAL-OPTIONS] subscription remove-subscription '
+    'DESTINATION FILTER [COMMAND-OPTIONS]',
+    'Remove indication subscription from the WBEM server.',
+    CMD_OPTION_HELP_HELP_LINE,
+    VERIFY_REMOVE_OPTION,
+    SELECT_OPTION,
+    # CMD_OPTION_OWNED_LINE, TODO: Should we include the owned option.
+    '--remove-associated-instances Attempt to remove the instances associated '
+]
+
+
+OK = True     # mark tests OK when they execute correctly
+RUN = True    # Mark OK = False and current test case being created RUN
+FAIL = False  # Any test currently FAILING or not tested yet
+
+# pylint: disable=line-too-long
+# Long lines for test cases are more readable.
+TEST_CASES = [
+
+    # List of testcases.
+    # Each testcase is a list with the following items:
+    # * desc: Description of testcase.
+    # * inputs: String, or tuple/list of strings, or dict of 'env', 'args',
+    #     'general', and 'stdin'. See the 'inputs' parameter of
+    #     CLITestsBase.command_test() in cli_test_extensions.py for detailed
+    #     documentation.
+    # * exp_response: Dictionary of expected responses (stdout, stderr, rc) and
+    #     test definition (test: <testname>). See the 'exp_response' parameter
+    #     of CLITestsBase.command_test() in cli_test_extensions.py for
+    #     detailed documentation.
+    # * mock: None, name of file (.mof or .py), or list thereof.
+    # * condition: If True the test is executed, if 'pdb' the test breaks in the
+    #     the debugger, if 'verbose' print verbose messages, if False the test
+    #     is skipped.
+
+    ['Verify subscription command --help response',
+     ['--help'],
+     {'stdout': SUBSCRIPTION_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify subscription command -h response',
+     ['-h'],
+     {'stdout': SUBSCRIPTION_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify subscription command --help command order',
+     ['--help'],
+     {'stdout': r'Commands:'
+                '.*\n  add-destination'
+                '.*\n  add-filter'
+                '.*\n  add-subscription'
+                '.*\n  list'
+                '.*\n  list-destinations'
+                '.*\n  list-filters'
+                '.*\n  list-subscriptions'
+                '.*\n  remove-destination'
+                '.*\n  remove-filter'
+                '.*\n  remove-subscription'
+                '.*\n  remove-server',
+      'test': 'regex'},
+     None, OK],
+
+    #
+    # Test help commands
+    #
+    ['Verify subscription command add-destination --help response',
+     ['add-destination', '--help'],
+     {'stdout': SUBSCRIPTION_ADD_DESTINATION_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify subscription command add-filter --help response',
+     ['add-filter', '--help'],
+     {'stdout': SUBSCRIPTION_ADD_FILTER_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify subscription command add-subscription --help response',
+     ['add-subscription', '--help'],
+     {'stdout': SUBSCRIPTION_ADD_SUBSCRIPTION_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify subscription command list-destinations --help response',
+     ['list-destinations', '--help'],
+     {'stdout': SUBSCRIPTION_LIST_DESTINATIONS_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify subscription command list-filters --help response',
+     ['list-filters', '--help'],
+     {'stdout': SUBSCRIPTION_LIST_FILTERS_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify subscription command list-subscriptions --help response',
+     ['list-subscriptions', '--help'],
+     {'stdout': SUBSCRIPTION_LIST_SUBSCRIPTIONS_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify subscription command remove-destination --help response',
+     ['remove-destination', '--help'],
+     {'stdout': SUBSCRIPTION_REMOVE_DESTINATION_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify subscription command remove-filter --help response',
+     ['remove-filter', '--help'],
+     {'stdout': SUBSCRIPTION_REMOVE_FILTER_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify subscription command remove-subscription --help response',
+     ['remove-subscription', '--help'],
+     {'stdout': SUBSCRIPTION_REMOVE_SUBSCRIPTION_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    #
+    #  Create a destination and list the connection in the next command
+    #
+    ['Verify add-destination succeeds and list.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ["subscription add-destination x1 -l http://someone:50000 ",
+                "-o simple subscription list"]},
+     {'stdout': ["CIM_class                     owned    permanent    all",
+                 "--------------------------  -------  -----------  -----",
+                 "CIM_IndicationSubscription        0            0      0",
+                 "CIM_IndicationFilter              0            0      0",
+                 "CIM_ListenerDestinationCIMXML     1            0      1",
+                 "TOTAL INSTANCES                   1            0      1"],
+      'stderr': [],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify add-destination list-destinations, remove destinations succeeds.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-destination dest1 -l http://blah:50000 ',
+                'subscription add-destination dest2  -l https://blah:50001 '
+                '--owned ',
+                'subscription add-destination perm1 '
+                '-l http://perm1:50002 --permanent',
+                '-o simple subscription list',
+                '-o simple subscription list-destinations',
+                '-o mof subscription list-destinations',
+                '-v subscription remove-destination dest1',
+                '-v subscription remove-destination dest2 --owned',
+                '-v subscription remove-destination perm1 --permanent',
+                '-o simple subscription list']},
+     {'stdout': ['Added owned destination: '
+                 'Name=pywbemdestination:defaultpywbemcliSubMgr:dest1',
+                 'Added owned destination: '
+                 'Name=pywbemdestination:defaultpywbemcliSubMgr:dest2',
+                 'Added permanent destination: Name=perm1',
+                 'scription instance counts: '
+                 'submgr-id=defaultpywbemcliSubMgr, '
+                 'svr-id=http://FakedUrl:5988',
+                 'CIM_class                     owned    permanent    all',
+                 '--------------------------  -------  -----------  -----',
+                 'CIM_IndicationSubscription        0            0      0',
+                 'CIM_IndicationFilter              0            0      0',
+                 'CIM_ListenerDestinationCIMXML     2            1      3',
+                 'Indication Destinations: submgr-id=defaultpywbemcliSubMgr,',
+                 'Ownership Identity Name Destination Persistence Protocol '
+                 'Subscription',
+                 # NOTE: Cannot test complete line because Name folds
+                 'owned  dest1 pywbemdestination:defaultpywbe '
+                 'http://blah:50000 3 2 0',
+                 'owned  dest2 pywbemdestination:defaultpywbe '
+                 'https://blah:50001 3 2 0',
+                 'permanent perm1 perm1 http://perm1:50002  2  2  0',
+                 'instance of CIM_ListenerDestinationCIMXML {',
+                 'Destination = "http://blah:50000"',
+                 'Destination = "https://blah:50001"',
+                 'Destination = "http://perm1:50002"',
+                 'Removed owned indication destination:',
+                 'Removed permanent indication destination',
+                 # Should be no destinations after the remove statements
+                 'CIM_ListenerDestinationCIMXML  0     0  0'
+
+                 ],
+      'stderr': [],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify add-filters add, list, remove multiple filters succeeds .',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-filter filter1 --query "SELECT from blah1" --query-language WQL',  # noqa: E501
+                'subscription add-filter filter2 --query "SELECT from blah2" --query-language DMTF:CQL --owned ',  # noqa: E501
+                'subscription add-filter perm1 --query "SELECT from blah3" --query-language DMTF:CQL --permanent ',  # noqa: E501
+                'subscription add-filter perm2 --query "SELECT from blah4" --query-language WQL --permanent ',  # noqa: E501
+                '-o simple subscription list',
+                '-o simple subscription list-filters',
+                '-o mof subscription list-filters',
+                '-v subscription remove-filter filter1',
+                '-v subscription remove-filter filter2 --owned',
+                '-v subscription remove-filter perm1 --permanent',
+                '-v subscription remove-filter perm2 --permanent',
+                '-o simple subscription list']},
+     {'stdout': ['Subscription instance counts: '
+                 'submgr-id=defaultpywbemcliSubMgr, '
+                 'svr-id=http://FakedUrl:5988',
+                 'CIM_class                     owned    permanent    all',
+                 '--------------------------  -------  -----------  -----',
+                 'CIM_IndicationSubscription        0            0      0',
+                 'CIM_IndicationFilter              2            2      4',
+                 'CIM_ListenerDestinationCIMXML     0            0      0',
+                 'Ownership  Identity Name Query  Query Source Subscription',
+                 'owned filter1 pywbemfilter:defaultpywbemcliS SELECT from blah1  WQL root/cimv2  0',  # noqa: E501
+                 'owned filter2 pywbemfilter:defaultpywbemcliS  SELECT from blah2  DMTF:CQL root/cimv2  0',  # noqa: E501
+                 'permanent perm1 perm1 SELECT from blah3 DMTF:CQL root/cimv2  0',  # noqa: E501
+                 'permanent perm2 perm2 SELECT from blah4  WQL root/cimv2  0',
+                 'Name = "perm1";',
+                 'Name = "perm2";',
+                 'Name = "pywbemfilter:defaultpywbemcliSubMgr:filter1";',
+                 'Name = "pywbemfilter:defaultpywbemcliSubMgr:filter2";',
+                 # No filters after removal
+                 'CIM_IndicationFilter              0            0      0',
+                 ],
+      'stderr': [],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify add-filters with source_namespaces succeeds.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-filter filter1 --query "xx" --permanent --source-namespaces interop --source-namespaces root/cimv2',  # noqa: E501
+                'subscription add-filter filter2 --query "xx2" --permanent --source-namespaces root/cimv3,root/cimv4',  # noqa: E501
+                '-o simple subscription list',
+                '-o simple subscription list --summary',
+                '-o text subscription list --summary',
+                '-o simple subscription list-filters',
+                '-o mof subscription list-filters',
+                'subscription remove-filter filter1 --permanent',
+                'subscription remove-filter filter2 --permanent',
+                '-o simple subscription list']},
+     {'stdout': ['Added permanent filter: Name=filter1',
+                 'Added permanent filter: Name=filter2',
+                 'CIM_class                     owned    permanent    all',
+                 '--------------------------  -------  -----------  -----',
+                 'CIM_IndicationSubscription        0            0      0',
+                 'CIM_IndicationFilter              0            2      2',
+                 'CIM_ListenerDestinationCIMXML     0            0      0',
+                 'Ownership  Identity  Name  Query Query Source Subscription',
+                 '        Property  Language  Namespaces     Count',
+                 'permanent  filter1  filter1  xx  WQL   interop       0',
+                 '                  root/cimv2',
+                 'permanent  filter2   filter2 xx2  WQL   root/cimv3      0',
+                 '                  root/cimv4',
+                 # Validate property in MOF
+                 'Removed permanent indication filter: identity=filter1, Name=filter1',   # noqa: E501
+                 'Removed permanent indication filter: identity=filter2, Name=filter2',   # noqa: E501
+                 'SourceNamespaces = { "interop", "root/cimv2" };',
+                 'SourceNamespaces = { "root/cimv3", "root/cimv4" };',
+                 # Test filters removed
+                 'CIM_IndicationFilter              0            0      0',
+                 ],
+      'stderr': [],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify add owned dest, filter, subscription OK.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-destination odest1 -l http://someone:50000',
+                'subscription add-filter ofilter1 -q "SELECT * from CIM_Indication" --owned',  # noqa: E501
+                'subscription add-subscription  pywbemdestination:defaultpywbemcliSubMgr:odest1  pywbemfilter:defaultpywbemcliSubMgr:ofilter1 --owned',  # noqa: E501
+                '-o simple subscription list']},
+     {'stdout': ['Added owned destination: Name=pywbemdestination:defaultpywbemcliSubMgr:odest1',  # noqa: E501
+                 'Added owned filter: Name=pywbemfilter:defaultpywbemcliSubMgr:ofilter1',  # noqa: E501
+                 'Added owned subscription: DestinationName=pywbemdestination:defaultpywbemcliSubMgr:odest1, FilterName=pywbemfilter:defaultpywbemcliSubMgr:ofilter1',   # noqa: E501
+                 'CIM_class                     owned    permanent    all',
+                 '--------------------------  -------  -----------  -----',
+                 'CIM_IndicationSubscription        1            0      1',
+                 'CIM_IndicationFilter              1            0      1',
+                 'CIM_ListenerDestinationCIMXML     1            0      1'],
+      'stderr': [],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify add owned dest, filter, subscription , verify list options.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-destination odest1 -l http://someone:50000',
+                'subscription add-filter ofilter1 -q "SELECT * from CIM_Indication" --owned',  # noqa: E501
+                'subscription add-subscription  pywbemdestination:defaultpywbemcliSubMgr:odest1  pywbemfilter:defaultpywbemcliSubMgr:ofilter1 --owned',  # noqa: E501
+                '-o simple subscription list',
+                '-o simple subscription list --summary',
+                '-o text subscription list --summary',
+                '-o plain subscription list-destinations',
+                '-o plain subscription list-destinations --names-only',
+                '-o plain subscription list-destinations --detail',
+                '-o mof=- subscription list-destinations --detail',
+                '-o plain subscription list-destinations --summary',
+                'subscription list-destinations --summary',
+                '-o plain subscription list-filters',
+                '-o mof subscription list-filters --detail',
+                '-o plain subscription list-filters --summary'
+                'subscription list-subscriptions --summary',
+                '-o plain subscription list-subscriptions',
+                '-o mof subscription list-subscriptions --detail',
+                '-o plain subscription list-subscriptions --summary',
+                'subscription list-subscriptions --summary']},
+     {'stdout': ['Added owned destination: Name=pywbemdestination:defaultpywbemcliSubMgr:odest1',  # noqa: E501
+                 'Added owned filter: Name=pywbemfilter:defaultpywbemcliSubMgr:ofilter1',  # noqa: E501
+                 'Added owned subscription: DestinationName=pywbemdestination:defaultpywbemcliSubMgr:odest1, FilterName=pywbemfilter:defaultpywbemcliSubMgr:ofilter1',   # noqa: E501
+                 'CIM_class                     owned    permanent    all',
+                 '--------------------------  -------  -----------  -----',
+                 'CIM_IndicationSubscription        1            0      1',
+                 'CIM_IndicationFilter              1            0      1',
+                 'CIM_ListenerDestinationCIMXML     1            0      1',
+                 'Indication Destinations: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988, type=all',  # noqa: E501
+                 'Ownership    Identity    Name       Destination      Persistence    Protocol    Subscription',  # noqa: E501
+                 '                         Type         Count',
+                 'owned        odest1      pywbemdestination:defaultpywbe  http://someone:50000       3    2        1',  # noqa: E501
+                 '           mcliSubMgr:odest1',
+                 'instance of CIM_ListenerDestinationCIMXML {',
+                 '   CreationClassName = "CIM_ListenerDestinationCIMXML";',
+                 '   SystemCreationClassName = "CIM_ComputerSystem";',
+                 '   SystemName = "MockSystem_WBEMServerTest";',
+                 '   PersistenceType = 3;',
+                 '   Name = "pywbemdestination:defaultpywbemcliSubMgr:odest1";',
+                 '   Destination = "http://someone:50000";',
+                 '   Protocol = 2;',
+                 '};',
+                 'Indication Filters: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988 type=all',  # noqa: E501
+                 'Ownership    Identity Name  Query Query Source Subscription',
+                 ' Property    Language    Namespaces      Count',
+                 'owned        ofilter1    pywbemfilter:defaultpywbemcliS  SELECT * from   WQL  root/cimv2          1',  # noqa: E501
+                 '           ubMgr:ofilter1    CIM_Indication',
+                 'instance of CIM_IndicationFilter {',
+                 '   CreationClassName = "CIM_IndicationFilter";',
+                 '   SystemCreationClassName = "CIM_ComputerSystem";',
+                 '   SystemName = "MockSystem_WBEMServerTest";',
+                 '   Name = "pywbemfilter:defaultpywbemcliSubMgr:ofilter1";',
+                 '   SourceNamespaces = { "root/cimv2" };',
+                 '   Query = "SELECT * from CIM_Indication";',
+                 '   QueryLanguage = "WQL";',
+                 '   IndividualSubscriptionSupported = true;',
+                 '};',
+                 'Indication Subscriptions: submgr-id=defaultpywbemcliSubMgr, svr-id=http://FakedUrl:5988, type=all',  # noqa: E501
+                 'Ownership    Handler        Filter    Handler        Filter          Filter Query    Subscription',  # noqa: E501
+                 '      Identity       Identity  Destination    Query           language        StartTime',  # noqa: E501
+                 # Issue 1055 Fails test. Should be owned but returns permanent
+                 # 'owned        odest1(owned)  ofilter1(owned)  http://someone:50000  SELECT * from CIM_Indication  WQL',  # noqa: E501
+                 'instance of CIM_IndicationSubscription {',
+                 '   Filter =',
+                 'interop:CIM_IndicationFilter.CreationClassName=', 'CIM_IndicationFilter',  # noqa: E501
+                 'pywbemfilter:defaultpywbemcliSubMgr:ofilter1',
+                 'SystemCreationClassName=', 'CIM_ComputerSystem', 'SystemName=', 'MockSystem_WBEMServerTest',  # noqa: E501
+                 ' Handler =',
+                 '  OnFatalErrorPolicy = 2;',
+                 '   RepeatNotificationPolicy = 2;',
+                 '   SubscriptionState = 2;',
+                 '};',
+                 'instance of CIM_IndicationFilter {',
+                 '   CreationClassName = "CIM_IndicationFilter";',
+                 '   SystemCreationClassName = "CIM_ComputerSystem";',
+                 '   SystemName = "MockSystem_WBEMServerTest";',
+                 '   Name = "pywbemfilter:defaultpywbemcliSubMgr:ofilter1";',
+                 '   SourceNamespaces = { "root/cimv2" };',
+                 '   Query = "SELECT * from CIM_Indication";',
+                 '   QueryLanguage = "WQL";',
+                 '   IndividualSubscriptionSupported = true;',
+                 '};',
+                 'instance of CIM_ListenerDestinationCIMXML {',
+                 '   CreationClassName = "CIM_ListenerDestinationCIMXML";',
+                 '   SystemCreationClassName = "CIM_ComputerSystem";',
+                 '   SystemName = "MockSystem_WBEMServerTest";',
+                 '   PersistenceType = 3;',
+                 '   Name = "pywbemdestination:defaultpywbemcliSubMgr:odest1";',
+                 '   Destination = "http://someone:50000";',
+                 '   Protocol = 2;',
+                 '};'],
+      'stderr': [],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify add dest, filter, subscription and remove --permanent OK.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-destination pdest1 -l http://someone:50000 --permanent',  # noqa: E501
+                'subscription add-filter pfilter1 -q "SELECT * from CIM_Indication" --permanent',  # noqa: E501
+                'subscription add-subscription pdest1 pfilter1 --permanent',
+                '-o simple subscription list',
+
+                'subscription remove-subscription pdest1 pfilter1',  # noqa: E501
+                'subscription remove-filter pfilter1 --permanent',
+                'subscription remove-destination pdest1 --permanent',
+                '-o simple subscription list'], },
+     {'stdout': ['CIM_class                     owned    permanent    all',
+                 '--------------------------  -------  -----------  -----',
+                 'CIM_IndicationSubscription        0            1      1',
+                 'CIM_IndicationFilter              0            1      1',
+                 'CIM_ListenerDestinationCIMXML     0            1      1',
+                 'CIM_IndicationSubscription        0            0      0',
+                 'CIM_IndicationFilter              0            0      0',
+                 'CIM_ListenerDestinationCIMXML     0            0      0'
+                 ],
+      'stderr': [],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify add dests, filters, subsubscription  --permanent/owned OK.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-destination pdest1 -l http://someone:50000 --permanent',  # noqa: E501
+                'subscription add-filter pfilter1 -q "SELECT * from CIM_Indication" --permanent',  # noqa: E501
+                'subscription add-subscription pdest1 pfilter1  --permanent',
+
+                'subscription add-destination odest1 -l http://someone:50001 --owned',  # noqa: E501
+                'subscription add-filter ofilter1 -q "SELECT * from CIM_Indication" --owned',  # noqa: E501
+                'subscription add-subscription odest1 ofilter1 --owned',  # noqa: E501
+
+                '-o simple subscription list',
+                '-o simple subscription list-destinations',
+                '-o simple subscription list-filters',
+                '-o simple subscription list-subscriptions', ]},
+     {'stdout': ['Added permanent destination: Name=pdest1',
+                 'Added permanent filter: Name=pfilter1',
+                 'Added permanent subscription: DestinationName=pdest1, FilterName=pfilter1',  # noqa: E501
+                 'Added owned destination: Name=pywbemdestination:defaultpywbemcliSubMgr:odest1',  # noqa: E501
+                 'Added owned filter: Name=pywbemfilter:defaultpywbemcliSubMgr:ofilter1',  # noqa: E501
+                 'Added owned subscription: DestinationName=pywbemdestination:defaultpywbemcliSubMgr:odest1, FilterName=pywbemfilter:defaultpywbemcliSubMgr:ofilter1',  # noqa: E501
+                 'CIM_class                     owned    permanent    all',
+                 '--------------------------  -------  -----------  -----',
+                 'CIM_IndicationSubscription        1            1      2',
+                 'CIM_IndicationFilter              1            1      2',
+                 'CIM_ListenerDestinationCIMXML     1            1      2',
+                 'Indication Destinations:',
+                 'permanent pdest1 pdest1  http://someone:50000  2  2  1',
+                 'owned odest1  pywbemdestination:defaultpywbe  http://someone:50001 3 2  1',  # noqa: E501
+                 'Indication Filters:',
+                 'permanent pfilter1 pfilter1 SELECT * from   WQL root/cimv2 1',
+                 'owned ofilter1  pywbemfilter:defaultpywbemcliS  SELECT * from   WQL root/cimv2 1',  # noqa: E501
+                 'Indication Subscriptions:',
+                 'permanent  pdest1(permanent) pfilter1(permanent)  http://someone:50000  SELECT * from CIM_Indication  WQL'],  # noqa: E501
+      'stderr': [],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify add dests, filters, subscription --permanent/owned, remove-server '
+     'OK.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-destination odest1 -l http://someone:50000 --owned',  # noqa: E501
+                'subscription add-filter ofilter1 -q "SELECT * from CIM_Indication" --owned',  # noqa: E501
+                'subscription add-subscription odest1 ofilter1 --owned',
+                'subscription add-destination pdest2 -l http://someone:50001  --permanent',  # noqa: E501
+                'subscription add-filter pfilter2 -q "SELECT * from CIM_Indication" --permanent',  # noqa: E501
+                'subscription add-subscription pdest2 pfilter2 --permanent',  # noqa: E501
+                '-o simple subscription list',
+                '-o simple subscription list-subscriptions',
+                'subscription remove-server',
+                '-o simple subscription list']},
+     {'stdout': ['http://FakedUrl:5988',
+                 'CIM_class                     owned    permanent    all',
+                 '--------------------------  -------  -----------  -----',
+                 'CIM_IndicationSubscription        1            1      2',
+                 'CIM_IndicationFilter              1            1      2',
+                 'CIM_ListenerDestinationCIMXML     1            1      2',
+                 # Fails test issue # 1055 The subscription should be owned
+                 # 'owned  odest1(owned) ofilter1(owned) http://someone:50000  SELECT * from CIM_Indication  WQL',  # noqa: E501
+                 'permanent pdest2(permanent) pfilter2(permanent) http://someone:50001  SELECT * from CIM_Indication  WQL',  # noqa: E501
+                 'CIM_IndicationSubscription        0            1      1',
+                 'CIM_IndicationFilter              0            1      1',
+                 'CIM_ListenerDestinationCIMXML     0            1      1', ],
+      'stderr': [],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify add dest, filter, subscrip & list-* handles --permanent, '
+     'remove-server OK.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-destination pdest1 -l http://blah:50000 --permanent',  # noqa: E501
+                'subscription add-destination odest1 -l http://blah:50000 --owned',  # noqa: E501'
+                'subscription add-filter pfilter1 -q "SELECT" --permanent',  # noqa: E501
+                'subscription add-filter ofilter1 -q "SELECT" --owned',  # noqa: E501
+                'subscription add-subscription pdest1 pfilter1 --permanent',
+                'subscription add-subscription odest1 ofilter1 --owned',
+                # Test list with --permanent option
+                '-o simple subscription list',
+                '-o plain subscription list-destinations --type permanent',
+                '-o plain subscription list-filters --type permanent',
+                '-o plain subscription list-subscriptions --type permanent',
+                'subscription remove-server',
+                '-o simple subscription list']},
+     {'stdout': ['Added permanent destination: Name=pdest1',
+                 'Added permanent filter: Name=pfilter1',
+                 'Added permanent subscription: DestinationName=pdest1, FilterName=pfilter1',  # noqa: E501
+                 'Added owned subscription: DestinationName=pywbemdestination:defaultpywbemcliSubMgr:odest1, FilterName=pywbemfilter:defaultpywbemcliSubMgr:ofilter1',  # noqa: E501
+                 # Confirm one permanent instance of each created
+                 'CIM_class                     owned    permanent    all',
+                 '--------------------------  -------  -----------  -----',
+                 'CIM_IndicationSubscription        1            1      2',
+                 'CIM_IndicationFilter              1            1      2',
+                 'CIM_ListenerDestinationCIMXML     1            1      2',
+                 # Test if displays permanent objects as table
+                 'permanent pfilter1 pfilter1 SELECT WQL root/cimv2  1',
+                 'permanent pdest1 pdest1 http://blah:50000 2 2 1',
+                 'permanent  pdest1(permanent) pfilter1(permanent) http://blah:50000 ',  # noqa: E501
+                 # Confirms remove server removed owned elements only
+                 'CIM_class                        owned    permanent    all',
+                 '-----------------------------  -------  -----------  -----',
+                 'CIM_IndicationSubscription           0            1      1',
+                 'CIM_IndicationFilter                 0            1      1',
+                 'CIM_ListenerDestinationCIMXML        0            1      1',
+                 ],
+      'stderr': [],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify remove_subscription --remove-associated-instances OK,',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-destination pdest1 -l http://blah:50000 --permanent',  # noqa: E501
+                'subscription add-filter pfilter1 -q "SELECT" --permanent',  # noqa: E501
+                'subscription add-subscription pdest1 pfilter1 --permanent',
+                # Add a permanent destination, filter, subscription
+                'subscription add-destination odest1 -l http://blah:50000 --owned',  # noqa: E501
+                'subscription add-filter ofilter1 -q "SELECT" --owned',  # noqa: E501
+                'subscription add-subscription odest1 ofilter1 --owned',
+                '-o simple subscription list',
+                'subscription remove-subscription odest1 ofilter1 --remove-associated-instances',  # noqa: E501
+                'subscription remove-subscription pdest1 pfilter1 --remove-associated-instances',  # noqa: E501
+                '-o simple subscription list']},
+     {'stdout': ['Added permanent destination: Name=pdest1',
+                 'Added permanent filter: Name=pfilter1',
+                 'Added permanent subscription: DestinationName=pdest1, FilterName=pfilter1',  # noqa: E501
+                 'Added owned destination: Name=pywbemdestination:defaultpywbemcliSubMgr:odest1',  # noqa: E501
+                 'Added owned filter: Name=pywbemfilter:defaultpywbemcliSubMgr:ofilter1',  # noqa: E501
+                 'Added owned subscription: DestinationName=pywbemdestination:defaultpywbemcliSubMgr:odest1, FilterName=pywbemfilter:defaultpywbemcliSubMgr:ofilter1',  # noqa: E501
+                 'CIM_class                     owned    permanent    all',
+                 '--------------------------  -------  -----------  -----',
+                 'CIM_IndicationSubscription        1            1      2',
+                 'CIM_IndicationFilter              1            1      2',
+                 'CIM_ListenerDestinationCIMXML     1            1      2',
+                 'Removed 1 subscription(s) for destination-id: odest1, filter-id: ofilter1.',  # noqa: E501
+                 'Removed 1 subscription(s) for destination-id: pdest1, filter-id: pfilter1.',  # noqa: E501
+                 'Removed destination: interop:CIM_ListenerDestinationCIMXML.CreationClassName="CIM_ListenerDestinationCIMXML",Name="pdest1",SystemCreationClassName="CIM_ComputerSystem",SystemName="MockSystem_WBEMServerTest"',  # noqa: E501
+                 'Removed filter: interop:CIM_IndicationFilter.CreationClassName="CIM_IndicationFilter",Name="pfilter1",SystemCreationClassName="CIM_ComputerSystem",SystemName="MockSystem_WBEMServerTest"',  # noqa: E501
+                 'CIM_IndicationSubscription        0            0      0',
+                 'CIM_IndicationFilter              0            0      0',
+                 'CIM_ListenerDestinationCIMXML     0            0      0',
+                 ],
+      'stderr': [],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify add-subscription with duplicate destinations no select fails,',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'env': {STARTUP_SCRIPT_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)},
+      'stdin': ['subscription add-destination pdest1 -l http://blah:5000 --permanent',  # noqa: E501
+                'subscription add-destination destdup -l http://blah:5001 --owned',  # noqa: E501
+                'subscription add-destination destdup -l http://blah:5002 --permanent',  # noqa: E501
+
+                'subscription add-filter pfilter1 -q "SELECT 3" --permanent',
+                'subscription add-filter filterdup -q "SELECT 2" --owned',
+                'subscription add-filter filterdup -q "SELECT 3" --permanent',
+                # This command generates click exception which is hidden
+                'subscription add-subscription destdup pfilter1 --permanent',
+                'subscription add-subscription pdest1 filterdup --permanent',
+                'subscription add-subscription destdup filterdup --permanent',
+                '-o simple subscription list', ]},
+     {'stdout': ['Added permanent destination: Name=pdest1',  # noqa: E501
+                 'Added owned destination: Name=pywbemdestination:defaultpywbemcliSubMgr:destdup',  # noqa: E501
+                 'Added permanent destination: Name=destdup',
+
+                 'Added permanent filter: Name=pfilter1',
+                 'Added owned filter: Name=pywbemfilter:defaultpywbemcliSubMgr:filterdup',  # noqa: E501
+                 'Added permanent filter: Name=filterdup',
+                 # No indication subscriptions created
+                 'CIM_class                     owned    permanent    all',
+                 '--------------------------  -------  -----------  -----',
+                 'CIM_IndicationSubscription        0            0      0',
+                 'CIM_IndicationFilter              1            2      3',
+                 'CIM_ListenerDestinationCIMXML     1            2      3',
+                 ],
+      'stderr': [],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify duplicate names,different paths on filters with --select OK.',
+     # SUBSCRIPTIONTEST_MOF adds filter subclass to allow creating conflicts
+     # Windows bypassed because the add-mof command not correctly created
+     # in stdin
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'env': {STARTUP_SCRIPT_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)},
+      'stdin': ['subscription add-filter duptestfilter -q "SELECT * from CIM_Indication" --permanent',  # noqa: E501
+                'server add-mof ' + str(SUBSCRIPTIONTEST_MOF_FILEPATH) + ' -n interop',  # noqa: E501
+                '-o simple subscription list',
+                'subscription remove-filter duptestfilter --permanent --select',
+                '-o simple subscription list'],
+      'platform': 'win32'},  # ignore this platform
+     {'stdout': ['CIM_IndicationFilter   0  2 2',
+                 '0: CIM_IndicationFilter.CreationClassName="CIM_IndicationFilter",Name="duptestfilter",SystemCreationClassName="CIM_ComputerSystem",SystemName="MockSystem_WBEMServerTest',  # noqa: E501
+                 '1: CIM_IndicationFilterSub.CreationClassName="CIM_IndicationFilterSub",Name="duptestfilter",SystemCreationClassName="CIM_ComputerSystem",SystemName="blah',  # noqa: E501
+                 'Removed permanent indication filter: identity=duptestfilter, Name=duptestfilter',  # noqa: E501
+                 'CIM_IndicationFilter   0  1 1'],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify add-destination permanent fails if IDENTITY already exists.',
+     # SUBSCRIPTIONTEST_MOF adds destination subclass to force conflicts
+     # Windows bypassed because the add-mof command not correctly created
+     # in stdin
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'env': {STARTUP_SCRIPT_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)},
+      'stdin': ['server add-mof ' + str(SUBSCRIPTIONTEST_MOF_FILEPATH) + ' -n interop',  # noqa: E501
+                'subscription add-destination duptestdest -l http://blah:5000 --permanent'],  # noqa: E501
+      'platform': 'win32'},  # ignore this platform
+     {'stderr': ['permanent destination: Name=[duptestdest] add failed. Duplicates URL of existing destination'],  # noqa: E501
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify add-filter permanent fails if IDENTITY already exists.',
+     # SUBSCRIPTIONTEST_MOF adds filter subclass to allow creating conflicts
+     # Windows bypassed because the add-mof command not correctly created
+     # in stdin
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'env': {STARTUP_SCRIPT_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)},
+      'stdin': ['server add-mof ' + str(SUBSCRIPTIONTEST_MOF_FILEPATH) + ' -n interop',  # noqa: E501
+                'subscription add-filter duptestfilter -q "blah" --permanent'],  # noqa: E501
+      'platform': 'win32'},  # ignore this platform
+     {'stderr': ['permanent filter: Name=[duptestfilter] add failed. Duplicates URL of existing filter'],  # noqa: E501
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify duplicate names,different paths on filters w/o --select OK.',
+     # Can only be created by adding filter subclass
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-filter duptestfilter -q "SELECT * from CIM_Indication" --permanent',  # noqa: E501
+                'server add-mof ' + str(SUBSCRIPTIONTEST_MOF_FILEPATH) + ' -n interop',  # noqa: E501
+                '-o simple subscription list',
+                # Test that that the remove-filter without --select OK
+                'subscription remove-filter duptestfilter --permanent',
+                '-o simple subscription list'],
+      'platform': 'win32'},  # ignore on windows
+     {'stderr': ['Remove failed. Multiple filters meet criteria identity=duptestfilter, owned=permanent.',  # noqa: E501
+                 '* CIM_IndicationFilter.CreationClassName="CIM_IndicationFilter",Name="duptestfilter",SystemCreationClassName="CIM_ComputerSystem",SystemName="MockSystem_WBEMServerTest',  # noqa: E501
+                 '* CIM_IndicationFilterSub.CreationClassName="CIM_IndicationFilterSub",Name="duptestfilter",SystemCreationClassName="CIM_ComputerSystem",SystemName="blah', ],  # noqa: E501
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify dup names, different paths on destinations OK w --select.',
+     # Can only be created by adding destination subclass
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'env': {STARTUP_SCRIPT_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)},
+      'stdin': ['subscription add-destination duptestdest -l http://blah:5000 --permanent',  # noqa: E501
+                'server add-mof ' + str(SUBSCRIPTIONTEST_MOF_FILEPATH) + ' -n interop',  # noqa: E501
+                '-o simple subscription list',
+                'subscription remove-destination duptestdest --permanent --select',  # noqa: E501
+                '-o simple subscription list'],
+      'platform': 'win32'},  # ignore on windows
+     {'stdout': ['CIM_ListenerDestinationCIMXML   0  2 2',
+                 '0: CIM_ListenerDestinationCIMXML.CreationClassName="CIM_ListenerDestinationCIMXML",Name="duptestdest",SystemCreationClassName="CIM_ComputerSystem",SystemName="MockSystem_WBEMServerTest',  # noqa: E501
+                 '1: CIM_ListenerDestinationCIMXMLSub.CreationClassName="CIM_ListenerDestinationCIMXMLSub",Name="duptestdest",SystemCreationClassName="CIM_ComputerSystem",SystemName="blah',  # noqa: E501
+                 'Removed permanent indication destination: identity=duptestdest, Name=duptestdest',  # noqa: E501
+                 'CIM_ListenerDestinationCIMXML   0  1 1'],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify dup names,different paths on destinations OK w/o --select.',
+     # Can only be created by adding destination subclass
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-destination duptestdest -l http://blah:5000 --permanent',  # noqa: E501
+                'server add-mof ' + str(SUBSCRIPTIONTEST_MOF_FILEPATH) + ' -n interop',  # noqa: E501
+                '-o simple subscription list',
+                # Test that that the remove-destination without --select OK
+                'subscription remove-destination duptestdest --permanent',
+                '-o simple subscription list'],
+      'platform': 'win32'},  # ignore on windows
+     {'stderr': ['Remove failed. Multiple destinations meet criteria identity=duptestdest, owned=permanent',  # noqa: E501
+                 '* CIM_ListenerDestinationCIMXML.CreationClassName="CIM_ListenerDestinationCIMXML",Name="duptestdest",SystemCreationClassName="CIM_ComputerSystem",SystemName="MockSystem_WBEMServerTest',  # noqa: E501
+                 '* CIM_ListenerDestinationCIMXMLSub.CreationClassName="CIM_ListenerDestinationCIMXMLSub",Name="duptestdest",SystemCreationClassName="CIM_ComputerSystem",SystemName="blah'],  # noqa: E501
+
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify add-subscription with duplicate destinations with select OK,',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'env': {STARTUP_SCRIPT_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)},
+      'stdin': ['subscription add-destination odest1 -l http://blah:5000 --owned',  # noqa: E501
+                'subscription add-destination destdup -l http://blah:5001 --owned',  # noqa: E501
+                'subscription add-destination destdup -l http://blah:5002 --permanent',  # noqa: E501
+
+                'subscription add-filter ofilter1 -q "SELECT 1" --owned',
+                'subscription add-filter filterdup -q "SELECT 2" --owned',
+                'subscription add-filter filterdup -q "SELECT 3" --permanent',
+                # This command generates click exception which is hidden
+                'subscription add-subscription odest1 ofilter1 --owned',
+                # This command triggers the prompt mock
+                'subscription add-subscription destdup ofilter1 --owned --select',  # noqa: E501
+                'subscription add-subscription odest1 filterdup --owned --select',  # noqa: E501
+                '-o simple subscription list',
+                '-o simple subscription list-subscriptions',
+                # This command should list the options and generate exception
+                'subscription remove-subscription destdup ofilter1 --remove-associated-instances',  # noqa: E501
+                # Following commands should each remove a subscription using
+                # --select and prompt mock
+                'subscription remove-subscription destdup ofilter1 --remove-associated-instances --select',  # noqa: E501
+                'subscription remove-subscription odest1 filterdup --remove-associated-instances --select',  # noqa: E501
+                'subscription remove-subscription odest1 ofilter1 --remove-associated-instances --select',  # noqa: E501
+                '-o simple subscription list-subscriptions',
+                '-o simple subscription list',
+                '-o simple subscription list-filters',
+                '-o simple subscription list-destinations']},
+     {'stdout': ['Added owned destination: Name=pywbemdestination:defaultpywbemcliSubMgr:odest1',  # noqa: E501
+                 'Added owned destination: Name=pywbemdestination:defaultpywbemcliSubMgr:destdup',  # noqa: E501
+                 'Added permanent destination: Name=destdup',
+
+                 'Added owned filter: Name=pywbemfilter:defaultpywbemcliSubMgr:ofilter1',  # noqa: E501
+                 'Added owned filter: Name=pywbemfilter:defaultpywbemcliSubMgr:filterdup',  # noqa: E501
+                 'Added permanent filter: Name=filterdup',
+
+                 'Added owned subscription: DestinationName=pywbemdestination:defaultpywbemcliSubMgr:odest1, FilterName=pywbemfilter:defaultpywbemcliSubMgr:ofilter1',  # noqa: E501
+                 'CIM_class                     owned    permanent    all',
+                 '--------------------------  -------  -----------  -----',
+                 'CIM_IndicationSubscription        3            0      3',
+                 'CIM_IndicationFilter              2            1      3',
+                 'CIM_ListenerDestinationCIMXML     2            1      3',
+                 'Removed 1 subscription(s) for destination-id: odest1, filter-id: ofilter1.',  # noqa: E501
+                 # TODO: Check'Removed 1 subscription(s) for destination-id: pdest1, filter-id: pfilter1.',  # noqa: E501
+                 'Removed destination: interop:CIM_ListenerDestinationCIMXML.CreationClassName="CIM_ListenerDestinationCIMXML",Name="destdup",SystemCreationClassName="CIM_ComputerSystem",SystemName="MockSystem_WBEMServerTest"',  # noqa: E501
+                 'Removed filter: interop:CIM_IndicationFilter.CreationClassName="CIM_IndicationFilter",Name="pywbemfilter:defaultpywbemcliSubMgr:ofilter1",SystemCreationClassName="CIM_ComputerSystem",SystemName="MockSystem_WBEMServerTest"',  # noqa: E501
+                 'CIM_IndicationSubscription        0            0      0',
+                 # 'CIM_IndicationFilter            0            0      0',
+                 # 'CIM_ListenerDestinationCIMXML   0            0      0',
+                 # TODO add this to test
+                 ],
+      'stderr': [],
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify remove-filter with permanent and owned same name OK.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-filter dupfilter -q "SELECT * from CIM_Indication"',  # noqa: E501
+                'subscription add-filter dupfilter -q "SELECT * from CIM_Indication" --permanent',  # noqa: E501
+                'subscription remove-filter dupfilter',
+                'subscription remove-filter dupfilter --permanent',
+                '-o simple subscription list']},
+     {'stdout': ['Removed owned indication filter: identity=dupfilter, Name=pywbemfilter:defaultpywbemcliSubMgr:dupfilter',  # noqa: E501
+                 'Removed permanent indication filter: identity=dupfilter, Name=dupfilter',  # noqa: E501
+                 'CIM_IndicationFilter   0  0 0'],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify duplicate add-destination fails second add.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-destination odest1 -l http://blah:5000 --owned',  # noqa: E501
+                'subscription add-destination odest1 -l http://blah:5000 --owned',  # noqa: E501
+                '-o simple subscription list']},
+     {'stdout': ['CIM_ListenerDestinationCIMXML   1  0 1'],
+      'stderr': ["add-destination failed. Name property "
+                 "'pywbemdestination:defaultpywbemcliSubMgr:odest1' "
+                 "already exists"],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify duplicate add-destination fails second add.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-destination odest1 -l http://blah:5000 --owned',  # noqa: E501
+                'subscription add-destination odest2 -l http://blah:5000 --owned',  # noqa: E501
+                '-o simple subscription list']},
+     {'stdout': ['CIM_ListenerDestinationCIMXML   1  0 1'],
+      'stderr': ["add-destination failed. Name property "
+                 "'pywbemdestination:defaultpywbemcliSubMgr:odest1' "
+                 "already exists"],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+
+    ['Verify add-filter duplicate identity/ownership  fails second add.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-filter ofilter1 -q "SELECT" --owned',
+                'subscription add-filter ofilter1 -q "SELECT" --owned',
+                '-o simple subscription list']},
+     {'stdout': ['CIM_IndicationFilter   1  0 1'],
+      'stderr': ["add-filter Failed. Filter name='ofilter1' already exists"],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    #
+    #  Error tests
+    #
+    # NOTE: Some tests to not require MOCK_SERVER_MODEL_FILE becasue they
+    # fail in click before load of mock file.
+    ['Verify any subscription command with no server specified fails.',
+     ['add-filter', 'ofilter1', '-q', 'blah', '--owned'],
+     {'stderr': ["No WBEM server defined."],
+      'rc': 1,
+      'test': 'innows'},
+     None, OK],
+
+    # NOTE: regex used in following tests because python 3.4 produces
+    # output for missing argument with double instead of single quote
+    ['Verify add-filter no identity fails.',
+     ['add-filter', '--owned'],
+     {'stderr': ["Missing argument .IDENTITY."],
+      'rc': 2,
+      'test': 'regex'},
+     None, OK],
+
+    ['Verify remove-filter no identity fails.',
+     ['remove-filter', '--owned'],
+     {'stderr': ["Missing argument .IDENTITY."],
+      'rc': 2,
+      'test': 'regex'},
+     None, OK],
+
+    ['Verify add-destination no identity fails.',
+     ['add-filter', '--owned'],
+     {'stderr': ["Missing argument .IDENTITY."],
+      'rc': 2,
+      'test': 'regex'},
+     None, OK],
+
+    ['Verify remove-destination no identity fails.',
+     ['add-filter', '--owned'],
+     {'stderr': ["Missing argument .IDENTITY."],
+      'rc': 2,
+      'test': 'regex'},
+     None, OK],
+
+    ['Verify add-subscription no identity fails.',
+     ['add-subscription', '--owned'],
+     {'stderr': ["Missing argument .DESTINATION."],
+      'rc': 2,
+      'test': 'regex'},
+     None, OK],
+
+    ['Verify add-subscription only one identity fails.',
+     ['add-subscription', 'pdest1', '--owned'],
+     {'stderr': ["Missing argument .FILTER."],
+      'rc': 2,
+      'test': 'regex'},
+     None, OK],
+
+    ['Verify remove-subscription no identity fails.',
+     ['remove-subscription'],
+     {'stderr': ["Missing argument .DESTINATION."],
+      'rc': 2,
+      'test': 'regex'},
+     None, OK],
+
+    ['Verify remove-subscription only one identity fails.',
+     ['add-subscription', 'pdest1', '--owned'],
+     {'stderr': ["Missing argument .FILTER."],
+      'rc': 2,
+      'test': 'regex'},
+     None, OK],
+
+    ['Verify add_destination  invalid url fails.',
+     ['add-destination', 'odest1', '--listener-url', 'fred://blah:50000', '--owned'],  # noqa: E501
+     {'stderr': ["add-destination failed: Unsupported scheme 'fred' in URL "
+                 "'fred://blah:50000"],
+      'rc': 1,
+      'test': 'innows'},
+     MOCK_SERVER_MODEL_FILE, OK],
+
+    ['Verify add_destination no port on url fails.',
+     ['add-destination', 'odest1', '--listener-url', 'http://blah', '--owned'],
+     {'stderr': ["add-destination failed: Port component missing in URL "
+                 "'http://blah'"],
+      'rc': 1,
+      'test': 'innows'},
+     MOCK_SERVER_MODEL_FILE, OK],
+
+    ['Verify add permanent subscription with owned filter/dest fails.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-destination odest1 -l http://blah:5000',
+                'subscription add-filter ofilter1 -q "SELECT * from CIM_Indication"',  # noqa: E501
+                'subscription add-subscription odest1 ofilter1 --permanent',
+                '-o simple subscription list']},
+     {'stdout': ["CIM_IndicationSubscription           0            0      0"],
+      'stderr': ["Permanent subscriptions cannot be created with owned filters "
+                 "or destinations."],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify remove-filter with associations fails.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-destination odest1 -l http://blah:5000',
+                'subscription add-filter ofilter1 -q "SELECT * from CIM_Indication"',  # noqa: E501
+                'subscription add-subscription odest1 ofilter1',
+                'subscription remove-filter ofilter1']},
+     {'stderr': ["remove-filter failed", "(CIM_ERR_FAILED)",
+                 "The indication filter is referenced by subscriptions"],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify remove-destination with associations fails.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-destination odest1 -l http://blah:5000',
+                'subscription add-filter ofilter1 -q "SELECT * from CIM_Indication"',  # noqa: E501
+                'subscription add-subscription odest1 ofilter1',
+                'subscription remove-destination odest1']},
+     {'stderr': ["remove-destination failed:", "(CIM_ERR_FAILED)",
+                 "The listener destination is referenced by subscriptions"],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify add-filter with colon in name fails.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription add-filter ofilter:1 -q "blah"', ]},
+     {'stderr': ["add-filter failed", "Filter ID contains ':': 'ofilter:1"],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify remove-destination unknown destination fails.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription remove-destination odest', ]},
+     {'stderr': ["No owned destination found foridentity=odest", ],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify remove-filter unknown filter fails.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription remove-filter ofilter1', ]},
+     {'stderr': ["No owned filter found foridentity=ofilter1", ],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify remove-subscription unknown destination/filter fails.',
+     {'general': ['-m', MOCK_SERVER_MODEL_PATH],
+      'stdin': ['subscription remove-subscription blah blah', ]},
+     {'stderr': ["No destination found for identity: blah", ],
+      'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    # TESTS TO IMPLEMENT
+    # 1. test of fail when add-subscription reverses dest and filter ids
+    # 2. test of fail when remove-subscription reverses dest and filter ids
+    # 3. TODO list with paths
+    # 4. Tests for subscription owned/permanent between filter/dest and fails
+    # 5. Tests of summary and --detail beyond existing tests
+    # 6. tests of output format text for those commands that implement this.
+    # 7. Remove with verify.
+    # 8. Test fail with destination and filter if create duplicated.
+    # 9. Add-subscription fail, value or type error
+    # 10. dest/filter_for_type, owned (list-destinations owned)
+    # 11. find_destinations_for_name( fail_if_none
+    # 12. subscription_class  select_id_str(
+    # 13. pick_one_path_from_instances_list( subscription
+    # 14. Owned filter or dest but permanent subscription
+    # 15. list-subscription text
+    # 16. List-destinations, MOF summary or detail
+    # 17. list-filters --detail and path
+]
+# pylint: enable=enable=line-too-long
+
+
+class TestSubcmdClass(CLITestsBase):  # pylint: disable=too-few-public-methods
+    """
+    Test all of the class command variations.
+    """
+    command_group = 'subscription'
+
+    @pytest.mark.parametrize(
+        "desc, inputs, exp_response, mock, condition",
+        TEST_CASES)
+    def test_class(self, desc, inputs, exp_response, mock, condition):
+        """
+        Common test method for those commands and options in the
+        class command that can be tested.  This includes:
+
+          * Subcommands like help that do not require access to a server
+
+          * Subcommands that can be tested with a single execution of a
+            pywbemcli command.
+        """
+        # Temp bypass of windows platform because of issue with one test
+        # TODO: Solve issue of concatenating model path into a string for
+        # windows platform.  This causes loss of backslashes.
+        # See test_generaloptions.py also
+        if 'platform' in inputs:
+            if sys.platform == inputs['platform']:
+                return
+
+        # Create the connection file from the 'yaml' input
+        if 'yaml' in inputs:
+            # pylint: disable=unspecified-encoding
+            with open(TEST_SUBSCRIPTIONS_FILE_PATH, "wt") as repo_file:
+                repo_file.write(inputs['yaml'])
+
+        # All tests in for subscriptions will use the subscriptions
+        # connections file.
+        connections_file = TEST_SUBSCRIPTIONS_FILE_PATH
+        if 'general' in inputs:
+            inputs['general'].extend(['--connections-file', connections_file])
+        else:
+            inputs = {"args": inputs}
+            inputs['general'] = ['--connections-file', connections_file]
+        assert '--connections-file' in inputs['general']
+
+        self.command_test(desc, self.command_group, inputs, exp_response,
+                          mock, condition)


### PR DESCRIPTION
This PR adds the new command group subscriptions. This command group includes commands to add, remove, and list subscriptions, filters, and listener destinations.  It also adds the corresponding tests and documentation for the new command group.

### Status of PR
1. Code complete for all of the subscription methods that add/list/remove destinations, filters, and subscriptions and remove server command.
2. A couple of items I marked Future  in _cmd_subscription.py. Would not expect to do these in current PR.
3. Test coverage 89%. Test coverage for errors incomplete,  List of about 15 more tests possible in test.subscription_cmds.py file.
4. Code restarts SubscriptionManager for each new command even in interactive mode. This means it gets instances from the server for each command executed. It would seem logical to pass the Subscription manager from command to command through either the pywbem_server or context object to avoid having to get the subscriptions from the server for each subscription command.  Propose second pr see issue #1067.   Note that this approach also has issues in that we would be reusing the list of instance previously retrieved from the server while some other client (or even the server could be changing the instances on the server). There is a DISCUSSION item on this work because keeping the subscription between commands leads to issues of caching.
5. Documentation complete but I am the only person who has reviewed it.  Have requested couple of other reviews but no responses yet.

### New Discussion Items:

None

### TODOS:
*  Add more tests. Have list of sever more tests in the test_subscriptions_cmd.py file. Current coverage is 89%
* Add server tests based on pegasus container (Make this separate branch)
* Make changes in accord with the discussions above.
   b. Add ability to retain SubscriptionManager between commands in interactive mode to avoid reloading subscriptions from server for each command. See issue #1056. This will be separate PR
  c. Extend the table display so that rows that are properties based on the Values qualifier include both components.  Right now
     the show only the numeric value of the property. This will be separate PR.
  d.  Make persistence type on add-destination an option.  **Proposal:** No for this PR.  We will wait for requirements to do this.

### Previous Resolved Design discussion items:

1. **DISCUSSION**  **RESOLVED BY going to IDENTITY ARGUMENT, see above**.I rewrote the subscription commands to handle the new destination form and API.  This makes tthe whole thing more consistent but leads to a real difference.
   a. To be consistent in all the commands I used the options --destination-id, --destination-name, --filter-id, --filter-name. While only the --name is needed for add-filter and add-destination, in order to refer to both the filter and the destination in add-subscription you need all 4 of parameters and options is logical.  However the result is very hard for the user to understand In think as well as being very long.  Here are some working examples:

```
# NOTE: I do not include the --owned parameter here. The code selects that from the use of ..._id, vs ...name
subscription add-destination -l http://blah:5000 --destination-id=dest1
subscription add-destination -l https://blah:5001 --destination-id=dest2
subscription add-destination -l http://blah:5003 --destination-name dperm1
subscription add-destination -l https://blah:5004 --destination-name dperm2
subscription add-destination -l http://blah:5005 --destination-name dperm3
subscription add-destination -l https://blah:5006 --destination-name dperm4

subscription add-filter --filter-id filter1 -q "SELECT * from CIM_Indication"
subscription add-filter --filter-id filter2 --query="SELECT fred from CIM_Indication" --owned
subscription add-filter --filter-id filter3 -q "SELECT * from CIM_Indication" --query-language DMTF:CQL --owned
subscription add-filter --name perm1 -q "SELECT * from CIM_Indication" --query-language DMTF:CQL --permanent
subscription add-filter --name perm2 -q "SELECT * from CIM_Indication" --query-language DMTF:CQL --permanent

subscription add-subscriptions --destination-id dest1 --filter-id filter1 --owned
subscription add-subscriptions --destination-id dest2  --filter-id filter1
subscription add-subscriptions --destination-name dperm1 --filter-name perm2 --permanent

```
    The reason for using destination-name and filter-name as the option names is because those distinctions are required for add-subscription (--name would exist for both destination and filter).  

    I have considered an option for the parameters of these commands:

    a. for filter and destination use argument to set the name component and --owned to clarify whether it is owned.  thus add-filter would look like 
     
 ```
     subscription add-filter <id-string> <options.
     subscription add-filter permfilter1 --permanent --query "..."
     subscription add-filter ownedfilter1 --owned  --query "..."  

```
    This eliminates the --filter-id, --destination_id but would mean that the name/id concept would not appear in add-filter and add-destionation.  Further since these names are used when adding subscriptions, things really get messy since the subscription must provide id for both filter and destination. Thus, subscriptions would have to have something like :+1: 

```
    subscription add-subscription filter-id ownedfilter1 filter-type owned destination-id dest1 dest-type owned

```
   This means that the user has possibly 3 parameters involving ownerhip, the filter owner, the destination owner, and the subscription owner.
   Because there is no uniqueness requirement between the filter_id string and the filter_name string so the unique identity of a filter cannot be determined just from the string itself but by the combination of name and ownership. 
 

1.  **DISCUSSION:** How we pick destinations to delete and to create the subscription.  
   c) Destinations - We currently use the destination property as our  identification  for removing owned destinations.  Therefore, there can be only a single owned destination for each destination url to keep the urls unique since there is no model uniqueness requirement for urls (They probably are unique since the combination of scheme, hostname, port should be unique). For --permanent destinations, there are no limits but that means that we have a real issue defining subscriptions since there could be multiple handlers with the same destination url.  NOTE: We reuse a owned destination if a destination object exists with the same url.
 **CONCLUSION:**  **DONE**I think this is adequate but need to test some more.

2. **DISCUSSION:** We are not using the capability to have multiple servers in a single subscription context since pywbemcli focuses on a single server. Alternative could be a "global" Subscription context in interactive mode but that makes no sense to me.  **PROPOSAL:** This is correct, so no change required.
**CONCLUSION:**  **DONE** We will not use this capability for now.

3. **DISCUSSION:** **DISCUSSION DONE** The SubscriptionManager allows for multiple SubscriptionManager Ids.  I put the parameter into the subcommands but with a default "Pywbemcli_sub_mgr" but commented it out for the moment.  What should we consider the goal of the this variable, identify pywbemcli, identify a particular client user, etc.? Some possibilities include:
**CONCLUSION:** we want something where the user can define a subscription manager ID with some level of persistence as the default for a series of operations and NOT be tied to typing it in with each command. 
We want to get this out to the level of something like environment variable.

   **Andy:** (Updated 09/04) The subscription_manager_id is described "to help the user identify these instances in a WBEM server.". Where it is used in instance property values, it is always accompanied by the client hostname, and pywbem is also identified in the property values. I think it should be defaulted to a standard string such as "default" and have overrides with an env var and an option.

  **Karl.**  * Are we opening any security doors if we make the user name public by making it part of every subscription???? 
                 * Note that the user name is (strangely one of the more difficult things to acquire correctly in python (may mean adding new requirement ( ex. psutil) to cover all supported OS's. **COMMENT/KS** We agreed that the user name is probably not the best approach and will continue with a default name and the ability to set an alternate name.

4. **DISCUSSION:** **The filter_id vs name mechanism in adding filters.**  **DONE** With the latest change to pywbem, the filter_id is used only with owned filters and the name only with permanent filters. Therefore use of the filter_id as an option in create-  filter implies owned and use of --owned implies that the options --filter_id will become our own format for the Name property.  
**CONCLUSION**:   FIXED with pywbem PR https://github.com/pywbem/pywbem/pull/2764.   We need to separate out the three pieces (filter_id, name, owned) so the user has a clean choice with these options in the various commands.  Right  now we have both filter_id and name options and the owned option.
**PROPOSALS:**
   a. Use just --name and --owned.  If --name and --owned, we use the name as filter_id.  If --name without owned it is used as the string supplied with the option.
  b. Use just --name and --filter_id with create-filter and remove-filter and do not include the --owned option for add_filter.  It becomes owned if --filter_id is used.  We could then drop the --owned.--permanent option from add_filter.    **I prefer this proposal**  The question is also, why do we include the --owned parameter in pywbem for add-filter since ownership is  determined by the use of the --filter-id/--name parameters.

   **Andy:** There are 3 possibilities for specifying the `add_filter()` parameters, and not just 2. See [my comment in pywbem issue 2757](https://github.com/pywbem/pywbem/issues/2757#issuecomment-906093611)
   **Update:KS** This was changed meanwhile so that we now have only two options: owned filters with filter_id, and permanent filters with name.  The code has been updated on 7 Sept to reflect the new form for  the name property. **DONE**

  **Karl** I noted in issue pywbem 2757 that there is an issue with the filter-id / name code vs. documentation.  The documentation appears to state that only owned filters can have filter_id. The code allows both owned and not-owned filters to have filter_id unless I am reading something wrong.  I looked at the documentation and not the code the first time.

**Karl** I am keeping the two parameters --filter-id and --name throughout the cmd line options.  Code updated to reflect the change to pywbem. **DONE**

5. **DISCUSSION:**  **Selecting filters to be removed:**  **DONE** The code currently allows you to define a filter to be removed by --filter-id or --name.  When --name is used, we assume that the the --name is unique since the name property is a key property.  However, since the filter_id is not guaranteed to be unique, this can result in multiple filters in the list to remove as shown in the following example:

   **Andy:** There is no filter-id in the filter instance. This value exists only in order to construct the "Name" property, and there is a UUID created in the "Name" property when it is used to create filter instances. Therefore, filter-id cannot be used to identify existing filter instances. I think we should use the "Name" property to identify the filter, and have some mechanism to deal with its possible but unlikely non-uniqueness. For example, we could allow using the key list portion of a WBEM URI to deal with it:

   * `name1` -> just "Name", reject if non-unique
   * `Name="name1",CreationClassName="class1",...`

   Since non-uniquenes is unlikely, it does not matter much if the fallback mechanism to deal with it is not so nice.
```
**Karl Reply**.  Actually, there can be the concept of filter-id as far as the user is concerned in that the filter_id is a component of a particular formatting of the name property.  We require filter-id parameter to add an owned filter so, therefore, for the user there is a concept of filter-id. Thus if we request remove of a filter with filter_id = filter1, the code searches for filters that have a Name with our structure of the value and the fiilter_id component of filter1.  The name property for owned filters is not pretty, for example.  

    "pywbemfilter:owned:leonard:pywbemcliSubMgr:filter2:f1e85edf-b2d5-4be2-b71d-fe3d6b1c761e";

The only part of this that is useful for the user is a) the filter-id part, and b) the guid only if they would have to select between two filters with the same filter-id

```
Presenting the paths  to the user to pick a filter to remove leaves the user with a guessing game in determining which filter to remove. There is not enough information in the path for the user to decide.  We need to present information that will allow the user to separate out which filter to remove.  Thus, it would appear we should present a. the query language, b) the query, c) the source namespaces since any of these could separate the filters.

Further, this is unworkable in any automated environment since the user does not know when the remove just works or returns with a select statement.  

**Possible solutions:**
  a,  pywbemtools insures that the filter_ids are unique when filters are created.  **COMMENT** We agreed that this was what we wanted and this is in the pywbem master now.
  b. Add a flag that would control behavior if multiple filters were selected. In the normal mode the command would generate an exception.  This flag (ex. --select) would present the list and the user would pick the filter to remove. 
  c. Release all filters with that filter_id, under assumption that user knows what they want to do.  
6. **DISCUSSION** Add one more option to remove-subscriptions, (`--remove-associated-instances`) that would attempt to remove also the filters and destinations associated with a subscription being removed (if they had no other associations). I think this is logical other than the very long name for the option
   **Andy:** I think automatic removal of the referenced filters and destinations should only be done for filters and destinations that are owned by the current client. That is the whole point of the ownership concept: to be sure that they are yours. The option could be named `--remove-owned`. 
  **Karl** - I agree.  It would be better to make this easier for owned destinations, etc. and harder for permanent destinations, etc. I will add the remove option but it should indicate that we are removing associations like `remove-associated-instances` or `remove-everything`, etc.  This would only remove associations if they were not associated with other subscriptions and if they  werre owned, themselves as well as the subscription being owned.  Thus, an owned subscription with owned destination but permanent filter would only remove the subscription and destination, but not the filter.

**CODE STATUS:** The basic structure of the code is complete and all of the commands implemented. However, the output formats are purely samples, and the mechanisms for choosing filter_id/name to delete or as option in lists is being revised now.
6. **DISCUSSION**  Use of GUID with name in destination path.  Do we agree that the current form of the CIM_IndicationDestination Name propery will be kept the same with the form shown below or will we modify this one also?

     "pywbemdestination:permanent:leonard:defaultpywbemcliSubMgr:d9a6b7aa-aaa4-45ab-bfcd-469524ec7a40";

This form has tthree issues:
1. It is very long with the guid. While the guid is truly unique it is awkward to use in a terminal environment.
2. It includes the client host name.
3. It does not give the user any indication of what the destination really is (i.e what is the url or other identity info) so using --select to pick one to release is a guessing game. Currently I create a "short" string with the Name, url, if one of multiple destinations is to be selected.