### PR TITLE
Fixes #991: Fixed mock script and added testcases for namespace creation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -131,15 +131,21 @@ Released: not yet
   for documentation.  Modify pywbemcli.py mutually excluseive options --server,
   --name, and --mock-server to use this class.
 
-* Increased minimum version of pywbem to 1.3.0. (issue #1020)
+* Increased minimum version of pywbem to 1.4.0. (issue #1020 and issue #991)
 
 * Support for Python 3.10: Added Python 3.10 in GitHub Actions tests, and in
   package metadata.
 
 * Implement an end-end test for the subscription command group.
 
-* Changed output format for table output of instance enumerate --no option to 
+* Changed output format for table output of instance enumerate --no option to
   show each key as a column in the table so that keys are more readable.
+
+* The '-v' option now displays better information about namespace creation
+  and deletion, particularly in mock environments. (related to issue #991)
+
+* Test: Added testcases for namespace creation and deletion. (related to
+  issue #991)
 
 **Cleanup:**
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -97,7 +97,8 @@ wheel==0.33.5; python_version >= '3.8'
 # Direct dependencies for install (must be consistent with requirements.txt)
 
 
-pywbem==1.3.0
+# TODO: Go back to released version 1.4.0 once available
+# pywbem==1.4.0
 # When using the GitHub master branch of pywbem, simply comment out the line
 # above, since links are not allowed in constraint files - the minimum will be
 # ensured by requirements.txt then.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,12 +8,13 @@
 
 # Direct dependencies (except pip, setuptools, wheel):
 
-pywbem>=1.3.0
+# TODO: Go back to released version 1.4.0 once available
+# pywbem>=1.4.0
 # When using the GitHub master branch of pywbem, comment out the line above,
 # activate the GitHub link based dependency below.
 # In that case, some of the install tests need to be disabled by setting
 # the 'PYWBEM_FROM_REPO' variable in in tests/install/test_install.sh.
-# git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
+git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
 
 nocaselist>=1.0.3
 nocasedict>=1.0.1

--- a/tests/unit/pywbemcli/simple_foo_mock_model.mof
+++ b/tests/unit/pywbemcli/simple_foo_mock_model.mof
@@ -1,0 +1,225 @@
+// This is a simple mof model that creates the qualifier declarations,
+// classes, and instances for a very simplistic model to be used in the
+// pywbemcli mock test environment. This model is used for the user
+// namespace.
+
+#pragma locale ("en_US")
+#pragma namespace ("foo")
+
+Qualifier Association : boolean = false,
+    Scope(association),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Indication : boolean = false,
+    Scope(class, indication),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Abstract : boolean = false,
+    Scope(class, association, indication),
+    Flavor(EnableOverride, Restricted);
+
+Qualifier Aggregate : boolean = false,
+    Scope(reference),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier EmbeddedInstance : string = null,
+    Scope(property, method, parameter);
+
+Qualifier EmbeddedObject : boolean = false,
+    Scope(property, method, parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Description : string = null,
+    Scope(any),
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+Qualifier In : boolean = true,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Key : boolean = false,
+    Scope(property, reference),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Out : boolean = false,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Override : string = null,
+    Scope(property, reference, method),
+    Flavor(EnableOverride, Restricted);
+
+Qualifier Static : boolean = false,
+    Scope(property, method),
+    Flavor(DisableOverride, ToSubclass);
+
+     [Abstract, Description ("Base class for classes that are referenced")]
+class CIM_BaseRef {
+        [Key, Description ("This is key property.")]
+    string InstanceID;
+};
+
+     [Description ("Class 1 that is referenced")]
+class CIM_FooRef1 : CIM_BaseRef {};
+
+     [Description ("Class 2 that is referenced")]
+class CIM_FooRef2 : CIM_BaseRef {};
+
+     [Association, Description ("Simple CIM Association")]
+class CIM_FooAssoc {
+
+        [Key, Description ("This is key property.")]
+    CIM_FooRef1 REF Ref1;
+
+        [Key, Description ("This is key property.")]
+    CIM_FooRef2 REF Ref2;
+};
+
+     [Abstract, Description ("Base class for classes having embedded instances")]
+class CIM_BaseEmb {};
+
+     [Description ("Class 1 that has embedded instances")]
+class CIM_FooEmb1 : CIM_BaseEmb {};
+
+     [Description ("Class 2 that has embedded instances")]
+class CIM_FooEmb2 : CIM_BaseEmb {};
+
+     [Description ("Class 3 that has embedded instances")]
+class CIM_FooEmb3 : CIM_BaseEmb {};
+
+     [Description ("Simple CIM Class")]
+class CIM_Foo {
+        [Key, Description ("This is key property.")]
+    string InstanceID;
+
+        [Description ("This is Uint32 property.")]
+    uint32 IntegerProp;
+
+        [Description("Embedded instance property"), EmbeddedInstance("CIM_FooEmb3")]
+    string cimfoo_emb3;
+
+        [Description ("Method with in and out parameters")]
+    uint32 Fuzzy(
+        [IN, OUT, Description("Define data to be returned in output parameter")]
+      string TestInOutParameter,
+        [IN, OUT, Description ( "Test of ref in/out parameter")]
+      CIM_FooRef1 REF TestRef,
+        [IN ( false ), OUT, Description("Rtns method name if exists on input")]
+      string OutputParam,
+        [IN , Description("Defines return value if provided.")]
+      uint32 OutputRtnValue);
+
+        [Description ("Static method with in and out parameters"), Static]
+    uint32 FuzzyStatic(
+        [IN, OUT, Description("Define data to be returned in output parameter")]
+      string TestInOutParameter,
+        [IN, OUT, Description ( "Test of ref in/out parameter")]
+      CIM_Foo REF TestRef,
+        [IN ( false ), OUT, Description("Rtns method name if exists on input")]
+      string OutputParam,
+        [IN , Description("Defines return value if provided.")]
+      uint32 OutputRtnValue,
+        [IN, Description("Embedded instance parameter"), EmbeddedInstance("CIM_FooEmb1")]
+      string cimfoo_emb1);
+
+        [ Description("Method with no parameters but embedded instance return"),
+          EmbeddedInstance("CIM_FooEmb2") ]
+    string DeleteNothing();
+};
+
+    [Description ("Subclass of CIM_Foo")]
+class CIM_Foo_sub : CIM_Foo {
+    string cimfoo_sub;
+};
+
+    [Description ("Subclass of CIM_Foo_sub")]
+class CIM_Foo_sub_sub : CIM_Foo_sub {
+    string cimfoo_sub_sub;
+        [Description("Sample method with input and output parameters")]
+    uint32 Method1(
+        [IN ( false), OUT, Description("Response param 2")]
+      string OutputParam2);
+};
+
+class CIM_Foo_sub2 : CIM_Foo {
+    string cimfoo_sub2;
+};
+
+
+// 1 instance of each CIM_FooRef* class
+
+instance of CIM_FooRef1 as $fooref11 {
+    InstanceID = "CIM_FooRef11";
+};
+
+instance of CIM_FooRef2 as $fooref21 {
+    InstanceID = "CIM_FooRef21";
+};
+
+
+// 1 instance of CIM_FooAssoc
+
+instance of CIM_FooAssoc as $fooassoc1 {
+    Ref1 = $fooref11;
+    Ref2 = $fooref21;
+};
+
+
+// 5 instances of CIM_Foo class
+
+instance of CIM_Foo as $foo1 {
+    InstanceID = "CIM_Foo1";
+    IntegerProp = 1;
+    };
+
+instance of CIM_Foo as $foo2 {
+    InstanceID = "CIM_Foo2";
+    IntegerProp = 2;
+    };
+
+instance of CIM_Foo as $foo3 { InstanceID = "CIM_Foo3"; };
+
+instance of CIM_Foo as $foo3 { InstanceID = "CIM_Foo30"; };
+
+instance of CIM_Foo as $foo3 { InstanceID = "CIM_Foo31"; };
+
+
+// 4 instances of CIM_Foo_sub class
+
+instance of CIM_Foo_sub as $foosub1{
+    InstanceID = "CIM_Foo_sub1";
+    IntegerProp = 4;
+    };
+
+instance of CIM_Foo_sub as $foosub1{
+    InstanceID = "CIM_Foo_sub2";
+    IntegerProp = 5;
+    };
+
+instance of CIM_Foo_sub as $foosub1{
+    InstanceID = "CIM_Foo_sub3";
+    IntegerProp = 6;
+    };
+
+instance of CIM_Foo_sub as $foosub1{
+    InstanceID = "CIM_Foo_sub4";
+    IntegerProp = 7;
+    };
+
+// 3 instances of CIM_Foo_sub_sub
+
+instance of CIM_Foo_sub_sub as $foosubsub1{
+    InstanceID = "CIM_Foo_sub_sub1";
+    IntegerProp = 8;
+    };
+
+instance of CIM_Foo_sub_sub as $foosubsub1{
+    InstanceID = "CIM_Foo_sub_sub2";
+    IntegerProp = 9;
+    };
+
+instance of CIM_Foo_sub_sub as $foosubsub1{
+    InstanceID = "CIM_Foo_sub_sub3";
+    IntegerProp = 10;
+
+    };

--- a/tests/unit/pywbemcli/simple_foo_mock_script.py
+++ b/tests/unit/pywbemcli/simple_foo_mock_script.py
@@ -1,10 +1,6 @@
 """
 Test mock script that prepares an Interop namespace and namespace provider,
-compiles MOF into user namespace 'root/cimv2', and then disables pull operations
-on the mock connection.
-
-This script is used to test the general options around enabling and disabling
-pull operations.
+and then compiles MOF that has a pragma namespace 'foo'.
 
 This mock script uses 'new-style' setup for Python >=3.5 and 'old-style' setup
 otherwise, and is therefore useable for all supported Python versions.
@@ -47,8 +43,6 @@ def _setup(conn, server, verbose):
       verbose (bool): Verbose flag
     """
 
-    conn.disable_pull_operations  # pylint: disable=pointless-statement
-
     if sys.version_info >= (3, 5):
         this_file_path = __file__
     else:
@@ -56,8 +50,7 @@ def _setup(conn, server, verbose):
         # of the current script when it is executed using exec(), so we hard
         # code the file path. This requires that the tests are run from the
         # repo main directory.
-        this_file_path = \
-            'tests/unit/pywbemcli/simple_disablepull_mock_script.py'
+        this_file_path = 'tests/unit/pywbemcli/simple_foo_mock_script.py'
         assert os.path.exists(this_file_path)
 
     # Prepare an Interop namespace and namespace provider
@@ -75,15 +68,13 @@ def _setup(conn, server, verbose):
     ns_provider = pywbem_mock.CIMNamespaceProvider(conn.cimrepository)
     conn.register_provider(ns_provider, INTEROP_NAMESPACE, verbose=verbose)
 
-    # Compile a MOF file into the default namespace
+    # Compile a MOF file where the target namespace is determined by a pragma
+    # namespace 'foo' in the MOF
 
-    mof_file = 'simple_mock_model.mof'
-    mof_path = os.path.join(os.path.dirname(this_file_path), mof_file)
-    conn.compile_mof_file(mof_path, namespace='root/cimv2', verbose=verbose)
-    register_dependents(conn, this_file_path, mof_file)
-
-    # Disable the pull operations for this test
-    conn.disable_pull_operations = True
+    foo_mof_file = 'simple_foo_mock_model.mof'
+    foo_mof_path = os.path.join(os.path.dirname(this_file_path), foo_mof_file)
+    conn.compile_mof_file(foo_mof_path, namespace=None, verbose=verbose)
+    register_dependents(conn, this_file_path, foo_mof_file)
 
 
 if sys.version_info >= (3, 5):

--- a/tests/unit/pywbemcli/simple_interop_mock_model.mof
+++ b/tests/unit/pywbemcli/simple_interop_mock_model.mof
@@ -1,7 +1,0 @@
-// This is a simple mof model that establishes a minimal Interop namespace
-
-#pragma namespace ("interop")
-#pragma include ("mock_interop.mof")
-
-#pragma namespace ("root/cimv2")
-#pragma include ("simple_mock_model.mof")

--- a/tests/unit/pywbemcli/standalone_mock_script.py
+++ b/tests/unit/pywbemcli/standalone_mock_script.py
@@ -88,7 +88,8 @@ def setup(conn, server, verbose):
     # Make the mock script standalone by compiling the required MOF file
     # and by registering it as a dependent file.
     mof_file = os.path.join(os.path.dirname(__file__), 'simple_mock_model.mof')
-    conn.compile_mof_file(mof_file, namespace=conn.default_namespace)
+    conn.compile_mof_file(mof_file, namespace=conn.default_namespace,
+                          verbose=verbose)
     conn.provider_dependent_registry.add_dependents(__file__, mof_file)
 
     provider = CIM_FooMethodProvider(conn.cimrepository)

--- a/tests/unit/pywbemcli/test_namespace_cmds.py
+++ b/tests/unit/pywbemcli/test_namespace_cmds.py
@@ -170,7 +170,7 @@ TEST_CASES = [
         ['list'],
         dict(
             rc=1,
-            stderr=['ModelError.*Interop namespace could not be determined'],
+            stderr=['ModelError.*Interop namespace does not exist'],
             test='regex'
         ),
         TEST_USER_MOCK_FILE, True
@@ -245,7 +245,7 @@ TEST_CASES = [
         ['create', 'interop'],
         dict(
             rc=1,
-            stderr=['ModelError.*Interop namespace could not be determined'],
+            stderr=['ModelError.*Interop namespace does not exist'],
             test='regex'
         ),
         TEST_USER_MOCK_FILE, True
@@ -419,7 +419,7 @@ TEST_CASES = [
         ['interop'],
         dict(
             rc=1,
-            stderr=['ModelError.*Interop namespace could not be determined'],
+            stderr=['ModelError.*Interop namespace does not exist'],
             test='regex'
         ),
         TEST_USER_MOCK_FILE, True

--- a/tests/unit/pywbemcli/test_namespace_creation.py
+++ b/tests/unit/pywbemcli/test_namespace_creation.py
@@ -1,0 +1,477 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests the namespace creation behavior.
+"""
+
+from __future__ import absolute_import, print_function
+
+import pytest
+
+from .cli_test_extensions import CLITestsBase
+
+
+# Mock environment #1: Namespace-neutral MOF, no Interop namespace
+MOCK1_MOF_FILE = 'simple_mock_model.mof'
+MOCK1_CLASS = 'CIM_Foo'
+MOCK1_FOO_NAMESPACE = 'foo'
+
+# Mock environment #2: Interop namespace and MOF with pragma namespace 'foo'
+MOCK2_SCRIPT_FILE = 'simple_foo_mock_script.py'
+MOCK2_FOO_MOF_FILE = 'simple_foo_mock_model.mof'
+MOCK2_FOO_CLASS = 'CIM_Foo'  # only in user namespace
+MOCK2_FOO_NAMESPACE = 'foo'
+MOCK2_INTEROP_MOF_FILE = 'mock_interop.mof'
+MOCK2_INTEROP_CLASS = 'CIM_ObjectManager'  # only in Interop namespace
+MOCK2_INTEROP_NAMESPACE = 'interop'
+
+# Mock environment #3: Interop namespace and namespace-neutral MOF
+MOCK3_SCRIPT_FILE = 'simple_interop_mock_script.py'
+MOCK3_FOO_MOF_FILE = 'simple_mock_model.mof'
+MOCK3_FOO_CLASS = 'CIM_Foo'  # only in user namespace
+MOCK3_FOO_NAMESPACE = 'foo'
+MOCK3_INTEROP_MOF_FILE = 'mock_interop.mof'
+MOCK3_INTEROP_CLASS = 'CIM_ObjectManager'  # only in Interop namespace
+MOCK3_INTEROP_NAMESPACE = 'interop'
+
+# Default namespace of pywbem when not specified
+DEFAULT_DEFAULT_NAMESPACE = 'root/cimv2'
+
+
+TEST_CASES = [
+
+    # List of testcases.
+    # Each testcase is a tuple with the following items:
+    # * desc: Description of testcase.
+    # * group: Command group of the pywbemcli command.
+    # * inputs: String, or tuple/list of strings, or dict of 'env', 'args',
+    #     'general', and 'stdin'. See the 'inputs' parameter of
+    #     CLITestsBase.command_test() in cli_test_extensions.py for detailed
+    #     documentation.
+    # * exp_response: Dictionary of expected responses (stdout, stderr, rc) and
+    #     test definition (test: <testname>). See the 'exp_response' parameter
+    #     of CLITestsBase.command_test() in cli_test_extensions.py for
+    #     detailed documentation.
+    # * mock: None, name of file (.mof or .py), or list thereof.
+    # * condition: If True the test is executed, if 'pdb' the test breaks in the
+    #     the debugger, if 'verbose' print verbose messages, if False the test
+    #     is skipped.
+
+    (
+        "Mock environment #1: Command mode 'class get' with no default "
+        "namespace specified can retrieve foo class",
+        'class',
+        dict(
+            args=['get', MOCK1_CLASS, '--nq'],
+            general=['-v']
+        ),
+        dict(
+            rc=0,
+            stdout=[
+                "^Compiling file .*{}".format(MOCK1_MOF_FILE),
+                "^Target namespace '{}'".format(DEFAULT_DEFAULT_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    DEFAULT_DEFAULT_NAMESPACE, MOCK1_CLASS),
+                "^class {} {{$".format(MOCK1_CLASS),
+            ],
+            test='regex'
+        ),
+        MOCK1_MOF_FILE, True
+    ),
+    (
+        "Mock environment #1: Command mode 'class get' with default namespace "
+        "'foo' specified can retrieve foo class",
+        'class',
+        dict(
+            args=['get', MOCK1_CLASS, '--nq'],
+            general=['-v', '-d', MOCK1_FOO_NAMESPACE]
+        ),
+        dict(
+            rc=0,
+            stdout=[
+                "^Compiling file .*{}".format(MOCK1_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK1_FOO_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK1_FOO_NAMESPACE, MOCK1_CLASS),
+                "^class {} {{$".format(MOCK1_CLASS),
+            ],
+            test='regex'
+        ),
+        MOCK1_MOF_FILE, True
+    ),
+    (
+        "Mock environment #1: Command mode 'class get' with command namespace "
+        "'foo' specified cannot retrieve foo class because it got created in "
+        "default default namespace",
+        'class',
+        dict(
+            args=['get', MOCK1_CLASS, '--nq', '-n', MOCK1_FOO_NAMESPACE],
+            general=['-v']
+        ),
+        dict(
+            rc=1,
+            stdout=[
+                "^Compiling file .*{}".format(MOCK1_MOF_FILE),
+                "^Target namespace '{}'".format(DEFAULT_DEFAULT_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    DEFAULT_DEFAULT_NAMESPACE, MOCK1_CLASS),
+            ],
+            stderr=[
+                "CIM_ERR_INVALID_NAMESPACE.* Namespace does not exist in CIM "
+                "repository: ''{}'".format(MOCK1_FOO_NAMESPACE),
+            ],
+            test='regex'
+        ),
+        MOCK1_MOF_FILE, True
+    ),
+    (
+        "Mock environment #1: Interactive mode 'class get' with default "
+        "namespace 'foo' specified can retrieve foo class",
+        None,
+        dict(
+            stdin=[
+                '-v -d {} class get {} --nq'.format(
+                    MOCK1_FOO_NAMESPACE, MOCK1_CLASS)
+            ]
+        ),
+        dict(
+            rc=0,
+            stdout=[
+                "^Compiling file .*{}".format(MOCK1_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK1_FOO_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK1_FOO_NAMESPACE, MOCK1_CLASS),
+                "^class {} {{$".format(MOCK1_CLASS),
+            ],
+            test='regex'
+        ),
+        MOCK1_MOF_FILE, True
+    ),
+    (
+        "Mock environment #1 with default namespace 'bar' specified on command "
+        "line: Interactive mode 'class get' with default namespace 'foo' "
+        "specified can retrieve foo class",
+        None,
+        dict(
+            general=['-d', 'bar'],
+            stdin=[
+                '-v -d {} class get {} --nq'.format(
+                    MOCK1_FOO_NAMESPACE, MOCK1_CLASS)
+            ]
+        ),
+        dict(
+            rc=0,
+            stdout=[
+                "^Compiling file .*{}".format(MOCK1_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK1_FOO_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK1_FOO_NAMESPACE, MOCK1_CLASS),
+                "^class {} {{$".format(MOCK1_CLASS),
+            ],
+            test='regex'
+        ),
+        MOCK1_MOF_FILE, True
+    ),
+    (
+        "Mock environment #1: Interactive mode 'class get' with command "
+        "namespace 'foo' specified cannot retrieve foo class because it got "
+        "created in default default namespace",
+        None,
+        dict(
+            stdin=[
+                '-v class get {} --nq -n {}'.format(
+                    MOCK1_CLASS, MOCK1_FOO_NAMESPACE)
+            ]
+        ),
+        dict(
+            rc=0,  # interactive mode rc=1 is not propagated to command line rc
+            stdout=[
+                "^Compiling file .*{}".format(MOCK1_MOF_FILE),
+                "^Target namespace '{}'".format(DEFAULT_DEFAULT_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    DEFAULT_DEFAULT_NAMESPACE, MOCK1_CLASS),
+            ],
+            stderr=[
+                "CIM_ERR_INVALID_NAMESPACE.* Namespace does not exist in CIM "
+                "repository: ''{}'".format(MOCK1_FOO_NAMESPACE),
+            ],
+            test='regex'
+        ),
+        MOCK1_MOF_FILE, True
+    ),
+    (
+        "Mock environment #2: Command mode 'class get' with no default "
+        "namespace specified cannot retrieve foo class because it accesses "
+        "the default default namespace",
+        'class',
+        dict(
+            args=['get', MOCK2_FOO_CLASS, '--nq'],
+            general=['-v']
+        ),
+        dict(
+            rc=1,
+            stdout=[
+                "^Creating namespace {} .in mock support.".format(
+                    MOCK2_INTEROP_NAMESPACE),
+                "^Compiling file .*{}".format(MOCK2_INTEROP_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK2_INTEROP_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK2_INTEROP_NAMESPACE, MOCK2_INTEROP_CLASS),
+                "^Compiling file .*{}".format(MOCK2_FOO_MOF_FILE),
+                "^Target namespace '{}'".format(DEFAULT_DEFAULT_NAMESPACE),
+                "^Switching target namespace to '{}'".format(
+                    MOCK2_FOO_NAMESPACE),
+                "^Creating namespace {} .in MOF compiler.".format(
+                    MOCK2_FOO_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK2_FOO_NAMESPACE, MOCK2_FOO_CLASS),
+            ],
+            stderr=[
+                "CIM_ERR_NOT_FOUND.: Class '{}' not found in namespace '{}'".
+                format(MOCK2_FOO_CLASS, DEFAULT_DEFAULT_NAMESPACE),
+            ],
+            test='regex'
+        ),
+        MOCK2_SCRIPT_FILE, True
+    ),
+    (
+        "Mock environment #2 with default namespace 'foo' specified on "
+        "command line: Command mode 'class get' can retrieve foo class",
+        'class',
+        dict(
+            args=['get', MOCK2_FOO_CLASS, '--nq'],
+            general=['-v', '-d', MOCK2_FOO_NAMESPACE]
+        ),
+        dict(
+            rc=0,
+            stdout=[
+                "^Creating namespace {} .in mock support.".format(
+                    MOCK2_INTEROP_NAMESPACE),
+                "^Compiling file .*{}".format(MOCK2_INTEROP_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK2_INTEROP_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK2_INTEROP_NAMESPACE, MOCK2_INTEROP_CLASS),
+                "^Compiling file .*{}".format(MOCK2_FOO_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK2_FOO_NAMESPACE),
+                "^Switching target namespace to '{}'".format(
+                    MOCK2_FOO_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK2_FOO_NAMESPACE, MOCK2_FOO_CLASS),
+                "^class {} {{$".format(MOCK2_FOO_CLASS),
+            ],
+            test='regex'
+        ),
+        MOCK2_SCRIPT_FILE, True
+    ),
+    (
+        "Mock environment #2: Command mode 'class get' with command namespace "
+        "'foo' specified can retrieve foo class",
+        'class',
+        dict(
+            args=['get', MOCK2_FOO_CLASS, '--nq', '-n', MOCK2_FOO_NAMESPACE],
+            general=['-v']
+        ),
+        dict(
+            rc=0,
+            stdout=[
+                "^Creating namespace {} .in mock support.".format(
+                    MOCK2_INTEROP_NAMESPACE),
+                "^Compiling file .*{}".format(MOCK2_INTEROP_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK2_INTEROP_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK2_INTEROP_NAMESPACE, MOCK2_INTEROP_CLASS),
+                "^Compiling file .*{}".format(MOCK2_FOO_MOF_FILE),
+                "^Target namespace '{}'".format(DEFAULT_DEFAULT_NAMESPACE),
+                "^Switching target namespace to '{}'".format(
+                    MOCK2_FOO_NAMESPACE),
+                "^Creating namespace {} .in MOF compiler.".format(
+                    MOCK2_FOO_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK2_FOO_NAMESPACE, MOCK2_FOO_CLASS),
+                "^class {} {{$".format(MOCK2_FOO_CLASS),
+            ],
+            test='regex'
+        ),
+        MOCK2_SCRIPT_FILE, True
+    ),
+    (
+        "Mock environment #2 with default namespace 'bar' specified on "
+        "command line: Interactive mode 'class get' with default namespace "
+        "'foo' specified can retrieve foo class",
+        None,
+        dict(
+            general=['-d', 'bar'],
+            stdin=[
+                '-v -d {} class get {} --nq'.format(
+                    MOCK2_FOO_NAMESPACE, MOCK2_FOO_CLASS)
+            ]
+        ),
+        dict(
+            rc=0,
+            stdout=[
+                "^Creating namespace {} .in mock support.".format(
+                    MOCK2_INTEROP_NAMESPACE),
+                "^Compiling file .*{}".format(MOCK2_INTEROP_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK2_INTEROP_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK2_INTEROP_NAMESPACE, MOCK2_INTEROP_CLASS),
+                "^Compiling file .*{}".format(MOCK2_FOO_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK2_FOO_NAMESPACE),
+                "^Switching target namespace to '{}'".format(
+                    MOCK2_FOO_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK2_FOO_NAMESPACE, MOCK2_FOO_CLASS),
+                "^class {} {{$".format(MOCK2_FOO_CLASS),
+            ],
+            test='regex'
+        ),
+        MOCK2_SCRIPT_FILE, True
+    ),
+    (
+        "Mock environment #2: Interactive mode 'class get' with command "
+        "namespace 'foo' specified can retrieve foo class",
+        None,
+        dict(
+            stdin=[
+                '-v class get {} --nq -n {}'.format(
+                    MOCK2_FOO_CLASS, MOCK2_FOO_NAMESPACE)
+            ]
+        ),
+        dict(
+            rc=0,
+            stdout=[
+                "^Creating namespace {} .in mock support.".format(
+                    MOCK2_INTEROP_NAMESPACE),
+                "^Compiling file .*{}".format(MOCK2_INTEROP_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK2_INTEROP_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK2_INTEROP_NAMESPACE, MOCK2_INTEROP_CLASS),
+                "^Compiling file .*{}".format(MOCK2_FOO_MOF_FILE),
+                "^Target namespace '{}'".format(DEFAULT_DEFAULT_NAMESPACE),
+                "^Switching target namespace to '{}'".format(
+                    MOCK2_FOO_NAMESPACE),
+                "^Creating namespace {} .in MOF compiler.".format(
+                    MOCK2_FOO_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK2_FOO_NAMESPACE, MOCK2_FOO_CLASS),
+                "^class {} {{$".format(MOCK2_FOO_CLASS),
+            ],
+            test='regex'
+        ),
+        MOCK2_SCRIPT_FILE, True
+    ),
+    (
+        # Testcase similar to issue #991, but with new foo mock script
+        "Mock environment #2: Interactive mode 'class get' with default "
+        "namespace 'interop' specified can retrieve interop class",
+        None,
+        dict(
+            stdin=[
+                '-v -d {} class get {} --nq'.format(
+                    MOCK2_INTEROP_NAMESPACE, MOCK2_INTEROP_CLASS)
+            ]
+        ),
+        dict(
+            rc=0,
+            stdout=[
+                "^Compiling file .*{}".format(MOCK2_INTEROP_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK2_INTEROP_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK2_INTEROP_NAMESPACE, MOCK2_INTEROP_CLASS),
+                "^Compiling file .*{}".format(MOCK2_FOO_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK2_INTEROP_NAMESPACE),
+                "^Switching target namespace to '{}'".format(
+                    MOCK2_FOO_NAMESPACE),
+                "^Creating namespace {} .in MOF compiler.".format(
+                    MOCK2_FOO_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK2_FOO_NAMESPACE, MOCK2_FOO_CLASS),
+                "^class {} {{$".format(MOCK2_INTEROP_CLASS),
+            ],
+            test='regex'
+        ),
+        MOCK2_SCRIPT_FILE, True
+    ),
+    (
+        # Testcase representing issue #991, but with fixed interop mock script
+        "Mock environment #3: Interactive mode 'class get' with default "
+        "namespace 'interop' specified can retrieve interop class",
+        None,
+        dict(
+            stdin=[
+                '-v -d {} class get {} --nq'.format(
+                    MOCK3_INTEROP_NAMESPACE, MOCK3_INTEROP_CLASS)
+            ]
+        ),
+        dict(
+            rc=0,
+            stdout=[
+                "^Compiling file .*{}".format(MOCK3_INTEROP_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK3_INTEROP_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK3_INTEROP_NAMESPACE, MOCK3_INTEROP_CLASS),
+                "^Compiling file .*{}".format(MOCK3_FOO_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK3_INTEROP_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK3_INTEROP_NAMESPACE, MOCK3_FOO_CLASS),
+                "^class {} {{$".format(MOCK3_INTEROP_CLASS),
+            ],
+            test='regex'
+        ),
+        MOCK3_SCRIPT_FILE, True
+    ),
+    (
+        "Mock environment #3 with default namespace 'interop' specified: "
+        "Interactive mode 'class get' can retrieve interop class",
+        None,
+        dict(
+            general=['-d', MOCK3_INTEROP_NAMESPACE],
+            stdin=[
+                '-v class get {} --nq'.format(MOCK3_INTEROP_CLASS)
+            ]
+        ),
+        dict(
+            rc=0,
+            stdout=[
+                "^Compiling file .*{}".format(MOCK3_INTEROP_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK3_INTEROP_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK3_INTEROP_NAMESPACE, MOCK3_INTEROP_CLASS),
+                "^Compiling file .*{}".format(MOCK3_FOO_MOF_FILE),
+                "^Target namespace '{}'".format(MOCK3_INTEROP_NAMESPACE),
+                "^Creating class {}:{}$".format(
+                    MOCK3_INTEROP_NAMESPACE, MOCK3_FOO_CLASS),
+                "^class {} {{$".format(MOCK3_INTEROP_CLASS),
+            ],
+            test='regex'
+        ),
+        MOCK3_SCRIPT_FILE, True
+    ),
+]
+
+
+class TestNamespaceCreation(CLITestsBase):
+    # pylint: disable=too-few-public-methods
+    """
+    Run all testcases for namespace creation behavior.
+    """
+
+    @pytest.mark.parametrize(
+        "desc, group, inputs, exp_response, mock, condition",
+        TEST_CASES)
+    def test_namespace(
+            self, desc, group, inputs, exp_response, mock, condition):
+        """
+        Run the test for a single testcase.
+        """
+        self.command_test(desc, group, inputs, exp_response, mock, condition)


### PR DESCRIPTION
For details, see commit message.

TODO:
* Pull pywbem from master branch once its PR https://github.com/pywbem/pywbem/pull/2823 is merged.
* Print verbose message when creating default namespace in mock env.

**DISCUSSION:**
* This fix did not require any changes in the namespace creation processing. Is this sufficient to address issue #991?