### PR TITLE
Fix issue where tests fail if keys not sorted

### DIFF
--- a/pywbemtools/pywbemcli/_display_cimobjects.py
+++ b/pywbemtools/pywbemcli/_display_cimobjects.py
@@ -362,8 +362,9 @@ def _display_paths_as_table(objects, table_width, table_format):
             for key_names, inst_names in objs_by_key_set.items():
                 # Build headers for this table with the common elements and key
                 # names for each key in the object. We use inst_names[0] to
-                # restore original case to key strings.
-                inst_keys = original_keys[key_names]
+                # restore original case to key strings. We sort keys for
+                # consistent table output.
+                inst_keys = sorted(original_keys[key_names])
 
                 rows = []
                 for instname in inst_names:

--- a/tests/unit/pywbemcli/test_display_cimobjects.py
+++ b/tests/unit/pywbemcli/test_display_cimobjects.py
@@ -42,7 +42,7 @@ from pywbemtools._output_formatting import DEFAULT_MAX_CELL_WIDTH
 
 from ..pytest_extensions import simplified_test_function
 
-OK = False    # mark tests OK when they execute correctly
+OK = True    # mark tests OK when they execute correctly
 RUN = True    # Mark OK = False and current test case being created RUN
 FAIL = False  # Any test currently FAILING or not tested yet
 SKIP = False  # mark tests that are to be skipped.
@@ -459,7 +459,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
                   4),
             kwargs={},
             exp_rtn=[
-                ['\n"AB"\n"CD"']],
+                ['"AB"\n"CD"']],
         ),
         None, None, OK),
 
@@ -504,7 +504,7 @@ TESTCASES_FORMAT_INSTANCES_AS_ROWS = [
                   20),
             kwargs={},
             exp_rtn=[
-                ['\n"20140922104920.524"\n"789+000"']],
+                ['"20140922104920.524"\n"789+000"']],
         ),
         None, None, OK),
 

--- a/tests/unit/pywbemcli/test_instance_cmds.py
+++ b/tests/unit/pywbemcli/test_instance_cmds.py
@@ -957,17 +957,17 @@ TEST_CASES = [
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify command enumerate with ssociation class inst name table output',
+    ['Verify command enumerate with association class inst name table output',
      {'args': ['enumerate', 'TST_A3', '--names-only'],
       'general': ['--output-format', 'table']},
      {'stdout': """InstanceNames: TST_A3
 +--------+-------------+---------+---------------------------------+---------------------------------+---------------------------------+
 | host   | namespace   | class   | key=                            | key=                            | key=                            |
-|        |             |         | Initiator                       | Target                          | LogicalUnit                     |
+|        |             |         | Initiator                       | LogicalUnit                     | Target                          |
 |--------+-------------+---------+---------------------------------+---------------------------------+---------------------------------|
-|        | root/cimv2  | TST_A3  | /root/cimv2:TST_EP.InstanceID=1 | /root/cimv2:TST_EP.InstanceID=2 | /root/cimv2:TST_LD.InstanceID=3 |
-|        | root/cimv2  | TST_A3  | /root/cimv2:TST_EP.InstanceID=1 | /root/cimv2:TST_EP.InstanceID=5 | /root/cimv2:TST_LD.InstanceID=6 |
-|        | root/cimv2  | TST_A3  | /root/cimv2:TST_EP.InstanceID=1 | /root/cimv2:TST_EP.InstanceID=7 | /root/cimv2:TST_LD.InstanceID=8 |
+|        | root/cimv2  | TST_A3  | /root/cimv2:TST_EP.InstanceID=1 | /root/cimv2:TST_LD.InstanceID=3 | /root/cimv2:TST_EP.InstanceID=2 |
+|        | root/cimv2  | TST_A3  | /root/cimv2:TST_EP.InstanceID=1 | /root/cimv2:TST_LD.InstanceID=6 | /root/cimv2:TST_EP.InstanceID=5 |
+|        | root/cimv2  | TST_A3  | /root/cimv2:TST_EP.InstanceID=1 | /root/cimv2:TST_LD.InstanceID=8 | /root/cimv2:TST_EP.InstanceID=7 |
 +--------+-------------+---------+---------------------------------+---------------------------------+---------------------------------+
 """,  # noqa: E501
       'rc': 0,

--- a/tests/unit/pywbemcli/test_subscription_cmds.py
+++ b/tests/unit/pywbemcli/test_subscription_cmds.py
@@ -785,8 +785,7 @@ TEST_CASES = [
                  '   Protocol = 2;',
                  # Result -o plain subscription list-destinations --names-only
                  'host    namespace    class   key=  key=  key=',
-                 'interop  CIM_ListenerDestinationCIMXML  CIM_ComputerSystem '
-                 'MockSystem_WBEMServerTest  CIM_ListenerDestinationCIMXML',
+                 'interop CIM_ListenerDestinationCIMXML  CIM_ListenerDestinationCIMXML  pywbemdestination:defaultpywbemcliSubMgr:odest1  CIM_ComputerSystem   MockSystem_WBEMServerTest',   # noqa: E501
                  # Result list
                  '1 CIMInstance(s) returned',
                  '};'],
@@ -836,7 +835,7 @@ TEST_CASES = [
                  '1 CIMInstance(s) returned',
                  # Result from -o plain subscription list-filters --names-only
                  'host  namespace  class key=  key=  key=  key=',
-                 'interop      CIM_IndicationFilter  CIM_ComputerSystem         MockSystem_WBEMServerTest  CIM_IndicationFilter  pywbemfilter:defaultpywbemcliSubMgr:ofilter1', ],  # noqa: E501
+                 'interop   CIM_IndicationFilter  CIM_IndicationFilter  pywbemfilter:defaultpywbemcliSubMgr:ofilter1  CIM_ComputerSystem  MockSystem_WBEMServerTest', ],  # noqa: E501
       'stderr': [],
       'test': 'innows'},
      None, OK],
@@ -868,7 +867,8 @@ TEST_CASES = [
                  '   Filter =',
                  'interop:CIM_IndicationFilter.CreationClassName=', 'CIM_IndicationFilter',  # noqa: E501
                  'pywbemfilter:defaultpywbemcliSubMgr:ofilter1',
-                 'SystemCreationClassName=', 'CIM_ComputerSystem', 'SystemName=', 'MockSystem_WBEMServerTest',  # noqa: E501
+                 'SystemCreationClassName=', 'CIM_ComputerSystem', 'SystemName=',  # noqa: E501
+                 'MockSystem_WBEMServerTest',
                  ' Handler =',
                  '  OnFatalErrorPolicy = 2;',
                  '   RepeatNotificationPolicy = 2;',


### PR DESCRIPTION
In order to create consistent table output for test of instances names
as table, the keys must be sorted.  Otherwise the column orders are not
consistent across different test targets, etc.  This simply sorts the
CIMInstanceName keys before the headers and rows are created for the
table.

Add tests for the changes where it caused test failures

Fixed test issue whee we were not completing all tests in one unit test.

Marked this one for 1.0.0 since it fixes the problem caused with PR #``44 that shows up in the release PR #1139

Since the changes that caused the issue were part of the work for version 1.0.0 I did not create a separate issue for this fix.