### PR TITLE
Modify _display_cimobjects - Part 1,  issue #4 subscriptions

### DIFF
--- a/pywbemtools/pywbemcli/_display_cimobjects.py
+++ b/pywbemtools/pywbemcli/_display_cimobjects.py
@@ -47,7 +47,7 @@ INT_TYPE_PATTERN = re.compile(r'^[su]int(8|16|32|64)$')
 
 
 def display_cim_objects(context, cim_objects, output_format, summary=False,
-                        sort=False, property_list=None):
+                        sort=False, property_list=None, quote_strings=True):
     """
     Display CIM objects in form determined by input parameters.
 
@@ -100,6 +100,11 @@ def display_cim_objects(context, cim_objects, output_format, summary=False,
         List of property names to be displayed, in the desired order, when the
         output format is a table, or None to use the default of sorting
         the properties alphabetically within key and non-key groups.
+
+      quote_strings (:class:`py.bool`):
+        If False, strings are not encased by quote marks in the table view for
+        instance displays. The default is True so that strings are encased in
+        quotes in all views.
     """
     # Note: In the docstring above, the line for parameter 'objects' was way too
     #       long. Since we are not putting it into docmentation, we folded it.
@@ -125,7 +130,8 @@ def display_cim_objects(context, cim_objects, output_format, summary=False,
         if output_format_is_table(output_format):
             _display_objects_as_table(cim_objects, output_format,
                                       context=context,
-                                      property_list=property_list)
+                                      property_list=property_list,
+                                      quote_strings=quote_strings)
         else:
             # Call to display each object
             for obj in cim_objects:
@@ -137,7 +143,8 @@ def display_cim_objects(context, cim_objects, output_format, summary=False,
     # This allows passing single objects to the table formatter (i.e. not lists)
     if output_format_is_table(output_format):
         _display_objects_as_table([object_], output_format, context=context,
-                                  property_list=property_list)
+                                  property_list=property_list,
+                                  quote_strings=quote_strings)
     elif output_format == 'mof':
         try:
             click.echo(object_.tomof())
@@ -181,7 +188,7 @@ def display_cim_objects(context, cim_objects, output_format, summary=False,
 
 
 def _display_objects_as_table(objects, output_format, context=None,
-                              property_list=None):
+                              property_list=None, quote_strings=True):
     """
     Call the method for each type of object to print that object type
     information as a table.
@@ -194,7 +201,8 @@ def _display_objects_as_table(objects, output_format, context=None,
         if isinstance(objects[0], CIMInstance):
             _display_instances_as_table(objects, table_width, output_format,
                                         context=context,
-                                        property_list=property_list)
+                                        property_list=property_list,
+                                        quote_strings=quote_strings)
         elif isinstance(objects[0], CIMClass):
             _display_classes_as_table(objects, table_width, output_format)
         elif isinstance(objects[0], CIMQualifierDeclaration):
@@ -353,7 +361,7 @@ def _display_qual_decls_as_table(qual_decls, table_width, table_format):
 
 def _format_instances_as_rows(insts, max_cell_width=DEFAULT_MAX_CELL_WIDTH,
                               include_classes=False, context=None,
-                              prop_names=None):
+                              prop_names=None, quote_strings=True):
     """
     Format the list of instances properties into as a list of the property
     values for each instance( a row of the table) gathered into a list of
@@ -443,7 +451,7 @@ def _format_instances_as_rows(insts, max_cell_width=DEFAULT_MAX_CELL_WIDTH,
                     val_str, _ = cimvalue_to_fmtd_string(
                         p.value, p.type, indent=0, maxline=max_cell_width,
                         line_pos=0, end_space=0, avoid_splits=False,
-                        valuemapping=valuemapping)
+                        valuemapping=valuemapping, quote_strings=quote_strings)
 
             line.append(val_str)
         lines.append(line)
