### PR TITLE
Increased Click to >=8.0.1 on py36+

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -45,9 +45,10 @@ safety>=1.9.0; python_version >= '3.5'
 dparse>=0.4.1,<0.5.0; python_version == '2.7'
 dparse>=0.5.1; python_version >= '3.5'
 # Safety requires Click>6.0 and the upgrade strategy 'eager' causes Click to be
-# upgraded to 8.0.0, unless we repeat the Click requirements from requirements.txt.
-Click>=7.1.1,<8.0; python_version == '2.7'
-Click>=7.1.1,<8.0; python_version >= '3.5'
+# upgraded to 8.0.0, unless we repeat the Click requirements from
+# requirements.txt. Keep them in sync.
+Click>=7.1.1,<8.0; python_version <= '3.5'
+Click>=8.0.1; python_version >= '3.6'
 
 # PyYAML is also pulled in by dparse and python-coveralls
 # PyYAML 5.3 fixed narrow build error on Python 2.7

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,9 @@ Released: not yet
 
 **Enhancements:**
 
+* Increased minimum version of Click to 8.0.1 on Python >= 3.6 to prepare for
+  new features. Adjusted testcases accordingly.
+
 **Cleanup:**
 
 * Extend use of general options in interactive mode to allow setting the

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -33,8 +33,8 @@ Help text for ``pywbemcli``:
       * Maintain a persistent list of named connections to WBEM servers
         and execute operations on them by name.
 
-      Pywbemcli implements command groups and commands to execute the CIM-XML operations defined by the DMTF CIM
-      Operations Over HTTP specification (DSP0200).
+      Pywbemcli implements command groups and commands to execute the CIM-XML operations defined by the DMTF CIM Operations
+      Over HTTP specification (DSP0200).
 
       The general options shown below can also be specified on any of the commands, positioned right after the 'pywbemcli'
       command name.
@@ -49,97 +49,80 @@ Help text for ``pywbemcli``:
       -n, --name NAME                 Use the WBEM server defined by the WBEM connection definition NAME. This option is
                                       mutually exclusive with the --server and --mock-server options, since each defines a
                                       WBEM server. Default: EnvVar PYWBEMCLI_NAME, or none.
-
       -m, --mock-server FILE          Use a mock WBEM server that is automatically created in pywbemcli and populated with
                                       CIM objects that are defined in the specified MOF file or Python script file. The
                                       files may be specified with relative or absolute path.See the pywbemcli documentation
                                       for more information. This option may be specified multiple times, and is mutually
                                       exclusive with the --server and --name options, since each defines a WBEM server.
                                       Default: EnvVar PYWBEMCLI_MOCK_SERVER, or none.
-
       -s, --server URL                Use the WBEM server at the specified URL with format: [SCHEME://]HOST[:PORT]. SCHEME
                                       must be "https" (default) or "http". HOST is a short or long hostname or literal
                                       IPV4/v6 address. PORT defaults to 5989 for https and 5988 for http. This option is
                                       mutually exclusive with the --mock-server and --name options, since each defines a
                                       WBEM server. Default: EnvVar PYWBEMCLI_SERVER, or none.
-
       -u, --user TEXT                 User name for the WBEM server.  Use "" to set default in interactive mode.Default:
                                       EnvVar PYWBEMCLI_USER, or none.
-
       -p, --password TEXT             Password for the WBEM server. Default: EnvVar PYWBEMCLI_PASSWORD, or prompted for if
                                       --user specified. Use "" to set default in interactive mode.
-
       --verify / --no-verify          If --verify, client verifies the X.509 server certificate presented by the WBEM server
                                       during TLS/SSL handshake. If --no-verify client bypasses verification. Default: EnvVar
                                       PYWBEMCLI_VERIFY, or "--verify".
-
       --ca-certs CACERTS              Certificates used to validate the certificate presented by the WBEM server during
                                       TLS/SSL handshake: FILE: Use the certs in the specified PEM file; DIR: Use the certs
                                       in the PEM files in the specified directory; "certifi" (pywbem 1.0 or later): Use the
                                       certs provided by the certifi Python package; Default: EnvVar PYWBEMCLI_CA_CERTS, or
                                       "certifi" (pywbem 1.0 or later), or the certs in the PEM files in the first existing
                                       directory from from a system defined list of directories (pywbem before 1.0).
-
       -c, --certfile FILE             Path name of a PEM file containing a X.509 client certificate that is used to enable
                                       TLS/SSL 2-way authentication by presenting the certificate to the WBEM server during
                                       TLS/SSL handshake.  Use "" to set default in interactive mode. Default: EnvVar
                                       PYWBEMCLI_CERTFILE, or none.
-
       -k, --keyfile FILE              Path name of a PEM file containing a X.509 private key that belongs to the certificate
                                       in the --certfile file. Not required if the private key is part of the --certfile
                                       file. Use "" to set default in interactive mode.Default: EnvVar PYWBEMCLI_KEYFILE, or
                                       none.
-
-      -t, --timeout INT               Client-side timeout in seconds for operations with the WBEM server. Default: EnvVar
-                                      PYWBEMCLI_TIMEOUT, or 30.
-
+      -t, --timeout INT               Client-side timeout (seconds) on data read for operations with the WBEM server. This
+                                      integer is the timeout for a single server request. Pywbem retries reads 2 times so
+                                      the delay for read timeout failure may be multiple times the timeout value.Default:
+                                      EnvVar PYWBEMCLI_TIMEOUT, or 30. Min/max:   [0<=x<=300]
       -U, --use-pull [yes|no|either]  Determines whether pull operations are used for operations with the WBEM server that
                                       return lists of instances, as follows: "yes" uses pull operations and fails if not
                                       supported by the server; "no" uses traditional operations; "either" (default) uses
                                       pull operations if supported by the server, and otherwise traditional operations.
                                       Default: EnvVar PYWBEMCLI_USE_PULL, or "either".
-
       --pull-max-cnt INT              Maximum number of instances to be returned by the WBEM server in each open or pull
                                       response, if pull operations are used. This is a tuning parameter that does not affect
                                       the external behavior of the commands. Default: EnvVar PYWBEMCLI_PULL_MAX_CNT, or 1000
-
       -T, --timestats / --no-timestats
                                       Display operation time statistics gathered by pywbemcli after each command. Otherwise
                                       statistics can be displayed with "statistics show" command. Default: EnvVar
                                       PYWBEMCLI_TIMESTATS, or no-timestats.
-
       -d, --default-namespace NAMESPACE
                                       Default namespace, to be used when commands do not specify the --namespace command
                                       option. Use "" to set default in interactive mode. Default: EnvVar
                                       PYWBEMCLI_DEFAULT_NAMESPACE, or root/cimv2.
-
       -o, --output-format FORMAT      Output format for the command result. The default and allowed output formats are
                                       command specific. The default output_format is None so that each command selects its
                                       own default format. Use "" to set default in interactive mode. FORMAT is: table
                                       formats: [table|plain|simple|grid|psql|rst|html]; CIM object formats:
                                       [mof|xml|repr|txt]]; TEXT formats: [text].
-
       -l, --log COMP[=DEST[:DETAIL]],...
                                       Enable logging of WBEM operations, defined by a list of log configuration strings
                                       with: COMP: [api|http|all]; DEST: [file|stderr|off], default: file; DETAIL:
                                       [all|paths|summary], default: all. "all=off" disables all logging. "all" is max
                                       logging. EnvVar: PYWBEMCLI_LOG. Default: no logging
-
       -v, --verbose / --no-verbose    Display extra information about the processing.
       --warn / --no-warn              Warnings control: True enables display of all Python warnings; False leaves warning
                                       control to the PYHONWARNINGS env var, which by default displays no warnings. Default:
                                       False.
-
       -C, --connections-file FILE PATH
                                       Path name of the connections file to be used. Default: EnvVar
                                       PYWBEMCLI_CONNECTIONS_FILE, or ".pywbemcli_connections.yaml" in the user's home
                                       directory (as determined using Python's os.path.expanduser("~"). See there for
                                       details, particularly for Windows). Use "" to set default in interactive mode.
-
       --pdb                           Pause execution in the built-in pdb debugger just before executing the command within
                                       pywbemcli. Ignored in interactive mode, but can be specified on each interactive
                                       command. Default: EnvVar PYWBEMCLI_PDB, or false.
-
       --version                       Show the version of this command and the pywbem package.
       -h, --help                      Show this help message.
 
@@ -177,8 +160,8 @@ Help text for ``pywbemcli class`` (see :ref:`class command group`):
 
       Creation and modification of classes is not currently supported.
 
-      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help')
-      can also be specified before the 'class' keyword.
+      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help') can
+      also be specified before the 'class' keyword.
 
     Command Options:
       -h, --help  Show this help message.
@@ -210,8 +193,8 @@ Help text for ``pywbemcli class associators`` (see :ref:`class associators comma
 
       List the classes associated with a class.
 
-      List the CIM classes that are associated with the specified class (CLASSNAME argument) in the specified CIM
-      namespace (--namespace option). If no namespace was specified, the default namespace of the connection is used.
+      List the CIM classes that are associated with the specified class (CLASSNAME argument) in the specified CIM namespace
+      (--namespace option). If no namespace was specified, the default namespace of the connection is used.
 
       The classes to be retrieved can be filtered by the --role, --result-role, --assoc-class, and --result-class options.
 
@@ -230,26 +213,21 @@ Help text for ``pywbemcli class associators`` (see :ref:`class associators comma
     Command Options:
       --ac, --assoc-class CLASSNAME   Filter the result set by association class name. Subclasses of the specified class
                                       also match.
-
       --rc, --result-class CLASSNAME  Filter the result set by result class name. Subclasses of the specified class also
                                       match.
-
       -r, --role PROPERTYNAME         Filter the result set by source end role name.
       --rr, --result-role PROPERTYNAME
                                       Filter the result set by far end role name.
       --nq, --no-qualifiers           Do not include qualifiers in the returned class(es). Default: Include qualifiers.
       --ico, --include-classorigin    Include class origin information in the returned class(es). Default: Do not include
                                       class origin information.
-
       --pl, --propertylist PROPERTYLIST
                                       Filter the properties included in the returned object(s). Multiple properties may be
                                       specified with either a comma-separated list or by using the option multiple times.
                                       Properties specified in this option that are not in the object(s) will be ignored. The
                                       empty string will include no properties. Default: Do not filter properties.
-
       --no, --names-only              Retrieve only the object paths (names). Default: Retrieve the complete objects
                                       including object paths.
-
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       -s, --summary                   Show only a summary (count) of the objects.
       -h, --help                      Show this help message.
@@ -274,21 +252,20 @@ Help text for ``pywbemcli class delete`` (see :ref:`class delete command`):
       Delete a CIM class (CLASSNAME argument) in a CIM namespace (--namespace option). If no namespace was specified, the
       default namespace of the connection is used.
 
-      If the class has instances, the command is rejected, unless the --include-instances option is specified, in which
-      case the instances are also deleted.
+      If the class has instances, the command is rejected, unless the --include-instances option is specified, in which case
+      the instances are also deleted.
 
-      If other classes in that namespace depend on the class to be deleted, the command is rejected. Dependencies
-      considered for this purpose are subclasses, referencing classes and embedding classes (EmbeddedInstance qualifier
-      only).
+      If other classes in that namespace depend on the class to be deleted, the command is rejected. Dependencies considered
+      for this purpose are subclasses, referencing classes and embedding classes (EmbeddedInstance qualifier only).
 
       WARNING: Deletion of instances will cause the removal of corresponding resources in the managed environment (i.e. in
       the real world). Some instances may not be deletable.
 
-      WARNING: Deleting classes can cause damage to the server: It can impact instance providers and other components in
-      the server. Use this command with caution.
+      WARNING: Deleting classes can cause damage to the server: It can impact instance providers and other components in the
+      server. Use this command with caution.
 
-      Many WBEM servers may not allow this operation or may severely limit the conditions under which a class can be
-      deleted from the server.
+      Many WBEM servers may not allow this operation or may severely limit the conditions under which a class can be deleted
+      from the server.
 
       Example:
 
@@ -298,7 +275,6 @@ Help text for ``pywbemcli class delete`` (see :ref:`class delete command`):
       --include-instances        Delete any instances of the class as well. WARNING: Deletion of instances will cause the
                                  removal of corresponding resources in the managed environment (i.e. in the real
                                  world).Default: Reject command if the class has any instances.
-
       --dry-run                  Enable dry-run mode: Do not actually delete the objects, but display what would be done.
       -n, --namespace NAMESPACE  Namespace to use for this command, instead of the default namespace of the connection.
       -h, --help                 Show this help message.
@@ -321,8 +297,8 @@ Help text for ``pywbemcli class enumerate`` (see :ref:`class enumerate command`)
       List top classes or subclasses of a class in a namespace.
 
       Enumerate CIM classes starting either at the top of the class hierarchy in the specified CIM namespace (--namespace
-      option), or at the specified class (CLASSNAME argument) in the specified namespace. If no namespace was specified,
-      the default namespace of the connection is used.
+      option), or at the specified class (CLASSNAME argument) in the specified namespace. If no namespace was specified, the
+      default namespace of the connection is used.
 
       The --local-only, --include-classorigin, and --no-qualifiers options determine which parts are included in each
       retrieved class.
