### PR TITLE
Remove deprecated option --force in class delete

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,11 @@ Released: not yet
   to be compatible with other commands that touch the default connection
   definition.
 
+* Removed the deprecated option ``--force`` from the ``class delete`` command.
+  It had been marked deprecated in pywbemtools version 0.9.0 and was superseded
+  by the ``--include-instances`` option which performs exactly the same function.
+  (see issue # 1142)
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -187,6 +192,11 @@ Released: not yet
   minimum-constraints.txt. (see issue #1076)
 
 * Add instance count tests to end-end testing against OpenPegasus.
+
+* Removed the deprecated option ``--force`` from the ``class delete`` command.
+  It had been created in pywbemtools version 0.8.0 and was deprecated in
+  version 0.90 in favor of the ``--include-instances`` option which performs
+  exactly the same function. (see issue # 1142)
 
 **Known issues:**
 

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -295,9 +295,6 @@ Help text for ``pywbemcli class delete`` (see :ref:`class delete command`):
         pywbemcli -n myconn class delete CIM_Foo -n interop
 
     Command Options:
-      -f, --force                Same as --include-instances. The -f / --force option has been deprecated and will be
-                                 removed in a future version.
-
       --include-instances        Delete any instances of the class as well. WARNING: Deletion of instances will cause the
                                  removal of corresponding resources in the managed environment (i.e. in the real
                                  world).Default: Reject command if the class has any instances.

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -256,8 +256,9 @@ in the default namespace of the connection.
 
 If the class has subclasses, the command is rejected.
 
-If the class has instances, the command is rejected, unless the ``--force``
-command option was specified, in which case the instances are also deleted.
+If the class has instances, the command is rejected, unless the
+``--include-instances`` command option was specified, in which case the
+instances are also deleted.
 
 WARNING: Deleting classes can cause damage to the server: It can impact
 instance providers and other components in the server. Use this command with

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -44,7 +44,6 @@ from ._common_options import propertylist_option, names_only_option, \
 from ._displaytree import display_class_tree
 from .._click_extensions import PywbemtoolsGroup, PywbemtoolsCommand, \
     CMD_OPTS_TXT, GENERAL_OPTS_TXT, SUBCMD_HELP_TXT
-from .._utils import pywbemtools_warn
 from .._options import add_options, help_option
 from .._output_formatting import output_format_is_table, \
     validate_output_format, format_table, warning_msg
@@ -186,9 +185,6 @@ def class_get(context, classname, **options):
 @class_group.command('delete', cls=PywbemtoolsCommand,
                      options_metavar=CMD_OPTS_TXT)
 @click.argument('classname', type=str, metavar='CLASSNAME', required=True,)
-@click.option('-f', '--force', is_flag=True, default=False,
-              help=u'Same as --include-instances. The -f / --force option has '
-                   'been deprecated and will be removed in a future version.')
 @click.option('--include-instances', is_flag=True, default=False,
               help=u'Delete any instances of the class as well. '
                    'WARNING: Deletion of instances will cause the removal '
@@ -1187,12 +1183,6 @@ def cmd_class_delete(context, classname, options):
     conn = context.pywbem_server.conn
 
     include_instances = options['include_instances']
-    if options['force']:
-        include_instances = options['force']
-        pywbemtools_warn(
-            "The --force / -f option has been deprecated and will be removed "
-            "in a future version. Use --include-instances instead.",
-            DeprecationWarning)
     dry_run = options['dry_run']
     dry_run_prefix = "Dry run: " if dry_run else ""
 

--- a/tests/unit/pywbemcli/test_class_cmds.py
+++ b/tests/unit/pywbemcli/test_class_cmds.py
@@ -109,7 +109,6 @@ CLASS_DELETE_HELP_LINES = [
     'Usage: pywbemcli [GENERAL-OPTIONS] class delete CLASSNAME '
     '[COMMAND-OPTIONS]',
     'Delete a class.',
-    '-f, --force Same as --include-instances.',
     '--include-instances Delete any instances of the class as well.',
     CMD_OPTION_NAMESPACE_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
@@ -1656,25 +1655,6 @@ TEST_CASES = [
      {'stdout': CLASS_DELETE_HELP_LINES,
       'test': 'innows'},
      None, OK],
-
-    # Class delete successful
-    ['Verify class command delete successful with no subclasses, '
-     '--force (deprecated)',
-     {'args': ['delete', 'CIM_Foo_sub_sub', '--force'],
-      'general': ['--warn']},
-     {'stderr': ['DeprecationWarning: The --force / -f option has been '
-                 'deprecated'],
-      'test': 'in'},
-     SIMPLE_MOCK_FILE, OK],
-
-    ['Verify class command delete successful with no subclasses, '
-     '-f (deprecated)',
-     {'args': ['delete', 'CIM_Foo_sub_sub', '-f'],
-      'general': ['--warn']},
-     {'stderr': ['DeprecationWarning: The --force / -f option has been '
-                 'deprecated'],
-      'test': 'in'},
-     SIMPLE_MOCK_FILE, OK],
 
     ['Verify class command delete successful with no subclasses, '
      '--include-instances',


### PR DESCRIPTION
Removed an option that was marked deprecated in pywbemtools 0.9.

This removes the option in the command definition, removes the use of
the option, removes 2 tests for the option, and updates changes.rst
to show the change and note this change in the deprecated list.