@@ -453,7 +461,7 @@ def _format_instances_as_rows(insts, max_cell_width=DEFAULT_MAX_CELL_WIDTH,
 
 def _display_instances_as_table(insts, table_width, table_format,
                                 include_classes=False, context=None,
-                                property_list=None):
+                                property_list=None, quote_strings=True):
     """
     Print the properties of the instances defined in insts as a table where
     each row is an instance and each column is a property value.
@@ -558,7 +566,8 @@ def _display_instances_as_table(insts, table_width, table_format,
 
     rows = _format_instances_as_rows(insts, max_cell_width=max_cell_width,
                                      include_classes=include_classes,
-                                     context=context, prop_names=prop_names)
+                                     context=context, prop_names=prop_names,
+                                     quote_strings=quote_strings)
 
     title = 'Instances: {}'.format(insts[0].classname)
     click.echo(format_table(rows, new_header_line, title=title,

--- a/tests/unit/pywbemcli/test_display_cimobjects.py
+++ b/tests/unit/pywbemcli/test_display_cimobjects.py
@@ -87,6 +87,16 @@ def simple_instance(pvalue=None):
     return inst
 
 
+def array_instance(pvalue, ptype):
+    """
+    Build an instance with a single property named P and the value  and type
+    defined. Used to build test instance with array properties because
+    type cannot be determined from the data since it is an array.
+    """
+    properties = [CIMProperty("P", pvalue, type=ptype)]
+    return CIMInstance("CIM_Foo", properties)
+
+
 def simple_instance_unsorted(pvalue=None):
     """
     Build a simple instance to test and return that instance. The properties
@@ -167,7 +177,86 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
                 ["false", "true", DATETIME1_STR, "99", "9999",
                  u'"Test String"']],
         ),
-        None, None, True, ),
+        None, None, OK),
+
+    (
+        "Verify simple instance to table with quote_strings=False",
+        dict(
+            args=(),
+            kwargs=dict(
+                insts=[simple_instance()],
+                quote_strings=False),
+            exp_rtn=[
+                ["false", "true", DATETIME1_STR, "99", "9999",
+                 u'Test String']],
+        ),
+        None, None, OK),
+
+    (
+        "Verify simple instance str array to table with quote_strings=False",
+        dict(
+            args=(),
+            kwargs=dict(
+                insts=[simple_instance(pvalue=["abc", 'def'])],
+                quote_strings=False),
+            exp_rtn=[
+                ['"abc", "def"']],
+        ),
+        None, None, OK),
+    (
+
+        "Verify simple instance int array with quote_strings=True",
+        dict(
+            args=(),
+            kwargs=dict(
+                insts=[array_instance(pvalue=[Uint32(12345), Uint32(67891)],
+                                      ptype='uint32')],
+                quote_strings=True),
+            exp_rtn=[
+                ['12345, 67891']],
+        ),
+        None, None, OK),
+
+    (
+        "Verify simple instance int array with col limit,quote_strings=True",
+        dict(
+            args=(),
+            kwargs=dict(
+                insts=[array_instance(pvalue=[Uint32(12345), Uint32(67891)],
+                                      ptype='uint32')],
+                max_cell_width=6,
+                quote_strings=True),
+            exp_rtn=[
+                ['12345,\n67891']],
+        ),
+        None, None, OK),
+
+    (
+        "Verify simple instance int array with quote_strings=False",
+        dict(
+            args=(),
+            kwargs=dict(
+                insts=[array_instance(pvalue=[Uint32(12345), Uint32(67891)],
+                                      ptype='uint32')],
+                quote_strings=False),
+            exp_rtn=[
+                ['12345, 67891']],
+        ),
+        None, None, OK),
+
+    (
+        "Verify simple instance int array with col limit,quote_strings=False",
+        dict(
+            args=(),
+            kwargs=dict(
+                insts=[array_instance(pvalue=[Uint32(12345), Uint32(67891)],
+                                      ptype='uint32')],
+                max_cell_width=6,
+                quote_strings=False),
+            exp_rtn=[
+                ['12345,\n67891']],
+        ),
+        None, None, OK),
 
     (
         "Verify simple instance to table with col limit",
@@ -178,7 +267,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
                 ["false", "true", DATETIME1_STR, "99", "9999",
                  u'"Test String"']],
         ),
-        None, None, True, ),
+        None, None, OK),
 
     (
         "Verify simple instance to table, unsorted",
@@ -189,7 +278,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
                 ["false", "true", DATETIME1_STR, "99", "9999",
                  u'"Test String"']],
         ),
-        None, None, True, ),
+        None, None, OK),
 
     (
         "Verify instance with 2 keys and 2 non-keys, unsorted",
@@ -219,7 +308,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
                 ['"K1"', '"K2"', '"V1"', '"V2"'],
             ],
         ),
