### PR TITLE
Fixes #1067 - cache Subscription info between commands.

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -307,6 +307,15 @@ This documentation uses a few special terms to refer to Python types:
    dynamic indication filter
       An :term: indication filter whose lifecycle is controlled by a client
 
+   subscription manager ID
+      A subscription manager ID is a string that is used as a component in
+      the value of the `Name` property of owned indication filter and listener
+      destination instances and thus allows identifying these instances
+      in a WBEM server. The SubscriptionManagerID allows creating groups
+      of owned indication destinations, filters and subscriptions.
+      The subscription manager ID is a fixed string (``defaultpywbemcliSubMgr``)
+      in pywbemcli
+
 .. _`Profile advertisement methodologies`:
 
 Profile advertisement methodologies

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -45,7 +45,10 @@ Storage Management Initiative Specification (`SMI-S`_).
 
 The pywbemtools package includes the following tools:
 
-1. :ref:`Pywbemcli command` - provides access to WBEM servers from the command line
+1. :ref:`Pywbemcli command` - a cli (command line interface) that provides
+   access to WBEM servers from the command line.
+2. :ref:`Pywbemlistener command` - a cli that can manage multiple provides a
+   WBEM indication listeners to receive and display WBEM indications.
 
 
 .. _`Supported environments`:

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -2623,9 +2623,10 @@ Help text for ``pywbemcli subscription add-filter`` (see :ref:`subscription add-
       --query-language TEXT     Filter query language for this subscription The query languages normally implemented are
                                 'DMTF:CQL' and 'WQL' .  Default: WQL
 
-      --source-namespaces TEXT  The namespace(s) for which the query is defined. If not defined, the default namespace of
-                                the server is used. Define multiple namespaces by using option multiple times or comma-
-                                separating namespaces names.
+      --source-namespaces TEXT  The namespace(s) for which the query is defined. Multiple values may be defined with a
+                                single comma-separated string of namespaces or multiple options. If defined the namespaces
+                                will be inserted into the SourceNamespaces property. Otherwise the property will not be
+                                created and the WBEM server should use the interop namespace for the indication filter.
 
       --owned / --permanent     Defines whether an owned or permanent filter, destination, or subscription is to be added.
                                 Default: owned
@@ -2710,13 +2711,21 @@ Help text for ``pywbemcli subscription list`` (see :ref:`subscription list comma
       Display indication subscriptions overview.
 
       This command provides an overview of the count of subscriptions, filters, and destinations retrieved from the WBEM
-      server.
+      server. The level of detail depends on the --summary and --detail options. '--summary' displays only a single count
+      for each; --detail displays a table for the instances of each. The default is to display a table of the count of
+      owned and permanent for each.
 
     Command Options:
-      --type [owned|permanent|all]  Defines whether the command is going to filter owned ,permanent, or all objects for the
-                                    response display.  Default: all
+      --type [owned|permanent|all]  Defines whether the command filters owned,  permanent, or all objects for the response.
+                                    Default: all
 
-      -s, --summary                 If True, show only summary count of instances
+      -s, --summary                 Show only summary count of instances This option is mutually exclusive with options:
+                                    (--detail).
+
+      -d, --detail                  Show more detailed information. Otherwise only non-null or predefined property values
+                                    are displayed. It applies to both MOF and TABLE output formats This option is mutually
+                                    exclusive with options: (--summary).
+
       -h, --help                    Show this help message.
 
 
@@ -2743,16 +2752,19 @@ Help text for ``pywbemcli subscription list-destinations`` (see :ref:`subscripti
       table or CIM objects (ex. mof) format using the --output general option (ex. --output mof).
 
     Command Options:
-      --type [owned|permanent|all]  Defines whether the command is going to filter owned ,permanent, or all objects for the
-                                    response display.  Default: all
+      --type [owned|permanent|all]  Defines whether the command filters owned,  permanent, or all objects for the response.
+                                    Default: all
 
       -d, --detail                  Show more detailed information. Otherwise only non-null or predefined property values
-                                    are displayed. It applies to both MOF and TABLE output formats
+                                    are displayed. It applies to both MOF and TABLE output formats This option is mutually
+                                    exclusive with options: (--summary).
 
       --names-only, --no            Show the CIMInstanceName elements of the instances. This only applies when the --output-
                                     format is one of the CIM object options (ex. mof
 
-      -s, --summary                 If True, show only summary count of instances
+      -s, --summary                 Show only summary count of instances This option is mutually exclusive with options:
+                                    (--detail).
+
       -h, --help                    Show this help message.
 
 
@@ -2779,16 +2791,19 @@ Help text for ``pywbemcli subscription list-filters`` (see :ref:`subscription li
       table or CIM objects (ex. mof) format using the --output general option (ex. --output mof).
 
     Command Options:
-      --type [owned|permanent|all]  Defines whether the command is going to filter owned ,permanent, or all objects for the
-                                    response display.  Default: all
+      --type [owned|permanent|all]  Defines whether the command filters owned,  permanent, or all objects for the response.
+                                    Default: all
 
       -d, --detail                  Show more detailed information. Otherwise only non-null or predefined property values
-                                    are displayed. It applies to both MOF and TABLE output formats
+                                    are displayed. It applies to both MOF and TABLE output formats This option is mutually
+                                    exclusive with options: (--summary).
 
       --names-only, --no            Show the CIMInstanceName elements of the instances. This only applies when the --output-
                                     format is one of the CIM object options (ex. mof
 
-      -s, --summary                 If True, show only summary count of instances
+      -s, --summary                 Show only summary count of instances This option is mutually exclusive with options:
+                                    (--detail).
+
       -h, --help                    Show this help message.
 
 
@@ -2817,16 +2832,19 @@ Help text for ``pywbemcli subscription list-subscriptions`` (see :ref:`subscript
       table or CIM objects (ex. mof) format using the --output general option (ex. --output mof).
 
     Command Options:
-      --type [owned|permanent|all]  Defines whether the command is going to filter owned ,permanent, or all objects for the
-                                    response display.  Default: all
+      --type [owned|permanent|all]  Defines whether the command filters owned,  permanent, or all objects for the response.
+                                    Default: all
 
       -d, --detail                  Show more detailed information. Otherwise only non-null or predefined property values
-                                    are displayed. It applies to both MOF and TABLE output formats
+                                    are displayed. It applies to both MOF and TABLE output formats This option is mutually
+                                    exclusive with options: (--summary).
 
       --names-only, --no            Show the CIMInstanceName elements of the instances. This only applies when the --output-
                                     format is one of the CIM object options (ex. mof
 
-      -s, --summary                 If True, show only summary count of instances
+      -s, --summary                 Show only summary count of instances This option is mutually exclusive with options:
+                                    (--detail).
+
       -h, --help                    Show this help message.
 
 

--- a/pywbemtools/pywbemcli/_pywbem_server.py
+++ b/pywbemtools/pywbemcli/_pywbem_server.py
@@ -128,7 +128,7 @@ class PywbemServer(object):
         self.certfile = certfile
         self.keyfile = keyfile
         self.ca_certs = ca_certs
-
+        self._subscription_manager = None
         # May be None in case of not-saved connection (e.g. connection save)
         self._connections_file = connections_file
 
@@ -440,6 +440,19 @@ class PywbemServer(object):
             raise click.ClickException("{cmd} requires user/password, but "
                                        "no password provided."
                                        .format(cmd=ctx.invoked_subcommand))
+
+    @property
+    def subscription_manager(self):
+        """
+        :term:`string`: Scheme with subscription manager object.
+        """
+        return self._subscription_manager
+
+    @subscription_manager.setter
+    def subscription_manager(self, subscriptionmgr):
+        """Setter method; for a description see the getter method."""
+
+        self._subscription_manager = subscriptionmgr
 
     def copy(self):
         """"

--- a/tests/unit/pywbemcli/test_subscription_cmds.py
+++ b/tests/unit/pywbemcli/test_subscription_cmds.py
@@ -783,8 +783,7 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-    ['Verify add dest, filter, subscription & list-* handles --permanent, '
-     'remove-server OK.',
+    ['Verify add dest, filter, subscrip & list-* handles --permanent, remove-server OK.',  # noqa: E501
      {'general': ['-m', MOCK_SERVER_MODEL_PATH],
       'stdin': ['subscription add-destination pdest1 -l http://blah:50000 --permanent',  # noqa: E501
                 'subscription add-destination odest1 -l http://blah:50000 --owned',  # noqa: E501'


### PR DESCRIPTION
Extends pywbemcli to cache subscription information between commands in
interactive mode.  While the permanent subscription information is also
cached, it is not used since pywbem enumerates subscriptions each time a
request for permanent instances is executed.

add cache of class CmdSubscriptionManager instance to PywbemServer
class and recovery when a command is called.  The instance is cached in
PywbemServer object so that there is a set of cached subscription data
for each wbem server created.

Since we do not cache the PywbemServer objects if the server is changed
in interactive mode, the subscription cache only exists where the server
definition is not changed.

This also adds documentation and corrects some documentation grammar and
formatting.

No significant to the functionality of the subscription command group