### PR TITLE
fixes issue #1039 extend set default connection command options

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -91,6 +91,20 @@ This documentation uses a few special terms to refer to Python types:
       ``PYWBEMCLI_CONNECTIONS_FILE`` environment variable, or with the
       :ref:`--connections-file general option`.
 
+      A connections file may also include a :term:`default-connection-name` that
+      defines a named connection in the file that is the default connection
+      to be created on pywbemcli startup.
+
+   default-connection-name
+      Each :term:`connections file` includes an attribute,
+      ``default-connection-name``, that contains the name of a connection
+      definition in the same connections file. Starting pywbemcli with without
+      specifying the a server on the command line (i.e specifying --server,
+      --name, or --mock-server options) triggers use of this name as the
+      current server.  This attribute can be defined, modified, or cleared with
+      the ``connection set-default``, command and modified with the
+      ``connection save`` or ``connection save`` commands.
+
    MOF
       MOF (Managed Object Format) is the language used by the DMTF to
       describe in textual form CIM objects including CIM classes,

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,6 +17,10 @@ Released: not yet
 * The PYWBEMCLI_TERMWIDTH environment variable was renamed to
   PYWBEMTOOLS_TERMWIDTH since it is common to all pywbemtools commands.
 
+* Changed option --default on command ``connection select`` to ``set-default``.
+  to be compatible with other commands that touch the default connection
+  definition.
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -62,6 +66,12 @@ Released: not yet
 * Generate exception when general options such as --user, --password, etc.
   that apply only to the server are used with the --mock-server general
   option. (see issue #1035)
+
+* Extend the capability to set the default connection in a connections file to
+  the connection save command and a specific command that will set or clear the
+  default.  Since the ability to set the default connection was only an
+  option in the connection select command it was difficult to find.  This makes
+  the functionality more visible and more usable.
 
 
 **Cleanup:**

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -693,13 +693,14 @@ Help text for ``pywbemcli connection`` (see :ref:`connection command group`):
       -h, --help  Show this help message.
 
     Commands:
-      export  Export the current connection.
-      show    Show a WBEM connection definition or the current connection.
-      delete  Delete a WBEM connection definition.
-      select  Select a WBEM connection definition as current or default.
-      test    Test the current connection with a predefined WBEM request.
-      save    Save the current connection to a new WBEM connection definition.
-      list    List the WBEM connection definitions.
+      export       Export the current connection.
+      show         Show a WBEM connection definition or the current connection.
+      delete       Delete a WBEM connection definition.
+      select       Select a WBEM connection definition as current or default.
+      test         Test the current connection with a predefined WBEM request.
+      save         Save the current connection to a new WBEM connection definition.
+      list         List the WBEM connection definitions.
+      set-default  Set a connection as the default connection.
 
 
 .. _`pywbemcli connection delete --help`:
@@ -718,8 +719,8 @@ Help text for ``pywbemcli connection delete`` (see :ref:`connection delete comma
 
       Delete a WBEM connection definition.
 
-      Delete a named connection definition from the connections file. If the NAME argument is omitted, prompt for
-      selecting one of the connection definitions in the connections file.
+      Delete a named connection definition from the connections file. If the NAME argument is omitted, a list of all
+      connection definitions is displayed on the terminal  and a prompt for selecting one of these connections.
 
       Example:
 
@@ -813,7 +814,10 @@ Help text for ``pywbemcli connection save`` (see :ref:`connection save command`)
         pywbemcli --server https://srv1 connection save mysrv
 
     Command Options:
-      -h, --help  Show this help message.
+      -f, --set-default  Set this definition as the default definition that will be loaded upon pywbemcli startup if no
+                         server or name is included on the command line.
+
+      -h, --help         Show this help message.
 
 
 .. _`pywbemcli connection select --help`:
@@ -836,9 +840,9 @@ Help text for ``pywbemcli connection select`` (see :ref:`connection select comma
       definition in the connections file must exist. If the NAME argument is omitted, a list of connection definitions
       from the connections file is presented with a prompt for the user to select a connection definition.
 
-      If the --default option is set, the default connection is set to the selected connection definition, in addition.
-      Once defined, the default connection will be used as a default in future executions of pywbemcli if none of the
-      server-defining general options (i.e. --server, --mock-server, or --name) was used.
+      If the --set-default option is set, the default connection is set to the selected connection definition, in
+      addition. Once defined, the default connection will be used as a default in future executions of pywbemcli if none
+      of the server-defining general options (i.e. --server, --mock-server, or --name) was used.
 
       The 'connection list' command marks the current connection with '*' and the default connection with '#'.
 
@@ -858,10 +862,38 @@ Help text for ``pywbemcli connection select`` (see :ref:`connection select comma
           . . .
 
     Command Options:
-      -d, --default  If set, the connection is set to be the default connection in the connections file in addition to
-                     setting it as the current connection.
+      -d, --set-default  If set, the connection is set to be the default connection in the connections file in addition to
+                         setting it as the current connection.
 
-      -h, --help     Show this help message.
+      -h, --help         Show this help message.
+
+
+.. _`pywbemcli connection set-default --help`:
+
+pywbemcli connection set-default --help
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+
+Help text for ``pywbemcli connection set-default`` (see :ref:`connection set-default command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] connection set-default NAME [COMMAND-OPTIONS]
+
+      Set a connection as the default connection.
+
+      Sets either the connection defined in the NAME argument as the default current connection definition or, if there is
+      no NAME argument on the command it sets the current connection (if there is one) as the default connection.
+
+      The character "?" may be used as the name argument to allow selecting the connection to be set as the default
+      connection interactively from all of the existing connection definitions.
+
+    Command Options:
+      --clear       Clear default connection name.
+      -v, --verify  Prompt user to verify change before changing the default connection definition).
+      -h, --help    Show this help message.
 
 
 .. _`pywbemcli connection show --help`:

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -1956,7 +1956,7 @@ implementations of WBEM servers such as the implementation of OpenPegasus.
 ``connection`` command group
 ----------------------------
 
-The ``connection`` command group has commands that manage named connection
+The ``connection`` command group includes commands that manage named connection
 definitions that are persisted in a :term:`connections file`.
 This allows maintaining multiple connection definitions and then using any
 one via the :ref:`--name general option`. Only a single connection is
@@ -1994,6 +1994,8 @@ The commands in this group are:
 * :ref:`Connection select command` - Select a WBEM connection definition as current or default.
 * :ref:`Connection show command` - Show connection info of a WBEM connection definition.
 * :ref:`Connection test command` - Test the current connection with a predefined WBEM request.
+* :ref:`Connection set-default command` - Sets or clears the default definition in a connections file.
+
 
 .. index:: pair: connection commands; connection delete
 
@@ -2162,6 +2164,14 @@ in the ``NAME`` argument.
 If a connection definition with that name already exists, it will be overwritten
 without notice.
 
+This command includes an option (``set-default``) that sets the default
+connection of the current connections file to the name of the definition being
+saved.
+
+.. code-block:: text
+
+    $ pywbemcli --server http://blah connection save <name> --set-default
+
 See :ref:`pywbemcli connection save --help` for the exact help output of the command.
 
 .. index:: pair: connection commands; connection select
@@ -2203,7 +2213,7 @@ mode of pywbemcli:
     +------------+------------------+-------------+-------------+-----------+------------+-----------------------------------------+
     | name       | server           | namespace   | user        |   timeout | verify     | mock-server                             |
     |------------+------------------+-------------+-------------+-----------+------------+-----------------------------------------|
-    | mock1      |                  | root/cimv2  |             |        30 | False      | tests/unit/simple_mock_model.mof        |
+    | #mock1     |                  | root/cimv2  |             |        30 | False      | tests/unit/simple_mock_model.mof        |
     | *mockassoc |                  | root/cimv2  |             |        30 | False      | tests/unit/simple_assoc_mock_model.mof  |
     | op         | http://localhost | root/cimv2  | me          |        30 | True       |                                         |
     +------------+------------------+-------------+-------------+-----------+------------+-----------------------------------------+
@@ -2297,6 +2307,79 @@ and ``--password`` and executes the test with successful result:
     Connection successful
 
 See :ref:`pywbemcli connection test --help` for the exact help output of the command.
+
+
+.. index:: pair: connection commands; connection set-default
+
+.. _`Connection set-default command`:
+
+``connection set-default`` command
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. index::
+    single: connection set-default command
+    pair: command; connection set-default
+
+The ``connection set-default`` command sets or clears the
+:term:`default-connection-name` attribute  in the currently specified
+:term:`connections file`.
+
+The :term:`default-connection-name` attribute allows a connection definition in a
+connections file to be loaded on startup without using the --name option.  If
+pywbemcli is started without --name, --server, or --mock-server options, the
+``default-connection-name`` attribute is retrieved from the file and, if defined,
+the name in the value of this attribute used as the name of the connection
+definition set as current connection.
+
+Thus, for example, if the default connection definition is ``mytests`` the
+connection definition for ``mytests`` is created each time pywbemcli is started
+with no --server, --mock-server or --name option.
+
+This command also allows clearing the value of the default connections file
+attribute with the option ``--clear``
+
+The following demonstrates displaying the connection information for the
+current default connection ``mytests``.
+
+.. code-block:: text
+
+    $ pywbemcli connection show
+
+    name: mytests (current, default)
+      server: http://blah
+      default-namespace: root/cimv2
+      user: None
+      password: None
+      timeout: 30
+      verify: True
+      certfile: None
+      keyfile: None
+      mock-server:
+      ca-certs: None
+
+    $ pywbemcli connection set-default --clear
+      Connection default name cleared replacing None
+
+    $ pywbemcli connection show
+      Error: No connection defined
+
+    $ pywbemcli connection set-default mytests
+       'mytests' set as default connection
+
+    $ pywbemcli connection show
+    WBEM server connections(brief): (#: default, *: current)
+
+    file: tmp.yaml
+    name       server           mock-server
+    ---------  ---------------  -------------
+    *#mytests  http://blah
+    blahblah   http://blahblah
+
+The current status of the :term:`default-connection-name` can be viewed with the
+:ref:`Connection show command` and :ref:`Connection list command`.
+
+See :ref:`pywbemcli connection set-default --help` for the exact help output
+of the command.
+
 
 .. index:: pair: repl; command
 

--- a/pywbemtools/pywbemcli/_context_obj.py
+++ b/pywbemtools/pywbemcli/_context_obj.py
@@ -206,7 +206,7 @@ class ContextObj(object):
         cmd = "{} {}".format(ctx.info_name or "",
                              ctx.invoked_subcommand or "")
         raise click.ClickException(
-            'No  current server for command "{}" that requires a WBEM server. '
+            'No current server for command "{}" that requires a WBEM server. '
             'Specify a server with the "--server", "--mock-server", or"--name" '
             'general option, by setting the corresponding environment '
             'variables, or in interactive mode '

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -58,11 +58,11 @@ from .._utils import pywbemtools_warn, get_terminal_width, \
 from .._options import add_options, help_option
 from .._output_formatting import OUTPUT_FORMAT_GROUPS
 
-
 __all__ = ['cli']
 
 PYWBEMCLI_STARTUP_ENVVAR = "PYWBEMCLI_STARTUP_SCRIPT"
 
+DEFAULT_DEFINITION_NAME = "not-saved"
 
 # Defaults for some options
 DEFAULT_VERIFY = True  # The default is to verify

--- a/tests/unit/pywbemcli/test_general_options.py
+++ b/tests/unit/pywbemcli/test_general_options.py
@@ -944,7 +944,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify select of test-default connection. sequence:1,4',
-     {'args': ['select', 'test-default', '--default'],
+     {'args': ['select', 'test-default', '--set-default'],
       'cmdgrp': 'connection', },
      {'stdout': ['test-default', 'current'],
       'test': 'innows'},
@@ -962,7 +962,7 @@ TEST_CASES = [
      {'general': ['--verbose'],
       'args': ['show'],
       'cmdgrp': 'connection', },
-     {'stdout': ['Current connection: "test-default"'],
+     {'stdout': ['test-default (current, default)'],
       'test': 'innows'},
      None, OK],
 


### PR DESCRIPTION
See commit  and issue #1039 for details:

Extends capability to set default connection name

1. adds --set-default to connection save command
2. adds command connection set-default
3. adds tests
4. adds documentation on the default connection name.

I did this one the other night when I realized that even I had forgotten how to use the default connection name and could not remember it.

Adding to the save is logical because that is often when you might want to set the connection you saves to default.  connection set-default command makes the whole idea public and also allows the user to clear the default if that is ever needed.

