### PR TITLE
Fix test_namespaces to match pywbem message change

### DIFF
--- a/tests/unit/pywbemcli/test_namespace_cmds.py
+++ b/tests/unit/pywbemcli/test_namespace_cmds.py
@@ -170,8 +170,8 @@ TEST_CASES = [
         ['list'],
         dict(
             rc=1,
-            stderr=['ModelError.*Interop namespace does not exist'],
-            test='regex'
+            stderr=['ModelError: Interop namespace does not exist'],
+            test='innows'
         ),
         TEST_USER_MOCK_FILE, True
     ),
@@ -245,8 +245,8 @@ TEST_CASES = [
         ['create', 'interop'],
         dict(
             rc=1,
-            stderr=['ModelError.*Interop namespace does not exist'],
-            test='regex'
+            stderr=['ModelError: Interop namespace does not exist'],
+            test='innows'
         ),
         TEST_USER_MOCK_FILE, True
     ),
@@ -419,8 +419,8 @@ TEST_CASES = [
         ['interop'],
         dict(
             rc=1,
-            stderr=['ModelError.*Interop namespace does not exist'],
-            test='regex'
+            stderr=['ModelError: Interop namespace does not exist'],
+            test='innows'
         ),
         TEST_USER_MOCK_FILE, True
     ),


### PR DESCRIPTION
Exception message changed in pywbem 1.4.0 and pywbemcli tests that
message on an exception for no interop namespace.

This just changes the message text tested.