@@ -343,47 +319,36 @@ Help text for ``pywbemcli class enumerate`` (see :ref:`class enumerate command`)
     Command Options:
       --di, --deep-inheritance        Include the complete subclass hierarchy of the requested classes in the result set.
                                       Default: Do not include subclasses.
-
       --lo, --local-only              Do not include superclass properties and methods in the returned class(es). Default:
                                       Include superclass properties and methods.
-
       --nq, --no-qualifiers           Do not include qualifiers in the returned class(es). Default: Include qualifiers.
       --ico, --include-classorigin    Include class origin information in the returned class(es). Default: Do not include
                                       class origin information.
-
       --no, --names-only              Retrieve only the object paths (names). Default: Retrieve the complete objects
                                       including object paths.
-
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       -s, --summary                   Show only a summary (count) of the objects.
       --association / --no-association
                                       Filter the returned classes to return only indication classes (--association) or
                                       classes that are not associations(--no-association). If the option is not defined no
                                       filtering occurs
-
       --indication / --no-indication  Filter the returned classes to return only indication classes (--indication) or
                                       classes that are not indications (--no-indication). If the option is not defined no
                                       filtering occurs
-
       --experimental / --no-experimental
                                       Filter the returned classes to return only experimental classes (--experimental) or
                                       classes that are not experimental (--no-iexperimental). If the option is not defined
                                       no filtering occurs
-
       --deprecated / --no-deprecated  Filter the returned classes to return only deprecated classes (--deprecated) or
                                       classes that are not deprecated (--no-deprecated). If the option is not defined no
                                       filtering occurs
-
       --since VERSION                 Filter the returned classes to return only classes  with a version qualifier ge the
                                       supplied string. The string must define a version of the form M.N.V consistent the
                                       definitions of the VERSION qualifier.
