### PR TITLE
Change docker test server image used in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ on:
 env:
   # WBEM server image on Docker Hub as repository:tag.
   # Keep the version in sync with the Makefile.
-  TEST_SERVER_IMAGE: keyporttech/smi-server:0.1.2
+  TEST_SERVER_IMAGE: kschopmeyer/openpegasus-server:0.1.1
   # Base file name of local tarball created from WBEM server image
-  TEST_SERVER_IMAGE_TAR: smi-server-0.1.2.tar.gz
+  TEST_SERVER_IMAGE_TAR: openpegasus-server:0.1.1.tar.gz
   # Local Docker image cache directory
   DOCKER_CACHE_DIR: ~/docker-cache
 

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ endif
 # Docker image for end2end tests.
 # Keep the version in sync with the test.yml workflow.
 ifndef TEST_SERVER_IMAGE
-  TEST_SERVER_IMAGE := keyporttech/smi-server:0.1.2
+  TEST_SERVER_IMAGE := kschopmeyer/openpegasus-server:0.1.1
 endif
 
 # Determine OS platform make runs on.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,19 @@ Released: not yet
 * Extend use of general options in interactive mode to allow setting the
   connections-file for an interactive command. (see issue #1037)
 
+* Change DOCKER TEST_SERVER_IMAGE defined in Makefile to use one created from
+  OpenPegasus toolset.  See github OpenPegasus/OpenPegasusDocker repository
+  for pegasus, pegasus tools, and pegasus docker build tools.  This image
+  should be faster and is smaller (lt 400 mb) although still too large. This
+  docker file was created using the Docker definition and makefiles in the
+  github project OpenPegasus and repository OpenPegasusDocker. It contains
+  a build of OpenPegasus on Ubuntu 20.04 platform with the OpenPegasus
+  test provider environment installed. The docker server image build was
+  tested against the OpenPegasus testsuite.  However, the interop namespace
+  was modified to use root/interop in the container. The image contains the
+  OpenPegasus components to run the server against a repository based on
+  the DMTF schema version 2.41.0.
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
Changed to a new image created with definitions in github repository
OpenPegasus/OpenPegasus.  Note that the image is in
kschopmeyer/openpegasus as openpegasus-server, vesion 0.1.1.  This image
is significantly smaller and should be faster.

Note: We will drop use of the docker images from kporttech and will hopefully move the images from the kschopmeyer repo to an OpenPegasus repo if Docker approves of that repository as an open source project.