### PR TITLE
Implement click extension to validate mutually exclusive options:

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -102,12 +102,22 @@ Released: not yet
 * Enhanced test matrix for push-driven runs on GitHub Actions to add
   Python 3.5 on macOS, and removing Python 3.5 minimum on Windows.
 
+<<<<<<< HEAD
 * Implement command group subscription that manages the creation, viewing and
   removal of indication subscription on WBEM servers. This creates a new command
   group 'subscription' and new commands for adding, removing, and displaying
   (list) indication destination, filter, and subscription instances on target
   WBEM servers. It includes the code for the new commands, a set of tests
   and the documentation for the new commands. (see issue #4)
+
+* Add new class MutuallyExclusiveOption to pywbemtools/_click_extensions.py to
+=======
+* Add new MutuallyExclusiveOption class to pywbemtools/_click_extensions.py to
+>>>>>>> WIP
+  allow defining command options as mutually exclusive.  See the class
+  for documentation.  Modify pywbemcli.py mutually excluseive options --server, 
+  --name, and --mock-server to use this class.
+
 
 **Cleanup:**
 

--- a/tests/unit/pywbemcli/test_connection_cmds.py
+++ b/tests/unit/pywbemcli/test_connection_cmds.py
@@ -308,10 +308,9 @@ TEST_CASES = [
     ['Verify --mock-server and --server together fail.',
      {'general': ['--mock-server', MOCK_FILE_PATH, '--server', 'http://blah'],
       'args': ['list']},
-     {'stderr': ['Conflicting server definitions:',
-                 'server:', 'http://blah',
-                 'mock-server:', MOCK_FILE_PATH],
-      'rc': 1,
+     {'stderr': ["Conflicting options: `mock-server` is mutually exclusive "
+                 "with options: (--name, --server)"],
+      'rc': 2,
       'test': 'innows'},
      None, OK],
 

--- a/tests/unit/pywbemcli/test_general_options.py
+++ b/tests/unit/pywbemcli/test_general_options.py
@@ -327,10 +327,9 @@ TEST_CASES = [
                   SIMPLE_MOCK_FILE_PATH],
       'cmdgrp': 'connection',
       'args': ['show']},
-     {'stderr': ['Conflicting server definitions:',
-                 'mock-server:', 'simple_mock_model.mof',
-                 'server:', 'http://blah'],
-      'rc': 1,
+     {'stderr': ["Conflicting options: `server` is mutually exclusive with "
+                 "options: (--mock-server, --name)"],
+      'rc': 2,
       'test': 'in'},
      None, OK],
 
@@ -338,21 +337,19 @@ TEST_CASES = [
      {'general': ['-m', SIMPLE_MOCK_FILE_PATH, '--name', 'MyConnName'],
       'cmdgrp': 'connection',
       'args': ['show']},
-     {'stderr': ['Error: Conflicting server definitions:',
-                 'mock-server:', SIMPLE_MOCK_FILE_PATH,
-                 'name:', 'MyConnName'],
-      'rc': 1,
+     {'stderr': ["Conflicting options: `connection-name` is mutually exclusive "
+                 "with options: (--mock-server, --server)"],
+      'rc': 2,
       'test': 'innows'},
      None, OK],
 
-    ['Verify simultaneous --server option and --name option fails',
+    ['Verify conflicting --server option and --name option fails',
      {'general': ['--server', 'http://blah', '--name', 'MyConnName'],
       'cmdgrp': 'connection',
       'args': ['show']},
-     {'stderr': ['Error: Conflicting server definitions:',
-                 'server:', 'http://blah',
-                 'name:', 'MyConnName'],
-      'rc': 1,
+     {'stderr': ["Conflicting options: `connection-name` is mutually exclusive "
+                 "with options: (--mock-server, --server)"],
+      'rc': 2,
       'test': 'innows'},
      None, OK],
 
@@ -776,10 +773,9 @@ TEST_CASES = [
                   '--server', 'http://blah'],
       'cmdgrp': 'instance',
       'args': ['enumerate', 'CIM_Foo']},
-     {'stderr': ['Error: Conflicting server definitions:',
-                 'mock-server:', SIMPLE_MOCK_FILE_PATH,
-                 'server:', 'http://blah'],
-      'rc': 1,
+     {'stderr': ['Conflicting options: `mock-server` is mutually exclusive '
+                 'with options: (--name, --server)'],
+      'rc': 2,
       'test': 'innows'},
      None, OK],
 
@@ -1126,12 +1122,11 @@ TEST_CASES = [
       'cmdgrp': None,
       },
      {'stdout': ["name not-saved (current)"],
-      'stderr': ['Conflicting server definitions:',
-                 'http://blah',
-                 'mock-server: tests/unit/pywbemcli/simple_mock_model.mof'],
+      'stderr': ["Conflicting options: `server` is mutually exclusive with "
+                 "options: (--mock-server, --name)"],
       'rc': 0,
       'test': 'innows'},
-     None, FAIL],  # TODO: this test fails on windows. Outputs don't compare'
+     None, OK],  # TODO: this test fails on windows. Outputs don't compare'
 
     ['Verify Change --name invalid in interactive mode. command no connections '
      'file',
@@ -1450,7 +1445,8 @@ TEST_CASES = [
     ['Test conflicting server definitions interactive mode --mock-server.',
      {'stdin': ['--server http://blah --mock-server '
                 'tests/unit/pywbemcli/simple_mock_model.mof']},
-     {'stderr': "Conflicting server definitions:",
+     {'stderr': "Conflicting options: `server` is mutually exclusive with "
+                "options: (--mock-server, --name)",
       'rc': 0,
       'test': 'innows'},
      None, OK],


### PR DESCRIPTION
This provides for defining mutually exclusive options in the click option definition. While it is less complete than the corresponding click contrib click-option-group that contribution only works for python 3.6+ and the author was never interested in including earlier versions of python.

**Marked as waiting because I want to test this against work in pr #987, subscription command which has mutually exclusive options**

Note that this pr includes the change to the pywbemcli --connection-name, --mock-server, and --server options without appending the new text to the help command.

This allows the following syntax for the option definition:

```

    @option('--fiirst-option',
        cls=MutuallyExclusiveOption,
        help="first-option blah.",
        mutually_exclusive=["another-option"],
        show_mutually_exclusive=True)

Which defined an option first_option option that is mutually exclusive with another-option.  If the two are included in the
same command the error:
```
Error: Conflicting options: 'first-option' is mutually exclusive with options: (--another-option) will be generated.

If show_mutually_exclusive is  True in the definition the text \:

```
This option is mutually exclusive with "options: (--another-option) is appended to the help.

If show_mutually_exclusive is not included as a parameter or is False, nothing is appended to the help.

There are no special tests added for this change the same as other click extensions.  The extensions are tested with the pywbemcli code itself.

