### PR TITLE
Added 'test' command to listener

### DIFF
--- a/docs/pywbemlistener/cmdshelp.rst
+++ b/docs/pywbemlistener/cmdshelp.rst
@@ -62,6 +62,7 @@ Help text for ``pywbemlistener``:
       show   Show a named WBEM indication listener.
       start  Start a named WBEM indication listener in the background.
       stop   Stop a named WBEM indication listener.
+      test   Send a test indication to a named WBEM indication listener.
       run    Run as a named WBEM indication listener.
 
 
@@ -262,4 +263,32 @@ Help text for ``pywbemlistener stop`` (see :ref:`pywbemlistener stop command`):
 
     Command Options:
       -h, --help  Show this help message.
+
+
+.. _`pywbemlistener test --help`:
+
+pywbemlistener test --help
+--------------------------
+
+
+
+Help text for ``pywbemlistener test`` (see :ref:`pywbemlistener test command`):
+
+
+::
+
+    Usage: pywbemlistener [GENERAL-OPTIONS] test NAME [COMMAND-OPTIONS]
+
+      Send a test indication to a named WBEM indication listener.
+
+      The indication is an alert indication with fixed properties. This allows testing the listener and what it does with
+      the indication.
+
+      Examples:
+
+        pywbemlistener test lis1
+
+    Command Options:
+      -c, --count INT  Count of test indications to send. Default: 1
+      -h, --help       Show this help message.
 

--- a/docs/pywbemlistener/commands.rst
+++ b/docs/pywbemlistener/commands.rst
@@ -26,6 +26,7 @@ The pywbemlistener commands are:
 * :ref:`pywbemlistener show command` - Show a named WBEM indication listener.
 * :ref:`pywbemlistener start command` - Start a named WBEM indication listener in the background.
 * :ref:`pywbemlistener stop command` -  Stop a named WBEM indication listener.
+* :ref:`pywbemlistener test command` -  Send a test indication to a named WBEM indication listener.
 * :ref:`pywbemlistener run command` - Run as a named WBEM indication listener.
 
 
@@ -220,6 +221,39 @@ Example:
     Shut down listener lis1 running at http://localhost:25989
 
 See :ref:`pywbemlistener stop --help` for the exact help output of the command.
+
+
+.. _`pywbemlistener test command`:
+
+``pywbemlistener test`` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``pywbemlistener test`` command sends a test indication to a running WBEM
+indication listener on the local system.
+
+Example:
+
+.. code-block:: text
+
+    $ pywbemlistener test lis1
+    Sending the following test indication:
+    instance of CIM_AlertIndication {
+       IndicationIdentifier = NULL;
+       IndicationTime = "20210711160151.847111+000";
+       AlertingElementFormat = 2;
+       AlertingManagedElement = NULL;
+       AlertType = 2;
+       Message = "Test message";
+       MessageID = "TEST0000";
+       OwningEntity = "TEST";
+       PerceivedSeverity = 2;
+       ProbableCause = 0;
+       SystemName = NULL;
+       MessageArguments = { };
+    };
+    Sent test indication to listener lis1 at http://localhost:25989
+
+See :ref:`pywbemlistener test --help` for the exact help output of the command.
 
 
 .. _`pywbemlistener run command`:

--- a/pywbemtools/pywbemlistener/_cmd_listener.py
+++ b/pywbemtools/pywbemlistener/_cmd_listener.py
@@ -35,7 +35,8 @@ import click
 import psutil
 import six
 
-from pywbem import WBEMListener, ListenerError
+from pywbem import WBEMListener, ListenerError, CIMInstance, CIMProperty, \
+    Uint16, WBEMConnection, Error
 
 from .._click_extensions import PywbemtoolsCommand, CMD_OPTS_TXT
 from .._options import add_options, help_option, validate_required_arg
