### PR TITLE
Fixes issue #1070, Sphinx fails python 2.7

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -63,7 +63,15 @@ PyYAML>=5.2,<5.3; python_version == '3.4'
 PyYAML>=5.3.1; python_version > '3.4'
 
 # Sphinx (no imports, invoked via sphinx-build script):
-Sphinx>=1.7.6
+# Keep in sync with rtd-requirements.txt
+# Sphinx 2.0.0 removed support for Python 2.7 and 3.4
+# Sphinx 4.0.0 breaks autodocsumm (issue #2697)
+# Sphinx 3.5.4 started including test for docutils version < 0.17  for 3.5.4
+# and < 0.18 for sphinx 4.
+Sphinx>=1.7.6,<2.0.0; python_version <= '3.4'
+Sphinx>=3.5.4,!=4.0.0; python_version >= '3.5'
+# Issue pwybem #2787 docutils v=0.18/Sphinx incompatibility
+docutils<0.18; python_version <= '3.4'
 sphinx-git>=10.1.1
 GitPython>=2.1.1;
 sphinxcontrib-fulltoc>=1.2.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -63,9 +63,12 @@ Released: not yet
 * Fixed install error of wrapt 1.13.0 on Python 2.7 on Windows due to lack of
   MS Visual C++ 9.0 on GitHub Actions, by pinning it to <1.13.
 
-* Fix issue with message from _common.py (parse_version_value) that was 
-  passed to warning_msg but should have been subclass of python warning.  
+* Fix issue with message from _common.py (parse_version_value) that was
+  passed to warning_msg but should have been subclass of python warning.
   Changed to use pywbemtools_warn(). (see issue #1041)
+
+* Fixed issue with Sphinx and python 2.7 by changing the sphinx requirements
+  in dev-requirements.txt and minimum-constraints.txt. (see issue #1070)
 
 **Enhancements:**
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -97,7 +97,8 @@ dparse>=0.5.1; python_version >= '3.5'
 tox==2.0.0
 
 # Sphinx (no imports, invoked via sphinx-build script):
-Sphinx==1.7.6
+Sphinx==1.7.6; python_version <= '3.4'
+Sphinx==3.5.4; python_version >= '3.5'
 sphinx-git==10.1.1
 GitPython==2.1.1
 sphinxcontrib-fulltoc==1.2.0

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -5,6 +5,15 @@ six>=1.14.0
 ply>=3.10
 PyYAML>=3.13
 # M2Crypto>=0.30.1  # we cannot install M2Crypto because RTD does not have Swig
-Sphinx>=1.7.6
+# Sphinx (no imports, invoked via sphinx-build script):
+# Keep in sync with rtd-requirements.txt
+# Sphinx 2.0.0 removed support for Python 2.7 and 3.4
+# Sphinx 4.0.0 breaks autodocsumm (issue #2697)
+# Sphinx 3.5.4 started including test for docutils version
+Sphinx>=1.7.6,<2.0.0; python_version <= '3.4'
+Sphinx>=3.5.4,!=4.0.0; python_version >= '3.5'
+# Issue pwybem #2787 docutils v=0.18/Sphinx incompatibility
+# Until Sphinx 4.3.0 is released.
+docutils<0.18; python_version <= '3.4'
 sphinx-git>=10.1.1
 sphinxcontrib-fulltoc>=1.2.0


### PR DESCRIPTION
Fixes an issue where Sphinx fails with python < 3.5 because of an update
to docutils to 0.18. Limited docutils for python 3.5.

We also set some of the Sphinx limits from pywbem dev_requirements.txt.