### PR TITLE
0.9: Ignored Pylint issue 'consider-using-f-string' in new Pylint 2.11

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -33,6 +33,9 @@ Released: not yet
   used the instance wildcard (e.g. 'CIM_ManagedSystemElement.?') and the
   enumerate instances operation failed for some reason. (issue #963)
 
+* Disabled new Pylint issue 'consider-using-f-string', since f-strings were
+  introduced only in Python 3.6.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/pylintrc
+++ b/pylintrc
@@ -73,7 +73,8 @@ disable=I0011, bad-option-value,
         wildcard-import, unused-wildcard-import,
         locally-enabled, superfluous-parens, useless-object-inheritance,
         consider-using-set-comprehension, unnecessary-pass, useless-return,
-        raise-missing-from, super-with-arguments, redundant-u-string-prefix
+        raise-missing-from, super-with-arguments, redundant-u-string-prefix,
+        consider-using-f-string
 
 # Note: The too-many-* messages are excluded temporarily, and should be dealt
 #       with at some point.


### PR DESCRIPTION
Rolls back PR #1050 into 0.9.1.