### PR TITLE
enhance instance table output to conditionally show null properties

### DIFF
--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -1104,6 +1104,10 @@ Help text for ``pywbemcli instance associators`` (see :ref:`instance associators
 
       --fql, --filter-query-language QUERY-LANGUAGE
                                       The filter query language to be used with --filter-query. Default: DMTF:FQL.
+      --show-null                     In the TABLE output formats, show properties with no value (i.e. Null) in all of the
+                                      instances to be displayed. Otherwise only properties at least one instance has a non-
+                                      Null property are displayed
+
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
                                       --namespace options.
 
@@ -1330,6 +1334,10 @@ Help text for ``pywbemcli instance enumerate`` (see :ref:`instance enumerate com
 
       --fql, --filter-query-language QUERY-LANGUAGE
                                       The filter query language to be used with --filter-query. Default: DMTF:FQL.
+      --show-null                     In the TABLE output formats, show properties with no value (i.e. Null) in all of the
+                                      instances to be displayed. Otherwise only properties at least one instance has a non-
+                                      Null property are displayed
+
       -h, --help                      Show this help message.
 
 
@@ -1379,6 +1387,10 @@ Help text for ``pywbemcli instance get`` (see :ref:`instance get command`):
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
                                       --namespace options.
+
+      --show-null                     In the TABLE output formats, show properties with no value (i.e. Null) in all of the
+                                      instances to be displayed. Otherwise only properties at least one instance has a non-
+                                      Null property are displayed
 
       -h, --help                      Show this help message.
 
@@ -1576,6 +1588,10 @@ Help text for ``pywbemcli instance references`` (see :ref:`instance references c
       --fq, --filter-query QUERY-STRING
                                       When pull operations are used, filter the instances in the result via a filter query.
                                       By default, and when traditional operations are used, no such filtering takes place.
+
+      --show-null                     In the TABLE output formats, show properties with no value (i.e. Null) in all of the
+                                      instances to be displayed. Otherwise only properties at least one instance has a non-
+                                      Null property are displayed
 
       --fql, --filter-query-language QUERY-LANGUAGE
                                       The filter query language to be used with --filter-query. Default: DMTF:FQL.

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -160,6 +160,13 @@ help_instancename_option = [              # pylint: disable=invalid-name
                  help=u'Show help message for specifying INSTANCENAME '
                       u'including use of the --key and --namespace options.')]
 
+show_null_option = [              # pylint: disable=invalid-name
+    click.option('--show-null', 'show_null', is_flag=True, required=False,
+                 help=u'In the TABLE output formats, show properties with no '
+                      u'value (i.e. Null) in all of the instances to be '
+                      u'displayed. Otherwise only properties at least '
+                      u'one instance has a non-Null property are displayed')]
+
 
 ##########################################################################
 #
@@ -201,6 +208,7 @@ def instance_group():
 @add_options(summary_option)
 @add_options(filter_query_option)
 @add_options(filter_query_language_option)
+@add_options(show_null_option)
 @add_options(help_option)
 @click.pass_obj
 def instance_enumerate(context, classname, **options):
@@ -240,6 +248,7 @@ def instance_enumerate(context, classname, **options):
 @add_options(keybinding_key_option)
 @add_options(namespace_option)
 @add_options(help_instancename_option)
+@add_options(show_null_option)
 @add_options(help_option)
 @click.pass_obj
 def instance_get(context, instancename, **options):
@@ -399,6 +408,7 @@ def instance_modify(context, instancename, **options):
 @add_options(summary_option)
 @add_options(filter_query_option)
 @add_options(filter_query_language_option)
+@add_options(show_null_option)
 @add_options(help_instancename_option)
 @add_options(help_option)
 @click.pass_obj
@@ -451,6 +461,7 @@ def instance_associators(context, instancename, **options):
 @add_options(namespace_option)
 @add_options(summary_option)
 @add_options(filter_query_option)
+@add_options(show_null_option)
 @add_options(filter_query_language_option)
 @add_options(help_instancename_option)
 @add_options(help_option)
@@ -1000,7 +1011,8 @@ def cmd_instance_get(context, instancename, options):
             PropertyList=property_list)
 
         display_cim_objects(context, instance, output_fmt,
-                            property_list=property_list)
+                            property_list=property_list,
+                            ignore_null_properties=not options['show_null'])
 
     except Error as er:
         raise pywbem_error_exception(er)
@@ -1187,7 +1199,8 @@ def cmd_instance_enumerate(context, classname, options):
 
         display_cim_objects(context, results, output_fmt,
                             summary=options['summary'], sort=True,
-                            property_list=property_list)
+                            property_list=property_list,
+                            ignore_null_properties=not options['show_null'])
 
     except Error as er:
         raise pywbem_error_exception(er)
@@ -1237,7 +1250,8 @@ def cmd_instance_references(context, instancename, options):
 
         display_cim_objects(context, results, output_fmt,
                             summary=options['summary'], sort=True,
-                            property_list=property_list)
+                            property_list=property_list,
+                            ignore_null_properties=not options['show_null'])
 
     except Error as er:
         raise pywbem_error_exception(er)
@@ -1288,7 +1302,8 @@ def cmd_instance_associators(context, instancename, options):
 
         display_cim_objects(context, results, output_fmt,
                             summary=options['summary'], sort=True,
-                            property_list=property_list)
+                            property_list=property_list,
+                            ignore_null_properties=not options['show_null'])
 
     except Error as er:
         raise pywbem_error_exception(er)

--- a/tests/unit/pywbemcli/common_options_help_lines.py
+++ b/tests/unit/pywbemcli/common_options_help_lines.py
@@ -110,3 +110,6 @@ CMD_OPTION_LEAFCLASSES_FILTER_HELP_LINE = \
 
 CMD_OPTION_HELP_INSTANCENAME_HELP_LINE = \
     '--hi, --help-instancename Show help message for specifying INSTANCENAME'
+
+CMD_OPTION_SHOW_NULL_HELP_LINE = \
+    '--show-null In the TABLE output formats, show properties with no '

--- a/tests/unit/pywbemcli/simple_instance_tablefmt_test.mof
+++ b/tests/unit/pywbemcli/simple_instance_tablefmt_test.mof
@@ -1,0 +1,124 @@
+// This is a simple mof model that creates the qualifier declarations,
+// classes, and instances to test the table output of instances including
+// functions showing/hiding properties with Null values
+
+#pragma locale ("en_US")
+Qualifier Association : boolean = false,
+    Scope(association),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Indication : boolean = false,
+    Scope(class, indication),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Abstract : boolean = false,
+    Scope(class, association, indication),
+    Flavor(EnableOverride, Restricted);
+
+Qualifier Aggregate : boolean = false,
+    Scope(reference),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier EmbeddedInstance : string = null,
+    Scope(property, method, parameter);
+
+Qualifier EmbeddedObject : boolean = false,
+    Scope(property, method, parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Description : string = null,
+    Scope(any),
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+Qualifier In : boolean = true,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Key : boolean = false,
+    Scope(property, reference),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Out : boolean = false,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+Qualifier Override : string = null,
+    Scope(property, reference, method),
+    Flavor(EnableOverride, Restricted);
+
+Qualifier Static : boolean = false,
+    Scope(property, method),
+    Flavor(DisableOverride, ToSubclass);
+
+     [Description ("Simple CIM Class Top level")]
+class CIM_Foo {
+        [Key, Description ("This is key property.")]
+    string InstanceID;
+        [Description ("This is Uint32 property.")]
+    uint32 IntegerProp;
+        [Description ("This property should always be Null for tests")]
+    string AlwaysNullProp;
+};
+
+    [Description ("Subclass of CIM_Foo that adds a single str property")]
+class CIM_FooStr : CIM_Foo {
+    string cimfoo_str;
+};
+
+    [Description ("Subclass of CIM_Foo adds single str always Null property")]
+class CIM_FooStrNull : CIM_Foo {
+    string AnotherAlwaysNull;
+};
+
+     [Association, Description ("Simple CIM Association CIM_Foo to CIM_Foo")]
+class CIM_FooAssoc {
+        [Key, Description ("This is key property.")]
+    string InstanceID;
+
+        [Description ("This first ref to CIM_Foo.")]
+    CIM_Foo REF Ref1;
+
+        [Description ("This is second reference to CIM_Foo.")]
+    CIM_Foo REF Ref2;
+};
+
+//
+// Instance definitions
+//
+
+// 3 instances of CIM_Foo class
+
+instance of CIM_Foo as $foo1{
+    InstanceID = "CIM_Foo1";
+    IntegerProp = 1;
+    AlwaysNullProp = null;
+};
+
+instance of CIM_Foo as $foo2{
+    InstanceID = "CIM_Foo2";
+    AlwaysNullProp = null;
+};
+
+instance of CIM_Foostr as $foostr1{
+    InstanceID = "CIM_Foostr1";
+    cimfoo_str = "String in subclass";
+    AlwaysNullProp = null;
+};
+
+instance of CIM_FooStrNull as $foostrnull1{
+    InstanceID = "CIM_FoostrNull1";
+    AlwaysNullProp = null;
+    AnotherAlwaysNull  = Null;
+};
+
+instance of CIM_FooAssoc {
+    InstanceID = "CIM_FooAssoc1";
+    Ref1 = $foo1;
+    Ref2 = $foo2;
+};
+
+instance of CIM_FooAssoc {
+    InstanceID = "CIM_FooAssoc2";
+    Ref1 = $foo1;
+    Ref2 = $foostr1;
+};

--- a/tests/unit/pywbemcli/test_display_cimobjects.py
+++ b/tests/unit/pywbemcli/test_display_cimobjects.py
@@ -16,7 +16,8 @@
 # limitations under the License.
 
 """
-Tests for _common.py functions.
+Tests for _common.py functions.  This is a unit test of the function and its
+API, not a test of pywbemcli commands.
 """
 
 from __future__ import absolute_import, print_function
@@ -37,9 +38,11 @@ from pywbem import CIMProperty, CIMInstance, CIMInstanceName, Uint32, Uint64, \
 from pywbemtools.pywbemcli._display_cimobjects import \
     _format_instances_as_rows, _display_instances_as_table
 
+from pywbemtools._output_formatting import DEFAULT_MAX_CELL_WIDTH
+
 from ..pytest_extensions import simplified_test_function
 
-OK = True     # mark tests OK when they execute correctly
+OK = True    # mark tests OK when they execute correctly
 RUN = True    # Mark OK = False and current test case being created RUN
 FAIL = False  # Any test currently FAILING or not tested yet
 SKIP = False  # mark tests that are to be skipped.
@@ -146,6 +149,57 @@ def simple_instance2(pvalue=None):
     return inst
 
 
+def simple_array_instance2(pvalue=None):
+    """
+    Build a simple instance to test and return that instance. The properties
+    in the instance are sorted by (lower cased) property name.
+
+    For this test all of the array elements have a single value
+    """
+    if pvalue:
+        properties = [CIMProperty("P", pvalue)]
+    else:
+        properties = [
+            CIMProperty("Pbf", is_array=True, value=[False]),
+            CIMProperty("Pbt", is_array=True, value=[True]),
+            CIMProperty("Pdt", is_array=True, value=[DATETIME1_OBJ]),
+            CIMProperty("Pint64", is_array=True, value=[Uint64(9999)]),
+            CIMProperty("Psint32", is_array=True, value=[Sint32(-2147483648)]),
+            CIMProperty("Pstr1", is_array=True, value=[u"Test String"]),
+            CIMProperty("Puint32", is_array=True, value=[Uint32(4294967295)]),
+        ]
+    inst = CIMInstance("CIM_Foo", properties)
+    return inst
+
+
+def simple_array_instance21(pvalue=None):
+    """
+    Build a simple instance to test and return that instance. The properties
+    in the instance are sorted by (lower cased) property name.
+
+    For this test all of the array elements have a two values
+    """
+    if pvalue:
+        properties = [CIMProperty("P", pvalue)]
+    else:
+        properties = [
+            CIMProperty("Pbf", is_array=True, value=[False, False]),
+            CIMProperty("Pbt", is_array=True, value=[True, True]),
+            CIMProperty("Pdt", is_array=True, value=[DATETIME1_OBJ,
+                                                     DATETIME1_OBJ]),
+            CIMProperty("Pint64", is_array=True, value=[Uint64(9999),
+                                                        Uint64(9999)]),
+            CIMProperty("Psint32", is_array=True, value=[Sint32(-2147483648),
+                                                         Sint32(-2147483648)]),
+            CIMProperty("Pstr1", is_array=True, value=[u"Test String",
+                                                       u"Test String"]),
+            CIMProperty("Puint32", is_array=True, value=[Uint32(4294967295),
+                                                         Uint32(4294967295)]),
+        ]
+    inst = CIMInstance("CIM_Foo", properties)
+    return inst
+
+
 def string_instance(tst_str):
     """
     Build a CIM instance with a single property.
@@ -185,6 +239,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
             args=(),
             kwargs=dict(
                 insts=[simple_instance()],
+                max_cell_width=DEFAULT_MAX_CELL_WIDTH,
                 quote_strings=False),
             exp_rtn=[
                 ["false", "true", DATETIME1_STR, "99", "9999",
@@ -198,6 +253,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
             args=(),
             kwargs=dict(
                 insts=[simple_instance(pvalue=["abc", 'def'])],
+                max_cell_width=DEFAULT_MAX_CELL_WIDTH,
                 quote_strings=False),
             exp_rtn=[
                 ['"abc", "def"']],
@@ -211,6 +267,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
             kwargs=dict(
                 insts=[array_instance(pvalue=[Uint32(12345), Uint32(67891)],
                                       ptype='uint32')],
+                max_cell_width=DEFAULT_MAX_CELL_WIDTH,
                 quote_strings=True),
             exp_rtn=[
                 ['12345, 67891']],
@@ -238,6 +295,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
             kwargs=dict(
                 insts=[array_instance(pvalue=[Uint32(12345), Uint32(67891)],
                                       ptype='uint32')],
+                max_cell_width=DEFAULT_MAX_CELL_WIDTH,
                 quote_strings=False),
             exp_rtn=[
                 ['12345, 67891']],
@@ -272,7 +330,8 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
     (
         "Verify simple instance to table, unsorted",
         dict(
-            args=([simple_instance_unsorted()], None),
+            args=([simple_instance_unsorted()],
+                  DEFAULT_MAX_CELL_WIDTH,),
             kwargs={},
             exp_rtn=[
                 ["false", "true", DATETIME1_STR, "99", "9999",
@@ -303,6 +362,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
                         ),
                     ),
                 ],
+                max_cell_width=DEFAULT_MAX_CELL_WIDTH,
             ),
             exp_rtn=[
                 ['"K1"', '"K2"', '"V1"', '"V2"'],
@@ -333,6 +393,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
                         ],
                     ),
                 ],
+                max_cell_width=DEFAULT_MAX_CELL_WIDTH,
             ),
             exp_rtn=[
                 ['', '"VP1a"', '"VP2a"', '"VP3a"'],
@@ -371,6 +432,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
                         ),
                     ),
                 ],
+                max_cell_width=DEFAULT_MAX_CELL_WIDTH,
             ),
             exp_rtn=[
                 ['', '', '"VP1a"', '"VP2a"'],
@@ -382,7 +444,8 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
     (
         "Verify simple instance with one string all components overflow line1",
         dict(
-            args=([simple_instance(pvalue="A B C D")], 4),
+            args=([simple_instance(pvalue="A B C D")],
+                  4),
             kwargs={},
             exp_rtn=[
                 ['"A "\n"B "\n"C "\n"D"']],
@@ -392,7 +455,8 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
     (
         "Verify simple instance with one string all components overflow line2",
         dict(
-            args=([simple_instance(pvalue="ABCD")], 4),
+            args=([simple_instance(pvalue="ABCD")],
+                  4),
             kwargs={},
             exp_rtn=[
                 ['\n"AB"\n"CD"']],
@@ -402,7 +466,8 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
     (
         "Verify simple instance with one string overflows line",
         dict(
-            args=([simple_instance(pvalue="A B C D")], 8),
+            args=([simple_instance(pvalue="A B C D")],
+                  8),
             kwargs={},
             exp_rtn=[
                 ['"A B C "\n"D"']],
@@ -412,7 +477,8 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
     (
         "Verify simple instance withone unit32 max val",
         dict(
-            args=([simple_instance(pvalue=Uint32(4294967295))], 8),
+            args=([simple_instance(pvalue=Uint32(4294967295))],
+                  8),
             kwargs={},
             exp_rtn=[
                 ['4294967295']],
@@ -423,7 +489,8 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
     (
         "Verify simple instance with one string fits on line",
         dict(
-            args=([simple_instance(pvalue="A B C D")], 12),
+            args=([simple_instance(pvalue="A B C D")],
+                  12),
             kwargs={},
             exp_rtn=[
                 ['"A B C D"']],
@@ -433,7 +500,8 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
     (
         "Verify datetime property, folded",
         dict(
-            args=([simple_instance(pvalue=DATETIME1_OBJ)], 20),
+            args=([simple_instance(pvalue=DATETIME1_OBJ)],
+                  20),
             kwargs={},
             exp_rtn=[
                 ['\n"20140922104920.524"\n"789+000"']],
@@ -443,7 +511,8 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
     (
         "Verify datetime property not folded",
         dict(
-            args=([simple_instance(pvalue=DATETIME1_OBJ)], 30),
+            args=([simple_instance(pvalue=DATETIME1_OBJ)],
+                  30),
             kwargs={},
             exp_rtn=[
                 ['"20140922104920.524789+000"']],
@@ -453,7 +522,8 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
     (
         "Verify integer property where len too small",
         dict(
-            args=([simple_instance(pvalue=Uint32(999999))], 4),
+            args=([simple_instance(pvalue=Uint32(999999))],
+                  4),
             kwargs={},
             exp_rtn=[['999999']],
         ),
@@ -464,7 +534,8 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
         dict(
             args=([CIMInstance('P', [CIMProperty('P',
                                                  type='char16',
-                                                 value='f')])], 4),
+                                                 value='f')])],
+                  4),
             kwargs={},
             exp_rtn=[[u"'f'"]],
         ),
@@ -478,7 +549,8 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
                                      CIMProperty('Q', value=None,
                                                  type='uint32'),
                                      CIMProperty('R', value=None,
-                                                 type='string'), ])], 4),
+                                                 type='string'), ])],
+                  4),
             kwargs={},
             exp_rtn=[[u'', u'', u'']],
         ),
@@ -583,6 +655,67 @@ false  true   "2014092"      9999  -2147483648  "Test "   4294967295
         ),
         None, None, not CLICK_ISSUE_1590
     ),
+
+    (
+        "Verify print of simple array instance to table with col limit",
+        dict(
+            args=([simple_array_instance2()], 80, 'simple'),
+            kwargs={},
+            exp_stdout="""\
+Instances: CIM_Foo
+Pbf    Pbt    Pdt          Pint64      Psint32  Pstr1        Puint32
+-----  -----  ---------  --------  -----------  --------  ----------
+false  true   "2014092"      9999  -2147483648  "Test "   4294967295
+              "2104920"                         "String"
+              ".524789"
+              "+000"
+""",
+        ),
+        None, None, not CLICK_ISSUE_1590
+    ),
+
+    (
+        "Verify print of simple array instance21 to table with col limit",
+        dict(
+            args=([simple_array_instance21()], 220, 'simple'),
+            kwargs={},
+            exp_stdout="""\
+Instances: CIM_Foo
+Pbf           Pbt         Pdt                           Pint64      Psint32                   Pstr1                   Puint32
+------------  ----------  ----------------------------  ----------  ------------------------  ----------------------  ----------------------
+false, false  true, true  "20140922104920.524789+000",  9999, 9999  -2147483648, -2147483648  "Test String", "Test "  4294967295, 4294967295
+                          "20140922104920.524789+000"                                         "String"
+""",   # noqa: E501
+        ),
+        None, None, not CLICK_ISSUE_1590
+    ),
+
+    # The following test fails apparently in an issue in the capsys so marked
+    # fail until we sort out issu es when a second instance is added. Did same
+    # ctest above with very largeell size and another with single instance
+    # and that works.  TODO
+    (
+        "Verify print of simple array instance21 to table with col limit",
+        dict(
+            args=([simple_array_instance21()], 80, 'simple'),
+            kwargs={},
+            exp_stdout="""\
+Instances: CIM_Foo
+Pbf    Pbt    Pdt          Pint64      Psint32  Pstr1        Puint32
+-----  -----  ---------  --------  -----------  --------  ----------
+false  true   "2014092"      9999  -2147483648  "Test "   4294967295
+              "2104920"                         "String"
+              ".524789"
+              "+000"
+false  true   "2014092"      9999  -2147483648  "Test "   4294967295
+              "2104920"                         "String"
+              ".524789"
+              "+000"
+""",
+        ),
+        None, None, FAIL  # WAS not CLICK_ISSUE_1590
+    ),
+
     (
         "Verify print of instance with reference property",
         dict(
@@ -633,7 +766,6 @@ def test_display_instances_as_table(
     args = kwargs['args']
     kwargs_ = kwargs['kwargs']
     exp_stdout = kwargs['exp_stdout']
-
     # The code to be tested
     _display_instances_as_table(*args, **kwargs_)
 

--- a/tests/unit/pywbemcli/test_subscription_cmds.py
+++ b/tests/unit/pywbemcli/test_subscription_cmds.py
@@ -855,7 +855,7 @@ TEST_CASES = [
                 '-o mof subscription list-subscriptions',
                 '-o mof subscription list --names-only',
                 '-o mof subscription list-subscriptions --detail',
-                'subscription list-subscriptions --summary']},
+                '-o mof subscription list-subscriptions --summary']},
      {'stdout': ['Added owned destination: Name=pywbemdestination:defaultpywbemcliSubMgr:odest1',  # noqa: E501
                  'Added owned filter: Name=pywbemfilter:defaultpywbemcliSubMgr:ofilter1',  # noqa: E501
                  'Added owned subscription: DestinationName=pywbemdestination:defaultpywbemcliSubMgr:odest1, FilterName=pywbemfilter:defaultpywbemcliSubMgr:ofilter1',   # noqa: E501


### PR DESCRIPTION
Modify the CIM instance table output to conditionally output  information on properties where all instances have Null properties.

This adds option --detail option to instance enumerate, references, and associators.  When this option is not set properties that no value in any instance in the properties to be displayed are not presented in the output  table unless the --detail option is included.

This is part one of the prs to fix issue 1131. We will set the next pr to the issue.

Changes one parameter in _format_instances_as_rows from keyword to positional (max_cell_width) since this method should not really have power over this parameter, it is already set.

See commit for details.