### PR TITLE
0.9: Ignored safety issue 42559 (pip)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,6 +373,7 @@ endif
 # - 42293: babel, before 2.9.1 CVS-2021-42771, Bable.locale issue
 # - 42297: Bleach before 3.11, a mutation XSS afects user calling bleach.clean
 # - 42298: Bleach before 3.12, mutation XSS affects bleach.clean
+# - 42559 pip, before 21.1 CVE-2021-3572
 
 safety_ignore_opts := \
 	-i 38100 \
@@ -409,6 +410,7 @@ safety_ignore_opts := \
 	-i 42203 \
 	-i 42297 \
 	-i 42298 \
+	-i 42559 \
 
 .PHONY: help
 help:


### PR DESCRIPTION
Rolls back PR #1089 into 0.9.1.