### PR TITLE
WIP WIP WIP Fix issue with docutils and Sphinx

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,5 @@
+version: 2
+
+python:
+   install:
+   - requirements: rtd-requirements.txt

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -6,5 +6,7 @@ ply>=3.10
 PyYAML>=3.13
 # M2Crypto>=0.30.1  # we cannot install M2Crypto because RTD does not have Swig
 Sphinx>=1.7.6
+# Temporary correction for issue #1070
+docutils==0.17.1
 sphinx-git>=10.1.1
 sphinxcontrib-fulltoc>=1.2.0


### PR DESCRIPTION
WIP
test fix  issue documented in issue #1070 where builddoc fails at least
with python 2.7.  This pins docutils to version <0.18 in rtd_requirements.txt

DOES NOT WORIK.