### PR TITLE
fixes issue # 995. Exception with enumerate instances ... -n interop

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,12 @@ Released: not yet
   ignores the command namespace option (-n) and usedsthe default
   namespace. (see issue #990)
 
+* Fix issue where an exception occurs if the user tries to display
+  cim instances as a table but the class for the instances returned are not in the
+  default namespace and an alternate namespace is defined for the command.
+  The function display_cim_objects(...) uses valuemapping_for_property() but
+  specifies the default namespace as the target.  (See issue #995)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/pywbemtools/pywbemcli/_display_cimobjects.py
+++ b/pywbemtools/pywbemcli/_display_cimobjects.py
@@ -427,7 +427,7 @@ def _format_instances_as_rows(insts, max_cell_width=DEFAULT_MAX_CELL_WIDTH,
                         try:
                             valuemapping = ValueMapping.for_property(
                                 conn,
-                                conn.default_namespace,
+                                inst.path.namespace,
                                 inst.classname,
                                 name)
                         except ValueError:

--- a/tests/unit/pywbemcli/test_class_cmds.py
+++ b/tests/unit/pywbemcli/test_class_cmds.py
@@ -62,8 +62,6 @@ INVOKE_METHOD_MOCK_FILE = INVOKE_METHOD_MOCK_FILE_0 if PYWBEM_0 else \
 SIMPLE_ASSOC_MOCK_FILE = 'simple_assoc_mock_model.mof'
 QUALIFIER_FILTER_MODEL = 'qualifier_filter_model.mof'
 
-MOCK_SERVER_MODEL = os.path.join('testmock', 'wbemserver_mock.py')
-
 TREE_TEST_MOCK_FILE = 'tree_test_mock_model.mof'
 
 SIMPLE_INTEROP_MOCK_FILE = 'simple_interop_mock_script.py'

--- a/tests/unit/pywbemcli/test_instance_cmds.py
+++ b/tests/unit/pywbemcli/test_instance_cmds.py
@@ -61,8 +61,9 @@ INVOKE_METHOD_MOCK_FILE_1 = 'simple_mock_invokemethod_v1old.py'
 INVOKE_METHOD_MOCK_FILE = INVOKE_METHOD_MOCK_FILE_0 if PYWBEM_0 else \
     INVOKE_METHOD_MOCK_FILE_1
 
-
 COMPLEX_ASSOC_MODEL = "complex_assoc_model.mof"
+
+WBEMSERVER_MOCK_MODEL = os.path.join('testmock', 'wbemserver_mock.py')
 
 
 #
@@ -1063,6 +1064,13 @@ Instances: TST_Person
       'rc': 0,
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
+
+    ['Verify instance enumerate to interop namespace as table works.',
+     {'args': ['enumerate', 'CIM_Namespace', '-n', 'interop'],
+      'general': ['-o', 'simple']},
+     {'stdout': "CreationClassName    Name    ObjectManagerCreationClassName",
+      'test': 'innows'},
+     WBEMSERVER_MOCK_MODEL, RUN],
 
     #
     # instance enumerate error returns

--- a/tests/unit/pywbemcli/test_server_cmds.py
+++ b/tests/unit/pywbemcli/test_server_cmds.py
@@ -233,7 +233,6 @@ TEST_CASES = [
       'test': 'innows'},
      MOCK_SERVER_MODEL, OK],
 
-
     ['Verify server command brand with --output table fails',
      {'args': ['brand'],
       'general': ['-o', 'simple']},


### PR DESCRIPTION
Exception when display as a table for enumerate instances where the Class defined in the request is not in the namespace specified by the --namespace option.  Code in display_cimobjects_as_table uses default namespace instead of the namespace of the instance so that the classname for the instance may not exist.

The fix is to get the class from the namespace defined for the instance.

Adds test for this condition in test_instance_cmds.py

NOTE: Minor changes to test_class_cmds.py - remove unused reference to the WBEMServerMock 

Marked as rollback needed since this is a bug and this pr ONLY fixes that bug but I do not see this as a priority issue.