### PR TITLE
Safety checks; Made constraints more consistent; Relaxed wrapt pinning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,6 +321,82 @@ else
   cwd := $(shell pwd)
 endif
 
+# Issues reported by safety command that are ignored.
+# Package upgrade strategy due to reported safety issues:
+# - For packages that are direct or indirect runtime requirements, upgrade
+#   the package version only if possible w.r.t. the supported environments and
+#   if the issue affects pywbem, and add to the ignore list otherwise.
+# - For packages that are direct or indirect development or test requirements,
+#   upgrade the package version only if possible w.r.t. the supported
+#   environments and add to the ignore list otherwise.
+# Current safety ignore list, with reasons:
+# Runtime dependencies:
+# - 38100: PyYAML on py34 cannot be upgraded; no issue since PyYAML FullLoader is not used
+# - 38834: urllib3 on py34 cannot be upgraded -> remains an issue on py34
+# Development and test dependencies:
+# - 38765: We want to test install with minimum pip versions.
+# - 38892: lxml cannot be upgraded on py34; no issue since HTML Cleaner of lxml is not used
+# - 38224: pylint cannot be upgraded on py27+py34
+# - 37504: twine cannot be upgraded on py34
+# - 37765: psutil cannot be upgraded on PyPy
+# - 38107: bleach cannot be upgraded on py34
+# - 38330: Sphinx cannot be upgraded on py27+py34
+# - 38546: Bleach
+# - 39194: lxml cannot be upgraded on py34; no issue since HTML Cleaner of lxml is not used
+# - 39195: lxml cannot be upgraded on py34; no issue since output file paths do not come from untrusted sources
+# - 39462: The CVE for tornado will be replaced by a CVE for Python, see https://github.com/tornadoweb/tornado/issues/2981
+# - 39611: PyYAML cannot be upgraded on py34+py35; We are not using the FullLoader.
+# - 39621: Pylint cannot be upgraded on py27+py34
+# - 39525: Jinja2 cannot be upgraded on py34
+# - 40072: lxml HTML cleaner in lxml 4.6.3 no longer includes the HTML5 'formaction'
+# - 38932: cryptography cannot be upgraded to 3.2 on py34
+# - 39252: cryptography cannot be upgraded to 3.3 on py34+py35
+# - 39606: cryptography cannot be upgraded to 3.3.2 on py34+py35
+# - 40291: pip cannot be upgraded to 21.1 py<3.6
+# - 40380..40386: notebook issues fixed in 6.1.5 which would prevent using notebook on py2
+# - 42218: pip <21.1 - unicode separators in git references
+# - 42253: Notebook, before 5.7.1 allows XSS via untrusted notebook
+# - 42254: Notebook before 5.7.2, allows XSS via crafted directory name
+# - 42293: babel, before 2.9.1 CVS-2021-42771, Bable.locale issue
+# - 42297: Bleach before 3.11, a mutation XSS afects user calling bleach.clean
+# - 42298: Bleach before 3.12, mutation XSS affects bleach.clean
+
+safety_ignore_opts := \
+	-i 38100 \
+	-i 38834 \
+	-i 38765 \
+	-i 38892 \
+	-i 38224 \
+	-i 37504 \
+	-i 37765 \
+	-i 38107 \
+	-i 38330 \
+	-i 38546 \
+	-i 39194 \
+	-i 39195 \
+	-i 39462 \
+	-i 39611 \
+	-i 39621 \
+	-i 39525 \
+	-i 40072 \
+	-i 38932 \
+	-i 39252 \
+	-i 39606 \
+	-i 40291 \
+	-i 40380 \
+	-i 40381 \
+	-i 40382 \
+	-i 40383 \
+	-i 40384 \
+	-i 40385 \
+	-i 40386 \
+	-i 42218 \
+	-i 42253 \
+	-i 42254 \
+	-i 42203 \
+	-i 42297 \
+	-i 42298 \
+
 .PHONY: help
 help:
 	@echo "Makefile for $(package_name) package"
