### PR TITLE
Add more tests to test_subscription_cmd.py

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -104,7 +104,6 @@ Released: not yet
 * Enhanced test matrix for push-driven runs on GitHub Actions to add
   Python 3.5 on macOS, and removing Python 3.5 minimum on Windows.
 
-<<<<<<< HEAD
 * Implement command group subscription that manages the creation, viewing and
   removal of indication subscription on WBEM servers. This creates a new command
   group 'subscription' and new commands for adding, removing, and displaying
@@ -112,10 +111,7 @@ Released: not yet
   WBEM servers. It includes the code for the new commands, a set of tests
   and the documentation for the new commands. (see issue #4)
 
-* Add new class MutuallyExclusiveOption to pywbemtools/_click_extensions.py to
-=======
 * Add new MutuallyExclusiveOption class to pywbemtools/_click_extensions.py to
->>>>>>> WIP
   allow defining command options as mutually exclusive.  See the class
   for documentation.  Modify pywbemcli.py mutually excluseive options --server, 
   --name, and --mock-server to use this class.


### PR DESCRIPTION
Adds a number of new tests for the subscription command.  However, this got us only about 1 % to 90% coverage

Note that this also makes some largely editorial changes to the
subscriprion command code. Thus we converted the varaible `owned` to
`owned_flag` to clarify between owned_choice the choice option and
the boolean owned/permanent.

Removed code that had been in pywbemcli because of an issue in pywbem
that was fixed.