### PR TITLE
Implement multiple namespaces for selected commands

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -27,6 +27,17 @@ Released: not yet
 * Increased minimum version of Click to 8.0.1 on Python >= 3.6 to prepare for
   new features. Adjusted testcases accordingly.
 
+  Extended class and instance enumerate/get/associators/references to allow
+  getting the objects from multiple namespaces with a single request.  This
+  extends the command option --namespace to allow multiple namespaces for
+  these commands using either comma-separated format
+  (ex. --namespace root/cimv2,root/cimv3) or multiple definitions of the option
+  (ex. --namespace root/cimv2 --namespace root/cimv3) The display of results
+  have been extended to include the namespace name for the objects in all
+  of the output formats if multiple namespaces are used. As before, the
+  namespaces are not shown if only a single or the default namespace is
+  requested.  (see issues # 1058 and #1059)
+
 **Cleanup:**
 
 * Extend use of general options in interactive mode to allow setting the

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -228,7 +228,9 @@ Help text for ``pywbemcli class associators`` (see :ref:`class associators comma
                                       empty string will include no properties. Default: Do not filter properties.
       --no, --names-only              Retrieve only the object paths (names). Default: Retrieve the complete objects
                                       including object paths.
-      -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
+      -n, --namespace NAMESPACE(s)    Namespace(s) to use for this command, instead of the default connection namespace. May
+                                      be specified multiple times using either the option multiple times and/or comma
+                                      separated list. Default: connection default namespace.
       -s, --summary                   Show only a summary (count) of the objects.
       -h, --help                      Show this help message.
 
@@ -326,7 +328,9 @@ Help text for ``pywbemcli class enumerate`` (see :ref:`class enumerate command`)
                                       class origin information.
       --no, --names-only              Retrieve only the object paths (names). Default: Retrieve the complete objects
                                       including object paths.
-      -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
+      -n, --namespace NAMESPACE(s)    Namespace(s) to use for this command, instead of the default connection namespace. May
+                                      be specified multiple times using either the option multiple times and/or comma
+                                      separated list. Default: connection default namespace.
       -s, --summary                   Show only a summary (count) of the objects.
       --association / --no-association
                                       Filter the returned classes to return only indication classes (--association) or
@@ -390,8 +394,9 @@ Help text for ``pywbemcli class find`` (see :ref:`class find command`):
         pywbemcli -n myconn class find *Foo*
 
     Command Options:
-      -n, --namespace NAMESPACE       Add a namespace to the search scope. May be specified multiple times. Default: Search
-                                      in all namespaces of the server.
+      -n, --namespace NAMESPACE(s)    Namespace(s) for search scope. May be specified multiple times using either the option
+                                      multiple times and/or comma separated list. Default: Search in all namespaces of the
+                                      server.
       -s, --sort                      Sort by namespace. Default is to sort by classname
       --association / --no-association
                                       Filter the returned classes to return only indication classes (--association) or
@@ -458,7 +463,9 @@ Help text for ``pywbemcli class get`` (see :ref:`class get command`):
                                       specified with either a comma-separated list or by using the option multiple times.
                                       Properties specified in this option that are not in the object(s) will be ignored. The
                                       empty string will include no properties. Default: Do not filter properties.
-      -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
+      -n, --namespace NAMESPACE(s)    Namespace(s) to use for this command, instead of the default connection namespace. May
+                                      be specified multiple times using either the option multiple times and/or comma
+                                      separated list. Default: connection default namespace.
       -h, --help                      Show this help message.
 
 
@@ -548,7 +555,9 @@ Help text for ``pywbemcli class references`` (see :ref:`class references command
                                       empty string will include no properties. Default: Do not filter properties.
       --no, --names-only              Retrieve only the object paths (names). Default: Retrieve the complete objects
                                       including object paths.
-      -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
+      -n, --namespace NAMESPACE(s)    Namespace(s) to use for this command, instead of the default connection namespace. May
+                                      be specified multiple times using either the option multiple times and/or comma
+                                      separated list. Default: connection default namespace.
       -s, --summary                   Show only a summary (count) of the objects.
       -h, --help                      Show this help message.
 
@@ -1030,7 +1039,9 @@ Help text for ``pywbemcli instance associators`` (see :ref:`instance associators
                                       including object paths.
       -k, --key KEYNAME=VALUE         Value for a key in keybinding of CIM instance name. May be specified multiple times.
                                       Allows defining keys without the issues of quotes. Default: No keybindings provided.
-      -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
+      -n, --namespace NAMESPACE(s)    Namespace(s) to use for this command, instead of the default connection namespace. May
+                                      be specified multiple times using either the option multiple times and/or comma
+                                      separated list. Default: connection default namespace.
       -s, --summary                   Show only a summary (count) of the objects.
       --fq, --filter-query QUERY-STRING
                                       When pull operations are used, filter the instances in the result via a filter query.
@@ -1085,8 +1096,9 @@ Help text for ``pywbemcli instance count`` (see :ref:`instance count command`):
       namespaces.
 
     Command Options:
-      -n, --namespace NAMESPACE       Add a namespace to the search scope. May be specified multiple times. Default: Search
-                                      in all namespaces of the server.
+      -n, --namespace NAMESPACE(s)    Namespace(s) for search scope. May be specified multiple times using either the option
+                                      multiple times and/or comma separated list. Default: Search in all namespaces of the
+                                      server.
       -s, --sort                      Sort by instance count. Otherwise sorted by class name.
       --ignore-class CLASSNAME        Class names of classes to be ignored (not counted). Allows counting instances in
                                       servers where instance retrieval may cause a CIMError or Error exception on some
@@ -1236,7 +1248,9 @@ Help text for ``pywbemcli instance enumerate`` (see :ref:`instance enumerate com
                                       specified with either a comma-separated list or by using the option multiple times.
                                       Properties specified in this option that are not in the object(s) will be ignored. The
                                       empty string will include no properties. Default: Do not filter properties.
-      -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
+      -n, --namespace NAMESPACE(s)    Namespace(s) to use for this command, instead of the default connection namespace. May
+                                      be specified multiple times using either the option multiple times and/or comma
+                                      separated list. Default: connection default namespace.
       --no, --names-only              Retrieve only the object paths (names). Default: Retrieve the complete objects
                                       including object paths.
       -s, --summary                   Show only a summary (count) of the objects.
@@ -1289,7 +1303,9 @@ Help text for ``pywbemcli instance get`` (see :ref:`instance get command`):
                                       empty string will include no properties. Default: Do not filter properties.
       -k, --key KEYNAME=VALUE         Value for a key in keybinding of CIM instance name. May be specified multiple times.
                                       Allows defining keys without the issues of quotes. Default: No keybindings provided.
-      -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
+      -n, --namespace NAMESPACE(s)    Namespace(s) to use for this command, instead of the default connection namespace. May
+                                      be specified multiple times using either the option multiple times and/or comma
+                                      separated list. Default: connection default namespace.
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
                                       --namespace options.
       --show-null                     In the TABLE output formats, show properties with no value (i.e. Null) in all of the
@@ -1472,7 +1488,9 @@ Help text for ``pywbemcli instance references`` (see :ref:`instance references c
                                       including object paths.
       -k, --key KEYNAME=VALUE         Value for a key in keybinding of CIM instance name. May be specified multiple times.
                                       Allows defining keys without the issues of quotes. Default: No keybindings provided.
-      -n, --namespace NAMESPACE       Namespace to use for this command, instead of the default namespace of the connection.
+      -n, --namespace NAMESPACE(s)    Namespace(s) to use for this command, instead of the default connection namespace. May
+                                      be specified multiple times using either the option multiple times and/or comma
+                                      separated list. Default: connection default namespace.
       -s, --summary                   Show only a summary (count) of the objects.
       --fq, --filter-query QUERY-STRING
                                       When pull operations are used, filter the instances in the result via a filter query.

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -292,9 +292,14 @@ The command options are:
    or just class names is sent to the server. When set, only the object paths (names)
    are requested. The default is to return the class definitions.
 
+index:    pair --namespace option; command option --namespace
+
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace`
    to use for this command, instead of the default namespace of the
-   :term:`current connection`.
+   :term:`current connection`. This option accepts single or multiple namespaces
+   and displays the results for the list of namespaces supplied.
+   See :ref: `Pywbemcli special command line features` for more information
+   on using multiple namespaces
 
 * ``-s``/``--summary`` - Displays a summary count of the objects that are returned
   by the request rather than a table or CIM object representation of each
@@ -352,6 +357,9 @@ The command options are:
 
 *  ``--dry-run`` - Do not actually delete the objects, but display what
    would be done.
+
+index:
+    pair --namespace option; command option --namespace
 
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace`
    to use for this command, instead of the default namespace of the
@@ -440,9 +448,16 @@ The command options are:
    or just class names is sent to the server. When set, only the object paths (names)
    are requested. The default is to return the class definitions.
 
+.. index::
+    pair: namespace; multiple namespaces
+    pair: --namespace option; command option --namespace
+
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace`
    to use for this command, instead of the default namespace of the
-   :term:`current connection`.
+   :term:`current connection`.  This option accepts single or multiple namespaces
+   and displays the results for the list of namespaces supplied.
+   See :ref: `Pywbemcli special command line features` for more information
+   on using multiple namespaces
 
 *  ``-s``/``--summary`` - Show only a summary (count) of the objects.
 
@@ -507,6 +522,9 @@ The command displays the namespaces and class names of the result using the
 ``txt`` output format (default), or using :term:`Table output formats`.
 
 The command options are:
+
+index:
+    pair --namespace option; command option --namespace
 
 *  ``--namespace`` ``-n`` ``NAMESPACE`` - Add a namespace to the search scope.
    This option may be specified multiple times or the namespace list may
@@ -607,9 +625,15 @@ The command options are:
    will be ignored. AN empty string will include no properties. If this option
    is not set, the server is expected to return all properties.
 
+.. index::
+    pair: namespace; multiple namespaces
+
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace`
    to use for this command, instead of the default namespace of the
-   :term:`current connection`.
+   :term:`current connection`. This option accepts single or multiple namespaces
+   and displays the results for the list of namespaces supplied.
+   See :ref: `Pywbemcli special command line features` for more information
+   on using multiple namespaces
 
 The class definition is displayed using :term:`CIM object output formats`.
 This command does not support :term:`Table output formats`.
@@ -687,6 +711,9 @@ The command options are:
 * ``--parameter``\``-p`` ``PARAMETERNAME=VALUE`` Specify a method input
   parameter with its value. May be used several time to define multiple input
   values.
+
+index:
+    pair --namespace option; command option --namespace
 
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace`
    to use for this command, instead of the default namespace of the
@@ -767,9 +794,15 @@ The command options are:
    or just class names is sent to the server. When set, only the object paths (names)
    are requested. The default is to return the class definitions.
 
+index:
+    pair --namespace option; command option --namespace
+
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace`
    to use for this command, instead of the default namespace of the
-   :term:`current connection`.
+   :term:`current connection`. This option accepts single or multiple namespaces
+   and displays the results for the list of namespaces supplied.
+   See :ref: `Pywbemcli special command line features` for more information
+   on using multiple namespaces
 
 .. code-block:: text
 
@@ -819,6 +852,9 @@ The command options are:
 
 *  ``--detail`/``-d``` - Show details about the class including the Version,
    Association, Indication, and Abstact qualifiers.
+
+index:
+    pair --namespace option; command option --namespace
 
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace`
    to use for this command, instead of the default namespace of the
@@ -952,9 +988,15 @@ The command options are:
    or just class names is sent to the server. When set, only the object paths (names)
    are requested. The default is to return the class definitions.
 
+index:
+    pair --namespace option; command option --namespace
+
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace`
    to use for this command, instead of the default namespace of the
-   :term:`current connection`.
+   :term:`current connection`. This option accepts single or multiple namespaces
+   and displays the results for the list of namespaces supplied.
+   See :ref: `Pywbemcli special command line features` for more information
+   on using multiple namespaces
 
 *  ``-s``/``--summary`` - Show only a summary (count) of the objects.
 
@@ -1045,9 +1087,12 @@ association classes.
 
 The command options are:
 
+.. index::
+    pair --namespace option; command option --namespace
+
 *  ``--namespace``/``-n`` ``NAMESPACE`` - Add a namespace to the search scope.
    May be specified multiple times. If this option is not specified the
-   search defaults to using all namespaces in the server.  Note that this
+   search defaults to searching all namespaces in the server.  Note that this
    option differs from the option of the same name in commands like
    ``instance enumerate`` in that it allows multiple namespaces and defaults
    to defining a list of all namespaces rather than defaulting to the
@@ -1181,6 +1226,9 @@ The command options are:
     change, to allow for verification of parameters. Default: Do not prompt for
     confirmation.
 
+.. index::
+    pair --namespace option; command option --namespace
+
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace` to
    use for this command, instead of the default namespace of the
    :term:``current connection``.
@@ -1221,6 +1269,9 @@ The command options are:
 *  ``--key``/``-k`` ``KEYNAME=VALUE`` - The value for a key in the keybinding of
    CIM instance name. May be specified multiple times. This option
    allows defining keys on the command line without the issues of quotes.
+
+.. index::
+    pair --namespace option; command option --namespace
 
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace` to
    use for this command, instead of the default namespace of the
@@ -1302,9 +1353,15 @@ The command options are:
    or just class names is sent to the server. When set, only the object paths (names)
    are requested. The default is to return the class definitions.
 
+.. index::
+    pair --namespace option; command option --namespace
+
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace` to
    use for this command, instead of the default namespace of the
-   :term:``current connection``.
+   :term:``current connection``. This option accepts single or multiple namespaces
+   and displays the results for the list of namespaces supplied.
+   See :ref: `Pywbemcli special command line features` for more information
+   on using multiple namespaces
 
 *  ``--summary``/``-s`` - Show only a summary (count) of the objects.
 
@@ -1442,9 +1499,15 @@ The command options are:
    allows defining keys on the command line without the issues of quotes.
    Default: No keybindings provided.
 
+.. index::
+    pair --namespace option; command option --namespace
+
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace` to
    use for this command, instead of the default namespace of the
-   :term:``current connection``.
+   :term:``current connection``. This option accepts single or multiple namespaces
+   and displays the results for the list of namespaces supplied.
+   See :ref: `Pywbemcli special command line features` for more information
+   on using multiple namespaces
 
 *  ``--help-instancename``/``--hi`` -  Show help message for specifying
    ``INSTANCENAME`` including use of the ``--key`` and ``--namespace``
@@ -1621,6 +1684,9 @@ The command arguments are:
    allows defining keys on the command line without the issues of quotes.
    Default: No keybindings provided.
 
+.. index::
+    pair --namespace option; command option --namespace
+
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace`
    to use for this command, instead of the default namespace of the
    :term:`current connection`.
@@ -1704,6 +1770,9 @@ The command options are:
    or just class names is sent to the server. When set, only the object paths (names)
    are requested. The default is to return the instances.
 
+.. index::
+    pair --namespace option; command option --namespace
+
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace` to
    use for this command, instead of the default namespace of the current connection.
 
@@ -1773,6 +1842,9 @@ The command options are:
   target server.   pywbemcli  does not validate the query language specified but
   passes it on to the WBEM server.
 
+.. index::
+    pair --namespace option; command option --namespace
+
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace`
    to use for this command, instead of the default namespace of the
    :term:`current connection`.
@@ -1840,6 +1912,9 @@ The command options are:
 *  ``--key``/``-k`` ``KEYNAME=VALUE`` - The value for a key in the keybinding of
    CIM instance name. May be specified multiple times. This option
    allows defining keys on the command line without the issues of quotes.
+
+.. index::
+    pair --namespace option; command option --namespace
 
 *  ``--namespace``/``-n`` ``NAMESPACE`` - This option defines the term:`Namespace`
    to use for this command, instead of the default namespace of the
@@ -2377,6 +2452,9 @@ resulting CIM objects to the target namespace in the WBEM server of the
 :term:`current connection`.
 
 The command options are:
+
+.. index::
+    pair --namespace option; command option --namespace
 
 *  ``--namespace``/``-n`` ``NAMESPACE`` This option defines the term:`Namespace` to
    use for this command, instead of the default namespace of the current connection.

--- a/docs/pywbemcli/features.rst
+++ b/docs/pywbemcli/features.rst
@@ -38,6 +38,25 @@ syntactic implementation of the features. This includes:
   for example, it can for experimental classes, association classes, and
   deprecated classes.
 
+.. index::
+    pair: namespace; multiple namespaces
+    pair: --namespace option; command option --namespace
+
+* The ability to view information on multiple namespaces in a single command.
+  Many of the pywbemcli commands target a term:`Namespace` in the WBEM server for
+  as the source of information (ex. enumerate, get, associators, references,
+  create, delete, modify). Commands like create, delete, and modify are
+  restricted to a single namespace which can be either the default namespace
+  defined for the connection or a namespace defined with the ``--namespace``
+  command option. Commands like enumerate, get, associators,
+  and references can be used to get CIM information from multiple namespaces
+  in a single pywbemcli request using the ``--namespace``
+  command option.  Thus, if single namespace is defined (``--namespace root/blah``)
+  that becomes the namespace for the command. However with these particular
+  commands, multiple namespaces can be specified (``--namespace root/cimv2,root/cimv3``
+  or ``--namespace root/cimv2 --namespace root/cimv3) and the CIM objects retrieved
+  from all of the namespaces on this list and displayed.
+
 
 .. _`pywbemcli commands to WBEM operations`:
 
@@ -87,7 +106,7 @@ GetClass                           class get CLASSNAME
 ModifyClass                        Not implemented
 CreateClass                        Not implemented
 DeleteClass                        class delete CLASSNAME
-**QualifierDeclaration ops:**
+**QualifierDeclaration Ops:**
 EnumerateQualifiers                qualifier enumerate
 GetQualifier                       qualifier get QUALIFIERNAME
 SetQualifier                       Not implemented

--- a/pywbemtools/_output_formatting.py
+++ b/pywbemtools/_output_formatting.py
@@ -100,6 +100,21 @@ def output_format_is_cimobject(output_format):
     return output_format in CIM_OBJECT_FORMATS
 
 
+def output_format_is_testgroup(output_format):
+    """
+    Return boolean indicating whether an output format is a text format.
+
+    Parameters:
+
+      output_format (:term:`string`):
+         The output format keyword (e.g. 'text') to be checked.
+
+    Returns:
+      bool: Boolean indicating whether the output format is a text format.
+    """
+    return output_format in TEXT_FORMATS
+
+
 def output_format_in_groups(output_format, format_groups):
     """
     Return boolean indicating whether an output format is in a given format

--- a/pywbemtools/pywbemcli/_cmd_subscription.py
+++ b/pywbemtools/pywbemcli/_cmd_subscription.py
@@ -1191,8 +1191,7 @@ class IndicationSubscription(BaseIndicationObjectInstance):
         return '{0} {1} {2}'.format(self._owned_flag, dest_str, filter_str)
 
 
-def display_inst_nonnull_props(context, options, instances, output_format,
-                               sort=False):
+def display_inst_nonnull_props(context, options, instances, output_format):
     """
     Display the instances defined in instances after removing any properties
     that are Null for all instances.
@@ -1207,8 +1206,7 @@ def display_inst_nonnull_props(context, options, instances, output_format,
     pl = list(pldict.keys())
 
     display_cim_objects(context, instances, output_format,
-                        summary=options['summary'], sort=sort,
-                        property_list=pl)
+                        summary=options['summary'], property_list=pl)
 
 
 def pick_one_inst_from_instances_list(csm, instances, pick_msg):
@@ -1676,7 +1674,7 @@ def cmd_subscription_list_destinations(context, options):
                                        output_format)
         else:
             display_cim_objects(context, destinations, output_format,
-                                summary=options['summary'], sort=True)
+                                summary=options['summary'])
 
     elif output_format_is_table(output_format):
         if options['names_only']:

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -992,6 +992,9 @@ def sort_cimobjects(cim_objects):
       string of the CIMClassName object. This makes the sort case insensitive.
       This case covers the result of 'class references/associators'.
 
+    The list is sorted by classname for class, instance objects and by wbem_uri
+    for objects that represent names (CIMInstanceName, etc.)
+
     Parameters:
 
       cim_objects (Sequence): Objects to be sorted.
@@ -1010,7 +1013,7 @@ def sort_cimobjects(cim_objects):
 
     tst_obj = cim_objects[0]
 
-    # This case covers result of 'class enumerate':
+    # Result of 'class enumerate':
     if isinstance(tst_obj, six.string_types):
         return sorted(cim_objects)
 
@@ -1018,7 +1021,11 @@ def sort_cimobjects(cim_objects):
         return sorted(cim_objects,
                       key=lambda obj: obj.classname)
 
-    if isinstance(tst_obj, (CIMClassName, CIMInstanceName)):
+    if isinstance(tst_obj, (CIMInstanceName)):
+        return sorted(cim_objects,
+                      key=lambda obj: obj.to_wbem_uri(format="canonical"))
+
+    if isinstance(tst_obj, (CIMClassName)):
         return sorted(cim_objects,
                       key=lambda obj: obj.to_wbem_uri(format="canonical"))
 
@@ -1038,7 +1045,7 @@ def sort_cimobjects(cim_objects):
         return sorted(cim_objects,
                       key=lambda obj: obj.name)
 
-    # This case covers result of 'class references/associators':
+    # Result of 'class references/associators':
     if isinstance(tst_obj, tuple):
         if not isinstance(tst_obj[0], CIMClassName) or \
                 not isinstance(tst_obj[1], CIMClass):

--- a/pywbemtools/pywbemcli/_common_options.py
+++ b/pywbemtools/pywbemcli/_common_options.py
@@ -71,6 +71,25 @@ namespace_option = [
                       u'default namespace of the connection.'),
 ]
 
+multiple_namespaces_option_dflt_conn = [
+    click.option('-n', '--namespace', type=str, multiple=True,
+                 required=False, metavar='NAMESPACE(s)',
+                 help=u'Namespace(s) to use for this command, instead of the '
+                      u'default connection namespace. May be specified '
+                      u'multiple times using either the option multiple times '
+                      u'and/or comma separated list. '
+                      u'Default: connection default namespace.'),
+]
+
+multiple_namespaces_option_dflt_all = [
+    click.option('-n', '--namespace', type=str, multiple=True,
+                 required=False, metavar='NAMESPACE(s)', default=[],
+                 help=u'Namespace(s) for search scope. May be specified '
+                      u'multiple times using either the option multiple times '
+                      u'and/or comma separated list. '
+                      u'Default: Search in all namespaces of the server.'),
+]
+
 summary_option = [
     click.option('-s', '--summary', is_flag=True, required=False,
                  help=u'Show only a summary (count) of the objects.'),
@@ -81,14 +100,6 @@ verify_option = [
                  help=u'Prompt for confirmation before performing a change, '
                       u'to allow for verification of parameters. '
                       u'Default: Do not prompt for confirmation.'),
-]
-
-multiple_namespaces_option = [
-    click.option('-n', '--namespace', type=str, multiple=True,
-                 required=False, metavar='NAMESPACE',
-                 help=u'Add a namespace to the search scope. '
-                      u'May be specified multiple times. '
-                      u'Default: Search in all namespaces of the server.'),
 ]
 
 class_filter_options = [

--- a/tests/unit/pywbemcli/common_options_help_lines.py
+++ b/tests/unit/pywbemcli/common_options_help_lines.py
@@ -76,13 +76,14 @@ CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE = \
     '--ico, --include-classorigin Include class origin information in the ' \
     'returned'
 
-CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE = \
-    '-n, --namespace NAMESPACE  Add a namespace to the search scope. May be'
+CMD_OPTION_MULTIPLE_NAMESPACE_ALL_HELP_LINE = \
+    '-n, --namespace NAMESPACE(s) Namespace(s) for search scope. May be ' \
+    'specified '
 
 CMD_OPTION_KEYS_HELP_LINE = \
-    '-k, --key KEYNAME=VALUE         Value for a key in keybinding of'
+    '-k, --key KEYNAME=VALUE   Value for a key in keybinding of'
 
-# NOTE: The FILTER help lines should exist as a group wherever used.
+# NOTE: The FILTER help lines below should exist as a group wherever used.
 
 CMD_OPTION_ASSOCIATION_FILTER_HELP_LINE = \
     '--association / --no-association'
@@ -97,19 +98,22 @@ CMD_OPTION_DEPRECATED_FILTER_HELP_LINE = \
     '--deprecated / --no-deprecated'
 
 CMD_OPTION_SINCE_FILTER_HELP_LINE = \
-    'Filter the returned classes to return only'
+    '--since VERSION Filter the returned classes to return only'
 
 CMD_OPTION_SCHEMA_FILTER_HELP_LINE = \
-    "Filter the returned classes to return only classes"
+    "--schema SCHEMA Filter the returned classes to return only classes"
 
 CMD_OPTION_SUBCLASSOF_FILTER_HELP_LINE = \
-    "Filter the returned classes to return only"
+    "--subclass-of CLASSNAME Filter the returned classes to return only"
 
 CMD_OPTION_LEAFCLASSES_FILTER_HELP_LINE = \
-    "Filter the returned classes to return only"
+    "--leaf-classes Filter the returned classes to return only"
 
 CMD_OPTION_HELP_INSTANCENAME_HELP_LINE = \
     '--hi, --help-instancename Show help message for specifying INSTANCENAME'
 
 CMD_OPTION_SHOW_NULL_HELP_LINE = \
     '--show-null In the TABLE output formats, show properties with no '
+
+CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE = \
+    'Namespace(s) to use for this command, instead of the'

--- a/tests/unit/pywbemcli/simple_three_ns_mock_script.py
+++ b/tests/unit/pywbemcli/simple_three_ns_mock_script.py
@@ -1,0 +1,122 @@
+"""
+Test mock script that prepares an Interop namespace and namespace provider,
+and then compiles namespace-neutral MOF into the default namespace (which may
+have been set from the outside).
+
+This mock script uses 'new-style' setup for Python >=3.5 and 'old-style' setup
+otherwise, and is therefore useable for all supported Python versions.
+On Python <3.5, the tests using this script must be run from the repo main
+directory.
+"""
+
+import sys
+import os
+import six
+import pywbem_mock
+
+# interop namespace used by this mock environment
+INTEROP_NAMESPACE = 'interop'
+THIRD_NAMESPACE = "root/cimv3"
+
+
+def register_dependents(conn, this_file_path, dependent_file_names):
+    """
+    Register a dependent file name with the pywbemcli dependent file api.
+    This insures that any change to a dependent file will cause the
+    script to be recompiled.
+    """
+    if isinstance(dependent_file_names, six.string_types):
+        dependent_file_names = [dependent_file_names]
+
+    for fn in dependent_file_names:
+        dep_path = os.path.join(os.path.dirname(this_file_path), fn)
+        conn.provider_dependent_registry.add_dependents(this_file_path,
+                                                        dep_path)
+
+
+def _setup(conn, server, verbose):
+    # pylint: disable=unused-argument
+    """
+    Setup for this mock script.
+
+    Parameters:
+      conn (FakedWBEMConnection): Connection
+      server (PywbemServer): Server
+      verbose (bool): Verbose flag
+    """
+
+    if sys.version_info >= (3, 5):
+        this_file_path = __file__
+    else:
+        # Unfortunately, it does not seem to be possible to find the file path
+        # of the current script when it is executed using exec(), so we hard
+        # code the file path. This requires that the tests are run from the
+        # repo main directory.
+        this_file_path = 'tests/unit/pywbemcli/simple_interop_mock_script.py'
+        assert os.path.exists(this_file_path)
+
+    # Create the third namespace before the interop namespace is created
+    # so that it exists when the pywbem server. This namespace creation done
+    # before interop created because of pywbem issue #2865
+    conn.add_namespace(THIRD_NAMESPACE, verbose=verbose)
+
+    # Prepare an Interop namespace and namespace provider
+
+    interop_mof_file = 'mock_interop.mof'
+    if INTEROP_NAMESPACE not in conn.cimrepository.namespaces:
+        conn.add_namespace(INTEROP_NAMESPACE, verbose=verbose)
+
+    interop_mof_path = os.path.join(
+        os.path.dirname(this_file_path), interop_mof_file)
+    conn.compile_mof_file(interop_mof_path, namespace=INTEROP_NAMESPACE,
+                          verbose=verbose)
+    register_dependents(conn, this_file_path, interop_mof_file)
+
+    ns_provider = pywbem_mock.CIMNamespaceProvider(conn.cimrepository)
+    conn.register_provider(ns_provider, INTEROP_NAMESPACE, verbose=verbose)
+
+    # Add namespace-neutral MOF to the default namespace and to the third
+    # namespace
+
+    mof_file = 'simple_mock_model.mof'
+    mof_path = os.path.join(os.path.dirname(this_file_path), mof_file)
+    register_dependents(conn, this_file_path, mof_file)
+
+    conn.compile_mof_file(mof_path, namespace=None, verbose=verbose)
+
+    # Create a third namespace that has same classes and the default
+    # namespace but different instances
+    # TODO add different class also
+
+    # Add the same classes and instances as in root/cimv2
+    conn.compile_mof_file(mof_path, namespace=THIRD_NAMESPACE, verbose=verbose)
+
+    inst_mof = "instance of CIM_Foo{ " \
+        "InstanceID = \"CIM_Foo3-third-ns\"; " \
+        "IntegerProp = 3; " \
+        "};"
+    conn.compile_mof_string(inst_mof, namespace=THIRD_NAMESPACE,
+                            verbose=verbose)
+
+
+if sys.version_info >= (3, 5):
+    # New-style setup
+
+    # If the function is defined directly, it will be detected and refused
+    # by the check for setup() functions on Python <3.5, despite being defined
+    # only conditionally. The indirect approach with exec() addresses that.
+    # pylint: disable=exec-used
+    exec("""
+def setup(conn, server, verbose):
+    _setup(conn, server, verbose)
+""")
+
+else:
+    # Old-style setup
+
+    global CONN  # pylint: disable=global-at-module-level
+    global SERVER  # pylint: disable=global-at-module-level
+    global VERBOSE  # pylint: disable=global-at-module-level
+
+    # pylint: disable=undefined-variable
+    _setup(CONN, SERVER, VERBOSE)  # noqa: F821

--- a/tests/unit/pywbemcli/test_class_cmds.py
+++ b/tests/unit/pywbemcli/test_class_cmds.py
@@ -46,8 +46,8 @@ _PYWBEM_VERSION = parse_version(pywbem_version)
 # pywbem 1.0.0 or later
 PYWBEM_1_0_0 = _PYWBEM_VERSION.release >= (1, 0, 0)
 
-# Create variable that is True if python version gt 3.5
-PYTHON_VER_GT_35 = sys.version_info > (3, 5)
+# Create variable that is True if python version ge 3.6
+PYTHON_GE_36 = sys.version_info > (3, 6)
 
 # Mock scripts with setup() function are supported
 MOCK_SETUP_SUPPORTED = sys.version_info >= (3, 5)
@@ -364,7 +364,7 @@ REFERENCES_CLASS_RTN_QUALS2 = [
     '};']
 
 
-OK = True     # mark tests OK when they execute correctly
+OK = False     # mark tests OK when they execute correctly
 RUN = True    # Mark OK = False and current test case being created RUN
 FAIL = False  # Any test currently FAILING or not tested yet
 
@@ -2637,7 +2637,7 @@ class CIM_FooRef2 : CIM_BaseRef {
 ''',  # noqa: E501
       'rc': 0,
       'test': 'innows'},
-     [THREE_NS_MOCK_FILE, "Bug Pywbem #2882"], PYTHON_VER_GT_35],
+     THREE_NS_MOCK_FILE, PYTHON_GE_36],
 
     # pylint: enable=line-too-long
 ]

--- a/tests/unit/pywbemcli/test_class_cmds.py
+++ b/tests/unit/pywbemcli/test_class_cmds.py
@@ -47,7 +47,7 @@ _PYWBEM_VERSION = parse_version(pywbem_version)
 PYWBEM_1_0_0 = _PYWBEM_VERSION.release >= (1, 0, 0)
 
 # Create variable that is True if python version gt 3.5
-PYTHON_VER_GT_35 = bool(sys.version_info > (3, 5))
+PYTHON_VER_GT_35 = sys.version_info > (3, 5)
 
 # Mock scripts with setup() function are supported
 MOCK_SETUP_SUPPORTED = sys.version_info >= (3, 5)
@@ -71,6 +71,7 @@ TREE_TEST_MOCK_FILE = 'tree_test_mock_model.mof'
 SIMPLE_INTEROP_MOCK_FILE = 'simple_interop_mock_script.py'
 
 THREE_NS_MOCK_FILE = 'simple_three_ns_mock_script.py'
+
 
 #
 # The following list defines the help for each command in terms of particular
@@ -2575,6 +2576,29 @@ class CIM_FooRef2 : CIM_BaseRef {
      {'args': ['associators', 'CIM_FooRef1',
                '--namespace', 'root/cimv2,root/cimv3'],
       'general': ['--output-format', 'xml']},
+     {'stdout': ['<!-- Namespace = root/cimv2 -->',
+                 '<CLASSPATH>',
+                 '<NAMESPACEPATH>',
+                 '<HOST>FakedUrl:5988</HOST>',
+                 '<LOCALNAMESPACEPATH>',
+                 '<NAMESPACE NAME="root"/>',
+                 '<NAMESPACE NAME="cimv2"/>',
+                 '</LOCALNAMESPACEPATH>',
+                 '</NAMESPACEPATH>',
+                 '</CLASSPATH>',
+                 '<!-- Namespace = root/cimv3 -->',
+                 '<CLASS NAME="CIM_FooRef2" SUPERCLASS="CIM_BaseRef">',
+                 '</QUALIFIER>',
+                 '</CLASS>'],
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    # pylint: disable=line-too-long
+    ['Verify associators from two namespaces xml output',
+     {'args': ['associators', 'CIM_FooRef1',
+               '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'xml']},
      {'stdout': '''<!-- Namespace = root/cimv2 -->
 <CLASSPATH>
     <NAMESPACEPATH>
@@ -2613,18 +2637,16 @@ class CIM_FooRef2 : CIM_BaseRef {
 ''',  # noqa: E501
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, PYTHON_VER_GT_35],  # Test fails python <= 3.5
-                                             # See bug pywbem #2882
+     [THREE_NS_MOCK_FILE, "Bug Pywbem #2882"], PYTHON_VER_GT_35],
+
     # pylint: enable=line-too-long
-
-
-    # TODO: Test class  REPR outputs
 ]
 
 # TODO command class delete. Extend this test to use stdin (delete, test)
 # namespace
 # TODO: add test for  errors: class invalid, namespace invalid
 # other tests.  Test local-only on top level
+# TODO: Test class  REPR outputs
 
 
 class TestSubcmdClass(CLITestsBase):  # pylint: disable=too-few-public-methods
@@ -2647,4 +2669,4 @@ class TestSubcmdClass(CLITestsBase):  # pylint: disable=too-few-public-methods
             pywbemcli command.
         """
         self.command_test(desc, self.command_group, inputs, exp_response,
-                          mock, condition, verbose=True)
+                          mock, condition)

--- a/tests/unit/pywbemcli/test_class_cmds.py
+++ b/tests/unit/pywbemcli/test_class_cmds.py
@@ -31,7 +31,8 @@ from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
     CMD_OPTION_NAMESPACE_HELP_LINE, CMD_OPTION_PROPERTYLIST_HELP_LINE, \
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE, \
     CMD_OPTION_LOCAL_ONLY_CLASS_HELP_LINE, CMD_OPTION_NO_QUALIFIERS_HELP_LINE, \
-    CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE, \
+    CMD_OPTION_MULTIPLE_NAMESPACE_ALL_HELP_LINE, \
+    CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE, \
     CMD_OPTION_ASSOCIATION_FILTER_HELP_LINE, \
     CMD_OPTION_INDICATION_FILTER_HELP_LINE, \
     CMD_OPTION_EXPERIMENTAL_FILTER_HELP_LINE, \
@@ -44,6 +45,9 @@ from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
 _PYWBEM_VERSION = parse_version(pywbem_version)
 # pywbem 1.0.0 or later
 PYWBEM_1_0_0 = _PYWBEM_VERSION.release >= (1, 0, 0)
+
+# Create variable that is True if python version gt 3.5
+PYTHON_VER_GT_35 = bool(sys.version_info > (3, 5))
 
 # Mock scripts with setup() function are supported
 MOCK_SETUP_SUPPORTED = sys.version_info >= (3, 5)
@@ -65,6 +69,8 @@ QUALIFIER_FILTER_MODEL = 'qualifier_filter_model.mof'
 TREE_TEST_MOCK_FILE = 'tree_test_mock_model.mof'
 
 SIMPLE_INTEROP_MOCK_FILE = 'simple_interop_mock_script.py'
+
+THREE_NS_MOCK_FILE = 'simple_three_ns_mock_script.py'
 
 #
 # The following list defines the help for each command in terms of particular
@@ -100,7 +106,7 @@ CLASS_ASSOCIATORS_HELP_LINES = [
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
     CMD_OPTION_NAMES_ONLY_HELP_LINE,
-    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
@@ -123,7 +129,7 @@ CLASS_ENUMERATE_HELP_LINES = [
     CMD_OPTION_NO_QUALIFIERS_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_NAMES_ONLY_HELP_LINE,
-    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
     # NOTE: The FILTER options are a group. Define all of them.
     CMD_OPTION_ASSOCIATION_FILTER_HELP_LINE,
@@ -143,7 +149,7 @@ CLASS_FIND_HELP_LINES = [
     '[COMMAND-OPTIONS]',
     'List the classes with matching class names on the server.',
     '-s, --sort  Sort by namespace. Default is to sort by',
-    CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE,
+    CMD_OPTION_MULTIPLE_NAMESPACE_ALL_HELP_LINE,
     # FILTER OPTIONS
     CMD_OPTION_ASSOCIATION_FILTER_HELP_LINE,
     CMD_OPTION_INDICATION_FILTER_HELP_LINE,
@@ -164,7 +170,7 @@ CLASS_GET_HELP_LINES = [
     CMD_OPTION_NO_QUALIFIERS_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
-    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
@@ -187,7 +193,7 @@ CLASS_REFERENCES_HELP_LINES = [
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
     CMD_OPTION_NAMES_ONLY_HELP_LINE,
-    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
@@ -536,13 +542,13 @@ TEST_CASES = [
       'test': 'in'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class command enumerate CIM_Foo summary table',
+    ['Verify class command enumerate CIM_Foo summary default output format',
      ['enumerate', 'CIM_Foo', '-s'],
      {'stdout': ['2 CIMClass(s) returned'],
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify class command enumerate CIM_Foo summary, table',
+    ['Verify class command enumerate CIM_Foo summary, default output format',
      ['enumerate', 'CIM_Foo', '--summary'],
      {'stdout': ['2 CIMClass(s) returned'],
       'test': 'innows'},
@@ -551,7 +557,7 @@ TEST_CASES = [
     ['Verify class command enumerate CIM_Foo summary table output',
      {'args': ['enumerate', 'CIM_Foo', '--summary'],
       'general': ['--output-format', 'table']},
-     {'stdout': ["""Summary of CIMClass returned
+     {'stdout': ["""Summary of CIMClass(s) returned
 +---------+------------+
 |   Count | CIM Type   |
 |---------+------------|
@@ -611,7 +617,7 @@ TEST_CASES = [
     ['Verify class command enumerate  --di --no --namespace',
      ['enumerate', '--di', '--no', '-n', 'interop'],
      {'stdout': ['CIM_Namespace', 'CIM_ObjectManager'],
-      'test': 'in'},
+      'test': 'innows'},
      SIMPLE_INTEROP_MOCK_FILE, OK],
 
     #
@@ -951,7 +957,6 @@ TEST_CASES = [
      {'stdout': ['0 objects returned'],
       'test': 'innows'},
      QUALIFIER_FILTER_MODEL, OK],
-
 
     ['Verify class command enumerate with --schema "NOT_EXIST".',
      ['enumerate', '--schema', 'NOT_EXIST', '--names-only'],
@@ -1336,7 +1341,7 @@ TEST_CASES = [
      SIMPLE_MOCK_FILE, OK],
     # pylint: enable=line-too-long
 
-    ['Verify class command enumerate  --di --no --namespace',
+    ['Verify class command get  --di --no --namespace',
      ['get', 'CIM_Namespace', '-n', 'interop'],
      {'stdout': ['class CIM_Namespace',
                  'string ObjectManagerCreationClassName;'],
@@ -2349,6 +2354,271 @@ TEST_CASES = [
       'rc': 0,
       'test': 'innows'},
      None, OK],
+
+    #
+    #  Multiple Namespaces Option tests --namespace a,b and -n a -n b
+    #  The following tests exercise the multiple-namespace functionality
+    #  for classes (enumerate, get, associators, references) and
+    #  corresponding names-only options.
+    #
+
+    ['Verify class get from two namespaces. single namespace/comma option',
+     {'args': ['get', 'CIM_Foo', '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': ['#pragma namespace ("root/cimv2")',
+                 '#pragma namespace ("root/cimv3")',
+                 'CIM_Foo {'],
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify class get from two namespaces use multiple namespace option',
+     {'args': ['get', 'CIM_Foo', '--namespace', 'root/cimv2',
+               '--namespace', 'root/cimv3']},
+     {'stdout': ['#pragma namespace ("root/cimv2")',
+                 '#pragma namespace ("root/cimv3")',
+                 'CIM_Foo {'],
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify class enumerate from two namespaces multiple namespace option,'
+     ' no classname',
+     {'args': ['enumerate', '--namespace', 'root/cimv2',
+               '--namespace', 'root/cimv3']},
+     {'stdout': ['#pragma namespace ("root/cimv2")',
+                 '#pragma namespace ("root/cimv3")',
+                 'class CIM_Foo {'],
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify class enumerate from two namespaces, CIM_Foo',
+     {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': ['#pragma namespace ("root/cimv2")',
+                 '#pragma namespace ("root/cimv3")',
+                 'class CIM_Foo_sub : CIM_Foo {'],
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify class enumerate from two namespaces summary',
+     {'args': ['enumerate', 'CIM_Foo', '--summary',
+               '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': ['root/cimv2 2 CIMClass(s) returned',
+                 'root/cimv3 2 CIMClass(s) returned'],
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify class enumerate from two namespaces summary, table',
+     {'args': ['enumerate', 'CIM_Foo', '--summary',
+               '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """Summary of CIMClass(s) returned
++-------------+---------+------------+
+| Namespace   |   Count | CIM Type   |
+|-------------+---------+------------|
+| root/cimv2  |       2 | CIMClass   |
+| root/cimv3  |       2 | CIMClass   |
++-------------+---------+------------+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify classnames (--no) enumerate from two namespaces summary',
+     {'args': ['enumerate', 'CIM_Foo', '--no', '--summary',
+               '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': """root/cimv2 2 CIMClassName(s) returned
+root/cimv3 2 CIMClassName(s) returned
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify classnames (--no) enumerate from two namespaces ',
+     {'args': ['enumerate', 'CIM_Foo', '--no',
+               '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': """
+root/cimv2:CIM_Foo_sub
+root/cimv2:CIM_Foo_sub2
+root/cimv3:CIM_Foo_sub
+root/cimv3:CIM_Foo_sub2
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify classnames enumerate from two namespaces --no --summary, -o table',
+     {'args': ['enumerate', 'CIM_Foo', '--no', '--summary',
+               '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """Summary of CIMClassName(s) returned
++-------------+---------+--------------+
+| Namespace   |   Count | CIM Type     |
+|-------------+---------+--------------|
+| root/cimv2  |       2 | CIMClassName |
+| root/cimv3  |       2 | CIMClassName |
++-------------+---------+--------------+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    #  References requests with multiple namespaces tests
+
+    ['Verify class references classnames from two namespaces',
+     {'args': ['references', 'CIM_FooRef1',
+               '--namespace', 'root/cimv2,root/cimv3'], },
+     {'stdout': """//FakedUrl:5988/root/cimv2:CIM_FooAssoc
+   [Association ( true ),
+    Description ( "Simple CIM Association" )]
+class CIM_FooAssoc {
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   CIM_FooRef1 REF Ref1;
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   CIM_FooRef2 REF Ref2;
+
+};
+
+//FakedUrl:5988/root/cimv3:CIM_FooAssoc
+   [Association ( true ),
+    Description ( "Simple CIM Association" )]
+class CIM_FooAssoc {
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   CIM_FooRef1 REF Ref1;
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   CIM_FooRef2 REF Ref2;
+
+};
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify references classname (--no) from two namespaces',
+     {'args': ['references', 'CIM_FooRef1', '--no',
+               '--namespace', 'root/cimv2,root/cimv3'], },
+     {'stdout': """//FakedUrl:5988/root/cimv2:CIM_FooAssoc
+//FakedUrl:5988/root/cimv3:CIM_FooAssoc
+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify class references from two namespaces, XML format, Min compare',
+     {'args': ['references', 'CIM_FooRef1',
+               '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'xml']},
+     {'stdout': '''<!-- Namespace = root/cimv2 -->
+<CLASSPATH>
+</CLASSPATH>
+<CLASS NAME="CIM_FooAssoc">
+</CLASS>
+<!-- Namespace = root/cimv3 -->
+''',
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, FAIL],  # Fails compare of XML
+
+    ['Verify class references from two namespaces, XML format, Min compare',
+     {'args': ['references', 'CIM_FooRef1',
+               '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'repr']},
+     {'stdout': """(CIMClassName(classname='CIM_FooAssoc',
+CIMClass(classname='CIM_FooAssoc',
+(CIMClassName(classname='CIM_FooAssoc', namespace='root/cimv3',
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, FAIL],  # Fails compare of XML
+
+    # Associators requests with multiple namespaces tests
+
+    ['Verify associators classnames from two namespaces --names-only',
+     {'args': ['associators', 'CIM_FooRef1', '--no',
+               '--namespace', 'root/cimv2,root/cimv3'], },
+     {'stdout': """//FakedUrl:5988/root/cimv2:CIM_FooRef2
+//FakedUrl:5988/root/cimv3:CIM_FooRef2
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify associators from two namespaces --names-only',
+     {'args': ['associators', 'CIM_FooRef1',
+               '--namespace', 'root/cimv2,root/cimv3'], },
+     {'stdout': """//FakedUrl:5988/root/cimv2:CIM_FooRef2
+   [Description ( "Class 2 that is referenced" )]
+class CIM_FooRef2 : CIM_BaseRef {
+};
+//FakedUrl:5988/root/cimv3:CIM_FooRef2
+   [Description ( "Class 2 that is referenced" )]
+class CIM_FooRef2 : CIM_BaseRef {
+};
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    # pylint: disable=line-too-long
+    ['Verify associators from two namespaces xml output',
+     {'args': ['associators', 'CIM_FooRef1',
+               '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'xml']},
+     {'stdout': '''<!-- Namespace = root/cimv2 -->
+<CLASSPATH>
+    <NAMESPACEPATH>
+        <HOST>FakedUrl:5988</HOST>
+        <LOCALNAMESPACEPATH>
+            <NAMESPACE NAME="root"/>
+            <NAMESPACE NAME="cimv2"/>
+        </LOCALNAMESPACEPATH>
+    </NAMESPACEPATH>
+    <CLASSNAME NAME="CIM_FooRef2"/>
+</CLASSPATH>
+
+<CLASS NAME="CIM_FooRef2" SUPERCLASS="CIM_BaseRef">
+    <QUALIFIER NAME="Description" TYPE="string" PROPAGATED="false" OVERRIDABLE="true" TOSUBCLASS="true" TRANSLATABLE="true">
+        <VALUE>Class 2 that is referenced</VALUE>
+    </QUALIFIER>
+</CLASS>
+
+<!-- Namespace = root/cimv3 -->
+<CLASSPATH>
+    <NAMESPACEPATH>
+        <HOST>FakedUrl:5988</HOST>
+        <LOCALNAMESPACEPATH>
+            <NAMESPACE NAME="root"/>
+            <NAMESPACE NAME="cimv3"/>
+        </LOCALNAMESPACEPATH>
+    </NAMESPACEPATH>
+    <CLASSNAME NAME="CIM_FooRef2"/>
+</CLASSPATH>
+
+<CLASS NAME="CIM_FooRef2" SUPERCLASS="CIM_BaseRef">
+    <QUALIFIER NAME="Description" TYPE="string" PROPAGATED="false" OVERRIDABLE="true" TOSUBCLASS="true" TRANSLATABLE="true">
+        <VALUE>Class 2 that is referenced</VALUE>
+    </QUALIFIER>
+</CLASS>
+''',  # noqa: E501
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, PYTHON_VER_GT_35],  # Test fails python <= 3.5
+                                             # See bug pywbem #2882
+    # pylint: enable=line-too-long
+
+
+    # TODO: Test class  REPR outputs
 ]
 
 # TODO command class delete. Extend this test to use stdin (delete, test)

--- a/tests/unit/pywbemcli/test_class_cmds.py
+++ b/tests/unit/pywbemcli/test_class_cmds.py
@@ -2647,4 +2647,4 @@ class TestSubcmdClass(CLITestsBase):  # pylint: disable=too-few-public-methods
             pywbemcli command.
         """
         self.command_test(desc, self.command_group, inputs, exp_response,
-                          mock, condition)
+                          mock, condition, verbose=True)

--- a/tests/unit/pywbemcli/test_common.py
+++ b/tests/unit/pywbemcli/test_common.py
@@ -339,7 +339,7 @@ TESTCASES_PICK_ONE_INDEX_FROM_LIST = [
     ('Verify returns correct choice, in this case ONE',
      dict(options=[u'ZERO', u'ONE', u'TWO'], choices=['1'], pa=None,
           exp_rtn=1),
-     None, None, RUN),
+     None, None, OK),
 
     ('Verify returns correct choice, in this case TWO',
      dict(options=[u'ZERO', u'ONE', u'TWO'], choices=['2'], pa=None,
@@ -1186,7 +1186,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             objects=[],
             exp_indexes=[]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "string: One object",
@@ -1194,7 +1194,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             objects=['abc'],
             exp_indexes=[0]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "string: Two objects, opposite sort order",
@@ -1202,7 +1202,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             objects=['xyz', 'abc'],
             exp_indexes=[1, 0]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMClass: One object",
@@ -1216,7 +1216,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[0]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMClass: Verify that equal sort keys are supported and sort is "
@@ -1241,7 +1241,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[1, 2, 0]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMClass: Verify that sort key is only by class name and does not "
@@ -1266,7 +1266,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[1, 2, 0]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMClassName: One object",
@@ -1276,7 +1276,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[0]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMClassName: Verify that equal sort keys are supported and sort is "
@@ -1289,7 +1289,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[1, 2, 0]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMClassName: Verify sort precedence of host, namespace, classname",
@@ -1302,7 +1302,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[1, 0, 3, 2]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMInstanceName: One object",
@@ -1316,7 +1316,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[0]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMInstanceName: Verify that equal sort keys are supported and sort "
@@ -1341,7 +1341,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[1, 2, 0]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMInstanceName: Verify sort precedence of host, namespace, "
@@ -1371,7 +1371,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[3, 2, 1, 0]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMInstance: One object",
@@ -1383,7 +1383,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[0]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMInstance: Verify that equal sort keys are supported and sort "
@@ -1402,7 +1402,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[2, 0, 1]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMInstance: Verify that sort is by instance path, and does not also"
@@ -1421,7 +1421,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[2, 0, 1]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMInstance: Invalid objects without path set",
@@ -1432,7 +1432,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=None
         ),
-        ValueError, None, True
+        ValueError, None, OK
     ),
     (
         "CIMQualifierDeclaration: One object",
@@ -1442,7 +1442,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[0]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMQualifierDeclaration: Verify that equal sort keys are supported "
@@ -1455,7 +1455,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[2, 0, 1]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "CIMQualifierDeclaration: Verify that sort key is by qualifier name, "
@@ -1468,7 +1468,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[1, 2, 0]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "tuple(CIMClassName, CIMClass): Three objects in opposite sort order "
@@ -1505,7 +1505,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=[1, 0, 2]
         ),
-        None, None, True
+        None, None, OK
     ),
     (
         "Invalid type: single tuple(CIMClass, CIMClassName)",
@@ -1523,7 +1523,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=None
         ),
-        TypeError, None, True
+        TypeError, None, OK
     ),
     (
         "Invalid type: single tuple(CIMInstanceName, CIMClass)",
@@ -1541,7 +1541,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=None
         ),
-        TypeError, None, True
+        TypeError, None, OK
     ),
     (
         "Invalid type: single int object",
@@ -1549,7 +1549,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             objects=[42],
             exp_indexes=None
         ),
-        TypeError, None, True
+        TypeError, None, OK
     ),
     (
         "Invalid type: two int objects",
@@ -1557,17 +1557,17 @@ TESTCASES_SORT_CIMOBJECTS = [
             objects=[42, 43],
             exp_indexes=None
         ),
-        TypeError, None, True
+        TypeError, None, OK
     ),
     (
         "Invalid type: Single CIMQualifier object",
         dict(
             objects=[
-                CIMQualifier('Key', value=True),
+                CIMQualifier('Key', value=OK),
             ],
             exp_indexes=None
         ),
-        TypeError, None, True
+        TypeError, None, OK
     ),
     (
         "Invalid type: Two CIMQualifier objects",
@@ -1578,7 +1578,7 @@ TESTCASES_SORT_CIMOBJECTS = [
             ],
             exp_indexes=None
         ),
-        TypeError, None, True
+        TypeError, None, OK
     ),
 ]
 
@@ -1606,7 +1606,8 @@ def test_sort_cimobjects(testcase, objects, exp_indexes):
     # order is incorrect.
     result_ids = [id(obj) for obj in result_objects]
     exp_ids = [id(objects[ix]) for ix in exp_indexes]
-    assert result_ids == exp_ids
+    assert result_ids == exp_ids, "Ids misorder\n{}\n{}".format(result_ids,
+                                                                exp_ids)
 
 
 TESTCASES_SPLIT_ARRAY_VALUE = [

--- a/tests/unit/pywbemcli/test_instance_cmds.py
+++ b/tests/unit/pywbemcli/test_instance_cmds.py
@@ -3637,7 +3637,7 @@ instance of CIM_Foo {
 """],
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, RUN],
+     THREE_NS_MOCK_FILE, OK],
 
     ['Verify instance get from two namespaces table output',
      {'args': ['get', 'CIM_Foo', '--key', 'InstanceID=CIM_Foo1', '--namespace',
@@ -3653,7 +3653,7 @@ instance of CIM_Foo {
 """],
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, RUN],
+     THREE_NS_MOCK_FILE, OK],
 
     # TODO xml, etc
 
@@ -3666,7 +3666,7 @@ instance of CIM_Foo {
      {'stdout': MULTIPLE_NS_ENUM_INST_RTN,
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, RUN],
+     THREE_NS_MOCK_FILE, OK],
 
     ['Verify instance enumerate from two namespaces summary',
      {'args': ['enumerate', 'CIM_Foo', '--summary',
@@ -3675,7 +3675,7 @@ instance of CIM_Foo {
                  'root/cimv3 13 CIMInstance(s) returned'],
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, RUN],
+     THREE_NS_MOCK_FILE, OK],
 
     ['Verify instance enumerate from two namespaces summary, --summary, table',
      {'args': ['enumerate', 'CIM_Foo', '--summary',
@@ -3691,7 +3691,7 @@ instance of CIM_Foo {
 """,
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, RUN],
+     THREE_NS_MOCK_FILE, OK],
 
     ['Verify instances (--no) enumerate from two namespaces --summary ',
      {'args': ['enumerate', 'CIM_Foo', '--no', '--summary',
@@ -3701,7 +3701,7 @@ root/cimv3 13 CIMInstanceName(s) returned
 """,
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, RUN],
+     THREE_NS_MOCK_FILE, OK],
 
     ['Verify namesnames (--no) enumerate from two namespaces ',
      {'args': ['enumerate', 'CIM_Foo_Sub', '--no',
@@ -3724,7 +3724,7 @@ root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub3"
 """,
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, RUN],
+     THREE_NS_MOCK_FILE, OK],
 
     ['Verify classnames enumerate from two namespaces --summary, -o table',
      {'args': ['enumerate', 'CIM_Foo', '--no', '--summary',
@@ -3740,7 +3740,7 @@ root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub3"
 """,
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, RUN],
+     THREE_NS_MOCK_FILE, OK],
 
 
     # instance references request
@@ -3753,7 +3753,7 @@ root/cimv3 1 CIMInstanceName(s) returned
 """,
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, RUN],
+     THREE_NS_MOCK_FILE, OK],
 
     ['Verify references names from two namespaces --summary, -o table',
      {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
@@ -3769,7 +3769,7 @@ root/cimv3 1 CIMInstanceName(s) returned
 """,
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, RUN],
+     THREE_NS_MOCK_FILE, OK],
 
     # pylint: disable=line-too-long
     ['Verify  references names  from two namespaces --summary, -o table',
@@ -3789,7 +3789,7 @@ root/cimv3 1 CIMInstanceName(s) returned
 """,   # noqa: E501
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, RUN],
+     THREE_NS_MOCK_FILE, OK],
     # pylint: enable=line-too-long
 
     ['Verify references names from two namespaces MOF',
@@ -3808,7 +3808,7 @@ instance of CIM_FooAssoc {
 """,
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, RUN],
+     THREE_NS_MOCK_FILE, OK],
 
 
     ['Verify references  names from two namespaces MOF, --no 2 namespaces',
@@ -3820,7 +3820,7 @@ instance of CIM_FooAssoc {
 ''',
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, RUN],
+     THREE_NS_MOCK_FILE, OK],
 
 
     # instance associators request
@@ -3840,7 +3840,7 @@ instance of CIM_FooAssoc {
 """,
       'rc': 0,
       'test': 'innows'},
-     THREE_NS_MOCK_FILE, RUN],
+     THREE_NS_MOCK_FILE, OK],
 
     # Test multi-namespace enum/get where there are no instances returned
 

--- a/tests/unit/pywbemcli/test_instance_cmds.py
+++ b/tests/unit/pywbemcli/test_instance_cmds.py
@@ -35,7 +35,8 @@ from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
     CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE, \
     CMD_OPTION_LOCAL_ONLY_INSTANCE_LIST_HELP_LINE, \
     CMD_OPTION_LOCAL_ONLY_INSTANCE_GET_HELP_LINE, \
-    CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE, \
+    CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE, \
+    CMD_OPTION_MULTIPLE_NAMESPACE_ALL_HELP_LINE, \
     CMD_OPTION_KEYS_HELP_LINE, \
     CMD_OPTION_ASSOCIATION_FILTER_HELP_LINE, \
     CMD_OPTION_INDICATION_FILTER_HELP_LINE, \
@@ -94,6 +95,8 @@ MOCK_CONFIRM_N_FILE = "mock_confirm_n.py"
 ALLTYPES_INVOKEMETHOD_MOCK_FILE = 'all_types_method_mock_v0.py' if PYWBEM_0 \
     else 'all_types_method_mock_v1old.py'
 
+THREE_NS_MOCK_FILE = 'simple_three_ns_mock_script.py'
+
 
 #
 # The following list define the help for each command in terms of particular
@@ -141,7 +144,7 @@ INSTANCE_ASSOCIATORS_HELP_LINES = [
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
     CMD_OPTION_NAMES_ONLY_HELP_LINE,
-    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_FILTER_QUERY_LINE,
     CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE,
@@ -157,7 +160,7 @@ INSTANCE_COUNT_HELP_LINES = [
     'Count the instances of each class with matching class name.',
     '-s, --sort Sort by instance count.',
     '--ignore-class CLASSNAME Class names of classes to be ignored (not counted). ',  # noqa: E501
-    CMD_OPTION_MULTIPLE_NAMESPACE_HELP_LINE,
+    CMD_OPTION_MULTIPLE_NAMESPACE_ALL_HELP_LINE,
     CMD_OPTION_ASSOCIATION_FILTER_HELP_LINE,
     CMD_OPTION_INDICATION_FILTER_HELP_LINE,
     CMD_OPTION_EXPERIMENTAL_FILTER_HELP_LINE,
@@ -194,7 +197,7 @@ INSTANCE_ENUMERATE_HELP_LINES = [
     CMD_OPTION_INCLUDE_QUALIFIERS_LIST_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
-    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE,
     CMD_OPTION_NAMES_ONLY_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_FILTER_QUERY_LINE,
@@ -211,7 +214,7 @@ INSTANCE_GET_HELP_LINES = [
     CMD_OPTION_INCLUDE_QUALIFIERS_GET_HELP_LINE,
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
-    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE,
     CMD_OPTION_KEYS_HELP_LINE,
     CMD_OPTION_HELP_INSTANCENAME_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
@@ -261,7 +264,7 @@ INSTANCE_REFERENCES_HELP_LINES = [
     CMD_OPTION_INCLUDE_CLASSORIGIN_HELP_LINE,
     CMD_OPTION_PROPERTYLIST_HELP_LINE,
     CMD_OPTION_NAMES_ONLY_HELP_LINE,
-    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_FILTER_QUERY_LINE,
     CMD_OPTION_FILTER_QUERY_LANGUAGE_LINE,
@@ -346,6 +349,151 @@ instance of CIM_Foo_sub_sub {
    IntegerProp = 9;
 };
 
+instance of CIM_Foo_sub_sub {
+   InstanceID = "CIM_Foo_sub_sub3";
+   IntegerProp = 10;
+};
+"""
+
+MULTIPLE_NS_ENUM_INST_RTN = """#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo2";
+   IntegerProp = 2;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo3";
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo30";
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo31";
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub1";
+   IntegerProp = 4;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub2";
+   IntegerProp = 5;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub3";
+   IntegerProp = 6;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub4";
+   IntegerProp = 7;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo_sub_sub {
+   InstanceID = "CIM_Foo_sub_sub1";
+   IntegerProp = 8;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo_sub_sub {
+   InstanceID = "CIM_Foo_sub_sub2";
+   IntegerProp = 9;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo_sub_sub {
+   InstanceID = "CIM_Foo_sub_sub3";
+   IntegerProp = 10;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo2";
+   IntegerProp = 2;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo3";
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo3-third-ns";
+   IntegerProp = 3;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo30";
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo31";
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub1";
+   IntegerProp = 4;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub2";
+   IntegerProp = 5;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub3";
+   IntegerProp = 6;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub4";
+   IntegerProp = 7;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo_sub_sub {
+   InstanceID = "CIM_Foo_sub_sub1";
+   IntegerProp = 8;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo_sub_sub {
+   InstanceID = "CIM_Foo_sub_sub2";
+   IntegerProp = 9;
+};
+
+#pragma namespace ("root/cimv3")
 instance of CIM_Foo_sub_sub {
    InstanceID = "CIM_Foo_sub_sub3";
    IntegerProp = 10;
@@ -920,7 +1068,7 @@ TEST_CASES = [
      ['enumerate', 'CIM_Foo', '--filter-query', 'InstanceID = 3'],
      {'stdout': ENUM_INSTANCE_RESP,
       'test': 'linesnows'},
-     SIMPLE_MOCK_FILE, OK],
+     SIMPLE_MOCK_FILE, RUN],
 
     ['Verify instance command enumerate with query, traditional ops fails',
      {'args': ['enumerate', 'CIM_Foo', '--filter-query', 'InstanceID = 3'],
@@ -977,7 +1125,7 @@ TEST_CASES = [
     ['Verify command enumerate with CIM_Foo summary table output',
      {'args': ['enumerate', 'CIM_Foo', '--summary'],
       'general': ['--output-format', 'table']},
-     {'stdout': """Summary of CIMInstance returned
+     {'stdout': """Summary of CIMInstance(s) returned
 +---------+-------------+
 |   Count | CIM Type    |
 |---------+-------------|
@@ -1278,7 +1426,7 @@ Instances: CIM_FooAssoc
 """,  # noqa: E501
       'rc': 0,
       'test': 'linesnows'},
-     INSTANCE_TABLE_MODEL_FILE, RUN],
+     INSTANCE_TABLE_MODEL_FILE, OK],
 
     ['Verify instance command associators of CIM_Foo as table returns correct '
      'properties without --show-null option',
@@ -1296,7 +1444,7 @@ Instances: CIM_Foo
 """,
       'rc': 0,
       'test': 'linesnows'},
-     INSTANCE_TABLE_MODEL_FILE, RUN],
+     INSTANCE_TABLE_MODEL_FILE, OK],
 
     ['Verify instance command associators of CIM_Foo as table returns correct '
      'properties with --show-null option',
@@ -1865,8 +2013,8 @@ Instances: CIM_Foo
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
-    ['Verify instance command get with instancename empty  prop list '
-     'returns  empty instance',
+    ['Verify instance command get with instancename and empty  prop list rtns '
+     'empty instance',
      ['get', 'CIM_Foo.InstanceID="CIM_Foo1"', '--pl', '""'],
      {'stdout': ['instance of CIM_Foo {',
                  '};',
@@ -1885,7 +2033,7 @@ Instances: CIM_Foo
 
 
 
-    ['Verify instance command -o grid get CIM_Foo',
+    ['Verify instance command -o simple get CIM_Foo',
      {'args': ['get', 'CIM_Foo.InstanceID="CIM_Foo1"'],
       'general': ['-o', 'simple']},
      {'stdout': """Instances: CIM_Foo
@@ -2474,7 +2622,7 @@ InstanceID      IntegerProp
      SIMPLE_MOCK_FILE, OK],
 
     #
-    #  instance references command
+    #  instance references command tests
     #
     ['Verify instance command references --help response',
      ['references', '--help'],
@@ -2607,7 +2755,7 @@ InstanceID      IntegerProp
      {'args': ['references', 'TST_Person.name="Mike"', '--no', '--summary',
                '--rc', 'TST_Lineage'],
       'general': ['--output-format', 'table']},
-     {'stdout': ["""Summary of CIMInstanceName returned
+     {'stdout': ["""Summary of CIMInstanceName(s) returned
 +---------+-----------------+
 |   Count | CIM Type        |
 |---------+-----------------|
@@ -2850,7 +2998,7 @@ InstanceID      IntegerProp
 """],
       'rc': 0,
       'test': 'linesnows'},
-     ASSOC_MOCK_FILE, RUN],
+     ASSOC_MOCK_FILE, OK],
 
     ['Verify instance command associators with --pl in unsorted order',
      {'args': ['associators', 'TST_Person.name="Mike"',
@@ -3452,6 +3600,250 @@ interop      TST_PersonExp        4
       'rc': 0,
       'test': 'innows'},
      ASSOC_MOCK_FILE, OK],
+
+    #
+    #  Multiple Namespaces Option tests --namespace a,b and -n a -n b
+    #  The following tests exercise the multiple-namespace functionality
+    #  for instances (enumerate, get, associators, references) and
+    #  corresponding names-only options.
+    #
+    #  Get request
+    #
+
+    ['Verify instance get from two namespaces. single namespace/comma option',
+     {'args': ['get', 'CIM_Foo', '--key', 'InstanceID=CIM_Foo1',
+               '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': ['#pragma namespace ("root/cimv2")',
+                 '#pragma namespace ("root/cimv3")',
+                 'instance of CIM_Foo {'],
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+
+    ['Verify instance get from two namespaces use multiple namespace option',
+     {'args': ['get', 'CIM_Foo', '--key', 'InstanceID=CIM_Foo1', '--namespace',
+               'root/cimv2', '--namespace', 'root/cimv3']},
+     {'stdout': ["""#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+"""],
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+
+    ['Verify instance get from two namespaces table output',
+     {'args': ['get', 'CIM_Foo', '--key', 'InstanceID=CIM_Foo1', '--namespace',
+               'root/cimv2', '--namespace', 'root/cimv3'],
+      'general': ['--output-format', 'table']},
+     {'stdout': ["""Instances: CIM_Foo
++-------------+--------------+---------------+
+| namespace   | InstanceID   |   IntegerProp |
+|-------------+--------------+---------------|
+| root/cimv2  | "CIM_Foo1"   |             1 |
+| root/cimv3  | "CIM_Foo1"   |             1 |
++-------------+--------------+---------------+
+"""],
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+
+    # TODO xml, etc
+
+    #
+    # Enumerate request
+    #
+
+    ['Verify instance enumerate from two namespaces, CIM_Foo',
+     {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': MULTIPLE_NS_ENUM_INST_RTN,
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+
+    ['Verify instance enumerate from two namespaces summary',
+     {'args': ['enumerate', 'CIM_Foo', '--summary',
+               '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': ['root/cimv2 12 CIMInstance(s) returned',
+                 'root/cimv3 13 CIMInstance(s) returned'],
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+
+    ['Verify instance enumerate from two namespaces summary, --summary, table',
+     {'args': ['enumerate', 'CIM_Foo', '--summary',
+               '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """Summary of CIMInstance(s) returned
++-------------+---------+-------------+
+| Namespace   |   Count | CIM Type    |
+|-------------+---------+-------------|
+| root/cimv2  |      12 | CIMInstance |
+| root/cimv3  |      13 | CIMInstance |
++-------------+---------+-------------+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+
+    ['Verify instances (--no) enumerate from two namespaces --summary ',
+     {'args': ['enumerate', 'CIM_Foo', '--no', '--summary',
+               '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': """root/cimv2 12 CIMInstanceName(s) returned
+root/cimv3 13 CIMInstanceName(s) returned
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+
+    ['Verify namesnames (--no) enumerate from two namespaces ',
+     {'args': ['enumerate', 'CIM_Foo_Sub', '--no',
+               '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': """
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub1"
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub2"
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub3"
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub4"
+root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub1"
+root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub2"
+root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub3"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub1"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub2"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub3"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub4"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub1"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub2"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub3"
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+
+    ['Verify classnames enumerate from two namespaces --summary, -o table',
+     {'args': ['enumerate', 'CIM_Foo', '--no', '--summary',
+               '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """Summary of CIMInstanceName(s) returned
++-------------+---------+-----------------+
+| Namespace   |   Count | CIM Type        |
+|-------------+---------+-----------------|
+| root/cimv2  |      12 | CIMInstanceName |
+| root/cimv3  |      13 | CIMInstanceName |
++-------------+---------+-----------------+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+
+
+    # instance references request
+
+    ['Verify classnames references from two namespaces --summary',
+     {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--no', '-s', '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': """root/cimv2 1 CIMInstanceName(s) returned
+root/cimv3 1 CIMInstanceName(s) returned
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+
+    ['Verify references names from two namespaces --summary, -o table',
+     {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--no', '-s', '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """Summary of CIMInstanceName(s) returned
++-------------+---------+-----------------+
+| Namespace   |   Count | CIM Type        |
+|-------------+---------+-----------------|
+| root/cimv2  |       1 | CIMInstanceName |
+| root/cimv3  |       1 | CIMInstanceName |
++-------------+---------+-----------------+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+
+    # pylint: disable=line-too-long
+    ['Verify  references names  from two namespaces --summary, -o table',
+     {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--no', '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """InstanceNames: CIM_FooAssoc
++---------------+-------------+--------------+-------------------------------------+-------------------------------------+
+| host          | namespace   | class        | key=                                | key=                                |
+|               |             |              | Ref1                                | Ref2                                |
+|---------------+-------------+--------------+-------------------------------------+-------------------------------------|
+| FakedUrl:5988 | root/cimv2  | CIM_FooAssoc | /root/cimv2:CIM_FooRef1.InstanceID= | /root/cimv2:CIM_FooRef2.InstanceID= |
+|               |             |              | "CIM_FooRef11"                      | "CIM_FooRef21"                      |
+| FakedUrl:5988 | root/cimv3  | CIM_FooAssoc | /root/cimv3:CIM_FooRef1.InstanceID= | /root/cimv3:CIM_FooRef2.InstanceID= |
+|               |             |              | "CIM_FooRef11"                      | "CIM_FooRef21"                      |
++---------------+-------------+--------------+-------------------------------------+-------------------------------------+
+""",   # noqa: E501
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+    # pylint: enable=line-too-long
+
+    ['Verify references names from two namespaces MOF',
+     {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': """#pragma namespace ("root/cimv2")
+instance of CIM_FooAssoc {
+   Ref1 = "/root/cimv2:CIM_FooRef1.InstanceID=\\"CIM_FooRef11\\"";
+   Ref2 = "/root/cimv2:CIM_FooRef2.InstanceID=\\"CIM_FooRef21\\"";
+};
+#pragma namespace ("root/cimv3")
+instance of CIM_FooAssoc {
+   Ref1 = "/root/cimv3:CIM_FooRef1.InstanceID=\\"CIM_FooRef11\\"";
+   Ref2 = "/root/cimv3:CIM_FooRef2.InstanceID=\\"CIM_FooRef21\\"";
+};
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+
+
+    ['Verify references  names from two namespaces MOF, --no 2 namespaces',
+     {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--no', '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': '''
+//FakedUrl:5988/root/cimv2:CIM_FooAssoc.Ref1="root/cimv2:CIM_FooRef1.InstanceID=\\"CIM_FooRef11\\"",Ref2="root/cimv2:CIM_FooRef2.InstanceID=\\"CIM_FooRef21\\""
+//FakedUrl:5988/root/cimv3:CIM_FooAssoc.Ref1="root/cimv3:CIM_FooRef1.InstanceID=\\"CIM_FooRef11\\"",Ref2="root/cimv3:CIM_FooRef2.InstanceID=\\"CIM_FooRef21\\""
+''',
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+
+
+    # instance associators request
+
+    ['Verify associators classnames from two namespaces --summary, -o table',
+     {'args': ['associators', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--no', '--summary', '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """Summary of CIMInstanceName(s) returned
++-------------+---------+-----------------+
+| Namespace   |   Count | CIM Type        |
+|-------------+---------+-----------------|
+| root/cimv2  |       1 | CIMInstanceName |
+| root/cimv3  |       1 | CIMInstanceName |
++-------------+---------+-----------------+
+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
+
+    # Test multi-namespace enum/get where there are no instances returned
+
 
     # TODO test results if we have keys that get hidden.  This will require
     # a more complex model with CreationClassName, etc. in paths.

--- a/tests/unit/pywbemcli/test_qualdecl_cmds.py
+++ b/tests/unit/pywbemcli/test_qualdecl_cmds.py
@@ -246,7 +246,7 @@ TEST_CASES = [
     ['Verify qualifier command enumerate summary returns qual decls table',
      {'args': ['enumerate', '--summary'],
       'general': ['--output-format', 'table']},
-     {'stdout': ["""Summary of CIMQualifierDeclaration returned
+     {'stdout': ["""Summary of CIMQualifierDeclaration(s) returned
 +---------+-------------------------+
 |   Count | CIM Type                |
 |---------+-------------------------|


### PR DESCRIPTION
This code properly defines and utilizes the multiple namespace name option for the commands that we expect to use multiple namespaces (see below) Issue #1058.  It also puts namespace name somewhere in the output when multiple namespaces are defined.  However, the output formatting is really still under discussion and therefore do not expect the output formatting to be correct at this point.  It also does not add tests for the multiple namespaces.

The ability to process multiple command options for the following
commands is implemented:

* class  enumerate
* class get
* class associators
* class references
* instance enumerate
* instance get
* instance associators
* instance references

The --namespace option has been modified for each of these commands to
allow multiple namespaces.

The results display has been modified to show the namespace as part of
the response if multiple namespaces are requested.  Otherwise the
existing display format is maintained. This was requirement for issue #1059 

TODO:  **DISCUSSION**
1. Agree on correct output formatting when multiple namespaces are defined on input. The pr contains my proposals for the formats for all of the output types for review. NOTE: There are examples of the output in comments below for review.
2. Agree on the discussion items in issue #1058 and implement any changes.
3. Add a new option --sort that would allow sorting the results by classname.  Today results are sorted by classname within a namespace but the overall grouping is namespace (if multiple namespaces), classname.   this would modify the order to order first by classname and then by namespace.  The reason for this would be so that the user could see objects representing the same class but different namespaces close together in the display.  I propose that this last item be a separate PR.