### PR TITLE
Ks/fix names only table

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -138,6 +138,9 @@ Released: not yet
 
 * Implement an end-end test for the subscription command group.
 
+* Changed output format for table output of instance enumerate --no option to 
+  show each key as a column in the table so that keys are more readable.
+
 **Cleanup:**
 
 * Prepared the development environment for having more than one pywbemtools

--- a/tests/unit/pywbemcli/test_instance_cmds.py
+++ b/tests/unit/pywbemcli/test_instance_cmds.py
@@ -806,35 +806,25 @@ TEST_CASES = [
 
     ['Verify instance command -o grid enumerate CIM_Foo --di --no',
      {'args': ['enumerate', 'CIM_Foo', '--di', '--no'],
-      'general': ['--output-format', 'grid']},
+      'general': ['--output-format', 'table']},
      {'stdout': """InstanceNames: CIM_Foo
-+--------+-------------+-----------------+-------------------------------+
-| host   | namespace   | class           | keysbindings                  |
-+========+=============+=================+===============================+
-|        | root/cimv2  | CIM_Foo         | InstanceID="CIM_Foo1"         |
-+--------+-------------+-----------------+-------------------------------+
-|        | root/cimv2  | CIM_Foo         | InstanceID="CIM_Foo2"         |
-+--------+-------------+-----------------+-------------------------------+
-|        | root/cimv2  | CIM_Foo         | InstanceID="CIM_Foo3"         |
-+--------+-------------+-----------------+-------------------------------+
-|        | root/cimv2  | CIM_Foo         | InstanceID="CIM_Foo30"        |
-+--------+-------------+-----------------+-------------------------------+
-|        | root/cimv2  | CIM_Foo         | InstanceID="CIM_Foo31"        |
-+--------+-------------+-----------------+-------------------------------+
-|        | root/cimv2  | CIM_Foo_sub     | InstanceID="CIM_Foo_sub1"     |
-+--------+-------------+-----------------+-------------------------------+
-|        | root/cimv2  | CIM_Foo_sub     | InstanceID="CIM_Foo_sub2"     |
-+--------+-------------+-----------------+-------------------------------+
-|        | root/cimv2  | CIM_Foo_sub     | InstanceID="CIM_Foo_sub3"     |
-+--------+-------------+-----------------+-------------------------------+
-|        | root/cimv2  | CIM_Foo_sub     | InstanceID="CIM_Foo_sub4"     |
-+--------+-------------+-----------------+-------------------------------+
-|        | root/cimv2  | CIM_Foo_sub_sub | InstanceID="CIM_Foo_sub_sub1" |
-+--------+-------------+-----------------+-------------------------------+
-|        | root/cimv2  | CIM_Foo_sub_sub | InstanceID="CIM_Foo_sub_sub2" |
-+--------+-------------+-----------------+-------------------------------+
-|        | root/cimv2  | CIM_Foo_sub_sub | InstanceID="CIM_Foo_sub_sub3" |
-+--------+-------------+-----------------+-------------------------------+
++--------+-------------+-----------------+------------------+
+| host   | namespace   | class           | key=             |
+|        |             |                 | InstanceID       |
+|--------+-------------+-----------------+------------------|
+|        | root/cimv2  | CIM_Foo         | CIM_Foo1         |
+|        | root/cimv2  | CIM_Foo         | CIM_Foo2         |
+|        | root/cimv2  | CIM_Foo         | CIM_Foo3         |
+|        | root/cimv2  | CIM_Foo         | CIM_Foo30        |
+|        | root/cimv2  | CIM_Foo         | CIM_Foo31        |
+|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub1     |
+|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub2     |
+|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub3     |
+|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub4     |
+|        | root/cimv2  | CIM_Foo_sub_sub | CIM_Foo_sub_sub1 |
+|        | root/cimv2  | CIM_Foo_sub_sub | CIM_Foo_sub_sub2 |
+|        | root/cimv2  | CIM_Foo_sub_sub | CIM_Foo_sub_sub3 |
++--------+-------------+-----------------+------------------+
 """,
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
@@ -946,27 +936,47 @@ TEST_CASES = [
      {'args': ['enumerate', 'CIM_Foo', '--names-only'],
       'general': ['--output-format', 'table']},
      {'stdout': """InstanceNames: CIM_Foo
-+--------+-------------+-----------------+-------------------------------+
-| host   | namespace   | class           | keysbindings                  |
-|--------+-------------+-----------------+-------------------------------|
-|        | root/cimv2  | CIM_Foo         | InstanceID="CIM_Foo1"         |
-|        | root/cimv2  | CIM_Foo         | InstanceID="CIM_Foo2"         |
-|        | root/cimv2  | CIM_Foo         | InstanceID="CIM_Foo3"         |
-|        | root/cimv2  | CIM_Foo         | InstanceID="CIM_Foo30"        |
-|        | root/cimv2  | CIM_Foo         | InstanceID="CIM_Foo31"        |
-|        | root/cimv2  | CIM_Foo_sub     | InstanceID="CIM_Foo_sub1"     |
-|        | root/cimv2  | CIM_Foo_sub     | InstanceID="CIM_Foo_sub2"     |
-|        | root/cimv2  | CIM_Foo_sub     | InstanceID="CIM_Foo_sub3"     |
-|        | root/cimv2  | CIM_Foo_sub     | InstanceID="CIM_Foo_sub4"     |
-|        | root/cimv2  | CIM_Foo_sub_sub | InstanceID="CIM_Foo_sub_sub1" |
-|        | root/cimv2  | CIM_Foo_sub_sub | InstanceID="CIM_Foo_sub_sub2" |
-|        | root/cimv2  | CIM_Foo_sub_sub | InstanceID="CIM_Foo_sub_sub3" |
-+--------+-------------+-----------------+-------------------------------+
-
++--------+-------------+-----------------+------------------+
+| host   | namespace   | class           | key=             |
+|        |             |                 | InstanceID       |
+|--------+-------------+-----------------+------------------|
+|        | root/cimv2  | CIM_Foo         | CIM_Foo1         |
+|        | root/cimv2  | CIM_Foo         | CIM_Foo2         |
+|        | root/cimv2  | CIM_Foo         | CIM_Foo3         |
+|        | root/cimv2  | CIM_Foo         | CIM_Foo30        |
+|        | root/cimv2  | CIM_Foo         | CIM_Foo31        |
+|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub1     |
+|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub2     |
+|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub3     |
+|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub4     |
+|        | root/cimv2  | CIM_Foo_sub_sub | CIM_Foo_sub_sub1 |
+|        | root/cimv2  | CIM_Foo_sub_sub | CIM_Foo_sub_sub2 |
+|        | root/cimv2  | CIM_Foo_sub_sub | CIM_Foo_sub_sub3 |
++--------+-------------+-----------------+------------------+
 """,
       'rc': 0,
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
+
+    ['Verify command enumerate with ssociation class inst name table output',
+     {'args': ['enumerate', 'TST_A3', '--names-only'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """InstanceNames: TST_A3
++--------+-------------+---------+---------------------+---------------------+---------------------+
+| host   | namespace   | class   | key=                | key=                | key=                |
+|        |             |         | Initiator           | Target              | LogicalUnit         |
+|--------+-------------+---------+---------------------+---------------------+---------------------|
+|        | root/cimv2  | TST_A3  | /root/cimv2:TST_EP. | /root/cimv2:TST_EP. | /root/cimv2:TST_LD. |
+|        |             |         | InstanceID=1        | InstanceID=2        | InstanceID=3        |
+|        | root/cimv2  | TST_A3  | /root/cimv2:TST_EP. | /root/cimv2:TST_EP. | /root/cimv2:TST_LD. |
+|        |             |         | InstanceID=1        | InstanceID=5        | InstanceID=6        |
+|        | root/cimv2  | TST_A3  | /root/cimv2:TST_EP. | /root/cimv2:TST_EP. | /root/cimv2:TST_LD. |
+|        |             |         | InstanceID=1        | InstanceID=7        | InstanceID=8        |
++--------+-------------+---------+---------------------+---------------------+---------------------+
+""",  # noqa: E501
+      'rc': 0,
+      'test': 'linesnows'},
+     COMPLEX_ASSOC_MODEL, OK],
 
     ['Verify command enumerate with CIM_Foo summary table output',
      {'args': ['enumerate', 'CIM_Foo', '--summary'],

--- a/tests/unit/pywbemcli/test_subscription_cmds.py
+++ b/tests/unit/pywbemcli/test_subscription_cmds.py
@@ -784,8 +784,9 @@ TEST_CASES = [
                  '   Destination = "http://someone:50000";',
                  '   Protocol = 2;',
                  # Result -o plain subscription list-destinations --names-only
-                 'host    namespace    class     keysbindings',
-                 'interop      CIM_ListenerDestinationCIMXML',
+                 'host    namespace    class   key=  key=  key=',
+                 'interop  CIM_ListenerDestinationCIMXML  CIM_ComputerSystem '
+                 'MockSystem_WBEMServerTest  CIM_ListenerDestinationCIMXML',
                  # Result list
                  '1 CIMInstance(s) returned',
                  '};'],
@@ -834,8 +835,8 @@ TEST_CASES = [
                  '};',
                  '1 CIMInstance(s) returned',
                  # Result from -o plain subscription list-filters --names-only
-                 'host    namespace    class   keysbindings',
-                 'interop   CIM_IndicationFilter', ],
+                 'host  namespace  class key=  key=  key=  key=',
+                 'interop      CIM_IndicationFilter  CIM_ComputerSystem         MockSystem_WBEMServerTest  CIM_IndicationFilter  pywbemfilter:defaultpywbemcliSubMgr:ofilter1', ],  # noqa: E501
       'stderr': [],
       'test': 'innows'},
      None, OK],
@@ -874,8 +875,9 @@ TEST_CASES = [
                  '   SubscriptionState = 2;',
                  '};',
                  # Limited result  -o plain ... list-subscriptions --name-only
-                 # The actual output it to ugly to compare.
-                 'host    namespace    class   keysbindings',
+                 'host    namespace    class   key=',
+                 'Filter Handler',
+                 'interop  CIM_IndicationSubscription  /interop:CIM_IndicationFilter.  /interop:CIM_ListenerDestinationCIMXML.',  # noqa: E501
                  '};'],
       'stderr': [],
       'test': 'innows'},


### PR DESCRIPTION
modify display code for commands like instance enumerate --no to actually display a table of the keys rather than just one column with all the keybindings.

Note: We did not go to an inter table for the reference properties because of the very limited support for nested tables in
tabulate.

for example, 

```

pywbemcli> -o table instance enumerate TST_A3 --no
InstanceNames: TST_A3
+--------+-------------+---------+---------------------+---------------------+---------------------+
| host   | namespace   | class   | key=                | key=                | key=                |
|        |             |         | Initiator           | LogicalUnit         | Target              |
|--------+-------------+---------+---------------------+---------------------+---------------------|
|        | root/cimv2  | TST_A3  | /root/cimv2:TST_EP. | /root/cimv2:TST_LD. | /root/cimv2:TST_EP. |
|        |             |         | InstanceID=1        | InstanceID=3        | InstanceID=2        |
|        | root/cimv2  | TST_A3  | /root/cimv2:TST_EP. | /root/cimv2:TST_LD. | /root/cimv2:TST_EP. |
|        |             |         | InstanceID=1        | InstanceID=6        | InstanceID=5        |
|        | root/cimv2  | TST_A3  | /root/cimv2:TST_EP. | /root/cimv2:TST_LD. | /root/cimv2:TST_EP. |
|        |             |         | InstanceID=1        | InstanceID=8        | InstanceID=7        |
+--------+-------------+---------+---------------------+---------------------+---------------------+

```
or

```
pywbemcli> -o table instance enumerate CIM_Foo --no --di
InstanceNames: CIM_Foo
+--------+-------------+-----------------+------------------+
| host   | namespace   | class           | key=             |
|        |             |                 | InstanceID       |
|--------+-------------+-----------------+------------------|
|        | root/cimv2  | CIM_Foo         | CIM_Foo1         |
|        | root/cimv2  | CIM_Foo         | CIM_Foo2         |
|        | root/cimv2  | CIM_Foo         | CIM_Foo3         |
|        | root/cimv2  | CIM_Foo         | CIM_Foo30        |
|        | root/cimv2  | CIM_Foo         | CIM_Foo31        |
|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub1     |
|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub2     |
|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub3     |
|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub4     |
|        | root/cimv2  | CIM_Foo_sub_sub | CIM_Foo_sub_sub1 |
|        | root/cimv2  | CIM_Foo_sub_sub | CIM_Foo_sub_sub2 |
|        | root/cimv2  | CIM_Foo_sub_sub | CIM_Foo_sub_sub3 |
+--------+-------------+-----------------+------------------+



