### PR TITLE
fix issue # 1108, correct issues in instance count

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -82,6 +82,11 @@ Released: not yet
   get_instanceNames() . Now generates an exception.
   (see issue #1105)
 
+* Fixed issues in "instance count" including unitialized variable and 
+  correctly finishing scan when errors occur. Adds new option to this command 
+  to allow user to ignore classes defined with this option (--ignore-class).
+  (see issues #1108 and #916 )
+
 **Enhancements:**
 
 * Added a 'pywbemlistener' command for running and managing WBEM listeners.

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -1142,6 +1142,10 @@ Help text for ``pywbemcli instance count`` (see :ref:`instance count command`):
       For example, "pywbem_*" returns classes whose name begins with "PyWBEM_", "pywbem_", etc. "*system*" returns classes
       whose names include the case insensitive string "system".
 
+      If a CIMError occurs on any enumerate, it is flagged with a warning message and the search for instances continues.
+      If an Error exception occurs (ex. Connection error) the scan is terminated under the assumption that the server may
+      have failed and the remaining items are shown as "Not scanned".
+
       This command can take a long time to execute since it potentially enumerates all instance names for all classes in
       all namespaces.
 
@@ -1150,6 +1154,12 @@ Help text for ``pywbemcli instance count`` (see :ref:`instance count command`):
                                       in all namespaces of the server.
 
       -s, --sort                      Sort by instance count. Otherwise sorted by class name.
+      --ignore-class CLASSNAME        Class names of classes to be ignored (not counted). Allows counting instances in
+                                      servers where instance retrieval may cause a CIMError or Error exceptionon some
+                                      classes. CIN errors on particular classes are ignored. Error exceptions cause scan to
+                                      stop and remaining classes status shown as 'not scanned'. Multiple class names are
+                                      allowed (one per option or comma-separated).
+
       --association / --no-association
                                       Filter the returned classes to return only indication classes (--association) or
                                       classes that are not associations(--no-association). If the option is not defined no

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -748,7 +748,46 @@ classnames to include or exclude classes with the corresponding qualifiers.
 Thus the ``--association`` option returns only classes or classnames that are
 association classes.
 
+Thus, for example:
+
+.. code-block:: text
+
+    $ pywbemcli --name mymock instance count --association -n root/cimv2
+      # Returns counts of instances of association classes from namespace root/cimv2
+
+    $ pywbemcli --name mymock instance count --experimental
+      # returns the counts of instances where the class has the experimental qualifier
+
+    $ pywbemcli -n mymock instance count CIM_* -n root/interop
+      # returns counts of instances in root/interop namespace where the classname
+      # starts with CIM_
+
+The ``--ignore-class`` option allows the user to ignore multiple selected
+classes in the scan for instances. This is useful in cases where the enumerate
+of instances of a class returns an error from the WBEM server. The command that
+will ignore some classes is as follows:
+
+.. code-block:: text
+
+    $ pywbemcli -n mymock instance count CIM_* -n root/interop --ignore-class classname1,classname2
+      # Ignores classname1 and classname2 and shows them in the table as
+
+      # classname1    ignored
+      # classname2    ignored
+
+    # The command form may also be used
+        $ pywbemcli -n mymock instance count CIM_* -n root/interop --ignore-class classname1 --ignore-class classname2
+
+
+
 Results for classes that have no instances are not displayed.
+
+The processing handles both CIMError exceptions (which are considered errors applicable
+to particular instances), and Error exceptions which are considered server
+errors so that the scan for instances is terminated).  In all cases it tries
+to include all classes in the display and adds status information
+in place of the count of instances returned when a particular class causes
+an exception.
 
 This command can take a long time to execute since it potentially enumerates
 all instance names for all classes in all namespaces.
@@ -775,7 +814,8 @@ Example:
 Count is useful to determine which classes in the environment are actually
 implemented. However this command can take a long time to execute because
 it must a) enumerate all classes in the namespace, b) enumerate the
-instances for each class.
+instances for each class that is defined by the classname glob and the
+namespace list..
 
 See :ref:`pywbemcli instance count --help` for the exact help output of the command.
 


### PR DESCRIPTION
Fixes issue where an unitialized varaible exception occurs if there is a
CIMError in handling of instance count, the count is incomplete if there is a Error exception, and there is no way to exclude
items to be counted other than selecting namespaces.

This pr:

1. Fixes the issue where we had an uninitialized variable after an exception. issue # 1108
2. Refactors the instance count to:
    a. Always output the full set of classes defined by the namespaces and class GLOB even if an error occurred. If an error occurred, the remaining rows use the string "not scanned" in place of a count.
   b. Add Error exception so we are catching the case of server failure.  In this case, the enumerate of instances
      is terminated.
   c. Add text in rows where the enumerate instance resulted in a CIMError noting the failure code.
   f. Add test in row where enumerate caused Error exception.

3. Adds a new option that defines a list of classes to be ignored when looking for instances.

This means that the command always shows all classes that either caused Error or CIMError or returned instances.
Shows the exception and CIMError as a warning.  Notes at the end of the list if there was a server failure. Even classes
that are defined as ignored are shown in the output with the count field being "ignored"

**DISCUSSION:** Should this also close issue #916, the OpenPegasus failure on instance count.  Part of it was our error in not catching the Error exception.  Now we catch this issue and the scan shows all results.  Thus pywbemcli works as best it can given that errors are coming back from server where we want to look at everything.

My proposal in the issue is to close the issue now since we are reporting what OpenPegasus is doing and that is our  job in pywbemcli

