### PR TITLE
Fix issue # 1041 - Use warning class for warnings about Version Qualifier

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -63,6 +63,10 @@ Released: not yet
 * Fixed install error of wrapt 1.13.0 on Python 2.7 on Windows due to lack of
   MS Visual C++ 9.0 on GitHub Actions, by pinning it to <1.13.
 
+* Fix issue with message from _common.py (parse_version_value) that was 
+  passed to warning_msg but should have been subclass of python warning.  
+  Changed to use pywbemtools_warn(). (see issue #1041)
+
 **Enhancements:**
 
 * Added a 'pywbemlistener' command for running and managing WBEM listeners.

--- a/pywbemtools/pywbemcli/_cmd_statistics.py
+++ b/pywbemtools/pywbemcli/_cmd_statistics.py
@@ -236,10 +236,12 @@ def get_objmgr_inst(context):
             raise click.ClickException(
                 'No instances of class {} found on server'.format(OBJMGR_CLN))
 
+        # Use warning_msg here rather than python Warnings class since this
+        # is to be always output.
         if len(objmanager_insts) > 1:
             warning_msg(
-                "Server returned multiple {} instances. Using first.".
-                format(objmanager_insts[0].classname))
+                "Server returned multiple  ObjectManager {0} instances. Using "
+                "first instance.".format(objmanager_insts[0].classname))
 
     except Error as er:
         raise click.ClickException(

--- a/tests/unit/pywbemcli/test_common.py
+++ b/tests/unit/pywbemcli/test_common.py
@@ -31,7 +31,8 @@ import pytest
 
 from pywbem import CIMClass, CIMProperty, CIMQualifier, CIMInstance, \
     CIMQualifierDeclaration, CIMInstanceName, Uint8, \
-    CIMClassName, CIMMethod, CIMParameter, __version__, MOFCompiler
+    CIMClassName, CIMMethod, CIMParameter, __version__, MOFCompiler, \
+    ToleratedSchemaIssueWarning
 
 from pywbem._mof_compiler import MOFWBEMConnection
 
@@ -2812,27 +2813,33 @@ TESTCASES_PARSE_VERSION_VALUE = [
     ('Verify invalid string with only two items returns 3 items',
      dict(ver="2.41",
           exp_rtn=[2, 41, 0]),
-     None, None, OK, ),
+     None, ToleratedSchemaIssueWarning, OK, ),
 
     ('Verify invalid string with 4 items returns 3 items',
      dict(ver="2.41.1.1",
           exp_rtn=[2, 41, 1]),
-     None, None, RUN, ),
+     None, ToleratedSchemaIssueWarning, OK, ),
 
     ('Verify invalid string with alphabetic characters returns 0.0.0',
      dict(ver="a.41.1",
           exp_rtn=[0, 0, 0]),
-     None, None, OK, ),
+     None, ToleratedSchemaIssueWarning, OK, ),
 
     ('Verify invalid string with alphabetic characters returns 0.0.0',
      dict(ver="2.abcdef.1",
           exp_rtn=[0, 0, 0]),
-     None, None, OK, ),
+     None, ToleratedSchemaIssueWarning, OK, ),
+
+
+    ('Verify invalid string with alphabetic characters returns 0.0.0',
+     dict(ver="xyz.abcdef.jkl",
+          exp_rtn=[0, 0, 0]),
+     None, ToleratedSchemaIssueWarning, OK, ),
 
     ('Verify invalid string empty returns 3 items',
      dict(ver="",
           exp_rtn=[0, 0, 0]),
-     None, None, OK, ),
+     None, ToleratedSchemaIssueWarning, OK, ),
 ]
 
 


### PR DESCRIPTION
Changes code to use pywbemtools_warning to handle issues with misformed value of Version Qualifier in classes in _cmd_class processing he --since option. 

See commit message for details