-        None, None, True, ),
+        None, None, OK),
 
     (
         "Verify 2 instances with different sets of properties",
@@ -250,7 +339,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
                 ['"VN1b"', '"VP1b"', '"VP2b"', ''],
             ],
         ),
-        None, None, True, ),
+        None, None, OK),
 
     (
         "Verify 2 instances where second one has path",
@@ -288,27 +377,27 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
                 ['"K1b"', '"K2b"', '"VP1b"', '"VP2b"'],
             ],
         ),
-        None, None, True, ),
+        None, None, OK),
 
     (
-        "Verify simple instance with one string all components overflow line",
+        "Verify simple instance with one string all components overflow line1",
         dict(
             args=([simple_instance(pvalue="A B C D")], 4),
             kwargs={},
             exp_rtn=[
                 ['"A "\n"B "\n"C "\n"D"']],
         ),
-        None, None, True, ),
+        None, None, OK),
 
     (
-        "Verify simple instance with one string all components overflow line",
+        "Verify simple instance with one string all components overflow line2",
         dict(
             args=([simple_instance(pvalue="ABCD")], 4),
             kwargs={},
             exp_rtn=[
                 ['\n"AB"\n"CD"']],
         ),
-        None, None, True, ),
+        None, None, OK),
 
     (
         "Verify simple instance with one string overflows line",
@@ -318,7 +407,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
             exp_rtn=[
                 ['"A B C "\n"D"']],
         ),
-        None, None, True, ),
+        None, None, OK),
 
     (
         "Verify simple instance withone unit32 max val",
@@ -328,7 +417,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
             exp_rtn=[
                 ['4294967295']],
         ),
-        None, None, True, ),
+        None, None, OK),
 
 
     (
@@ -339,27 +428,27 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
             exp_rtn=[
                 ['"A B C D"']],
         ),
-        None, None, True, ),
+        None, None, OK),
 
     (
-        "Verify datetime property",
+        "Verify datetime property, folded",
         dict(
             args=([simple_instance(pvalue=DATETIME1_OBJ)], 20),
             kwargs={},
             exp_rtn=[
                 ['\n"20140922104920.524"\n"789+000"']],
         ),
-        None, None, True, ),
+        None, None, OK),
 
     (
-        "Verify datetime property",
+        "Verify datetime property not folded",
         dict(
             args=([simple_instance(pvalue=DATETIME1_OBJ)], 30),
             kwargs={},
             exp_rtn=[
                 ['"20140922104920.524789+000"']],
         ),
-        None, None, True, ),
+        None, None, OK),
 
     (
         "Verify integer property where len too small",
@@ -368,7 +457,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
             kwargs={},
             exp_rtn=[['999999']],
         ),
-        None, None, True, ),
+        None, None, OK),
 
     (
         "Verify char16 property",
@@ -379,7 +468,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
             kwargs={},
             exp_rtn=[[u"'f'"]],
         ),
-        None, None, True, ),
+        None, None, OK),
 
     (
         "Verify properties with no value",
@@ -393,7 +482,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
             kwargs={},
             exp_rtn=[[u'', u'', u'']],
         ),
-        None, None, True, ),
+        None, None, OK),
 
     (
         "Verify format of instance with reference property as row entry",
@@ -411,7 +500,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
             exp_rtn=[
                 [u'"/:REF_CLN.k1=\\"v1\\""']],
         ),
-        None, None, True, ),
+        None, None, OK),
 ]
 
 
@@ -518,6 +607,9 @@ P
         None, None, not CLICK_ISSUE_1590 and PYWBEM_1_0_0B1
     ),
 ]
+
+# NOTE: The following test cannot use simplified test function because it uses
+# pytest capsys to capture date.
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR is is a prerequisite to pr # 987, simple subscriptions.

This commits changes to just the display_cimobjects and it adds tests. 

Modify _display_cimobjects and cimvalueformatter to allow creating
formatted strings without surrounding quote marks within tables
specifically for instance displays by implementing new parameter
"quote_strings". When quote_strings is False, display_cim_objects oes not set the surrounding quotes on strings
on instances displayed as tables.  This will gain horizontal space in
the tables without really removing string visibility since it will
remove the head and tail quote on each line of a string but the string
is clearly visible within a table cell.

Note that arrays of strings will still be quoted because the
user cannot clearly separate the strings in the array without
the quotes

Adds test for new parameter in display_cimobjects