### PR TITLE
Normalize formatting on the execute_cmd(lambda...) calls

### DIFF
--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -146,8 +146,8 @@ def class_enumerate(context, classname, **options):
 
       pywbemcli -n myconn class enumerate CIM_Foo -n interop
     """
-    context.execute_cmd(lambda: cmd_class_enumerate(context, classname,
-                                                    options))
+    context.execute_cmd(
+        lambda: cmd_class_enumerate(context, classname, options))
 
 
 @class_group.command('get', cls=PywbemtoolsCommand,
@@ -271,8 +271,8 @@ def class_invokemethod(context, classname, methodname, **options):
 
       pywbemcli -n myconn class invokemethod CIM_Foo methodx -p p1=9 -p p2=Fred
     """
-    context.execute_cmd(lambda: cmd_class_invokemethod(context, classname,
-                                                       methodname, options))
+    context.execute_cmd(
+        lambda: cmd_class_invokemethod(context, classname, methodname, options))
 
 
 @class_group.command('references', cls=PywbemtoolsCommand,
@@ -318,8 +318,8 @@ def class_references(context, classname, **options):
 
       pywbemcli -n myconn class references CIM_Foo -n interop
     """
-    context.execute_cmd(lambda: cmd_class_references(context, classname,
-                                                     options))
+    context.execute_cmd(
+        lambda: cmd_class_references(context, classname, options))
 
 
 @class_group.command('associators', cls=PywbemtoolsCommand,
@@ -372,8 +372,8 @@ def class_associators(context, classname, **options):
 
       pywbemcli -n myconn class associators CIM_Foo -n interop
     """
-    context.execute_cmd(lambda: cmd_class_associators(context, classname,
-                                                      options))
+    context.execute_cmd(
+        lambda: cmd_class_associators(context, classname, options))
 
 
 @class_group.command('find', cls=PywbemtoolsCommand,
@@ -415,8 +415,9 @@ def class_find(context, classname_glob, **options):
 
       pywbemcli -n myconn class find *Foo*
     """
-    context.execute_cmd(lambda: cmd_class_find(context, classname_glob,
-                                               options))
+
+    context.execute_cmd(
+        lambda: cmd_class_find(context, classname_glob, options))
 
 
 @class_group.command('tree', cls=PywbemtoolsCommand,

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -320,8 +320,8 @@ def connection_set_default(context, name, **options):
     connection to be set as the default connection interactively from all of
     the existing connection definitions.
     """
-    context.execute_cmd(lambda: cmd_connection_set_default(context, name,
-                                                           options))
+    # pylint: disable=line-too-long
+    context.execute_cmd(lambda: cmd_connection_set_default(context, name, options))  # noqa: E501
 
 
 ################################################################

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -225,8 +225,8 @@ def instance_enumerate(context, classname, **options):
     defined by the --output-format general option. Table formats on instances
     will be replaced with MOF format.
     """
-    context.execute_cmd(lambda: cmd_instance_enumerate(context, classname,
-                                                       options))
+    context.execute_cmd(
+        lambda: cmd_instance_enumerate(context, classname, options))
 
 
 @instance_group.command('get', cls=PywbemtoolsCommand,
@@ -260,8 +260,8 @@ def instance_get(context, instancename, **options):
         show_help_instancename()
         return
     validate_required_arg(instancename, 'INSTANCENAME')
-    context.execute_cmd(lambda: cmd_instance_get(context, instancename,
-                                                 options))
+    context.execute_cmd(
+        lambda: cmd_instance_get(context, instancename, options))
 
 
 @instance_group.command('delete', cls=PywbemtoolsCommand,
@@ -288,8 +288,8 @@ def instance_delete(context, instancename, **options):
         show_help_instancename()
         return
     validate_required_arg(instancename, 'INSTANCENAME')
-    context.execute_cmd(lambda: cmd_instance_delete(context, instancename,
-                                                    options))
+    context.execute_cmd(
+        lambda: cmd_instance_delete(context, instancename, options))
 
 
 @instance_group.command('create', cls=PywbemtoolsCommand,
@@ -321,8 +321,8 @@ def instance_create(context, classname, **options):
 
       pywbemcli instance create CIM_blah -P id=3 -P arr="bla bla",foo
     """
-    context.execute_cmd(lambda: cmd_instance_create(context, classname,
-                                                    options))
+    context.execute_cmd(
+        lambda: cmd_instance_create(context, classname, options))
 
 
 @instance_group.command('modify', cls=PywbemtoolsCommand,
@@ -368,8 +368,8 @@ def instance_modify(context, instancename, **options):
         show_help_instancename()
         return
     validate_required_arg(instancename, 'INSTANCENAME')
-    context.execute_cmd(lambda: cmd_instance_modify(context, instancename,
-                                                    options))
+    context.execute_cmd(
+        lambda: cmd_instance_modify(context, instancename, options))
 
 
 @instance_group.command('associators', cls=PywbemtoolsCommand,
@@ -429,8 +429,8 @@ def instance_associators(context, instancename, **options):
         show_help_instancename()
         return
     validate_required_arg(instancename, 'INSTANCENAME')
-    context.execute_cmd(lambda: cmd_instance_associators(context, instancename,
-                                                         options))
+    context.execute_cmd(
+        lambda: cmd_instance_associators(context, instancename, options))
 
 
 @instance_group.command('references', cls=PywbemtoolsCommand,
@@ -482,8 +482,8 @@ def instance_references(context, instancename, **options):
         show_help_instancename()
         return
     validate_required_arg(instancename, 'INSTANCENAME')
-    context.execute_cmd(lambda: cmd_instance_references(context, instancename,
-                                                        options))
+    # pylint: disable=line-too-long
+    context.execute_cmd(lambda: cmd_instance_references(context, instancename, options))  # noqa: E501
 
 
 @instance_group.command('invokemethod', cls=PywbemtoolsCommand,
@@ -533,10 +533,8 @@ def instance_invokemethod(context, instancename, methodname, **options):
         return
     validate_required_arg(instancename, 'INSTANCENAME')
     validate_required_arg(methodname, 'METHODNAME')
-    context.execute_cmd(lambda: cmd_instance_invokemethod(context,
-                                                          instancename,
-                                                          methodname,
-                                                          options))
+    # pylint: disable=line-too-long
+    context.execute_cmd(lambda: cmd_instance_invokemethod(context, instancename, methodname, options))  # noqa: E501
 
 
 @instance_group.command('query', cls=PywbemtoolsCommand,
@@ -681,8 +679,8 @@ def instance_shrub(context, instancename, **options):
         show_help_instancename()
         return
     validate_required_arg(instancename, 'INSTANCENAME')
-    context.execute_cmd(lambda: cmd_instance_shrub(context, instancename,
-                                                   options))
+    # pylint: disable=line-too-long
+    context.execute_cmd(lambda: cmd_instance_shrub(context, instancename, options))  # noqa: E501
 
 
 ####################################################################

--- a/pywbemtools/pywbemcli/_cmd_qualifier.py
+++ b/pywbemtools/pywbemcli/_cmd_qualifier.py
@@ -77,8 +77,8 @@ def qualifier_get(context, qualifiername, **options):
     In the output, the qualifier declaration will formatted as defined by the
     --output-format general option.
     """
-    context.execute_cmd(lambda: cmd_qualifier_get(context, qualifiername,
-                                                  options))
+    context.execute_cmd(
+        lambda: cmd_qualifier_get(context, qualifiername, options))
 
 
 @qualifier_group.command('delete', cls=PywbemtoolsCommand,
@@ -103,8 +103,8 @@ def qualifier_delete(context, qualifiername, **options):
     In the output, the qualifier declaration will formatted as defined by the
     --output-format general option.
     """
-    context.execute_cmd(lambda: cmd_qualifier_delete(
-        context, qualifiername, options))
+    context.execute_cmd(
+        lambda: cmd_qualifier_delete(context, qualifiername, options))
 
 
 @qualifier_group.command('enumerate', cls=PywbemtoolsCommand,

--- a/pywbemtools/pywbemcli/_cmd_subscription.py
+++ b/pywbemtools/pywbemcli/_cmd_subscription.py
@@ -199,8 +199,8 @@ def subscription_add_destination(context, identity, **options):
 
     If the --verbose general option is set, the created instance is displayed.
     """
-    context.execute_cmd(lambda: cmd_subscription_add_destination(
-        context, identity, options))
+    context.execute_cmd(
+        lambda: cmd_subscription_add_destination(context, identity, options))
 
 
 @subscription_group.command('add-filter', cls=PywbemtoolsCommand,
@@ -262,8 +262,8 @@ def subscription_add_filter(context, identity, **options):
 
     If the --verbose general option is set, the created instance is displayed.
     """
-    context.execute_cmd(lambda: cmd_subscription_add_filter(
-        context, identity, options))
+    context.execute_cmd(
+        lambda: cmd_subscription_add_filter(context, identity, options))
 
 
 @subscription_group.command('add-subscription', cls=PywbemtoolsCommand,
@@ -327,8 +327,9 @@ def subscription_add_subscription(context, destination_identity,
 
     If the --verbose general option is set, the created instance is displayed.
     """
-    context.execute_cmd(lambda: cmd_subscription_add_subscription(
-        context, destination_identity, filter_identity, options))
+    # pylint: disable=line-too-long
+    context.execute_cmd(
+        lambda: cmd_subscription_add_subscription(context, destination_identity, filter_identity, options))  # noqa: E501
 
 
 @subscription_group.command('list', cls=PywbemtoolsCommand,
@@ -372,8 +373,8 @@ def subscription_list_destinations(context, **options):
     options and can be displayed as either a table or CIM objects (ex. mof)
     format using the --output general option (ex. --output mof).
     """
-    context.execute_cmd(lambda: cmd_subscription_list_destinations(context,
-                                                                   options))
+    context.execute_cmd(
+        lambda: cmd_subscription_list_destinations(context, options))
 
 
 @subscription_group.command('list-filters', cls=PywbemtoolsCommand,
@@ -424,8 +425,8 @@ def subscription_list_subscriptions(context, **options):
     format using the --output general option (ex. --output mof).
 
     """
-    context.execute_cmd(lambda: cmd_subscription_list_subscriptions(
-        context, options))
+    context.execute_cmd(
+        lambda: cmd_subscription_list_subscriptions(context, options))
 
 
 @subscription_group.command('remove-destination', cls=PywbemtoolsCommand,
@@ -467,8 +468,8 @@ def subscription_remove_destination(context, identity, **options):
     and terminates the
     command.
     """
-    context.execute_cmd(lambda: cmd_subscription_remove_destination(
-        context, identity, options))
+    context.execute_cmd(
+        lambda: cmd_subscription_remove_destination(context, identity, options))
 
 
 @subscription_group.command('remove-filter', cls=PywbemtoolsCommand,
@@ -505,8 +506,8 @@ def subscription_remove_filter(context, identity, **options):
     used pywbemcli displays the paths of the instances and terminates the
     command.
     """
-    context.execute_cmd(lambda: cmd_subscription_remove_filter(
-        context, identity, options))
+    context.execute_cmd(
+        lambda: cmd_subscription_remove_filter(context, identity, options))
 
 
 @subscription_group.command('remove-subscription', cls=PywbemtoolsCommand,
@@ -559,8 +560,9 @@ def subscription_remove_subscription(context, destination_identity,
     unless the option --remove-associated-instances is included in the command
     and the associated instances are not used in any other association.
     """
-    context.execute_cmd(lambda: cmd_subscription_remove_subscription(
-        context, destination_identity, filter_identity, options))
+    context.execute_cmd(
+        # pylint: disable=line-too-long
+        lambda: cmd_subscription_remove_subscription(context, destination_identity, filter_identity, options))  # noqa: E501
 
 
 @subscription_group.command('remove-server', cls=PywbemtoolsCommand,
@@ -575,8 +577,8 @@ def subscription_remove_server(context, **options):
     all owned indication subscriptions, owned indication filters, and owned
     listener destinations for this server-id from the WBEM server.
     """
-    context.execute_cmd(lambda: cmd_subscription_remove_server(context,
-                                                               options))
+    context.execute_cmd(
+        lambda: cmd_subscription_remove_server(context, options))
 
 
 #####################################################################


### PR DESCRIPTION
Normalized the formatting of the execite_cmd(lambda...) calls that are part of each command definition  just to reduce slightly the
number of debug steps to get through these calls.  With multiline calls
there was always an extra step cmd to handle the multiline calls. This
reduces everything to just one step cmd.

I just got tired of hitting the extra step cmd in debuging