### PR TITLE
Fix issue #1172, Does not define default format for cmd

### DIFF
--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -495,7 +495,6 @@ def to_wbem_uri_folded(path, uri_format='standard', max_len=15):
             case_keys = [case(k) for k in keys]
             keys = sorted(case_keys)
         return keys
-
     last_fold = 0
     if uri_format not in ('standard', 'canonical', 'cimobject', 'historical'):
         raise ValueError('Invalid format argument: {0}'.format(uri_format))


### PR DESCRIPTION
output of profile centralinsts.  Fixed code that tests for
output types to only allow table type and also rewrote the
cmd_profile_centralinsts to better format the table for output
by folding the instance paths when required.

I consider this a minor issue so no need to rollback