### PR TITLE
Fix issue # 1037 - allow --connections-file in interactive mode

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,9 @@ Released: not yet
 
 **Cleanup:**
 
+* Extend use of general options in interactive mode to allow setting the
+  connections-file for an interactive command. (see issue #1037)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/docs/pywbemcli/cmdlineinterface.rst
+++ b/docs/pywbemcli/cmdlineinterface.rst
@@ -233,7 +233,9 @@ of that definition with commands in the interactive mode.
 
 NOTE: The effects of any general option entered in the interactive mode exists
 only for that command and the original definition from the command line is
-restored for the next command. The changes to the connections file are retained.
+restored for the next command. Any changes to the :term:`connections file`
+defined in the interactive mode and executed in the same command are retained
+(ex. setting the default connection).
 
 Thus:
 
@@ -405,7 +407,7 @@ the current input. Pressing the right arrow → or c-e will insert this
 suggestion.
 
 General options can be entered in the interactive mode but they generally only
-apply to the current command defined on the same command input as the general
+apply to the current command defined in the same command input as the general
 option.  Thus, to modify the output format for a particular command, enter the
 --output-format general option before the command.  The following command
 sets the output format to ``table`` before executing the command and then

--- a/docs/pywbemcli/generaloptions.rst
+++ b/docs/pywbemcli/generaloptions.rst
@@ -50,8 +50,8 @@ once and retain their value throughout the execution of the interactive mode.
 
 General options defined in the command line may be overwritten by specifying
 them on interactive mode commands. The resulting new value is used only for
-that one command, and is not retained between interactive mode command
-executions.
+that one command, and is not retained for subsequent interactive mode commands.
+
 
 In the following example, the :ref:`--output-format general option` is used
 on an interactive mode command to overwrite the default output format, and the
@@ -667,9 +667,6 @@ The actually used path name of the connections file is shown in the
 
 The connection definitions in the connections file are managed with the
 commands in the :ref:`connection command group`.
-
-In the interactive mode, this option may not be modified after the command
-line is processed.
 
 .. index:: triple: --pdb; general options; pdb
 

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -745,12 +745,15 @@ def cli(ctx, server, connection_name, default_namespace, user, password,
     # env variables or the command line pywbemcli startup
 
     else:  # ctx.obj exists. Processing an interactive command.
-        # Issue # 920Imposed this limit to avoid confusion of changing
-        # connections file in interactive mode
+        # If connection file general option exists, get the new connection_repo.
+        # This overrides the existing ctx defined repo only for current command.
         if connections_file:
-            raise click.ClickException('General option "--connections-file" '
-                                       'not allowed in interactive mode.')
-        connections_repo = ctx.obj.connections_repo
+            connections_repo = ConnectionRepository(connections_file, verbose)
+        elif connections_file == "":
+            connections_repo = DEFAULT_CONNECTIONS_FILE
+        else:
+            connections_repo = ctx.obj.connections_repo
+
         # Apply the general options from the command line options
         # or from the context object to modify the PywbemServer object and
         # for a new ContextObj for the command
@@ -913,14 +916,8 @@ def cli(ctx, server, connection_name, default_namespace, user, password,
         if verbose:
             click.echo("Log configured to {}".format(log))
 
-        # Commented out because we do not allow modification of the
-        # connection file and have already set connections_repo in line
-        # above. This code would have allowed resetting to default.
-        # See issue #920
-        # if connections_repo is None:
-        #    connections_repo = ctx.obj.connections_repo
-        # elif connections_repo == "":
-        #    connections_repo = DEFAULT_CONNECTIONS_FILE
+        # NOTE: connection-file general option handled as first test because
+        # it could be used for other option processing
 
         if pdb is None:
             pdb = ctx.obj.pdb

--- a/tests/unit/pywbemcli/test_general_options.py
+++ b/tests/unit/pywbemcli/test_general_options.py
@@ -825,8 +825,8 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-    ['Verify -n option with non-existent connection file fails',
-     {'general': ['-n', 'namedoesnotexist'],
+    ['Verify --namen option with non-existent connection file fails',
+     {'general': ['--name', 'namedoesnotexist'],
       'cmdgrp': 'connection',
       'args': ['show']},
      {'stderr': ['Connection definition',
@@ -1082,19 +1082,10 @@ TEST_CASES = [
       'test': 'regex'},
      None, OK],
 
-    ['Verify --connection-file general option not allowed in interactive mode.',
+    ['Verify --connection-file general option in interactive mode bad file.',
      {'general': ['--server', 'http://blah', ],
-      'stdin': ['--connections-file blah.yaml connection list']},
-     {'stderr': ['General option "--connections-file" not allowed in '
-                 'interactive mode'],
-      'test': 'innows'},
-     None, OK],
-
-    ['Verify -C general option not allowed in interactive mode.',
-     {'general': ['--server', 'http://blah', ],
-      'stdin': ['-C blah.yaml connection list']},
-     {'stderr': ['General option "--connections-file" not allowed in '
-                 'interactive mode'],
+      'stdin': ['--connections-file blah.yaml --name blah connection list']},
+     {'stderr': ["Connections file ", "blah.yaml", "does not exist"],
       'test': 'innows'},
      None, OK],
 
@@ -1179,6 +1170,29 @@ TEST_CASES = [
                  'NAMEDOESNOTEXIST',
                  'not found in connections file'],
       'rc': 0,
+      'test': 'innows'},
+     None, OK],
+
+    # Test that interactive --connections-file works. The connections file
+    # is set in an interactive command and not there in third command.
+    ['Verify --connection-file general option in interactive mode works.',
+     {'connections_file_args': (TEST_CONNECTIONS_FILE_PATH,
+                                TEST_CONNECTIONS_FILE_DICT),
+      'general': ['--server', 'http://initialserver', ],
+      'stdin': ['-o table connection show',
+                '-v --connections-file {} -n blah connection list'.
+                format(TEST_CONNECTIONS_FILE_PATH),
+                # Show that the original server is restored
+                'connection show']},
+     {'stdout': ["| name | not-saved (current) |",     # Results, first cmd
+                 "| server  | http://initialserver |",
+                 # results from second command (defines new connection file)
+                 "Connections file loaded",         # test blah.yaml loaded
+                 "tmp_general_options.yaml",        # and the name of the file
+                 "*blah",                           # test connection list cmd
+                 # results from third command (connection show)
+                 "name   not-saved (current)",
+                 "server http://initialserver", ],
       'test': 'innows'},
      None, OK],
 


### PR DESCRIPTION
Modify to allow use of --connections-file general option on a command in
interactive mode.  This is same behavior as other commands.  The defined
connections file is enabled only for that command that includes the
option.