### PR TITLE
0.9: Fixed install error of wrapt 1.13.0 on Python 2.7/3.4

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -94,6 +94,9 @@ lazy-object-proxy>=1.4.3,<1.5.0; python_version == '3.4'
 lazy-object-proxy>=1.4.3; python_version >= '3.5'
 # platformdirs is used by pylint starting with its 2.10
 platformdirs>=2.2.0; python_version >= '3.6'
+wrapt>=1.11.2,<1.13; python_version == '2.7'
+wrapt>=1.11.2,<1.13; python_version == '3.4'
+wrapt>=1.11.2; python_version >= '3.5'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 # flake8 3.9.0 has removed support for py34 and pip 19.1.1 on py34 does not deal

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,8 @@ Released: not yet
 * Disabled new Pylint issue 'consider-using-f-string', since f-strings were
   introduced only in Python 3.6.
 
+* Fixed install error of wrapt 1.13.0 on Python 2.7/3.4, by pinning it to <1.13.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -114,6 +114,7 @@ typed-ast==1.3.0; python_version == '3.4' and implementation_name=='cpython'
 typed-ast==1.4.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
 lazy-object-proxy==1.4.3
 platformdirs==2.2.0; python_version >= '3.6'
+wrapt==1.11.2
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 flake8==3.8.0
@@ -208,5 +209,4 @@ traitlets==4.3.1
 wcwidth==0.1.7
 webencodings==0.5.1
 widgetsnbextension==1.2.6
-wrapt==1.11.2
 zipp==0.5.2


### PR DESCRIPTION
Rolls back PR #1060 into 0.9.1.