### PR TITLE
Fix issue with dependency and more-itertools, issue #1077

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,6 +22,10 @@ pluggy>=0.13.0
 colorama>=0.3.9,<0.4.0; python_version <= '3.4'
 colorama>=0.4.0; python_version >= '3.5'
 
+# more-itertools version 8.11 requires python 3.6, See issue #2796
+more-itertools>=4.0.0,!=8.11.0; python_version < '3.6'
+more-itertools>=4.0.0; python_version >= '3.6'
+
 # Virtualenv
 # Virtualenv 20.0.19 has an issue where it does not install pip on Python 3.4.
 # Virtualenv 20.0.32 has an issue where it raises AttributeError on Python 3.4.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -70,6 +70,9 @@ Released: not yet
 * Fixed issue with Sphinx and python 2.7 by changing the sphinx requirements
   in dev-requirements.txt and minimum-constraints.txt. (see issue #1070)
 
+* Modify dev-requirements.txt to limit version of more-itertools to != 8.11.0
+  for python < 3.6. (see issue #1077)
+
 **Enhancements:**
 
 * Added a 'pywbemlistener' command for running and managing WBEM listeners.
@@ -120,6 +123,7 @@ Released: not yet
   the copy() method was added to  pywbem (see issue #1030).  This fixes issue
   in python 2.7 with exception and avoids copying the FakedWBEMConnection
   CIM repository.
+
 
 **Known issues:**
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -181,7 +181,7 @@ jupyter_core==4.2.1
 linecache2==1.0.0
 MarkupSafe==0.23
 mistune==0.8.1
-more-itertools==5.0.0
+more-itertools==4.0.0
 nbconvert==5.0.0
 nbformat==4.2.0
 notebook==4.3.1


### PR DESCRIPTION
Based on PR #1072- Sphinx issue

Modify dev-requirements.txt to limit version of more-itertools for
python >= 3.5. Eliminates bug where new release of more-tools did did
not limit python versions.

NOTE: I marked this one for rollback but remember that this is a pytest based issue for us so the question is whether we should rollback something that is our tests only