@@ -388,6 +389,29 @@ def listener_list(context):
     commands.
     """
     context.execute_cmd(lambda: cmd_listener_list(context))
+
+
+@cli.command('test', cls=PywbemtoolsCommand, options_metavar=CMD_OPTS_TXT)
+@click.argument('name', type=str, metavar='NAME', required=False)
+@click.option('-c', '--count', type=int, metavar='INT',
+              required=False, default=1,
+              help=u'Count of test indications to send. '
+              'Default: 1')
+@add_options(help_option)
+@click.pass_obj
+def listener_test(context, name, **options):
+    """
+    Send a test indication to a named WBEM indication listener.
+
+    The indication is an alert indication with fixed properties. This allows
+    testing the listener and what it does with the indication.
+
+    Examples:
+
+      pywbemlistener test lis1
+    """
+    validate_required_arg(name, 'NAME')
+    context.execute_cmd(lambda: cmd_listener_test(context, name, options))
 
 
 ################################################################
@@ -1195,3 +1219,66 @@ def cmd_listener_list(context):
         click.echo("No running listeners")
     else:
         display_list_listeners(listeners, table_format=context.output_format)
+
+
+def cmd_listener_test(context, name, options):
+    """
+    Send a test indication to a named listener.
+    """
+    listeners = get_listeners(name)
+    if not listeners:
+        raise click.ClickException(
+            "No running listener found with name {}".format(name))
+    listener = listeners[0]
+
+    count = options['count']  # optional but defaulted
+    if count < 1:
+        raise click.ClickException(
+            "Invalid count specified: {}".format(count))
+
+    # Construct an alert indication
+    indication = CIMInstance("CIM_AlertIndication")
+    indication['IndicationIdentifier'] = \
+        CIMProperty('IndicationIdentifier', value=None, type='string')
+    indication['AlertingElementFormat'] = Uint16(2)  # CIMObjectPath
+    indication['AlertingManagedElement'] = \
+        CIMProperty('AlertingManagedElement', value=None, type='string')
+    indication['AlertType'] = Uint16(2)  # Communications Alert
+    indication['Message'] = "Test message"
+    indication['OwningEntity'] = 'TEST'
+    indication['PerceivedSeverity'] = Uint16(2)  # Information
+    indication['ProbableCause'] = Uint16(0)  # Unknown
+    indication['SystemName'] = \
+        CIMProperty('SystemName', value=None, type='string')
+    indication['MessageArguments'] = \
+        CIMProperty('MessageArguments', value=[], type='string', is_array=True)
+    indication['IndicationTime'] = datetime.now()
+    indication['MessageID'] = 'TESTnnnn'
+
+    context.spinner_stop()
+
+    click.echo("Sending the following test indication:\n{}".
+               format(indication.tomof()))
+
+    for i in range(1, count + 1):
+
+        indication['MessageID'] = 'TEST{:04d}'.format(i)
+
+        conn_kwargs = {}
+        conn_kwargs['creds'] = None
+        if listener.scheme == 'https':
+            url = 'https://localhost:{}'.format(listener.port)
+            conn_kwargs['x509'] = None
+            conn_kwargs['no_verification'] = True
+        else:  # http
+            url = 'http://localhost:{}'.format(listener.port)
+
+        conn = WBEMConnection(url, **conn_kwargs)
+
+        try:
+            conn.ExportIndication(indication)
+        except Error as exc:
+            raise click.ClickException(str(exc))
+
+        click.echo("Sent test indication #{} to listener {} at {}".
+                   format(i, name, url))

--- a/tests/unit/pywbemlistener/test_test_cmd.py
+++ b/tests/unit/pywbemlistener/test_test_cmd.py
@@ -1,0 +1,169 @@
+# (C) Copyright 2021 Inova Development Inc.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test the 'pywbemlistener test' command.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+
+from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NOWIN
+
+# Output patterns for 'pywbemlistener list --help'
+TEST_HELP_PATTERNS = [
+    r"^Usage: pywbemlistener \[GENERAL-OPTIONS\] test NAME "
+    r"\[COMMAND-OPTIONS\]$",
+    r"^Command Options:$",
+    r"^ *-c, --count INT ?",
+    r"^ *-h, --help ?",
+]
+
+TEST_TESTCASES = [
+
+    # List of testcases.
+    # Each testcase is a list with the following items:
+    # * desc: Description of the testcase.
+    # * inputs: Dictionary of inputs (args, env, listeners).
+    #     See pywbemlistener_test() for details.
+    # * exp_results: Dictionary of expected results (rc, stdout, stderr, log,
+    #     test). See pywbemlistener_test() for details.
+    # * condition: Condition for running the testcase and how to run it
+    #     (True, False, 'pdb', 'verbose').
+    #     See pywbemlistener_test() for details.
+
+    (
+        "Verify output of 'test --help'",
+        dict(
+            args=['test', '--help'],
+        ),
+        dict(
+            stdout=TEST_HELP_PATTERNS,
+            test='contains',
+        ),
+        RUN,
+    ),
+    (
+        "Verify output of 'test -h'",
+        dict(
+            args=['test', '-h'],
+        ),
+        dict(
+            stdout=TEST_HELP_PATTERNS,
+            test='contains',
+        ),
+        RUN,
+    ),
+    (
+        "Verify 'test' with no listener running",
+        dict(
+            args=['test', 'lis1'],
+            listeners=[]
+        ),
+        dict(
+            rc=1,
+            stderr=[
+                r"^Error: No running listener found with name lis1$",
+            ],
+            test='all',
+        ),
+        RUN,
+    ),
+    (
+        "Verify 'test' with one http listener running",
+        dict(
+            args=['test', 'lis1'],
+            listeners=[
+                ['lis1', '--scheme', 'http', '--port', '50001'],
+            ]
+        ),
+        dict(
+            stdout=[
+                r"^Sending the following test indication:$",
+                r"^instance of ",
+                r"^Sent test indication #1 to listener lis1 at ",
+            ],
+            test='contains',
+        ),
+        RUN_NOWIN,
+    ),
+    (
+        "Verify 'test' with one http listener running and -c 2",
+        dict(
+            args=['test', 'lis1', '-c', '2'],
+            listeners=[
+                ['lis1', '--scheme', 'http', '--port', '50001'],
+            ]
+        ),
+        dict(
+            stdout=[
+                r"^Sending the following test indication:$",
+                r"^instance of ",
+                r"^Sent test indication #1 to listener lis1 at ",
+                r"^Sent test indication #2 to listener lis1 at ",
+            ],
+            test='contains',
+        ),
+        RUN_NOWIN,
+    ),
+    (
+        "Verify 'test' with one http listener running and --count 2",
+        dict(
+            args=['test', 'lis1', '--count', '2'],
+            listeners=[
+                ['lis1', '--scheme', 'http', '--port', '50001'],
+            ]
+        ),
+        dict(
+            stdout=[
+                r"^Sending the following test indication:$",
+                r"^instance of ",
+                r"^Sent test indication #1 to listener lis1 at ",
+                r"^Sent test indication #2 to listener lis1 at ",
+            ],
+            test='contains',
+        ),
+        RUN_NOWIN,
+    ),
+    (
+        "Verify 'test' with one http listener running and invalid --count 0",
+        dict(
+            args=['test', 'lis1', '--count', '0'],
+            listeners=[
+                ['lis1', '--scheme', 'http', '--port', '50001'],
+            ]
+        ),
+        dict(
+            rc=1,
+            stderr=[
+                r"^Error: Invalid count specified: 0$",
+            ],
+            test='all',
+        ),
+        RUN_NOWIN,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, inputs, exp_results, condition",
+    TEST_TESTCASES
+)
+def test_lis_test(desc, inputs, exp_results, condition):
+    """
+    Test the 'pywbemlistener test' command.
+    """
+    pywbemlistener_test(desc, inputs, exp_results, condition)


### PR DESCRIPTION
For details, see commit message.
Ready to be reviewed and tested!

**TEST Instructions:**

1. Check out this branch and reinstall pywbemtools and pywbem to pick up the required pywbem changes:
    ```
    git checkout andy/listener-send
    pip uninstall -y pywbem
    make clobber install
    ```

2. Start a listener with output to an indication log file:
    ```
    pywbemlistener start lis1 -s http --indi-file lis1.log
    ```

3. Send a test indication to that listener:
    ```
    pywbemlistener test lis1
    ```

4. Look at the indication log file:
    ```
    cat lis1.log
    ```

DONE:
* Added tests
* Add `ExportIndication()` to `pywbem.WBEMConnection` (done in PR https://github.com/pywbem/pywbem/pull/2734)
* Add documentation (this PR)
* Discussions (done):
  * the approach in general -> go
  * targeting only pywbemlistener based listeners -> yes
  * using a fixed alert indication -> yes
  * Should we rename the command to 'test'? -> yes

Note that this command depends on support in pywbem for the ExportIndication export message. See  https://github.com/pywbem/pywbem/issues/2729 -> Has been implemented in PR https://github.com/pywbem/pywbem/pull/2734 -> Merged.