### PR TITLE
[WIP] Use click 8.0.0 + with Python > 3.5

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,10 @@ Released: not yet
 
 **Cleanup:**
 
+  Modify pywbemtools to use the library click version 8.x for python version
+  greater than 3.5 which is the minimum version of python usable with
+  click 8.x. With python <= 3.5, click < 8.x is used.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,13 +23,13 @@ six>=1.16.0; python_version >= '3.10'
 # Click 7.0 has issue #1231 on Windows which we circumvent in the test code
 # Click 7.1 has a bug with output capturing
 # Click 7.1 removed support for Python 3.4
-# Click 8.0 is incompatible with pywbemcli. See issues #816 (python 2.7 not
+# Click 8.0 is incompatible with pywbemcli <3.6. See issues #816 (python 2.7 not
 #     supported) and #819 (click-repl incompatible)
 # The Click requirements were copied into dev-requirements.txt in order not to
 # have the safety package upgrade it. Keep them in sync.
 Click>=7.1.1,<8.0; python_version == '2.7'
 Click>=7.0,<7.1; python_version == '3.4'
-Click>=7.1.1,<8.0; python_version >= '3.5'
+Click>=7.1.1; python_version >= '3.6'
 click-spinner>=0.1.8
 click-repl>=0.1.6
 asciitree>=0.3.3


### PR DESCRIPTION
Testing capability to advance to click 8 for some versions of click now that the issue with click-repl has been fixed.

This PR eliminates the click version limit of < 8.0 for python version gt 3.5. The python 3.5 limit is based on clicks limit of 3.6 as minimum supported version.

The following is the set of differences I have found so far.

1. The cmdshelp.rst files do not have a space between each option with click8 and there are some minor differences in line length formatting with click 8  the lines may be a few characters shorter with click 8.  Note that in click 7, the extra line between each option display was inconsistent in that it was not always there.  In many cases only some of the options showed the extra empty line.
2. The method click.get_terminal_size() has been deprecated and will be removed in favor of shutils.get_terminal_size(0) in click 8.1.  This would probably have to be generalized so we did not get caught with an issue when they release click 8
3. There are some information differences with click 8 in help output.  For example with click 7 "PYWBEMCLI_TIMEOUT, or 30" but with click 8 the output is "PYWBEMCLI_TIMEOUT, or 30.  [0<=x<=300]".
4. There are some behavior differences in interactive mode beteen click7 and click 8 in displaying of options information. The information is shown but less information appears to be shown if the user simply enters the comand and TAB. However that may be an issue with the use of the autosuggest component of prompt toolkit

NOTE: The completion mechanism is completely different in click 8 from click 7 but that only shows up in click and click repl and we appear to handle that (Note that there NO tests that cover use of completion)