### PR TITLE
Fixes issue in class invokemethod with cmd namespace option (-n)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -24,6 +24,11 @@ Released: not yet
 * Test: Fixed that test_utils.py changed the PYWBEMCLI_TERMWIDTH env var
   for testing purposes without restoring it.
 
+* Fixes issue where the command:
+  ``class invokemethod <class> <method> -n <namespace>``
+  ignores the command namespace option (-n) and usedsthe default
+  namespace. (see issue #990)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -869,8 +869,11 @@ def cmd_class_invokemethod(context, classname, methodname, options):
     """
     Create an instance and submit to a WBEM server
     """
+
     try:
-        process_invokemethod(context, classname, methodname, options)
+        cln = CIMClassName(classname, namespace=options['namespace'])
+        process_invokemethod(context, cln, methodname, options['namespace'],
+                             options['parameter'])
     except Error as er:
         raise pywbem_error_exception(er)
 

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -1113,7 +1113,8 @@ def cmd_instance_invokemethod(context, instancename, methodname,
     instancepath = get_instancename(context, instancename, options)
 
     try:
-        process_invokemethod(context, instancepath, methodname, options)
+        process_invokemethod(context, instancepath, methodname,
+                             options['namespace'], options['parameter'])
     except Error as er:
         raise pywbem_error_exception(er)
 

--- a/tests/unit/pywbemcli/test_class_cmds.py
+++ b/tests/unit/pywbemcli/test_class_cmds.py
@@ -66,6 +66,8 @@ MOCK_SERVER_MODEL = os.path.join('testmock', 'wbemserver_mock.py')
 
 TREE_TEST_MOCK_FILE = 'tree_test_mock_model.mof'
 
+SIMPLE_INTEROP_MOCK_FILE = 'simple_interop_mock_script.py'
+
 #
 # The following list defines the help for each command in terms of particular
 # parts of lines that are to be tested.//FakedUrl:5988
@@ -608,6 +610,12 @@ TEST_CASES = [
                  '<METHOD( | .+ )NAME="DeleteNothing"'],
       'test': 'regex'},
      SIMPLE_MOCK_FILE, OK],
+
+    ['Verify class command enumerate  --di --no --namespace',
+     ['enumerate', '--di', '--no', '-n', 'interop'],
+     {'stdout': ['CIM_Namespace', 'CIM_ObjectManager'],
+      'test': 'in'},
+     SIMPLE_INTEROP_MOCK_FILE, OK],
 
     #
     # Enumerate commands with the filter options
@@ -1331,6 +1339,13 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
     # pylint: enable=line-too-long
 
+    ['Verify class command enumerate  --di --no --namespace',
+     ['get', 'CIM_Namespace', '-n', 'interop'],
+     {'stdout': ['class CIM_Namespace',
+                 'string ObjectManagerCreationClassName;'],
+      'test': 'innows'},
+     SIMPLE_INTEROP_MOCK_FILE, OK],
+
     # get command errors
 
     ['Verify class command get invalid classname',
@@ -1416,6 +1431,13 @@ TEST_CASES = [
                  "  root/cimv2: CIM_Foo_sub_sub"],
       'test': 'lines'},
      SIMPLE_MOCK_FILE, OK],
+
+    ['Verify class command find simple name in interop namespace',
+     ['find', 'CIM_*'],
+     {'stdout': ["  interop: CIM_Namespace",
+                 "  interop: CIM_ObjectManager"],
+      'test': 'in'},
+     SIMPLE_INTEROP_MOCK_FILE, OK],
 
     ['Verify class command find name in known namespace -o grid',
      {'general': ['-o', 'grid'],
@@ -1829,6 +1851,14 @@ TEST_CASES = [
       'test': 'innows'},
      [SIMPLE_MOCK_FILE, 'reject_deleteinstance_provider.py'],
      MOCK_SETUP_SUPPORTED],
+
+    ['Verify class command delete using --namespace interop fails because of '
+     'instances',
+     ['delete', 'CIM_ObjectManager', '-n', 'interop'],
+     {'stderr': ['Cannot delete class', 'instances'],
+      'rc': 1,
+      'test': 'innows'},
+     SIMPLE_INTEROP_MOCK_FILE, OK],
 
     #
     # command "class tree"
@@ -2253,6 +2283,22 @@ TEST_CASES = [
       'rc': 0,
       'test': 'lines'},
      [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
+
+    ['Verify class command invokemethod CIM_Foo.FuzzyStatic() with --namespace',
+     ['invokemethod', 'CIM_Foo', 'FuzzyStatic', '--namespace', 'root/cimv2'],
+     {'stdout': ["ReturnValue=0"],
+      'rc': 0,
+      'test': 'lines'},
+     [SIMPLE_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
+
+    # Cannot do a test with interop as default because of issue #991
+    ['Verify class command invokemethod CIM_Foo.FuzzyStatic() with --namespace'
+     ' interop not found to validate that --namspace used',
+     ['invokemethod', 'CIM_Foo', 'FuzzyStatic', '--namespace', 'interop'],
+     {'stderr': ["CIM_ERR_NOT_FOUND", "not found in namespace 'interop'"],
+      'rc': 1,
+      'test': 'innows'},
+     [SIMPLE_INTEROP_MOCK_FILE, INVOKE_METHOD_MOCK_FILE], OK],
 
     ['Verify class command invokemethod CIM_Foo.FuzzyStatic() - one in parm',
      ['invokemethod', 'CIM_Foo', 'FuzzyStatic',


### PR DESCRIPTION
The option was being ignored with the command

    pywbemcli class invoke method ... -n <namespacename>

1 Modifies process method to assure only  CIMClassName and
CIMInstanceName on input

2. Add code to set namespace in objectname if the option exists.

3. Adds test for this option on invokemethod

4. Adds tests of other class commands with multiple namespaces.

This pr does NOT add tests across namespaces for the other commands (instance, qualifier) that use the --namespace command option.  That will be a separate issue. NOTE: All the other class commands did correctly handle the cross namespace execution.