### PR TITLE
Fix issue #1018, timeout issues

### DIFF
--- a/docs/pywbemcli/generaloptions.rst
+++ b/docs/pywbemcli/generaloptions.rst
@@ -393,12 +393,29 @@ any subsequent pywbemcli commands:
 ``--timeout`` general option
 """"""""""""""""""""""""""""
 
-The argument value of the ``--timeout``/``-t`` general option is an integer that
-defines the
-client side timeout in seconds. The pywbem client includes a timeout mechanism
-that closes a WBEM connection if there is no response to a request to the WBEM
-server in the time defined by this value. Pywbemcli defaults to a
-predefined timeout (normally 30 seconds) if this option is not defined.
+The argument value of the ``--timeout``/``-t`` general option is an integer
+that defines the client side read timeout in seconds. The pywbem client
+includes a timeout mechanism that closes a WBEM connection and terminates the
+current pywbemcli request if there is no response to a WBEM server request
+in the time defined by timeout with multiple retries. A read timeout
+occurs any time no bytes have been received on the underlying socket for
+timeout seconds.
+
+See ``pywbemcli --help`` for the actual retry count value.  Thus, the actual
+time to command failure is multiple times the value of this option. Therefore
+a request that does not receive any response data and with timeout value of
+5 would timeout in, for example ( 5 sec * 3 (request and retries)) = 15 seconds.
+
+Pywbemcli defaults to a predefined read timeout (normally 30 seconds) if this
+option is not defined.
+
+The connection functionality has a separate timeout time set by pywbem and
+set at 10 seconds also with retries. The connection timeout is not modifiable
+by pywbemcli.
+
+In general the timeout value should only be modified where there is a specific
+reason such as specific commands or servers that have very long delay before
+returning data.
 
 .. index:: triple: --verify; general options; verify
 

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -35,6 +35,8 @@ from pywbem import LOGGER_SIMPLE_NAMES, \
     DEFAULT_LOG_DETAIL_LEVEL
 from pywbem import __version__ as pywbem_version
 
+from pywbem._cim_operations import HTTP_READ_RETRIES
+
 from .config import PYWBEMCLI_NAME_ENVVAR, PYWBEMCLI_SERVER_ENVVAR, \
     PYWBEMCLI_MOCK_SERVER_ENVVAR, \
     PYWBEMCLI_DEFAULT_NAMESPACE_ENVVAR, PYWBEMCLI_USER_ENVVAR, \
@@ -57,6 +59,7 @@ from .._utils import pywbemtools_warn, get_terminal_width, \
     CONNECTIONS_FILENAME, DEFAULT_CONNECTIONS_FILE
 from .._options import add_options, help_option
 from .._output_formatting import OUTPUT_FORMAT_GROUPS
+
 
 __all__ = ['cli']
 
@@ -508,10 +511,13 @@ def _create_server_instance(
               metavar='INT',
               # defaulted in code
               envvar=PYWBEMCLI_TIMEOUT_ENVVAR,
-              help=u'Client-side timeout in seconds for operations with the '
-                   u'WBEM server. '
-                   u'Default: EnvVar {ev}, or {default}.'.
-                   format(ev=PYWBEMCLI_TIMEOUT_ENVVAR,
+              help=u'Client-side timeout (seconds) on data read for '
+                   u'operations with the WBEM server. This integer is the '
+                   u'timeout for a single server request. Pywbem retries '
+                   u'reads {rt} times so the delay for read timeout failure '
+                   u'may be multiple times the timeout value.'
+                   u'Default: EnvVar {ev}, or {default}. Min/max: '.
+                   format(rt=HTTP_READ_RETRIES, ev=PYWBEMCLI_TIMEOUT_ENVVAR,
                           default=DEFAULT_CONNECTION_TIMEOUT))
 @click.option('-U', '--use-pull', type=click.Choice(['yes', 'no', 'either']),
               # defaulted in code

--- a/tests/unit/pywbemcli/test_general_options.py
+++ b/tests/unit/pywbemcli/test_general_options.py
@@ -151,7 +151,7 @@ GENERAL_HELP_LINES = [
     "--verify / --no-verify  If --verify, client verifies the X.509 server",
     "--ca-certs CACERTS  Certificates used to validate the certificate",
     "-c, --certfile FILE  Path name of a PEM file containing a X.509",
-    "-t, --timeout INT  Client-side timeout in seconds for operations",
+    "-t, --timeout INT  Client-side timeout (seconds) on data read for",
     "-U, --use-pull [yes|no|either] Determines whether pull operations are ",
     "--pull-max-cnt INT  Maximum number of instances to be returned by",
     "-T, --timestats / --no-timestats",


### PR DESCRIPTION
The issue documents  the fact that the time to timeout a WBEM operation may not be the same as the time specified in the --timeout general option.

Document in the help the fact that the actual timeout of commands is not
the same as the --timeout <int> general option value.

Further explain this in the  documentation for the general option --timeout.  

This does not
change any code since all the parameterization for retries and timeouts
is in pywbem.  A corresponding issue https://github.com/pywbem/pywbem/issues/2853
was filed for pywbem.