### PR TITLE
Fixes issue #1105, pywbemcli abort exception for wildcard instance request

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -75,6 +75,13 @@ Released: not yet
 
 * Fixed new issues raised by pylint 2.12.2.
 
+* Fixed issue with instance commands (ex. instance get, references, etc) that
+  use the wildcard .? to request that pywbemcli present list of possible
+  instances.  It was not handling the non-existence of class in the
+  target namespace correctly and would crash because no instances were returned
+  get_instanceNames() . Now generates an exception.
+  (see issue #1105)
+
 **Enhancements:**
 
 * Added a 'pywbemlistener' command for running and managing WBEM listeners.

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -943,6 +943,10 @@ def get_instancename(context, instancename, options):
             instance_path.namespace = options.get('namespace') or \
                 conn.default_namespace
 
+    if instance_path is None:
+        raise click.ClickException(
+            "No instance paths found for instancename {0}".format(instancename))
+
     return instance_path
 
 

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -247,7 +247,6 @@ def pick_instance(context, objectname, namespace=None):
         raise pywbem_error_exception(ex)
 
     if not instance_names:
-        click.echo('No instance paths found for {}'.format(objectname))
         return None
 
     try:

--- a/tests/unit/pywbemcli/test_instance_cmds.py
+++ b/tests/unit/pywbemcli/test_instance_cmds.py
@@ -1462,6 +1462,29 @@ Instances: TST_Person
       'test': 'regex'},
      ASSOC_MOCK_FILE, OK],
 
+    ['get with INSTANCENAME/wildcard with invalid classname',
+     ['get', 'CIM_DoesNotExist.?'],
+     {'stderr': ["CIMError: 5 (CIM_ERR_INVALID_CLASS): Class "
+                 "'CIM_DoesNotExist' not found in namespace 'root/cimv2'"],
+      'rc': 1,
+      'test': 'in'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['get with INSTANCENAME/wildcard with no instances',
+     ['get', 'CIM_FooEmb1.?'],
+     {'stderr': ["No instance paths found for instancename CIM_FooEmb1.?"],
+      'rc': 1,
+      'test': 'in'},
+     SIMPLE_MOCK_FILE, RUN],
+
+    ['INSTANCENAME with invalid namespace and wildcard',
+     ['get', 'CIM_Foo.?', '-n', 'root/DoesNotExist'],
+     {'stderr': ["CIMError: 3 (CIM_ERR_INVALID_NAMESPACE): Namespace does not "
+                 "exist in CIM repository: 'root/DoesNotExist'"],
+      'rc': 1,
+      'test': 'in'},
+     SIMPLE_MOCK_FILE, OK],
+
     ['INSTANCENAME with wildcard keybinding, --key option (error)',
      {'general': [],
       'args': ['get', 'TST_Person.?', '--key', 'name=Saara'],
@@ -2458,6 +2481,12 @@ Instances: TST_Person
       'rc': 1,
       'test': 'innows'},
      ASSOC_MOCK_FILE, OK],
+    ['Verify instance command references, invalid instance name',
+     ['references', 'TST_Blah.blah="abc.?"'],
+     {'stderr': "",
+      'rc': 1,
+      'test': 'innows'},
+     ASSOC_MOCK_FILE, OK],
 
     ['Verify instance command references with wildcard keybinding',
      {'general': [],
@@ -2497,6 +2526,23 @@ Instances: TST_Person
       'rc': 1,
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance command references with no instances of CIM_FooFooEmb1',
+     {'args': ['references', 'CIM_FooEmb1.?'],
+      'general': ['--output-format', 'text']},
+     {'stderr': ['Output format "text"', 'not allowed', 'Only CIM formats:',
+                 'TABLE formats:'],
+      'rc': 1,
+      'test': 'innows'},
+     SIMPLE_MOCK_FILE, RUN],
+
+    ['references with INSTANCENAME/wildcard with invalid classname',
+     ['references', 'CIM_DoesNotExist.?'],
+     {'stderr': ["CIMError: 5 (CIM_ERR_INVALID_CLASS): Class "
+                 "'CIM_DoesNotExist' not found in namespace 'root/cimv2'"],
+      'rc': 1,
+      'test': 'in'},
+     ASSOC_MOCK_FILE, OK],
 
     # TODO add more invalid references tests
 


### PR DESCRIPTION
Abort exception for instance get xxx.? where no instances are found. This applies to instance references, etc. also

Pywbemcli does not correctly handle issue where an instance references
classname.? has an invalid classname.

It returns an None classname from the get_instancename

Added specific test for CIMError that generates a click exception.