### PR TITLE
0.9: Relaxed wrapt pinning to just py27 on windows

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -94,9 +94,10 @@ lazy-object-proxy>=1.4.3,<1.5.0; python_version == '3.4'
 lazy-object-proxy>=1.4.3; python_version >= '3.5'
 # platformdirs is used by pylint starting with its 2.10
 platformdirs>=2.2.0; python_version >= '3.6'
-wrapt>=1.11.2,<1.13; python_version == '2.7'
-wrapt>=1.11.2,<1.13; python_version == '3.4'
-wrapt>=1.11.2; python_version >= '3.5'
+# wrapt 1.13.0 started depending on MS Visual C++ 9.0 on Python 2.7 on Windows,
+#   which is not available by default on GitHub Actions
+wrapt>=1.11.2,<1.13; sys_platform == 'win32' and python_version == '2.7'
+wrapt>=1.11.2; python_version >= '3.4'
 
 # Flake8 and dependents (no imports, invoked via flake8 script):
 # flake8 3.9.0 has removed support for py34 and pip 19.1.1 on py34 does not deal

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,7 +36,8 @@ Released: not yet
 * Disabled new Pylint issue 'consider-using-f-string', since f-strings were
   introduced only in Python 3.6.
 
-* Fixed install error of wrapt 1.13.0 on Python 2.7/3.4, by pinning it to <1.13.
+* Fixed install error of wrapt 1.13.0 on Python 2.7 on Windows due to lack of
+  MS Visual C++ 9.0 on GitHub Actions, by pinning it to <1.13.
 
 **Enhancements:**
 


### PR DESCRIPTION
Rolls back PR #1062 into 0.9.1.