### PR TITLE
Add test for end-end test of instance count

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -82,8 +82,8 @@ Released: not yet
   get_instanceNames() . Now generates an exception.
   (see issue #1105)
 
-* Fixed issues in "instance count" including unitialized variable and 
-  correctly finishing scan when errors occur. Adds new option to this command 
+* Fixed issues in "instance count" including unitialized variable and
+  correctly finishing scan when errors occur. Adds new option to this command
   to allow user to ignore classes defined with this option (--ignore-class).
   (see issues #1108 and #916 )
 
@@ -165,6 +165,8 @@ Released: not yet
 
 * Remove the file minimum-constraints-base.txt and put contents into
   minimum-constraints.txt. (see issue #1076)
+
+* Add instance count tests to end-end testing against OpenPegasus.
 
 **Known issues:**
 

--- a/tests/end2endtest/test_instance_count.py
+++ b/tests/end2endtest/test_instance_count.py
@@ -1,0 +1,82 @@
+# Copyright 2021 IBM Corp. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Basic server tests.
+"""
+
+from __future__ import absolute_import, print_function
+
+import re
+
+# pylint: disable=unused-import
+from .utils import server_url  # noqa: F401
+# pylint: enable=unused-import
+from ..unit.utils import execute_command
+
+
+def create_table(stdout):
+    """
+    Convert the returned table to a list of lists, one item for each
+    component in an inner list and one list for each row in the outer list
+    """
+    table_lines = stdout.strip('\n').split('\n')[3:]
+    table = []
+    for line in table_lines:
+        # match 3 groups of characters separated by spaces
+        m = re.match(r'^(\S+) *(\S+) *(.+?)$', line)
+        assert m, "Cannot parse output line: {!r}".format(line)
+        table.append(m.groups())
+    return table
+
+
+def test_instance_count(server_url):
+    # pylint: disable=redefined-outer-name
+    """
+    Test instance count command against OpenPegasus server.
+    """
+
+    # Check the instance count operation that will return a success and
+    # valid data
+    rc, stdout, stderr = execute_command(
+        'pywbemcli',
+        ['-s', server_url, '--no-verify', '-o', 'simple', 'instance', 'count',
+         '-n', 'root/cimv2'])
+    assert rc == 0
+    assert stderr == ''
+
+    table_lines = create_table(stdout)
+    # Why this not in rslt assert ('Namespace', 'Class', 'count') in table_lines
+    assert ('root/cimv2', 'PG_ComputerSystem', '1') in table_lines
+    assert ('root/cimv2', 'PG_OperatingSystem', '1') in table_lines
+
+    # Test instance count against OpenPegasus with option that produces
+    # CIMError from the server but from which pywbemcli should simply
+    # produce a line in a report.
+    rc, stdout, stderr = execute_command(
+        'pywbemcli',
+        ['-s', server_url, '--no-verify', '-o', 'simple', 'instance', 'count',
+         '-n', 'test/EmbeddedInstance/dynamic'])
+    assert rc == 0
+
+    table_lines = create_table(stdout)
+    assert ('test/EmbeddedInstance/dynamic', 'CIM_Error', 'CIMError 1') \
+        in table_lines
+
+# FUTURE: Add test that causes Error exception ex. count against PG_Internal
+# namespace. Issue is that the probably breaks test environment since the
+# docker server is down. The only way this could work is to be the last test
+# agains the container assuming that the container is restarted for each tests
+# against a particular environment or having the container automatically #
+# restart.


### PR DESCRIPTION
Adds tests to execute instance count against openpegasus container.

Note this test fails until pr #1109 is merged in.