@@ -653,7 +729,7 @@ flake8_$(pymn).done: Makefile develop_$(pymn).done $(flake8_rc_file) $(py_src_fi
 safety_$(pymn).done: Makefile develop_$(pymn).done minimum-constraints.txt
 	@echo "makefile: Running pyup.io safety check"
 	-$(call RM_FUNC,$@)
-	-safety check -r minimum-constraints.txt --full-report
+	safety check -r minimum-constraints.txt --full-report $(safety_ignore_opts)
 	echo "done" >$@
 	@echo "makefile: Done running pyup.io safety check"
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -98,7 +98,7 @@ astroid>=2.1.0,<2.3; python_version == '3.4'
 astroid>=2.3.3; python_version >= '3.5'
 # typed-ast is used by astroid on py34..py37
 # typed-ast 1.4.0 removed support for Python 3.4.
-typed-ast>=1.3.0,<1.4.0; python_version == '3.4' and implementation_name=='cpython'
+typed-ast>=1.3.2,<1.4.0; python_version == '3.4' and implementation_name=='cpython'
 typed-ast>=1.4.0,<1.5.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
 # lazy-object-proxy 1.5.0 dropped support for py34 but declared it as supported
 lazy-object-proxy>=1.4.3; python_version == '2.7'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -124,6 +124,13 @@ Released: not yet
   in python 2.7 with exception and avoids copying the FakedWBEMConnection
   CIM repository.
 
+- Add list of security issues to be ignored by Makefile security test and enable
+  failure of build if security test fails. This brings Pywbemtools into line
+  with pywbem Makefile.Reordered some of the items in the minumum_constraints.txt file
+  to better compare with the pywbem file and also commented out all minimum constraints
+  for Jupyter and its dependencies since we have no notebooks in pywbemcli
+  today. Modified minimum version of typed-ast, pylint and astrid to match pywbem
+  and pass saftey tests. 
 
 **Known issues:**
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -90,8 +90,8 @@ coveralls==2.1.2; python_version >= '3.5'
 # Safety CI by pyup.io
 safety==1.8.7; python_version <= '3.4'
 safety==1.9.0; python_version >= '3.5'
-dparse>=0.4.1; python_version <= '3.4'
-dparse>=0.5.1; python_version >= '3.5'
+dparse==0.4.1; python_version <= '3.4'
+dparse==0.5.1; python_version >= '3.5'
 
 # Tox
 tox==2.0.0
@@ -110,13 +110,13 @@ sphinx-rtd-theme==0.5.0
 # PyLint (no imports, invoked via pylint script)
 pylint==1.6.4; python_version == '2.7'
 pylint==2.2.2; python_version == '3.4'
-pylint==2.4.4; python_version >= '3.5'
+pylint==2.5.2; python_version >= '3.5'
 astroid==1.4.9; python_version == '2.7'
 astroid==2.1.0; python_version == '3.4'
-astroid==2.3.3; python_version >= '3.5'
+astroid==2.4.0; python_version >= '3.5'
 # typed-ast is used by astroid on py34..py37
-typed-ast==1.3.0; python_version == '3.4' and implementation_name=='cpython'
-typed-ast==1.4.0; python_version >= '3.5' and python_version < '3.8' and implementation_name=='cpython'
+typed-ast==1.3.2; python_version == '3.4' and implementation_name=='cpython'
+typed-ast==1.4.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
 lazy-object-proxy==1.4.3
 platformdirs==2.2.0; python_version >= '3.6'
 wrapt==1.11.2
@@ -137,12 +137,45 @@ readme-renderer==23.0
 pkginfo==1.4.2
 
 # Jupyter Notebook (no imports, invoked via jupyter script):
-#jupyter==1.0.0
+# The jupyter package is not installed on Python 3.4 on Windows, because its
+# (indirectly) dependent pywin32 package is not available on Pypi for
+# Python 3.4.
+# NOTE: Jupyter Notebooks not currently provided with pywbemcli
+#jupyter==1.0.0; python_version != '3.4' or sys_platform != 'win32'
+#ipython==5.1.0; python_version == '2.7'
+#ipython==6.0; python_version == '3.4' and sys_platform != 'win32'
+#ipython==7.0; python_version == '3.5'
+#ipython==7.10; python_version >= '3.6'
+#ipykernel==4.5.2; python_version != '3.4' or sys_platform != 'win32'
+#ipython_genutils==0.1.0; python_version != '3.4' or sys_platform != 'win32'
+#ipywidgets==5.2.2; python_version != '3.4' or sys_platform != 'win32'
+#jupyter_console==5.0.0; python_version == '2.7'
+#jupyter_console==5.0.0; python_version == '3.4' and sys_platform != 'win32'
+#jupyter_console==6.0.0; python_version >= '3.5'
+#jupyter_client==4.4.0; python_version != '3.4' or sys_platform != 'win32'
+#jupyter_core==4.2.1; python_version != '3.4' or sys_platform != 'win32'
+#nbconvert==5.0.0; python_version != '3.4' or sys_platform != 'win32'
+#nbformat==4.2.0; python_version != '3.4' or sys_platform != 'win32'
+#notebook==4.3.1; python_version != '3.4' or sys_platform != 'win32'
+#pyrsistent==0.14.0; python_version != '3.4' or sys_platform != 'win32'
+
+# Pywin32 is used (at least?) by jupyter.
+#pywin32==222; sys_platform == 'win32' and python_version == '2.7'
+#pywin32==222; sys_platform == 'win32' and python_version >= '3.5' and python_version <= '3.6'
+#pywin32==223; sys_platform == 'win32' and python_version == '3.7'
+#pywin32==227; sys_platform == 'win32' and python_version >= '3.8'
 
 # Address issue that pyparsing 3.0.0b2 gets installed on py27 (used by packaging)
 pyparsing==2.3.1
 
 # Indirect dependencies for develop (not in dev-requirements.txt)
+
+bleach==3.3.0; python_version == '2.7'
+bleach==3.1.2; python_version == '3.4'
+bleach==3.3.0; python_version >= '3.5'
+
+# Indirect dependencies for develop (not in dev-requirements.txt)
+
 alabaster==0.7.9
 appnope==0.1.0
 args==0.1.0
@@ -150,9 +183,7 @@ atomicwrites==1.2.1
 attrs==18.2.0
 Babel==2.3.4
 backports.functools-lru-cache==1.5; python_version < "3.3"
-bleach==3.1.4; python_version == "2.7"
-bleach==2.1.4; python_version == "3.4"
-bleach==3.1.4; python_version >= "3.5"
+
 certifi==2019.9.11
 chardet==3.0.2
 clint==0.5.1
@@ -168,23 +199,13 @@ html5lib==0.999999999
 idna==2.5
 imagesize==0.7.1
 importlib-metadata==0.12
-ipykernel==4.5.2
-ipython==5.1.0
-ipython_genutils==0.1.0
-ipywidgets==5.2.2
 isort==4.2.15
 Jinja2==2.8
 jsonschema==2.5.1
-jupyter_client==4.4.0
-jupyter_console==5.0.0
-jupyter_core==4.2.1
 linecache2==1.0.0
 MarkupSafe==0.23
 mistune==0.8.1
-more-itertools==4.0.0
-nbconvert==5.0.0
-nbformat==4.2.0
-notebook==4.3.1
+more-itertools==5.0.0
 packaging==17.0
 pandocfilters==1.4.1
 pathlib2==2.2.1
@@ -192,7 +213,7 @@ pbr==1.8.0
 pexpect==4.2.1
 pickleshare==0.7.4
 ptyprocess==0.5.1
-py==1.5.1
+py==1.10.0
 pytz==2016.10
 pyzmq==16.0.4
 qtconsole==4.2.1


### PR DESCRIPTION
Modified Makefile to test for security issues against list in the Makefile.  This duplicates the code in pywbem except with a slightly different list. So now pywbemcli make will fail  if safety test fails.

Also made version mods to pylint, typed-ast, and astroid to pass tests and match pywbem.