-
       --schema SCHEMA                 Filter the returned classes to return only classes where the classname scheme
                                       component (characters before the "_" match the scheme provided.
-
       --subclass-of CLASSNAME         Filter the returned classes to return only classes that are a subclass of the option
                                       value.
-
       --leaf-classes                  Filter the returned classes to return only leaf (classes; classes with no subclass.
       -h, --help                      Show this help message.
 
@@ -408,9 +373,9 @@ Help text for ``pywbemcli class find`` (see :ref:`class find command`):
       namespaces of the WBEM server, or in the specified namespace (--namespace option).
 
       The CLASSNAME-GLOB argument is a wildcard expression that is matched on class names case insensitively. The special
-      characters from Unix file name wildcarding are supported ('*' to match zero or more characters, '?' to match a
-      single character, and '[]' to match character ranges). To avoid shell expansion of wildcard characters, the
-      CLASSNAME-GLOB argument should be put in quotes.
+      characters from Unix file name wildcarding are supported ('*' to match zero or more characters, '?' to match a single
+      character, and '[]' to match character ranges). To avoid shell expansion of wildcard characters, the CLASSNAME-GLOB
+      argument should be put in quotes.
 
       For example, "pywbem_*" returns classes whose name begins with "PyWBEM_", "pywbem_", etc. "*system*" returns classes
       whose names include the case insensitive string "system".
@@ -427,36 +392,28 @@ Help text for ``pywbemcli class find`` (see :ref:`class find command`):
     Command Options:
       -n, --namespace NAMESPACE       Add a namespace to the search scope. May be specified multiple times. Default: Search
                                       in all namespaces of the server.
-
       -s, --sort                      Sort by namespace. Default is to sort by classname
       --association / --no-association
                                       Filter the returned classes to return only indication classes (--association) or
                                       classes that are not associations(--no-association). If the option is not defined no
                                       filtering occurs
-
       --indication / --no-indication  Filter the returned classes to return only indication classes (--indication) or
                                       classes that are not indications (--no-indication). If the option is not defined no
                                       filtering occurs
-
       --experimental / --no-experimental
                                       Filter the returned classes to return only experimental classes (--experimental) or
                                       classes that are not experimental (--no-iexperimental). If the option is not defined
                                       no filtering occurs
-
       --deprecated / --no-deprecated  Filter the returned classes to return only deprecated classes (--deprecated) or
                                       classes that are not deprecated (--no-deprecated). If the option is not defined no
                                       filtering occurs
-
       --since VERSION                 Filter the returned classes to return only classes  with a version qualifier ge the
                                       supplied string. The string must define a version of the form M.N.V consistent the
                                       definitions of the VERSION qualifier.
-
       --schema SCHEMA                 Filter the returned classes to return only classes where the classname scheme
                                       component (characters before the "_" match the scheme provided.
-
       --subclass-of CLASSNAME         Filter the returned classes to return only classes that are a subclass of the option
                                       value.
-
       --leaf-classes                  Filter the returned classes to return only leaf (classes; classes with no subclass.
       -h, --help                      Show this help message.
 
@@ -493,17 +450,14 @@ Help text for ``pywbemcli class get`` (see :ref:`class get command`):
     Command Options:
       --lo, --local-only              Do not include superclass properties and methods in the returned class(es). Default:
                                       Include superclass properties and methods.
-
       --nq, --no-qualifiers           Do not include qualifiers in the returned class(es). Default: Include qualifiers.
       --ico, --include-classorigin    Include class origin information in the returned class(es). Default: Do not include
                                       class origin information.
-
       --pl, --propertylist PROPERTYLIST
                                       Filter the properties included in the returned object(s). Multiple properties may be
                                       specified with either a comma-separated list or by using the option multiple times.
                                       Properties specified in this option that are not in the object(s) will be ignored. The
                                       empty string will include no properties. Default: Do not filter properties.
-
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       -h, --help                      Show this help message.
 
@@ -543,7 +497,6 @@ Help text for ``pywbemcli class invokemethod`` (see :ref:`class invokemethod com
       -p, --parameter PARAMETERNAME=VALUE
                                       Specify a method input parameter with its value. May be specified multiple times.
                                       Default: No input parameters.
-
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       -h, --help                      Show this help message.
 
@@ -584,21 +537,17 @@ Help text for ``pywbemcli class references`` (see :ref:`class references command
     Command Options:
       --rc, --result-class CLASSNAME  Filter the result set by result class name. Subclasses of the specified class also
                                       match.
-
       -r, --role PROPERTYNAME         Filter the result set by source end role name.
       --nq, --no-qualifiers           Do not include qualifiers in the returned class(es). Default: Include qualifiers.
       --ico, --include-classorigin    Include class origin information in the returned class(es). Default: Do not include
                                       class origin information.
-
       --pl, --propertylist PROPERTYLIST
                                       Filter the properties included in the returned object(s). Multiple properties may be
                                       specified with either a comma-separated list or by using the option multiple times.
                                       Properties specified in this option that are not in the object(s) will be ignored. The
                                       empty string will include no properties. Default: Do not filter properties.
-
       --no, --names-only              Retrieve only the object paths (names). Default: Retrieve the complete objects
                                       including object paths.
-
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       -s, --summary                   Show only a summary (count) of the objects.
       -h, --help                      Show this help message.
@@ -624,11 +573,11 @@ Help text for ``pywbemcli class tree`` (see :ref:`class tree command`):
 
       - If CLASSNAME is omitted, the complete class hierarchy of the specified   namespace is retrieved.
 
-      - If CLASSNAME is specified but not --superclasses, the class and its   subclass hierarchy in the specified
-      namespace are retrieved.
+      - If CLASSNAME is specified but not --superclasses, the class and its   subclass hierarchy in the specified namespace
+      are retrieved.
 
-      - If CLASSNAME and --superclasses are specified, the class and its   superclass ancestry up to the top-level class
-      in the specified namespace   are retrieved.
+      - If CLASSNAME and --superclasses are specified, the class and its   superclass ancestry up to the top-level class in
+      the specified namespace   are retrieved.
 
       If no namespace was specified, the default namespace of the connection is used.
 
@@ -636,8 +585,7 @@ Help text for ``pywbemcli class tree`` (see :ref:`class tree command`):
 
       The --detail options to display extra information about each class including:
 
-      -  The Version qualifier value if the class includes a version    qualifier. This is normally a string with 3
-      integers
+      -  The Version qualifier value if the class includes a version    qualifier. This is normally a string with 3 integers
 
       -  Information about each class type (Association, Indication, Abstract)
 
@@ -653,7 +601,6 @@ Help text for ``pywbemcli class tree`` (see :ref:`class tree command`):
       -s, --superclasses         Show the superclass hierarchy. Default: Show the subclass hierarchy.
       -d, --detail               Show details about the class: the Version,  Association, Indication, and Abstact
                                  qualifiers.
-
       -n, --namespace NAMESPACE  Namespace to use for this command, instead of the default namespace of the connection.
       -h, --help                 Show this help message.
 
@@ -675,17 +622,17 @@ Help text for ``pywbemcli connection`` (see :ref:`connection command group`):
       Command group for WBEM connection definitions.
 
       This command group defines commands to manage persistent WBEM connection definitions that have a name. The names of
-      these connection definitions can then be used as shorthand for the WBEM server or mock server via the '--name'
-      general option.
+      these connection definitions can then be used as shorthand for the WBEM server or mock server via the '--name' general
+      option.
 
       The connection definitions are stored in a connections file. By default, the connections file is
       '.pywbemcli_connections.yaml' in the user's home directory. The location of the user's home directory depends on the
-      operating system used. It is determined with Python's 'os.path.expanduser("~")', which works on all operating
-      systems including Windows. The default path name of the connections file can be overwritten using the
+      operating system used. It is determined with Python's 'os.path.expanduser("~")', which works on all operating systems
+      including Windows. The default path name of the connections file can be overwritten using the
       'PYWBEMCLI_CONNECTIONS_FILE' environment variable, or with the '--connections-file' general option.
 
-      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help')
-      can also be specified before the 'connection' keyword.
+      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help') can
+      also be specified before the 'connection' keyword.
 
     Command Options:
       -h, --help  Show this help message.
@@ -814,7 +761,6 @@ Help text for ``pywbemcli connection save`` (see :ref:`connection save command`)
     Command Options:
       -f, --set-default  Set this definition as the default definition that will be loaded upon pywbemcli startup if no
                          server or name is included on the command line.
-
       -h, --help         Show this help message.
 
 
@@ -835,12 +781,12 @@ Help text for ``pywbemcli connection select`` (see :ref:`connection select comma
       Select a WBEM connection definition as current or default.
 
       Select the connection definition named NAME from the connections file to be the current connection. The connection
-      definition in the connections file must exist. If the NAME argument is omitted, a list of connection definitions
-      from the connections file is presented with a prompt for the user to select a connection definition.
+      definition in the connections file must exist. If the NAME argument is omitted, a list of connection definitions from
+      the connections file is presented with a prompt for the user to select a connection definition.
 
-      If the --set-default option is set, the default connection is set to the selected connection definition, in
-      addition. Once defined, the default connection will be used as a default in future executions of pywbemcli if none
-      of the server-defining general options (i.e. --server, --mock-server, or --name) was used.
+      If the --set-default option is set, the default connection is set to the selected connection definition, in addition.
+      Once defined, the default connection will be used as a default in future executions of pywbemcli if none of the
+      server-defining general options (i.e. --server, --mock-server, or --name) was used.
 
       The 'connection list' command marks the current connection with '*' and the default connection with '#'.
 
@@ -862,7 +808,6 @@ Help text for ``pywbemcli connection select`` (see :ref:`connection select comma
     Command Options:
       -d, --set-default  If set, the connection is set to be the default connection in the connections file in addition to
                          setting it as the current connection.
-
       -h, --help         Show this help message.
 
 
@@ -912,8 +857,8 @@ Help text for ``pywbemcli connection show`` (see :ref:`connection show command`)
 
       Show the name and attributes of a WBEM connection definition or the current connection, as follows:
 
-      * If the NAME argument is specified, display the connection information   with that name from the connections file
-      or the current connection if it   is the same name.
+      * If the NAME argument is specified, display the connection information   with that name from the connections file or
+      the current connection if it   is the same name.
 
       * If the NAME argument is '?', the command presents a list of connection   definitions from the connections file and
       prompts the user to   select one, which is then displayed.
@@ -956,8 +901,8 @@ Help text for ``pywbemcli connection test`` (see :ref:`connection test command`)
 
       Test the current connection with a predefined WBEM request.
 
-      Execute the EnumerateClassNames operation on the default namespace against the current connection to confirm that
-      the connection exists and is working.
+      Execute the EnumerateClassNames operation on the default namespace against the current connection to confirm that the
+      connection exists and is working.
 
       Examples:
 
@@ -966,7 +911,6 @@ Help text for ``pywbemcli connection test`` (see :ref:`connection test command`)
     Command Options:
       --test-pull  If set, the connection is tested to determine if theDMTF defined pull operations (ex.
                    OpenEnumerateInstancesare implemented since these are optional.
-
       -h, --help   Show this help message.
 
 
@@ -1011,8 +955,8 @@ Help text for ``pywbemcli instance`` (see :ref:`instance command group`):
 
       Modification of instances is not currently supported.
 
-      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help')
-      can also be specified before the 'instance' keyword.
+      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help') can
+      also be specified before the 'instance' keyword.
 
     Command Options:
       -h, --help  Show this help message.
@@ -1056,8 +1000,8 @@ Help text for ``pywbemcli instance associators`` (see :ref:`instance associators
       The instances to be retrieved can be filtered by the --filter-query, --role, --result-role, --assoc-class, and
       --result-class options.
 
-      The --include-qualifiers, --include-classorigin, and --propertylist options determine which parts are included in
-      each retrieved instance.
+      The --include-qualifiers, --include-classorigin, and --propertylist options determine which parts are included in each
+      retrieved instance.
 
       The --names-only option can be used to show only the instance paths.
 
@@ -1067,47 +1011,37 @@ Help text for ``pywbemcli instance associators`` (see :ref:`instance associators
     Command Options:
       --ac, --assoc-class CLASSNAME   Filter the result set by association class name. Subclasses of the specified class
                                       also match.
-
       --rc, --result-class CLASSNAME  Filter the result set by result class name. Subclasses of the specified class also
                                       match.
-
       -r, --role PROPERTYNAME         Filter the result set by source end role name.
       --rr, --result-role PROPERTYNAME
                                       Filter the result set by far end role name.
       --iq, --include-qualifiers      When traditional operations are used, include qualifiers in the returned instances.
                                       Some servers may ignore this option. By default, and when pull operations are used,
                                       qualifiers will never be included.
-
       --ico, --include-classorigin    Include class origin information in the returned instance(s). Some servers may ignore
                                       this option. Default: Do not include class origin information.
-
       --pl, --propertylist PROPERTYLIST
                                       Filter the properties included in the returned object(s). Multiple properties may be
                                       specified with either a comma-separated list or by using the option multiple times.
                                       Properties specified in this option that are not in the object(s) will be ignored. The
                                       empty string will include no properties. Default: Do not filter properties.
-
       --no, --names-only              Retrieve only the object paths (names). Default: Retrieve the complete objects
                                       including object paths.
-
       -k, --key KEYNAME=VALUE         Value for a key in keybinding of CIM instance name. May be specified multiple times.
                                       Allows defining keys without the issues of quotes. Default: No keybindings provided.
-
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       -s, --summary                   Show only a summary (count) of the objects.
       --fq, --filter-query QUERY-STRING
                                       When pull operations are used, filter the instances in the result via a filter query.
                                       By default, and when traditional operations are used, no such filtering takes place.
-
       --fql, --filter-query-language QUERY-LANGUAGE
                                       The filter query language to be used with --filter-query. Default: DMTF:FQL.
       --show-null                     In the TABLE output formats, show properties with no value (i.e. Null) in all of the
                                       instances to be displayed. Otherwise only properties at least one instance has a non-
                                       Null property are displayed
-
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
                                       --namespace options.
-
       -h, --help                      Show this help message.
 
 
@@ -1128,17 +1062,17 @@ Help text for ``pywbemcli instance count`` (see :ref:`instance count command`):
       Count the instances of each class with matching class name.
 
       Display the count of instances of each CIM class whose class name matches the specified wildcard expression
-      (CLASSNAME-GLOB) in all CIM namespaces of the WBEM server, or in the specified namespaces (--namespace option).
-      This differs from instance enumerate, etc. in that it counts the instances specifically for the classname of each
-      instance returned, not including subclasses.
+      (CLASSNAME-GLOB) in all CIM namespaces of the WBEM server, or in the specified namespaces (--namespace option).  This
+      differs from instance enumerate, etc. in that it counts the instances specifically for the classname of each instance
+      returned, not including subclasses.
 
       The CLASSNAME-GLOB argument is a wildcard expression that is matched on class names case insensitively. The special
-      characters from Unix file name wildcarding are supported ('*' to match zero or more characters, '?' to match a
-      single character, and '[]' to match character ranges). To avoid shell expansion of wildcard characters, the
-      CLASSNAME-GLOB argument should be put in quotes.
+      characters from Unix file name wildcarding are supported ('*' to match zero or more characters, '?' to match a single
+      character, and '[]' to match character ranges). To avoid shell expansion of wildcard characters, the CLASSNAME-GLOB
+      argument should be put in quotes.
 
-      If CLASSNAME-GLOB is not specified, then all classes in the specified namespaces are counted (same as when
-      specifying CLASSNAME-GLOB as "*").
+      If CLASSNAME-GLOB is not specified, then all classes in the specified namespaces are counted (same as when specifying
+      CLASSNAME-GLOB as "*").
 
       For example, "pywbem_*" returns classes whose name begins with "PyWBEM_", "pywbem_", etc. "*system*" returns classes
       whose names include the case insensitive string "system".
@@ -1147,48 +1081,39 @@ Help text for ``pywbemcli instance count`` (see :ref:`instance count command`):
       If an Error exception occurs (ex. Connection error) the scan is terminated under the assumption that the server may
       have failed and the remaining items are shown as "Not scanned".
 
-      This command can take a long time to execute since it potentially enumerates all instance names for all classes in
-      all namespaces.
+      This command can take a long time to execute since it potentially enumerates all instance names for all classes in all
+      namespaces.
 
     Command Options:
       -n, --namespace NAMESPACE       Add a namespace to the search scope. May be specified multiple times. Default: Search
                                       in all namespaces of the server.
-
       -s, --sort                      Sort by instance count. Otherwise sorted by class name.
       --ignore-class CLASSNAME        Class names of classes to be ignored (not counted). Allows counting instances in
                                       servers where instance retrieval may cause a CIMError or Error exception on some
                                       classes. CIM errors on particular classes are ignored. Error exceptions cause scan to
                                       stop and remaining classes status shown as 'not scanned'. Multiple class names are
                                       allowed (one per option or comma-separated).
-
       --association / --no-association
                                       Filter the returned classes to return only indication classes (--association) or
                                       classes that are not associations(--no-association). If the option is not defined no
                                       filtering occurs
-
       --indication / --no-indication  Filter the returned classes to return only indication classes (--indication) or
                                       classes that are not indications (--no-indication). If the option is not defined no
                                       filtering occurs
-
       --experimental / --no-experimental
                                       Filter the returned classes to return only experimental classes (--experimental) or
                                       classes that are not experimental (--no-iexperimental). If the option is not defined
                                       no filtering occurs
-
       --deprecated / --no-deprecated  Filter the returned classes to return only deprecated classes (--deprecated) or
                                       classes that are not deprecated (--no-deprecated). If the option is not defined no
                                       filtering occurs
-
       --since VERSION                 Filter the returned classes to return only classes  with a version qualifier ge the
                                       supplied string. The string must define a version of the form M.N.V consistent the
                                       definitions of the VERSION qualifier.
-
       --schema SCHEMA                 Filter the returned classes to return only classes where the classname scheme
                                       component (characters before the "_" match the scheme provided.
-
       --subclass-of CLASSNAME         Filter the returned classes to return only classes that are a subclass of the option
                                       value.
-
       --leaf-classes                  Filter the returned classes to return only leaf (classes; classes with no subclass.
       -h, --help                      Show this help message.
 
@@ -1209,9 +1134,9 @@ Help text for ``pywbemcli instance create`` (see :ref:`instance create command`)
 
       Create an instance of a class in a namespace.
 
-      Create a CIM instance of the specified creation class (CLASSNAME argument) in the specified CIM namespace
-      (--namespace option), with the specified properties (--property options) and display the CIM instance path of the
-      created instance. If no namespace was specified, the default namespace of the connection is used.
+      Create a CIM instance of the specified creation class (CLASSNAME argument) in the specified CIM namespace (--namespace
+      option), with the specified properties (--property options) and display the CIM instance path of the created instance.
+      If no namespace was specified, the default namespace of the connection is used.
 
       The properties to be initialized and their new values are specified using the --property option, which may be
       specified multiple times.
@@ -1228,10 +1153,8 @@ Help text for ``pywbemcli instance create`` (see :ref:`instance create command`)
                                       Initial property value for the new instance. May be specified multiple times. Array
                                       property values are specified as a comma-separated list; embedded instances are not
                                       supported. Default: No initial properties provided.
-
       -V, --verify                    Prompt for confirmation before performing a change, to allow for verification of
                                       parameters. Default: Do not prompt for confirmation.
-
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       -h, --help                      Show this help message.
 
@@ -1261,11 +1184,9 @@ Help text for ``pywbemcli instance delete`` (see :ref:`instance delete command`)
     Command Options:
       -k, --key KEYNAME=VALUE    Value for a key in keybinding of CIM instance name. May be specified multiple times. Allows
                                  defining keys without the issues of quotes. Default: No keybindings provided.
-
       -n, --namespace NAMESPACE  Namespace to use for this command, instead of the default namespace of the connection.
       --hi, --help-instancename  Show help message for specifying INSTANCENAME including use of the --key and --namespace
                                  options.
-
       -h, --help                 Show this help message.
 
 
@@ -1303,38 +1224,30 @@ Help text for ``pywbemcli instance enumerate`` (see :ref:`instance enumerate com
       --lo, --local-only              When traditional operations are used, do not include superclass properties in the
                                       returned instances. Some servers may ignore this option. By default, and when pull
                                       operations are used, superclass properties will always be included.
-
       --di, --deep-inheritance        Include subclass properties in the returned instances. Default: Do not include
                                       subclass properties.
-
       --iq, --include-qualifiers      When traditional operations are used, include qualifiers in the returned instances.
                                       Some servers may ignore this option. By default, and when pull operations are used,
                                       qualifiers will never be included.
-
       --ico, --include-classorigin    Include class origin information in the returned instance(s). Some servers may ignore
                                       this option. Default: Do not include class origin information.
-
       --pl, --propertylist PROPERTYLIST
                                       Filter the properties included in the returned object(s). Multiple properties may be
                                       specified with either a comma-separated list or by using the option multiple times.
                                       Properties specified in this option that are not in the object(s) will be ignored. The
                                       empty string will include no properties. Default: Do not filter properties.
-
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       --no, --names-only              Retrieve only the object paths (names). Default: Retrieve the complete objects
                                       including object paths.
-
       -s, --summary                   Show only a summary (count) of the objects.
       --fq, --filter-query QUERY-STRING
                                       When pull operations are used, filter the instances in the result via a filter query.
                                       By default, and when traditional operations are used, no such filtering takes place.
-
       --fql, --filter-query-language QUERY-LANGUAGE
                                       The filter query language to be used with --filter-query. Default: DMTF:FQL.
       --show-null                     In the TABLE output formats, show properties with no value (i.e. Null) in all of the
                                       instances to be displayed. Otherwise only properties at least one instance has a non-
                                       Null property are displayed
-
       -h, --help                      Show this help message.
 
 
@@ -1365,30 +1278,23 @@ Help text for ``pywbemcli instance get`` (see :ref:`instance get command`):
     Command Options:
       --lo, --local-only              Do not include superclass properties in the returned instance. Some servers may ignore
                                       this option. Default: Include superclass properties.
-
       --iq, --include-qualifiers      Include qualifiers in the returned instance. Not all servers return qualifiers on
                                       instances. Default: Do not include qualifiers.
-
       --ico, --include-classorigin    Include class origin information in the returned instance(s). Some servers may ignore
                                       this option. Default: Do not include class origin information.
-
       --pl, --propertylist PROPERTYLIST
                                       Filter the properties included in the returned object(s). Multiple properties may be
                                       specified with either a comma-separated list or by using the option multiple times.
                                       Properties specified in this option that are not in the object(s) will be ignored. The
                                       empty string will include no properties. Default: Do not filter properties.
-
       -k, --key KEYNAME=VALUE         Value for a key in keybinding of CIM instance name. May be specified multiple times.
                                       Allows defining keys without the issues of quotes. Default: No keybindings provided.
-
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
                                       --namespace options.
-
       --show-null                     In the TABLE output formats, show properties with no value (i.e. Null) in all of the
                                       instances to be displayed. Otherwise only properties at least one instance has a non-
                                       Null property are displayed
-
       -h, --help                      Show this help message.
 
 
@@ -1408,16 +1314,16 @@ Help text for ``pywbemcli instance invokemethod`` (see :ref:`instance invokemeth
 
       Invoke a method on an instance.
 
-      Invoke a CIM method (METHODNAME argument) on a CIM instance with the specified input parameters (--parameter
-      options), and display the method return value and output parameters.
+      Invoke a CIM method (METHODNAME argument) on a CIM instance with the specified input parameters (--parameter options),
+      and display the method return value and output parameters.
 
       For information on how to specify the instance using INSTANCENAME and the --key and --namespace options, invoke with
       --help-instancename.
 
       The method input parameters are specified using the --parameter option, which may be specified multiple times.
 
-      Pywbemcli retrieves the class definition of the creation class of the instance from the server in order to verify
-      that the specified input parameters are consistent with the parameter characteristics in the method definition.
+      Pywbemcli retrieves the class definition of the creation class of the instance from the server in order to verify that
+      the specified input parameters are consistent with the parameter characteristics in the method definition.
 
       Use the 'class invokemethod' command to invoke CIM methods on CIM classes.
 
@@ -1430,14 +1336,11 @@ Help text for ``pywbemcli instance invokemethod`` (see :ref:`instance invokemeth
                                       Specify a method input parameter with its value. May be specified multiple times.
                                       Array property values are specified as a comma-separated list; embedded instances are
                                       not supported. Default: No input parameters.
-
       -k, --key KEYNAME=VALUE         Value for a key in keybinding of CIM instance name. May be specified multiple times.
                                       Allows defining keys without the issues of quotes. Default: No keybindings provided.
-
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
                                       --namespace options.
-
       -h, --help                      Show this help message.
 
 
@@ -1463,8 +1366,8 @@ Help text for ``pywbemcli instance modify`` (see :ref:`instance modify command`)
       The properties to be modified and their new values are specified using the --property option, which may be specified
       multiple times.
 
-      The --propertylist option allows restricting the set of properties to be modified. Given that the set of properties
-      to be modified is already determined by the specified --property options, it does not need to be specified.
+      The --propertylist option allows restricting the set of properties to be modified. Given that the set of properties to
+      be modified is already determined by the specified --property options, it does not need to be specified.
 
       Example:
 
@@ -1475,23 +1378,18 @@ Help text for ``pywbemcli instance modify`` (see :ref:`instance modify command`)
                                       Property to be modified, with its new value. May be specified once for each property
                                       to be modified. Array property values are specified as a comma-separated list;
                                       embedded instances are not supported. Default: No properties modified.
-
       --pl, --propertylist PROPERTYLIST
                                       Reduce the properties to be modified (as per --property) to a specific property list.
                                       Multiple properties may be specified with either a comma-separated list or by using
                                       the option multiple times. The empty string will cause no properties to be modified.
                                       Default: Do not reduce the properties to be modified.
-
       -V, --verify                    Prompt for confirmation before performing a change, to allow for verification of
                                       parameters. Default: Do not prompt for confirmation.
-
       -k, --key KEYNAME=VALUE         Value for a key in keybinding of CIM instance name. May be specified multiple times.
                                       Allows defining keys without the issues of quotes. Default: No keybindings provided.
-
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
                                       --namespace options.
-
       -h, --help                      Show this help message.
 
 
@@ -1540,16 +1438,16 @@ Help text for ``pywbemcli instance references`` (see :ref:`instance references c
 
       List the instances referencing an instance.
 
-      List the CIM (association) instances that reference the specified CIM instance, and display the returned instances,
-      or instance paths if --names-only was specified.
+      List the CIM (association) instances that reference the specified CIM instance, and display the returned instances, or
+      instance paths if --names-only was specified.
 
       For information on how to specify the instance using INSTANCENAME and the --key and --namespace options, invoke with
       --help-instancename.
 
       The instances to be retrieved can be filtered by the --filter-query, --role and --result-class options.
 
-      The --include-qualifiers, --include-classorigin, and --propertylist options determine which parts are included in
-      each retrieved instance.
+      The --include-qualifiers, --include-classorigin, and --propertylist options determine which parts are included in each
+      retrieved instance.
 
       The --names-only option can be used to show only the instance paths.
 
@@ -1559,42 +1457,33 @@ Help text for ``pywbemcli instance references`` (see :ref:`instance references c
     Command Options:
       --rc, --result-class CLASSNAME  Filter the result set by result class name. Subclasses of the specified class also
                                       match.
-
       -r, --role PROPERTYNAME         Filter the result set by source end role name.
       --iq, --include-qualifiers      When traditional operations are used, include qualifiers in the returned instances.
                                       Some servers may ignore this option. By default, and when pull operations are used,
                                       qualifiers will never be included.
-
       --ico, --include-classorigin    Include class origin information in the returned instance(s). Some servers may ignore
                                       this option. Default: Do not include class origin information.
-
       --pl, --propertylist PROPERTYLIST
                                       Filter the properties included in the returned object(s). Multiple properties may be
                                       specified with either a comma-separated list or by using the option multiple times.
                                       Properties specified in this option that are not in the object(s) will be ignored. The
                                       empty string will include no properties. Default: Do not filter properties.
-
       --no, --names-only              Retrieve only the object paths (names). Default: Retrieve the complete objects
                                       including object paths.
-
       -k, --key KEYNAME=VALUE         Value for a key in keybinding of CIM instance name. May be specified multiple times.
                                       Allows defining keys without the issues of quotes. Default: No keybindings provided.
-
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       -s, --summary                   Show only a summary (count) of the objects.
       --fq, --filter-query QUERY-STRING
                                       When pull operations are used, filter the instances in the result via a filter query.
                                       By default, and when traditional operations are used, no such filtering takes place.
-
       --show-null                     In the TABLE output formats, show properties with no value (i.e. Null) in all of the
                                       instances to be displayed. Otherwise only properties at least one instance has a non-
                                       Null property are displayed
-
       --fql, --filter-query-language QUERY-LANGUAGE
                                       The filter query language to be used with --filter-query. Default: DMTF:FQL.
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
                                       --namespace options.
-
       -h, --help                      Show this help message.
 
 
@@ -1625,34 +1514,29 @@ Help text for ``pywbemcli instance shrub`` (see :ref:`instance shrub command`):
       --help-instancename.
 
       Normally the association information is displayed as a tree but it may also be displayed as a table or as one of the
-      object formats (ex. MOF) of all instances that are part of the shrub if one of the cim object formats is selected
-      with the global output_format parameter.
+      object formats (ex. MOF) of all instances that are part of the shrub if one of the cim object formats is selected with
+      the global output_format parameter.
 
       Results are formatted as defined by the output format global option.
 
     Command Options:
       --ac, --assoc-class CLASSNAME   Filter the result set by association class name. Subclasses of the specified class
                                       also match.
-
       --rc, --result-class CLASSNAME  Filter the result set by result class name. Subclasses of the specified class also
                                       match.
-
       -r, --role PROPERTYNAME         Filter the result set by source end role name.
       --rr, --result-role PROPERTYNAME
                                       Filter the result set by far end role name.
       -k, --key KEYNAME=VALUE         Value for a key in keybinding of CIM instance name. May be specified multiple times.
                                       Allows defining keys without the issues of quotes. Default: No keybindings provided.
-
       -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
       -s, --summary                   Show only a summary (count) of the objects.
       -f, --fullpath                  Normally the instance paths in the tree views are by hiding some keys with ~ to make
                                       the tree simpler to read. This includes keys that have the same value for all
                                       instances and the "CreationClassName" key.  Whenthis option is used the full instance
                                       paths are displayed.
-
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
                                       --namespace options.
-
       -h, --help                      Show this help message.
 
 
@@ -1674,8 +1558,8 @@ Help text for ``pywbemcli namespace`` (see :ref:`namespace command group`):
 
       This command group defines commands to create, delete and list namespaces in a WBEM server.
 
-      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help')
-      can also be specified before the 'namespace' keyword.
+      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help') can
+      also be specified before the 'namespace' keyword.
 
     Command Options:
       -h, --help  Show this help message.
@@ -1710,8 +1594,8 @@ Help text for ``pywbemcli namespace create`` (see :ref:`namespace create command
       The Interop namespace must exist on the server and cannot be created using this command, because that namespace is
       required to implement client requests to manage namespaces.
 
-      WBEM servers may not allow this operation or may severely limit the conditions under which a namespace can be
-      created on the server.
+      WBEM servers may not allow this operation or may severely limit the conditions under which a namespace can be created
+      on the server.
 
       Example:
 
@@ -1747,9 +1631,9 @@ Help text for ``pywbemcli namespace delete`` (see :ref:`namespace delete command
       If the --include-objects option is specified, the dependency order of classes is determined, and the instances are
       deleted first in that order, then the classes in that order, and at last the qualifier types. This ensures that no
       dangling dependencies remain at any point in the operation. Dependencies that are considered for this purpose are
-      subclasses, referencing classes and embedding classes (EmbeddedInstance qualifier only). Cross-namespace
-      associations are deleted in the targeted namespace and are assumed to be properly handled by the server in the other
-      namespace. (i.e. to be cleaned up there as well without requiring a deletion by the client).
+      subclasses, referencing classes and embedding classes (EmbeddedInstance qualifier only). Cross-namespace associations
+      are deleted in the targeted namespace and are assumed to be properly handled by the server in the other namespace.
+      (i.e. to be cleaned up there as well without requiring a deletion by the client).
 
       WARNING: Deletion of instances will cause the removal of corresponding resources in the managed environment (i.e. in
       the real world). Some instances may not be deletable.
@@ -1757,8 +1641,8 @@ Help text for ``pywbemcli namespace delete`` (see :ref:`namespace delete command
       WARNING: Deletion of classes or qualifier types can cause damage to the server: It can impact instance providers and
       other components in the server. WBEM servers may not allow the deletion of classes or qualifier declarations.
 
-      WBEM servers may not allow deletion of namespaces or may severely limit the conditions under which a namespace can
-      be deleted.
+      WBEM servers may not allow deletion of namespaces or may severely limit the conditions under which a namespace can be
+      deleted.
 
       Example:
 
@@ -1768,7 +1652,6 @@ Help text for ``pywbemcli namespace delete`` (see :ref:`namespace delete command
       --include-objects  Delete any objects in the namespace as well. WARNING: Deletion of instances will cause the removal
                          of corresponding resources in the managed environment (i.e. in the real world). Default: Reject
                          command if the namespace has any objects.
-
       --dry-run          Enable dry-run mode: Do not actually delete the objects, but display what would be done.
       -h, --help         Show this help message.
 
@@ -1837,11 +1720,10 @@ Help text for ``pywbemcli profile`` (see :ref:`profile command group`):
 
       Command group for WBEM management profiles.
 
-      This command group defines commands to inspect and manage the WBEM management profiles maintained by the WBEM
-      server.
+      This command group defines commands to inspect and manage the WBEM management profiles maintained by the WBEM server.
 
-      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help')
-      can also be specified before the 'server' keyword.
+      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help') can
+      also be specified before the 'server' keyword.
 
     Command Options:
       -h, --help  Show this help message.
@@ -1868,8 +1750,8 @@ Help text for ``pywbemcli profile centralinsts`` (see :ref:`profile centralinsts
       List WBEM management profile central instances on the server.
 
       Retrieve the CIM instances that are central instances of the specified WBEM management profiles, and display these
-      instances. By default, all management profiles advertized on the server are included. The profiles can be filtered
-      by using the --organization and --profile options.
+      instances. By default, all management profiles advertized on the server are included. The profiles can be filtered by
+      using the --organization and --profile options.
 
       The central instances are determined using all methodologies defined in DSP1033 V1.1 in the order of
       GetCentralInstances, central class, and scoping class methodology.
@@ -1889,7 +1771,6 @@ Help text for ``pywbemcli profile centralinsts`` (see :ref:`profile centralinsts
                                       Optional. Required only if profiles supports only scoping methodology
       --sp, --scoping-path CLASSLIST  Optional. Required only if profiles supports only scoping methodology. Multiples
                                       allowed
-
       --rd, --reference-direction [snia|dmtf]
                                       Navigation direction for association.  [default: dmtf]
       -h, --help                      Show this help message.
@@ -1911,8 +1792,8 @@ Help text for ``pywbemcli profile list`` (see :ref:`profile list command`):
 
       List WBEM management profiles advertised by the server.
 
-      Retrieve  the WBEM management profiles advertised by the WBEM server, and display information about each profile.
-      WBEM management profiles are defined by DMTF and SNIA and define the management functionality that is available.
+      Retrieve  the WBEM management profiles advertised by the WBEM server, and display information about each profile. WBEM
+      management profiles are defined by DMTF and SNIA and define the management functionality that is available.
 
       The retrieved profiles can be filtered using the --organization and --profile options.
 
@@ -1943,8 +1824,8 @@ Help text for ``pywbemcli qualifier`` (see :ref:`qualifier command group`):
 
       This command group defines commands to inspect and delete CIM qualifier declarations in the WBEM Server.
 
-      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help')
-      can also be specified before the 'qualifier' keyword.
+      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help') can
+      also be specified before the 'qualifier' keyword.
 
     Command Options:
       -h, --help  Show this help message.
@@ -1974,8 +1855,8 @@ Help text for ``pywbemcli qualifier delete`` (see :ref:`qualifier delete command
       Delete a CIM qualifier declaration (QUALIFIERNAME argument) in a CIM namespace (--namespace option). If no namespace
       was specified, the default namespace of the connection is used.
 
-      This command executes the DeleteQualifier operation against the WBEM server and leaves it to the WBEM server to
-      reject the operation if any classes in the namespace use the qualifier.
+      This command executes the DeleteQualifier operation against the WBEM server and leaves it to the WBEM server to reject
+      the operation if any classes in the namespace use the qualifier.
 
       In the output, the qualifier declaration will formatted as defined by the --output-format general option.
 
@@ -2027,8 +1908,8 @@ Help text for ``pywbemcli qualifier get`` (see :ref:`qualifier get command`):
 
       Get a qualifier declaration.
 
-      Get a CIM qualifier declaration (QUALIFIERNAME argument) in a CIM namespace (--namespace option). If no namespace
-      was specified, the default namespace of the connection is used.
+      Get a CIM qualifier declaration (QUALIFIERNAME argument) in a CIM namespace (--namespace option). If no namespace was
+      specified, the default namespace of the connection is used.
 
       In the output, the qualifier declaration will formatted as defined by the --output-format general option.
 
@@ -2088,8 +1969,8 @@ Help text for ``pywbemcli server`` (see :ref:`server command group`):
       This command group defines commands to inspect and manage core components of a WBEM server including server
       attributes, namespaces, compiling MOF, the Interop namespace and schema information.
 
-      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help')
-      can also be specified before the 'server' keyword.
+      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help') can
+      also be specified before the 'server' keyword.
 
     Command Options:
       -h, --help  Show this help message.
@@ -2123,15 +2004,15 @@ Help text for ``pywbemcli server add-mof`` (see :ref:`server add-mof command`):
       The MOF files are specified with the MOFFILE argument, which may be specified multiple times. The minus sign ('-')
       specifies the standard input.
 
-      Initially, the target namespace is the namespace specified with the --namespace option or if not specified the
-      default namespace of the connection. If the MOF contains '#pragma namespace' directives, the target namespace will
-      be changed accordingly.
+      Initially, the target namespace is the namespace specified with the --namespace option or if not specified the default
+      namespace of the connection. If the MOF contains '#pragma namespace' directives, the target namespace will be changed
+      accordingly.
 
       MOF include files (specified with the '#pragma include' directive) are searched first in the directory of the
       including MOF file, and then in the directories specified with the --include option.
 
-      Any CIM objects (instances, classes and qualifiers) specified in the MOF files are created in the server, or
-      modified if they already exist in the server.
+      Any CIM objects (instances, classes and qualifiers) specified in the MOF files are created in the server, or modified
+      if they already exist in the server.
 
       The global --verbose option will show the CIM objects that are created or modified.
 
@@ -2140,7 +2021,6 @@ Help text for ``pywbemcli server add-mof`` (see :ref:`server add-mof command`):
       -I, --include INCLUDEDIR   Path name of a MOF include directory. May be specified multiple times.
       -d, --dry-run              Enable dry-run mode: Don't actually modify the server. Connection to the server is still
                                  required for reading.
-
       -h, --help                 Show this help message.
 
 
@@ -2160,8 +2040,8 @@ Help text for ``pywbemcli server brand`` (see :ref:`server brand command`):
 
       Get the brand of the server.
 
-      Brand information is defined by the server implementor and may or may not be available. Pywbem attempts to collect
-      the brand information from multiple sources.
+      Brand information is defined by the server implementor and may or may not be available. Pywbem attempts to collect the
+      brand information from multiple sources.
 
     Command Options:
       -h, --help  Show this help message.
@@ -2232,8 +2112,8 @@ Help text for ``pywbemcli server namespaces`` (see :ref:`server namespaces comma
 
       The Interop namespace must exist on the server.
 
-      Deprecated: The 'server namespaces' command is deprecated and will be removed in a future version. Use the
-      'namespace list' command instead.
+      Deprecated: The 'server namespaces' command is deprecated and will be removed in a future version. Use the 'namespace
+      list' command instead.
 
     Command Options:
       -h, --help  Show this help message.
@@ -2258,9 +2138,9 @@ Help text for ``pywbemcli server remove-mof`` (see :ref:`server remove-mof comma
       The MOF files are specified with the MOFFILE argument, which may be specified multiple times. The minus sign ('-')
       specifies the standard input.
 
-      Initially, the target namespace is the namespace specified with the --namespace option or if not specified the
-      default namespace of the connection. If the MOF contains '#pragma namespace' directives, the target namespace will
-      be changed accordingly.
+      Initially, the target namespace is the namespace specified with the --namespace option or if not specified the default
+      namespace of the connection. If the MOF contains '#pragma namespace' directives, the target namespace will be changed
+      accordingly.
 
       MOF include files (specified with the '#pragma include' directive) are searched first in the directory of the
       including MOF file, and then in the directories specified with the --include option.
@@ -2274,7 +2154,6 @@ Help text for ``pywbemcli server remove-mof`` (see :ref:`server remove-mof comma
       -I, --include INCLUDEDIR   Path name of a MOF include directory. May be specified multiple times.
       -d, --dry-run              Enable dry-run mode: Don't actually modify the server. Connection to the server is still
                                  required for reading.
-
       -h, --help                 Show this help message.
 
 
@@ -2294,16 +2173,15 @@ Help text for ``pywbemcli server schema`` (see :ref:`server schema command`):
 
       Get information about the server schemas.
 
-      Gets information about the schemas and CIM schemas that define the classes in each namespace. The information
-      provided includes:   * The released DMTF CIM schema version that was the source for the     qualifier declarations
-      and classes for the namespace.   * Experimental vs. final elements in the schema   * Schema name (defined by the
-      prefix on each class before the first '_')   * Class count
+      Gets information about the schemas and CIM schemas that define the classes in each namespace. The information provided
+      includes:   * The released DMTF CIM schema version that was the source for the     qualifier declarations and classes
+      for the namespace.   * Experimental vs. final elements in the schema   * Schema name (defined by the prefix on each
+      class before the first '_')   * Class count
 
     Command Options:
       -n, --namespace NAMESPACE  Namespace to use for this command, instead of the default namespace of the connection.
       -d, --detail               Display details about each schema in the namespace rather than accumulated for the
                                  namespace.
-
       -h, --help                 Show this help message.
 
 
@@ -2323,20 +2201,20 @@ Help text for ``pywbemcli statistics`` (see :ref:`statistics command group`):
 
       Command group for WBEM operation statistics.
 
-      This command group defines commands to control the gathering and display of statistical data about the WBEM
-      operations issued by pywbemcli or processed by a WBEM server.
+      This command group defines commands to control the gathering and display of statistical data about the WBEM operations
+      issued by pywbemcli or processed by a WBEM server.
 
-      Pywbemcli maintains statistics about the WBEM operations it has issued. This includes the Client Time measured on
-      the client side and the Server Time measured by the WBEM server and reported in the 'WBEMServerResponseTime' header
-      field in the CIM-XML response (if supported by the WBEM server).
+      Pywbemcli maintains statistics about the WBEM operations it has issued. This includes the Client Time measured on the
+      client side and the Server Time measured by the WBEM server and reported in the 'WBEMServerResponseTime' header field
+      in the CIM-XML response (if supported by the WBEM server).
 
       The WBEM server may also support maintaining statistics about the WBEM operations it has processed (possibly by
       multiple clients). Pywbemcli supports enabling or disabling the statistics gathering on the WBEM server via the
       'GatherStatisticalData' property in the 'CIM_ObjectManager' instance for the WBEM server and supports retrieving and
       displaying the server maintained statistics.
 
-      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help')
-      can also be specified before the 'statistics' keyword.
+      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help') can
+      also be specified before the 'statistics' keyword.
 
     Command Options:
       -h, --help  Show this help message.
@@ -2392,12 +2270,12 @@ Help text for ``pywbemcli statistics server-off`` (see :ref:`statistics server-o
 
       Disable server maintained statistics.
 
-      This command deactivates the gathering of statistics in the current WBEM server and also deactivates the returning
-      of server response times in the CIM-XML response for inclusion in the client maintained statistics, by setting the
+      This command deactivates the gathering of statistics in the current WBEM server and also deactivates the returning of
+      server response times in the CIM-XML response for inclusion in the client maintained statistics, by setting the
       'GatherStatisticalData' property to False in the 'CIM_ObjectManager' instance for the WBEM server.
 
-      This command fails if the server does not support gathering statistics or does not allow a client to modify the
-      state of statistics gathering.
+      This command fails if the server does not support gathering statistics or does not allow a client to modify the state
+      of statistics gathering.
 
       This command does not affect the state of the client maintained statistics other than whether the server response
       times are included. See the '--timestats' general option for controlling the displaying of client maintained
@@ -2427,8 +2305,8 @@ Help text for ``pywbemcli statistics server-on`` (see :ref:`statistics server-on
       server response times in the CIM-XML response for inclusion in the client maintained statistics, by setting the
       'GatherStatisticalData' property to True in the 'CIM_ObjectManager' instance for the WBEM server.
 
-      This command fails if the server does not support gathering statistics or does not allow a client to modify the
-      state of statistics gathering.
+      This command fails if the server does not support gathering statistics or does not allow a client to modify the state
+      of statistics gathering.
 
       This command does not affect the state of the client maintained statistics other than whether the server response
       times are included. See the '--timestats' general option for controlling the displaying of client maintained
@@ -2482,8 +2360,8 @@ Help text for ``pywbemcli statistics show`` (see :ref:`statistics show command`)
 
       Display client maintained statistics.
 
-      Display the statistics gathered by pywbemcli. This includes the server response times received from the WBEM server
-      in the 'WBEMServerResponseTime' header field of the CIM-XML response, if supported and enabled.
+      Display the statistics gathered by pywbemcli. This includes the server response times received from the WBEM server in
+      the 'WBEMServerResponseTime' header field of the CIM-XML response, if supported and enabled.
 
       These statistics are independent of the server maintained statistics which can be displayed with the command
       'statistics server-show'.
@@ -2534,8 +2412,8 @@ Help text for ``pywbemcli subscription`` (see :ref:`subscription command group`)
       This group uses the pywbem subscription manager to create, view, and remove CIM Indication subscriptions for a WBEM
       Server.
 
-      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help')
-      can also be specified before the command. These are NOT retained after the command is executed.
+      In addition to the command-specific options shown in this help text, the general options (see 'pywbemcli --help') can
+      also be specified before the command. These are NOT retained after the command is executed.
 
     Command Options:
       -h, --help  Show this help message.
@@ -2578,15 +2456,15 @@ Help text for ``pywbemcli subscription add-destination`` (see :ref:`subscription
 
       The required IDENTITY argument along with the --owned/--permanent option define the ``Name`` key property of the new
       instance.  If the instance is to be owned by the current SubscriptionManager, pywbemcli creates a 'Name' property
-      value with the format: "pywbemdestination:" <SubscriptionManagerID> ":" <IDENTITY>. If the destination instance is
-      to be permanent, the value of the IDENTITY argument becomes the value of the 'Name' property.
+      value with the format: "pywbemdestination:" <SubscriptionManagerID> ":" <IDENTITY>. If the destination instance is to
+      be permanent, the value of the IDENTITY argument becomes the value of the 'Name' property.
 
       Owned destinations are added or updated conditionally: If the destination instance to be added is already registered
       with this subscription manager and has the same property values, it is not created or modified. If an instance with
       this path and properties does not exist yet (the normal case), it is created on the WBEM server.
 
-      Permanent listener destinations are created unconditionally, and it is up to the user to ensure that such an
-      instance does not already exist.
+      Permanent listener destinations are created unconditionally, and it is up to the user to ensure that such an instance
+      does not already exist.
 
       If the --verbose general option is set, the created instance is displayed.
 
@@ -2594,10 +2472,8 @@ Help text for ``pywbemcli subscription add-destination`` (see :ref:`subscription
       -l, --listener-url URL  Defines the URL of the target listener in the format: [SCHEME://]HOST:PORT. SCHEME must be
                               "https" (default) or "http". HOST is a short or long hostname or literal IPV4/v6 address. PORT
                               is a positive integer and is required
-
       --owned / --permanent   Defines whether an owned or permanent filter, destination, or subscription is to be added.
                               Default: owned
-
       -h, --help              Show this help message.
 
 
@@ -2620,19 +2496,19 @@ Help text for ``pywbemcli subscription add-filter`` (see :ref:`subscription add-
       This command adds an indication filter to a WBEM server, by creating an indication filter instance (CIM class
       "CIM_IndicationFilter") in the Interop namespace of the server.
 
-      A indication listener defines the query and query language to be used by the WBEM server to create indications for
-      an indication subscription.
+      A indication listener defines the query and query language to be used by the WBEM server to create indications for an
+      indication subscription.
 
       The required IDENTITY argument of the command and the --owned/--permanent option defines the 'Name' key property of
-      the the created instance.  If the the instance is to be owned by the current SubscriptionManager, pywbemcli
-      indirectly specifies the 'Name' property value with the format: "pywbemfilter:" "<SubscriptionManagerID>" ":"
-      <identity>``. If the destination instance is to be permanent, the value of the IDENTITY argument directly becomes
-      the value of the Name property.
+      the the created instance.  If the the instance is to be owned by the current SubscriptionManager, pywbemcli indirectly
+      specifies the 'Name' property value with the format: "pywbemfilter:" "<SubscriptionManagerID>" ":" <identity>``. If
+      the destination instance is to be permanent, the value of the IDENTITY argument directly becomes the value of the Name
+      property.
 
-      Owned indication filters are added or updated conditionally: If the indication filter instance to be added is
-      already registered with this subscription manager and has the same property values, it is not created or modified.
-      If it has the same path but different property values, it is modified to get the desired property values. If an
-      instance with this path does not exist yet (the normal case), it is created.
+      Owned indication filters are added or updated conditionally: If the indication filter instance to be added is already
+      registered with this subscription manager and has the same property values, it is not created or modified. If it has
+      the same path but different property values, it is modified to get the desired property values. If an instance with
+      this path does not exist yet (the normal case), it is created.
 
       Permanent indication filters are created unconditionally; it is up to the user to ensure that such an instance does
       not exist yet.
@@ -2642,18 +2518,14 @@ Help text for ``pywbemcli subscription add-filter`` (see :ref:`subscription add-
     Command Options:
       -q, --query FILTER        Filter query definition. This is a SELECT statement in the query language defined in the
                                 filter-query-language parameter  [required]
-
       --query-language TEXT     Filter query language for this subscription The query languages normally implemented are
                                 'DMTF:CQL' and 'WQL' .  Default: WQL
-
       --source-namespaces TEXT  The namespace(s) for which the query is defined. Multiple values may be defined with a
                                 single comma-separated string of namespaces or multiple options. If defined the namespaces
                                 will be inserted into the SourceNamespaces property. Otherwise the property will not be
                                 created and the WBEM server typically use the Interop namespace for the indication filter.
-
       --owned / --permanent     Defines whether an owned or permanent filter, destination, or subscription is to be added.
                                 Default: owned
-
       -h, --help                Show this help message.
 
 
@@ -2677,44 +2549,40 @@ Help text for ``pywbemcli subscription add-subscription`` (see :ref:`subscriptio
       creates an instance of CIM association class "CIM_IndicationSubscription" in the Interop namespace of the server.
 
       The destination and filter instances to be used in the subscription is based on the DESTINATIONID and FILTERID
-      arguments which define the the 'Handler' and 'Filter' reference properties of the subscription instance to be
-      created.
+      arguments which define the the 'Handler' and 'Filter' reference properties of the subscription instance to be created.
 
       The required DESTINATIONID argument defines the existing destination instance that will be attached to the 'Handler'
-      reference of the association class. This argument may consist of either the value of the 'Name' property of the
-      target destination instance or the identity of that instance.  The identity is the full value of the 'Name' property
-      for permanent destinations and is a component of the 'Name' property for owned instances. If just the identity is
-      used, this will result in multiple destinations being found if the same string is defined as the identity of an
-      owned and permanent destination.
+      reference of the association class. This argument may consist of either the value of the 'Name' property of the target
+      destination instance or the identity of that instance.  The identity is the full value of the 'Name' property for
+      permanent destinations and is a component of the 'Name' property for owned instances. If just the identity is used,
+      this will result in multiple destinations being found if the same string is defined as the identity of an owned and
+      permanent destination.
 
-      The required FILTERID argument defines the existing filter instance that will be attached to the 'Filter' reference
-      of the association class. This argument may consist of either the value of the 'Name' property of the target filter
+      The required FILTERID argument defines the existing filter instance that will be attached to the 'Filter' reference of
+      the association class. This argument may consist of either the value of the 'Name' property of the target filter
       instance or the identity of that instance.  The identity is the full value of the 'Name' property for permanent
-      filters and is a component of the 'Name' property for owned instances. If just the identity is used, this will
-      result in multiple filters being found if the same string is defined as the identity of an owned and permanent
-      filter.
+      filters and is a component of the 'Name' property for owned instances. If just the identity is used, this will result
+      in multiple filters being found if the same string is defined as the identity of an owned and permanent filter.
 
       When creating permanent subscriptions, the indication filter and the listener destinations must not be owned. for
       owned subscriptions, indication filter and listener destination may be either owned or permanent.
 
-      Owned subscriptions are added or updated conditionally: If the subscription instance to be added is already
-      registered with this subscription manager and has the same path, it is not created.
+      Owned subscriptions are added or updated conditionally: If the subscription instance to be added is already registered
+      with this subscription manager and has the same path, it is not created.
 
-      Permanent subscriptions are created unconditionally, and it is up to the user to ensure that such an instance does
-      not already exist.
+      Permanent subscriptions are created unconditionally, and it is up to the user to ensure that such an instance does not
+      already exist.
 
-      Upon successful return of this method, the added subscription is active on the WBEM server, so that the specified
-      WBEM listeners may immediately receive indications.
+      Upon successful return of this method, the added subscription is active on the WBEM server, so that the specified WBEM
+      listeners may immediately receive indications.
 
       If the --verbose general option is set, the created instance is displayed.
 
     Command Options:
       --owned / --permanent  Defines whether an owned or permanent filter, destination, or subscription is to be added.
                              Default: owned
-
       --select               Prompt user to select from multiple objects that match the IDENTITY. Otherwise, if the command
                              finds multiple instance that match the IDENTITY, the operation fails.
-
       -h, --help             Show this help message.
 
 
@@ -2736,20 +2604,17 @@ Help text for ``pywbemcli subscription list`` (see :ref:`subscription list comma
 
       This command provides an overview of the count of subscriptions, filters, and destinations retrieved from the WBEM
       server. The level of detail depends on the --summary and --detail options. '--summary' displays only a single count
-      for each; --detail displays a table for the instances of each. The default is to display a table of the count of
-      owned and permanent for each.
+      for each; --detail displays a table for the instances of each. The default is to display a table of the count of owned
+      and permanent for each.
 
     Command Options:
       --type [owned|permanent|all]  Defines whether the command filters owned,  permanent, or all objects for the response.
                                     Default: all
-
       -s, --summary                 Show only summary count of instances. This option is mutually exclusive with options:
                                     (--detail, --names-only).
-
       -d, --detail                  Show more detailed information. Otherwise only non-null or predefined property values
                                     are displayed. It applies to both MOF and TABLE output formats. This option is mutually
                                     exclusive with options: (--names-only, --summary).
-
       -h, --help                    Show this help message.
 
 
@@ -2778,18 +2643,14 @@ Help text for ``pywbemcli subscription list-destinations`` (see :ref:`subscripti
     Command Options:
       --type [owned|permanent|all]  Defines whether the command filters owned,  permanent, or all objects for the response.
                                     Default: all
-
       -d, --detail                  Show more detailed information. Otherwise only non-null or predefined property values
                                     are displayed. It applies to both MOF and TABLE output formats. This option is mutually
                                     exclusive with options: (--names-only, --summary).
-
       --names-only, --no            Show the CIMInstanceName elements of the instances. This only applies when the --output-
                                     format is one of the CIM object options (ex. mof. This option is mutually exclusive with
                                     options: (--detail, --summary).
-
       -s, --summary                 Show only summary count of instances. This option is mutually exclusive with options:
                                     (--detail, --names-only).
-
       -h, --help                    Show this help message.
 
 
@@ -2809,8 +2670,8 @@ Help text for ``pywbemcli subscription list-filters`` (see :ref:`subscription li
 
       Display indication filters on the WBEM server.
 
-      Display existing CIM indication filters (CIM_IndicationFilter class) on the current connection. The indication
-      filters to be displayed can be filtered by the owned choice option (owned, permanent, all).
+      Display existing CIM indication filters (CIM_IndicationFilter class) on the current connection. The indication filters
+      to be displayed can be filtered by the owned choice option (owned, permanent, all).
 
       The data display is determined by the --detail, --names-only, and --summary options and can be displayed as either a
       table or CIM objects (ex. mof) format using the --output general option (ex. --output mof).
@@ -2818,18 +2679,14 @@ Help text for ``pywbemcli subscription list-filters`` (see :ref:`subscription li
     Command Options:
       --type [owned|permanent|all]  Defines whether the command filters owned,  permanent, or all objects for the response.
                                     Default: all
-
       -d, --detail                  Show more detailed information. Otherwise only non-null or predefined property values
                                     are displayed. It applies to both MOF and TABLE output formats. This option is mutually
                                     exclusive with options: (--names-only, --summary).
-
       --names-only, --no            Show the CIMInstanceName elements of the instances. This only applies when the --output-
                                     format is one of the CIM object options (ex. mof. This option is mutually exclusive with
                                     options: (--detail, --summary).
-
       -s, --summary                 Show only summary count of instances. This option is mutually exclusive with options:
                                     (--detail, --names-only).
-
       -h, --help                    Show this help message.
 
 
@@ -2860,19 +2717,15 @@ Help text for ``pywbemcli subscription list-subscriptions`` (see :ref:`subscript
     Command Options:
       --type [owned|permanent|all]  Defines whether the command filters owned,  permanent, or all objects for the response.
                                     Default: all
-
       -d, --detail                  Show more detailed information including MOF of referenced listeners and filters.
                                     Otherwise only non-null or predefined property values are displayed. The extra
                                     properties applies to both MOF and TABLE output formats. This option is mutually
                                     exclusive with options: (--names-only, --summary).
-
       --names-only, --no            Show the CIMInstanceName elements of the instances. This only applies when the --output-
                                     format is one of the CIM object options (ex. mof. This option is mutually exclusive with
                                     options: (--detail, --summary).
-
       -s, --summary                 Show only summary count of instances. This option is mutually exclusive with options:
                                     (--detail, --names-only).
-
       -h, --help                    Show this help message.
 
 
@@ -2892,16 +2745,16 @@ Help text for ``pywbemcli subscription remove-destination`` (see :ref:`subscript
 
       Remove a listener destination from the WBEM server.
 
-      Removes a listener destination instance (CIM_ListenerDestinationCIMXML) from the WBEM server where the instance to
-      be removed is identified by the IDENTITY argument and optional owned option of the command.
+      Removes a listener destination instance (CIM_ListenerDestinationCIMXML) from the WBEM server where the instance to be
+      removed is identified by the IDENTITY argument and optional owned option of the command.
 
       The required IDENTITY argument may be the value of the IDENTITY used to create the destination or may be the full
       value of the destination 'Name' property. This is the value of the 'Name' property for permanent destinations and a
       component of the 'Name' property for owned destinations.
 
       If the instance is owned by the current pywbem SubscriptionManager, pywbemcli indirectly specifies the Name property
-      value with the format: "pywbemdestination:" "<SubscriptionManagerID>" ":" <IDENTITY>``. If the destination instance
-      is permanent, the value of the IDENTITY argument is the value of the Name property.
+      value with the format: "pywbemdestination:" "<SubscriptionManagerID>" ":" <IDENTITY>``. If the destination instance is
+      permanent, the value of the IDENTITY argument is the value of the Name property.
 
       Some listener_destination instances on a server may be static in which case the server should generate an exception.
       Pywbemcli has no way to identify these static destinations and they will appear as permanent destination instances.
@@ -2913,10 +2766,8 @@ Help text for ``pywbemcli subscription remove-destination`` (see :ref:`subscript
     Command Options:
       --owned / --permanent  Defines whether an owned or permanent filter, destination, or subscription is to be removed.
                              Default: owned
-
       --select               Prompt user to select from multiple objects that match the IDENTITY. Otherwise, if the command
                              finds multiple instance that match the IDENTITY, the operation fails.
-
       -h, --help             Show this help message.
       -v, --verify           Prompt user to verify instances to be removed before request is sent to WBEM server.
 
@@ -2937,12 +2788,12 @@ Help text for ``pywbemcli subscription remove-filter`` (see :ref:`subscription r
 
       Remove an indication filter from the WBEM server.
 
-      Removes a single indication filter instance (CIM_IndicationFilter class) from the WBEM server where the instance to
-      be removed is identified by the IDENTITY argument and optional --owned option of the command.
+      Removes a single indication filter instance (CIM_IndicationFilter class) from the WBEM server where the instance to be
+      removed is identified by the IDENTITY argument and optional --owned option of the command.
 
-      The required IDENTITY argument may be the value of the IDENTITY used to create the filter or may be the full value
-      of the filter Name property. For permanent filters the value of the Name property is required; for owned
-      destinations the IDENTITY component of the Name property is sufficient.
+      The required IDENTITY argument may be the value of the IDENTITY used to create the filter or may be the full value of
+      the filter Name property. For permanent filters the value of the Name property is required; for owned destinations the
+      IDENTITY component of the Name property is sufficient.
 
       If the instance is owned by the current pywbem SubscriptionManager, pywbemcli indirectly specifies the Name property
       value with the format: "pywbemfilter:" "<SubscriptionManagerID>" ":" <IDENTITY>``. If the destination instance is
@@ -2955,10 +2806,8 @@ Help text for ``pywbemcli subscription remove-filter`` (see :ref:`subscription r
     Command Options:
       --owned / --permanent  Defines whether an owned or permanent filter, destination, or subscription is to be removed.
                              Default: owned
-
       --select               Prompt user to select from multiple objects that match the IDENTITY. Otherwise, if the command
                              finds multiple instance that match the IDENTITY, the operation fails.
-
       -v, --verify           Prompt user to verify instances to be removed before request is sent to WBEM server.
       -h, --help             Show this help message.
 
@@ -3010,12 +2859,12 @@ Help text for ``pywbemcli subscription remove-subscription`` (see :ref:`subscrip
       The required DESTINATIONID argument defines the existing destination instance that will be attached to the Filter
       reference of the association class. This argument may consist of either the value of the Name property of the target
       destination instance or the identity of that instance.  The identity is the full value of the Name property for
-      permanent destinations and is a component of the Name property for owned instances. If just the identity is used,
-      this will result in multiple destinations being found if the same string is defined as the identity of an owned and
+      permanent destinations and is a component of the Name property for owned instances. If just the identity is used, this
+      will result in multiple destinations being found if the same string is defined as the identity of an owned and
       permanent destination.
 
-      The required FILTERID argument defines the existing filter instance that will be attached to the 'Filter' reference
-      of the association class. This argument may consist of either the value of the 'Name' property of the target filter
+      The required FILTERID argument defines the existing filter instance that will be attached to the 'Filter' reference of
+      the association class. This argument may consist of either the value of the 'Name' property of the target filter
       instance or the identity of that instance.  The identity is the full value of the 'Name' property for permanent
       filters and is a component of the 'Name' property for owned instances. If just the identity is used, this may result
       in multiple filters being found if the same string is defined as the identity of an owned and permanent filter.
@@ -3027,9 +2876,7 @@ Help text for ``pywbemcli subscription remove-subscription`` (see :ref:`subscrip
       -v, --verify                   Prompt user to verify instances to be removed before request is sent to WBEM server.
       --remove-associated-instances  Attempt to remove the instances associated with this subscription. They will only be
                                      removed if they do not participate in any other associations.
-
       --select                       Prompt user to select from multiple objects that match the IDENTITY. Otherwise, if the
                                      command finds multiple instance that match the IDENTITY, the operation fails.
-
       -h, --help                     Show this help message.
 

--- a/docs/pywbemlistener/cmdshelp.rst
+++ b/docs/pywbemlistener/cmdshelp.rst
@@ -18,8 +18,8 @@ Help text for ``pywbemlistener``:
 
       The pywbemlistener command can run and manage WBEM listeners.
 
-      Each listener is a process that executes the 'pywbemlistener run' command to receive WBEM indications sent from a
-      WBEM server.
+      Each listener is a process that executes the 'pywbemlistener run' command to receive WBEM indications sent from a WBEM
+      server.
 
       A listener process can be started with the 'pywbemlistener start' command and stopped with the 'pywbemlistener stop'
       command.
@@ -40,20 +40,15 @@ Help text for ``pywbemlistener``:
     General Options:
       -o, --output-format FORMAT  Output format for the command result. FORMAT is one of the table formats:
                                   [table|plain|simple|grid|psql|rst|html].
-
       -l, --logdir DIR            Enable logging of the 'pywbemlistener run' command output to a file in a log directory.
                                   The file will be named 'pywbemlistener_NAME.log' where NAME is the listener name. Default:
                                   EnvVar PYWBEMLISTENER_LOGDIR, or no logging.
-
       -v, --verbose               Verbosity level. Can be specified multiple times: -v: Display indication processing
                                   settings; -vv: Display interactions between start and run commands.
-
       --pdb                       Pause execution in the built-in pdb debugger just before executing the command within
                                   pywbemlistener. Default: EnvVar PYWBEMLISTENER_PDB, or no debugger.
-
       --warn                      Enable display of all Python warnings. Default: Leave warning control to the
                                   PYTHONWARNINGS EnvVar, which by default displays no warnings.
-
       --version                   Show the version of this command and the pywbem package.
       -h, --help                  Show this help message.
 
@@ -123,35 +118,26 @@ Help text for ``pywbemlistener run`` (see :ref:`pywbemlistener run command`):
     Command Options:
       --start-pid PID              PID of the "pywbemlistener start" process to be notified about the startup of the run
                                    command. Default: No such notification will happen.
-
       -p, --port PORT              The port number the listener will open to receive indications. This can be any available
                                    port. Default: 25989
-
       -s, --scheme SCHEME          The scheme used by the listener (http, https). Default: https
       -c, --certfile FILE          Path name of a PEM file containing the certificate that will be presented as a server
                                    certificate during SSL/TLS handshake. Required when using https. The file may in addition
                                    contain the private key of the certificate. Default: EnvVar PYWBEMLISTENER_CERTFILE, or
                                    no certificate file.
-
       -k, --keyfile FILE           Path name of a PEM file containing the private key of the server certificate. Required
                                    when using https and when the certificate file does not contain the private key. Default:
                                    EnvVar PYWBEMLISTENER_KEYFILE, or no key file.
-
       --indi-call MODULE.FUNCTION  Call a Python function for each received indication. Invoke with --help-call for details
                                    on the function interface. Default: No function is called.
-
       --indi-file FILE             Append received indications to a file. The format can be modified using the --indi-format
                                    option. Default: Not appended.
-
       --indi-format FORMAT         Sets the format to be used when displaying received indications. Invoke with --help-
                                    format for details on the format specification. Default: "{dt} {h} {i_mof}".
-
       --help-format                Show help message for the format specification used with the --indi-format option and
                                    exit.
-
       --help-call                  Show help message for calling a Python function for each received indication when using
                                    the --indi-call option and exit.
-
       -h, --help                   Show this help message.
 
 
@@ -208,32 +194,24 @@ Help text for ``pywbemlistener start`` (see :ref:`pywbemlistener start command`)
     Command Options:
       -p, --port PORT              The port number the listener will open to receive indications. This can be any available
                                    port. Default: 25989
-
       -s, --scheme SCHEME          The scheme used by the listener (http, https). Default: https
       -c, --certfile FILE          Path name of a PEM file containing the certificate that will be presented as a server
                                    certificate during SSL/TLS handshake. Required when using https. The file may in addition
                                    contain the private key of the certificate. Default: EnvVar PYWBEMLISTENER_CERTFILE, or
                                    no certificate file.
-
       -k, --keyfile FILE           Path name of a PEM file containing the private key of the server certificate. Required
                                    when using https and when the certificate file does not contain the private key. Default:
                                    EnvVar PYWBEMLISTENER_KEYFILE, or no key file.
-
       --indi-call MODULE.FUNCTION  Call a Python function for each received indication. Invoke with --help-call for details
                                    on the function interface. Default: No function is called.
-
       --indi-file FILE             Append received indications to a file. The format can be modified using the --indi-format
                                    option. Default: Not appended.
-
       --indi-format FORMAT         Sets the format to be used when displaying received indications. Invoke with --help-
                                    format for details on the format specification. Default: "{dt} {h} {i_mof}".
-
       --help-format                Show help message for the format specification used with the --indi-format option and
                                    exit.
-
       --help-call                  Show help message for calling a Python function for each received indication when using
                                    the --indi-call option and exit.
-
       -h, --help                   Show this help message.
 
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -106,10 +106,11 @@ nocaselist==1.0.3
 nocasedict==1.0.1
 six==1.14.0; python_version <= '3.9'
 six==1.16.0; python_version >= '3.10'
-Click==7.1.1; python_version == '2.7'
-Click==7.1.1; python_version >= '3.5'
+Click==7.1.1; python_version <= '3.5'
+Click==8.0.1; python_version >= '3.6'
 click-spinner==0.1.8
-click-repl==0.1.6
+click-repl==0.1.6; python_version <= '3.5'
+click-repl==0.2; python_version >= '3.6'
 asciitree==0.3.3
 tabulate==0.8.2; python_version <= '3.9'
 tabulate==0.8.8; python_version >= '3.10'

--- a/pywbemtools/_click_extensions.py
+++ b/pywbemtools/_click_extensions.py
@@ -4,6 +4,7 @@ This file contains extensions to Click for pywbemtools.
 
 import sys
 from collections import OrderedDict
+import packaging.version
 
 import click
 
@@ -11,6 +12,9 @@ import click
 GENERAL_OPTS_TXT = '[GENERAL-OPTIONS]'
 CMD_OPTS_TXT = '[COMMAND-OPTIONS]'
 SUBCMD_HELP_TXT = "COMMAND [ARGS] " + CMD_OPTS_TXT
+
+# Click version as a tuple
+CLICK_VERSION = packaging.version.parse(click.__version__).release
 
 
 class PywbemtoolsGroup(click.Group):
@@ -107,6 +111,21 @@ class PywbemtoolsTopGroup(click.Group):
                 cmd_list.append(cmd_list.pop(i - pop_count))
                 pop_count += 1
         return cmd_list
+
+    def __call__(self, *args, **kwargs):
+        """
+        This method is called once for each execution of the pywbemtools
+        command, by the generated command entry point code (e.g. the 'pywbemcli'
+        script).
+
+        This method extends the default behavior by disabling wildcard expansion
+        on Windows, when using Click 8.0.1 or higher (that is the version which
+        introduced this argument).
+        """
+        if CLICK_VERSION >= (8, 0, 1):
+            kwargs = dict(kwargs)
+            kwargs['windows_expand_args'] = False
+        return self.main(*args, **kwargs)
 
 
 class PywbemtoolsCommand(click.Command):

--- a/pywbemtools/_utils.py
+++ b/pywbemtools/_utils.py
@@ -22,6 +22,7 @@ from __future__ import print_function, absolute_import
 
 import os
 import io
+import shutil
 import warnings
 import inspect
 from datetime import datetime
@@ -132,10 +133,7 @@ def pywbemtools_warn_explicit(*args, **kwargs):
 
 def get_terminal_width():
     """
-    Return the terminal width to use.
-
-    Note: On Windows, click.get_terminal_size() results in terminal sizes of 0
-    in some cases.
+    Return the terminal width to use, as an integer.
     """
 
     terminal_width = os.getenv(TERMWIDTH_ENVVAR, None)
@@ -147,7 +145,16 @@ def get_terminal_width():
             pass
 
     if USE_TERMINAL_WIDTH:
-        return click.get_terminal_size()[0]
+        # We first try shutil.get_terminal_size() which was added in Python 3.3.
+        # Click 8.0 has deprecated click.get_terminal_size() and issues a
+        # DeprecationWarning, but on Python 2.7, Click is pinned to <8.0, so we
+        # can use click.get_terminal_size() without triggering the
+        # DeprecationWarning.
+        try:
+            ts = shutil.get_terminal_size()
+        except AttributeError:
+            ts = click.get_terminal_size()
+        return ts[0]
 
     return DEFAULT_TABLE_WIDTH
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,10 +26,12 @@ six>=1.16.0; python_version >= '3.10'
 #     supported) and #819 (click-repl incompatible)
 # The Click requirements were copied into dev-requirements.txt in order not to
 # have the safety package upgrade it. Keep them in sync.
-Click>=7.1.1,<8.0; python_version == '2.7'
-Click>=7.1.1,<8.0; python_version >= '3.5'
+Click>=7.1.1,<8.0; python_version <= '3.5'
+Click>=8.0.1; python_version >= '3.6'
 click-spinner>=0.1.8
-click-repl>=0.1.6
+# click-repl 0.2 is needed for compatibility with Click 8.0.
+click-repl>=0.1.6; python_version <= '3.5'
+click-repl>=0.2; python_version >= '3.6'
 asciitree>=0.3.3
 # tabulate 0.8.8 fixes ImportError on Python 3.10.
 tabulate>=0.8.2; python_version <= '3.9'

--- a/tests/unit/pywbemcli/test_general_options.py
+++ b/tests/unit/pywbemcli/test_general_options.py
@@ -31,6 +31,7 @@ from pywbemtools._utils import CONNECTIONS_FILENAME
 
 from .cli_test_extensions import CLITestsBase, PYWBEM_0, PYWBEM_1
 from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
+from ..utils import CLICK_VERSION
 
 TEST_DIR = os.path.dirname(__file__)
 
@@ -401,7 +402,10 @@ TEST_CASES = [
       'cmdgrp': 'connection',
       'args': ['show']},
      {'stderr': ['Invalid value', '-U', '--use-pull',
-                 'invalid choice: blah. (choose from yes, no, either)'],
+                 'invalid choice: blah. (choose from yes, no, either)'
+                 if CLICK_VERSION < (8, 0) else
+                 "'blah' is not one of 'yes', 'no', 'either'"
+                 ],
       'rc': 2,
       'test': 'innows'},
      None, OK],
@@ -420,7 +424,9 @@ TEST_CASES = [
       'cmdgrp': 'connection',
       'args': ['show']},
      {'stderr': ['Invalid value for', '--pull-max-cnt',
-                 'blah is not a valid integer'],
+                 "blah is not a valid integer"
+                 if CLICK_VERSION < (8, 0) else
+                 "'blah' is not a valid integer"],
       'rc': 2,
       'test': 'innows'},
      None, OK],  # Only tests that the option is accepted

--- a/tests/unit/pywbemlistener/test_start_cmd.py
+++ b/tests/unit/pywbemlistener/test_start_cmd.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import, print_function
 import pytest
 
 from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NOWIN
+from ..utils import CLICK_VERSION
 
 
 # Default indication format (must be in sync with actual default format)
@@ -132,8 +133,10 @@ START_TESTCASES = [
         ),
         dict(
             rc=2,
-            stderr=[r"Invalid value for .*--scheme.: invalid choice: "
-                    r"badscheme"],
+            stderr=[r"Invalid value for .*--scheme.: " +
+                    r"invalid choice: badscheme"
+                    if CLICK_VERSION < (8, 0) else
+                    r"'badscheme' is not one of 'http', 'https'"],
             test='contains',
         ),
         RUN,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -20,6 +20,7 @@ Tests for _utils.py module
 from __future__ import absolute_import, print_function
 
 import os
+import shutil
 import mock
 import click
 import six
@@ -362,8 +363,8 @@ def test_to_unicode(testcase, obj, exp_result):
     assert act_result == exp_result
 
 
-# Special value to expect width returned by click.get_terminal_size()
-CLICK_TERMINAL_WIDTH = -1
+# Special value to expect the actual terminal width.
+ACTUAL_TERMINAL_WIDTH = -1
 
 TESTCASES_GET_TERMINAL_WIDTH = [
 
@@ -379,8 +380,7 @@ TESTCASES_GET_TERMINAL_WIDTH = [
     #   * default_table_width_conf: Input value for DEFAULT_TABLE_WIDTH config
     #     parameter, None for using the built-in default.
     #   * exp_result: Expected returned terminal width. The special value
-    #     CLICK_TERMINAL_WIDTH can be used to expect the click terminal width
-    #     as determined by click.get_terminal_size().
+    #     ACTUAL_TERMINAL_WIDTH can be used to expect the actual terminal width.
     # * exp_exc_types: Expected exception type(s), or None.
     # * exp_warn_types: Expected warning type(s), or None.
     # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
@@ -391,7 +391,7 @@ TESTCASES_GET_TERMINAL_WIDTH = [
             termwidth_env=None,
             use_terminal_width_conf=None,
             default_table_width_conf=None,
-            exp_result=CLICK_TERMINAL_WIDTH,
+            exp_result=ACTUAL_TERMINAL_WIDTH,
         ),
         None, None, True
     ),
@@ -411,7 +411,7 @@ TESTCASES_GET_TERMINAL_WIDTH = [
             termwidth_env='abc',
             use_terminal_width_conf=None,
             default_table_width_conf=None,
-            exp_result=CLICK_TERMINAL_WIDTH,
+            exp_result=ACTUAL_TERMINAL_WIDTH,
         ),
         None, None, True
     ),
@@ -421,7 +421,7 @@ TESTCASES_GET_TERMINAL_WIDTH = [
             termwidth_env=None,
             use_terminal_width_conf=True,
             default_table_width_conf=83,
-            exp_result=CLICK_TERMINAL_WIDTH,
+            exp_result=ACTUAL_TERMINAL_WIDTH,
         ),
         None, None, True
     ),
@@ -493,8 +493,11 @@ def test_get_terminal_width(
         # are not mistaken as expected exceptions
         assert testcase.exp_exc_types is None
 
-        if exp_result == CLICK_TERMINAL_WIDTH:
-            exp_result = click.get_terminal_size()[0]
+        if exp_result == ACTUAL_TERMINAL_WIDTH:
+            try:
+                exp_result = shutil.get_terminal_size()[0]
+            except AttributeError:
+                exp_result = click.get_terminal_size()[0]
 
         assert act_result == exp_result
 

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -41,6 +41,10 @@ import click
 import six
 from six.moves import shlex_quote
 
+
+# Click version as a tuple
+CLICK_VERSION = packaging.version.parse(click.__version__).release
+
 # Click issue #1231:
 # On Windows, the Click package has the issue that it writes '\n' at the Python
 # level as '\r\r\n' at the level of the Windows shell, and Popen() with
@@ -53,7 +57,6 @@ from six.moves import shlex_quote
 # all Python versions except 3.4. It turns out that the circumvention is also
 # needed on Python 2.7, even though Click 7.1 is used there (not clear why).
 # The CLICK_ISSUE_1231 boolean indicates that the Click issue is present.
-CLICK_VERSION = packaging.version.parse(click.__version__)
 CLICK_ISSUE_1231 = sys.version_info[0:2] <= (3, 4) and sys.platform == 'win32'
 
 


### PR DESCRIPTION
See commit message.

Note that I closed the earlier PR #1073 as a duplicate. See its description for a number of incompatibilities that may still be there (pending the test results in this PR).

TODOs: Fix errors that surfaced in this PR when using Click 8 (e.g. Python 3.10 / latest):
* DONE - Unexpected DeprecationWarnings:
  - In pywbemtools/_utils.py:150: DeprecationWarning: 'click.get_terminal_size()' is deprecated and will be removed in Click 8.1. Use 'shutil.get_terminal_size()' instead.  **(KS COMMENT )** See click issue https://github.com/pallets/click/issues/1736 . Not unexpected. We could move this one to a separate PR if you want to. Looks like click 8.1 will be at least a month or two out.
* DONE - Click-generated error messages have changed:
  - From "invalid choice: blah. (choose from yes, no, either)" to "'blah' is not one of 'yes', 'no', 'either'"
  - From: "blah is not a valid integer" to "'blah' is not a valid integer"
  - From: "invalid choice: badscheme'" to: "'badscheme' is not one of 'http', 'https'"
* DONE - "Error: Got unexpected extra arguments" when using "*" as a command line argument on windows/py10/latest.
  This is caused by Click 8.0 expanding wildcards on Windows, see Click PR https://github.com/pallets/click/pull/1830.
  Click 8.0.1 introduced a flag to disable that, see Click PR https://github.com/pallets/click/pull/1918.

 **COMMENT ks** These differences do not bother me as long as the tests do not break. They are more explanatory

**COMMENT AM** The tests do break because of these.