### PR TITLE
Fix issue using instance get with multiple namespace (-n) option

### DIFF
--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -167,7 +167,7 @@ Help text for ``pywbemcli class`` (see :ref:`class command group`):
       -h, --help  Show this help message.
 
     Commands:
-      enumerate     List top classes or subclasses of a class in a namespace.
+      enumerate     List top classes or subclasses of a class in namespace(s).
       get           Get a class.
       delete        Delete a class.
       invokemethod  Invoke a method on a class.
@@ -296,7 +296,7 @@ Help text for ``pywbemcli class enumerate`` (see :ref:`class enumerate command`)
 
     Usage: pywbemcli [GENERAL-OPTIONS] class enumerate CLASSNAME [COMMAND-OPTIONS]
 
-      List top classes or subclasses of a class in a namespace.
+      List top classes or subclasses of a class in namespace(s).
 
       Enumerate CIM classes starting either at the top of the class hierarchy in the specified CIM namespace (--namespace
       option), or at the specified class (CLASSNAME argument) in the specified namespace. If no namespace was specified, the
@@ -1219,7 +1219,7 @@ Help text for ``pywbemcli instance enumerate`` (see :ref:`instance enumerate com
       List the instances of a class.
 
       Enumerate the CIM instances of the specified class (CLASSNAME argument), including instances of subclasses in the
-      specified CIM namespace (--namespace option), and display the returned instances, or instance paths if --names-only
+      specified CIM namespace(s) (--namespace option), and display the returned instances, or instance paths if --names-only
       was specified. If no namespace was specified, the default namespace of the connection is used.
 
       The instances to be retrieved can be filtered by the --filter-query option.
@@ -1899,15 +1899,17 @@ Help text for ``pywbemcli qualifier enumerate`` (see :ref:`qualifier enumerate c
 
       List the qualifier declarations in a namespace.
 
-      Enumerate the CIM qualifier declarations in the specified CIM namespace (--namespace option). If no namespace was
+      Enumerate the CIM qualifier declarations in the specified CIM namespace(s) (--namespace option). If no namespace was
       specified, the default namespace of the connection is used.
 
       In the output, the qualifier declaration will formatted as defined by the --output-format general option.
 
     Command Options:
-      -n, --namespace NAMESPACE  Namespace to use for this command, instead of the default namespace of the connection.
-      -s, --summary              Show only a summary (count) of the objects.
-      -h, --help                 Show this help message.
+      -n, --namespace NAMESPACE(s)  Namespace(s) to use for this command, instead of the default connection namespace. May
+                                    be specified multiple times using either the option multiple times and/or comma
+                                    separated list. Default: connection default namespace.
+      -s, --summary                 Show only a summary (count) of the objects.
+      -h, --help                    Show this help message.
 
 
 .. _`pywbemcli qualifier get --help`:
@@ -1932,8 +1934,10 @@ Help text for ``pywbemcli qualifier get`` (see :ref:`qualifier get command`):
       In the output, the qualifier declaration will formatted as defined by the --output-format general option.
 
     Command Options:
-      -n, --namespace NAMESPACE  Namespace to use for this command, instead of the default namespace of the connection.
-      -h, --help                 Show this help message.
+      -n, --namespace NAMESPACE(s)  Namespace(s) to use for this command, instead of the default connection namespace. May
+                                    be specified multiple times using either the option multiple times and/or comma
+                                    separated list. Default: connection default namespace.
+      -h, --help                    Show this help message.
 
 
 .. _`pywbemcli repl --help`:

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -1507,7 +1507,8 @@ The command options are:
    :term:``current connection``. This option accepts single or multiple namespaces
    and displays the results for the list of namespaces supplied.
    See :ref: `Pywbemcli special command line features` for more information
-   on using multiple namespaces
+   on using multiple namespaces. The instance must exist in all of the defined
+   namespaces.
 
 *  ``--help-instancename``/``--hi`` -  Show help message for specifying
    ``INSTANCENAME`` including use of the ``--key`` and ``--namespace``
@@ -2039,6 +2040,12 @@ The qualifier declaration is named with the ``QUALIFIERNAME`` argument and is
 in the namespace specified with the ``-namespace``/``-n`` command option, or
 otherwise in the default namespace of the connection.
 
+The ``-namespace``/``-n`` command option option defines the term:`Namespace` to
+use for this command, instead of the default namespace of the :term:`current
+connection`.  This option accepts single or multiple namespaces and displays
+the results for the list of namespaces supplied. See :ref: `Pywbemcli special
+command line features` for more information on using multiple namespaces
+
 The qualifier declaration is displayed using :term:`CIM object output formats`
 or :term:`Table output formats`.
 
@@ -2107,6 +2114,12 @@ The command format is:
 
 The namespace is specified with the ``-namespace``/``-n`` command option, or
 otherwise is the default namespace of the connection.
+
+The ``-namespace``/``-n`` command option option defines the term:`Namespace` to
+use for this command, instead of the default namespace of the :term:`current
+connection`.  This option accepts single or multiple namespaces and displays
+the results for the list of namespaces supplied. See :ref: `Pywbemcli special
+command line features` for more information on using multiple namespaces
 
 The qualifier declaration is displayed using :term:`CIM object output formats`
 or :term:`Table output formats`.
@@ -2260,8 +2273,6 @@ WBEM server itself:
 
 * :ref:`Server brand command` - Get the brand of the server.
 * :ref:`Server info command` - Get information about the server.
-* :ref:`Server interop command` - Get the Interop namespace of the server.
-* :ref:`Server namespaces command` - List the namespaces of the server.
 * :ref:`Server add-mof command` - Compile the MOF files defined.
 * :ref:`Server remove-mof command` - Remove the MOF objects from the server.
 * :ref:`Server schema command` - List the namespaces of the server.

--- a/docs/pywbemcli/features.rst
+++ b/docs/pywbemcli/features.rst
@@ -27,41 +27,47 @@ syntactic implementation of the features. This includes:
   with only a change of an option on the commands that request CIM instances or
   classes. The ``--names-only``/``--no`` command option defines whether only the
   name or the complete object will be displayed.
+  See :ref:`Displaying CIM instances/classes or their names`
 
 * The ability to define complete INSTANCE name command arguments or
-  interactively select the instance namesfrom a list presented by
+  interactively select the instance names from a list presented by
   pywbemcli for certain objects rather than typing in long names the full name.
-  see :ref:`Specifying the INSTANCENAME command argument`.
+  See :ref:`Specifying the INSTANCENAME command argument`.
+
+.. index::
+  pair: classes; filter options
+  pair: instances; filter options
 
 * The ability to filter classes and instances returned from a number of the
   enumerate commands filtered by characteristics of the classes. Thus,
   for example, it can for experimental classes, association classes, and
-  deprecated classes.
+  deprecated classes. See :ref:`Filtering responses for specific types of classes`
 
 .. index::
     pair: namespace; multiple namespaces
     pair: --namespace option; command option --namespace
 
 * The ability to view information on multiple namespaces in a single command.
-  Many of the pywbemcli commands target a term:`Namespace` in the WBEM server for
-  as the source of information (ex. enumerate, get, associators, references,
-  create, delete, modify). Commands like create, delete, and modify are
-  restricted to a single namespace which can be either the default namespace
-  defined for the connection or a namespace defined with the ``--namespace``
-  command option. Commands like enumerate, get, associators,
-  and references can be used to get CIM information from multiple namespaces
-  in a single pywbemcli request using the ``--namespace``
-  command option.  Thus, if single namespace is defined (``--namespace root/blah``)
-  that becomes the namespace for the command. However with these particular
-  commands, multiple namespaces can be specified (``--namespace root/cimv2,root/cimv3``
-  or ``--namespace root/cimv2 --namespace root/cimv3) and the CIM objects retrieved
-  from all of the namespaces on this list and displayed.
+  Many of the pywbemcli commands target a term:`Namespace` in the WBEM server
+  for as the source of information (ex. enumerate, get, associators,
+  references). Commands like create, delete, and modify are restricted to a
+  single namespace which can be either the default namespace defined for the
+  connection or a namespace defined with the ``--namespace`` command option.
+  Commands like enumerate, get, associators, and references can be used to get
+  CIM information from multiple namespaces in a single pywbemcli request using
+  the ``--namespace`` command option.  Thus, if single namespace is defined
+  (``--namespace root/blah``) that becomes the namespace for the command.
+  However with these particular commands, multiple namespaces can be specified
+  (``--namespace root/cimv2,root/cimv3`` or ``--namespace root/cimv2
+  --namespace root/cimv3``) and the CIM objects retrieved from all of the
+  namespaces on this list and displayed. See :ref:`Using multiple namespaces
+  with server requests`.
 
 
-.. _`pywbemcli commands to WBEM operations`:
+.. _`pywbemcli command relation to WBEM operations`:
 
-pywbemcli commands to WBEM operations
--------------------------------------
+pywbemcli command relation to WBEM operations
+---------------------------------------------
 
 The following table defines which pywbemcli commands are used for the
 corresponding WBEM operations.
@@ -482,3 +488,92 @@ the root classes).
     $ pywbemcli --name mymock class enumerate --no --deep-inheritance --no-association
     TST_Person
     TST_Lineage
+
+
+.. index::
+    pair: namespace; multiple namespaces
+    pair: --namespace option; command option --namespace
+
+.. _`Using multiple namespaces with server requests`:
+
+Using multiple namespaces with server requests
+----------------------------------------------
+
+This feature was added in pywbemcli version 1.1.0.
+
+Generally the CIM/XML commands defined by the DMTF execute operations on a single
+:term:`CIM namespace` in the WBEM server.  Thus, the command:
+
+    instance enumerate <classname> -n interop
+
+is a request to the WBEM server to return instances of of <classname> from
+namespace ``interop``.
+
+However, pywbemcli expands this to allow some requests to be executed against
+multiple namespaces in a single request.  This was done primarily to allow
+viewing CIM objects in the server across namespaces (ex. comparing classes
+between namespaces).
+
+The commands enumerate, get, associators, and references for the command groups
+class and instance allow issuing requests on multiple namespaces in a single
+pywbemcli command. The qualifiers group enumerate command also handles multiple
+namespaces. Multiple namespace for a command is defined with the
+``--namespace`` option by defining the set of namespaces to be included  rather
+than just a single namespace. If the ``default-namespace`` is not defined is
+the connection default namespace.
+
+The responses are displayed in the same form as with a single namespace except
+that the namespace is included for each type of display to allow the user to
+determine which data is in which namespace.  With MOF, the namespace appears as
+a MOF namespace pragma (commented because not all WBEM server compilers honor the
+namespace pragma). With tables, a namespace column is included.
+
+For example:
+
+.. code-block:: text
+
+    # pywbemcli instance enumerate CIM_Door --namespace root/cimv2, root/cimv3
+
+    # pywbemcli instance get CIM_Subscription.? --namespace root/cimv2 --namespace root/cimv3
+
+
+returns the instances of CIM_Door from two namespaces.
+
+A table output has the following form with table output
+
+.. code-block:: text
+
+    pywbemcli> -o table instance enumerate CIM_Foo -n root/cimv2,root/cimv3
+    Instances: CIM_Foo
+    +-------------+---------------------+---------------+
+    | namespace   | InstanceID          | IntegerProp   |
+    |-------------+---------------------+---------------|
+    | root/cimv2  | "CIM_Foo1"          | 1             |
+    | root/cimv2  | "CIM_Foo2"          | 2             |
+    | root/cimv2  | "CIM_Foo3"          |               |
+    | root/cimv2  | "CIM_Foo30"         |               |
+    | root/cimv2  | "CIM_Foo31"         |               |
+    | root/cimv2  | "CIM_Foo_sub1"      | 4             |
+    | root/cimv2  | "CIM_Foo_sub2"      | 5             |
+    | root/cimv2  | "CIM_Foo_sub3"      | 6             |
+    | root/cimv2  | "CIM_Foo_sub4"      | 7             |
+    | root/cimv3  | "CIM_Foo1"          | 1             |
+    | root/cimv3  | "CIM_Foo2"          | 2             |
+    | root/cimv3  | "CIM_Foo3"          |               |
+    | root/cimv3  | "CIM_Foo3-third-ns" | 3             |
+    | root/cimv3  | "CIM_Foo30"         |               |
+    | root/cimv3  | "CIM_Foo31"         |               |
+    | root/cimv3  | "CIM_Foo_sub1"      | 4             |
+    | root/cimv3  | "CIM_Foo_sub2"      | 5             |
+    | root/cimv3  | "CIM_Foo_sub3"      | 6             |
+    | root/cimv3  | "CIM_Foo_sub4"      | 7             |
+    +-------------+---------------------+---------------+
+
+The --namespace option can be defined either using multiple definitions of the
+option: ``--namespace root/cimv2 --namespace root/cimv3`` or as a single
+options with the namespace names comma-separated: ``--namespace root/cimv2,root/cimv3``.
+
+The :ref:`Class find command` and  also process multiple namespaces in a single
+request but the default if the namespace is not provided is to use all of the
+namespaces defined in the server since the goal of these commands is to execute
+a wide search for the define class or instance entities.

--- a/tests/unit/pywbemcli/mock_prompt_pick_response_11.py
+++ b/tests/unit/pywbemcli/mock_prompt_pick_response_11.py
@@ -1,7 +1,3 @@
-# The previous statement is used by pywbemcli to force this script to be
-# run at pywbemcli startup and not included in the list of --mock-server
-# files that are used to build the repository.  This is a development
-# test aid.
 # (C) Copyright 2019 IBM Corp.
 # (C) Copyright 2019 Inova Development Inc.
 # All Rights Reserved
@@ -17,6 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# The previous statement is used by pywbemcli to force this script to be
+# run at pywbemcli startup and not included in the list of --mock-server
+# files that are used to build the repository.  This is a development
+# test aid.
 """
     Python code to mock pywbemcli._common.pywbemcli_prompt. Returns the
     value defined in RETURN_VALUE
@@ -31,6 +32,11 @@
 
     This file is enabled during testing through the PYWBEMCLI_STARTUP_SCRIPT
     environment variable.
+
+    The environment variable is used by pywbemcli to force this script to be
+    run at pywbemcli startup and not included in the list of --mock-server
+    files that are used to build the repository.  This is a development
+    test aid.
 """
 from mock import Mock
 

--- a/tests/unit/pywbemcli/mock_prompt_pick_response_12.py
+++ b/tests/unit/pywbemcli/mock_prompt_pick_response_12.py
@@ -1,4 +1,3 @@
-
 # (C) Copyright 2019 IBM Corp.
 # (C) Copyright 2019 Inova Development Inc.
 # All Rights Reserved
@@ -14,6 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# The previous statement is used by pywbemcli to force this script to be
+# run at pywbemcli startup and not included in the list of --mock-server
+# files that are used to build the repository.  This is a development
+# test aid.
 """
     Python code to mock pywbemcli._common.pywbemcli_prompt. Returns the
     value defined in RETURN_VALUE
@@ -37,7 +41,7 @@
 from mock import Mock
 
 import pywbemtools
-RETURN_VALUE = "1"
+RETURN_VALUE = "12"
 
 
 def mock_prompt(msg):

--- a/tests/unit/pywbemcli/mock_prompt_pick_response_3.py
+++ b/tests/unit/pywbemcli/mock_prompt_pick_response_3.py
@@ -1,7 +1,3 @@
-# The previous statement is used by pywbemcli to force this script to be
-# run at pywbemcli startup and not included in the list of --mock-server
-# files that are used to build the repository.  This is a development
-# test aid.
 # (C) Copyright 2019 IBM Corp.
 # (C) Copyright 2019 Inova Development Inc.
 # All Rights Reserved
@@ -31,6 +27,11 @@
 
     This file is enabled during testing through the PYWBEMCLI_STARTUP_SCRIPT
     environment variable.
+
+    The environment variable is used by pywbemcli to force this script to be
+    run at pywbemcli startup and not included in the list of --mock-server
+    files that are used to build the repository.  This is a development
+    test aid.
 """
 from mock import Mock
 

--- a/tests/unit/pywbemcli/mock_prompt_pick_response_5.py
+++ b/tests/unit/pywbemcli/mock_prompt_pick_response_5.py
@@ -1,7 +1,3 @@
-# The previous statement is used by pywbemcli to force this script to be
-# run at pywbemcli startup and not included in the list of --mock-server
-# files that are used to build the repository.  This is a development
-# test aid.
 # (C) Copyright 2019 IBM Corp.
 # (C) Copyright 2019 Inova Development Inc.
 # All Rights Reserved

--- a/tests/unit/pywbemcli/test_class_cmds.py
+++ b/tests/unit/pywbemcli/test_class_cmds.py
@@ -87,13 +87,15 @@ CLASS_HELP_LINES = [
     'Usage: pywbemcli [GENERAL-OPTIONS] class COMMAND [ARGS] [COMMAND-OPTIONS]',
     'Command group for CIM classes.',
     CMD_OPTION_HELP_HELP_LINE,
-    'associators   List the classes associated with a class.',
+    'enumerate     List top classes or subclasses of a class in namespace(s).',
+    'get           Get a class.',
     'delete        Delete a class.',
-    'enumerate     List top classes or subclasses of a class in a namespace.',
     'find          List the classes with matching class names on the server.',
     'get           Get a class.',
     'invokemethod  Invoke a method on a class.',
+    'associators   List the classes associated with a class.',
     'references    List the classes referencing a class.',
+    'find          List the classes with matching class names on the server.',
     'tree          Show the subclass or superclass hierarchy for a class.',
 ]
 
@@ -126,7 +128,7 @@ CLASS_DELETE_HELP_LINES = [
 CLASS_ENUMERATE_HELP_LINES = [
     'Usage: pywbemcli [GENERAL-OPTIONS] class enumerate CLASSNAME '
     '[COMMAND-OPTIONS]',
-    'List top classes or subclasses of a class in a namespace.',
+    'List top classes or subclasses of a class in namespace(s).',
     '--di, --deep-inheritance Include the complete subclass hierarchy',
     CMD_OPTION_LOCAL_ONLY_CLASS_HELP_LINE,
     CMD_OPTION_NO_QUALIFIERS_HELP_LINE,
@@ -609,7 +611,6 @@ CIMFOO_SUB_SUB_NO_QUALS_XML = """<CLASS NAME="CIM_Foo_sub_sub" SUPERCLASS="CIM_F
 </CLASS>
 """  # noqa E501
 # pylint: enable=line-too-long
-
 
 OK = True     # mark tests OK when they execute correctly
 RUN = True    # Mark OK = False and current test case being created RUN

--- a/tests/unit/pywbemcli/test_instance_cmds.py
+++ b/tests/unit/pywbemcli/test_instance_cmds.py
@@ -89,6 +89,7 @@ MOCK_PROMPT_0_FILE = "mock_prompt_0.py"
 MOCK_PROMPT_PICK_RESPONSE_3_FILE = 'mock_prompt_pick_response_3.py'
 MOCK_PROMPT_PICK_RESPONSE_5_FILE = 'mock_prompt_pick_response_5.py'
 MOCK_PROMPT_PICK_RESPONSE_11_FILE = 'mock_prompt_pick_response_11.py'
+MOCK_PROMPT_PICK_RESPONSE_12_FILE = 'mock_prompt_pick_response_12.py'
 MOCK_CONFIRM_Y_FILE = "mock_confirm_y.py"
 MOCK_CONFIRM_N_FILE = "mock_confirm_n.py"
 
@@ -1637,8 +1638,8 @@ Instances: CIM_Foo
     ['INSTANCENAME with namespace, option --namespace with same ns (error)',
      ['get', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
       '--namespace', 'root/cimv2'],
-     {'stderr': "Using the --namespace option conflicts with specifying a "
-                "namespace",
+     {'stderr': ["Using --namespace option:",
+                 "conflicts with specifying namespace in INSTANCENAME:"],
       'rc': 1,
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
@@ -1646,8 +1647,8 @@ Instances: CIM_Foo
     ['INSTANCENAME with namespace, option -n with same ns (error)',
      ['get', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
       '-n', 'root/cimv2'],
-     {'stderr': "Using the --namespace option conflicts with specifying a "
-                "namespace",
+     {'stderr': ["Using --namespace option:",
+                 "conflicts with specifying namespace in INSTANCENAME:"],
       'rc': 1,
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
@@ -1655,8 +1656,8 @@ Instances: CIM_Foo
     ['INSTANCENAME with namespace, option --namespace with diff ns (error)',
      ['get', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
       '--namespace', 'test/cimv2'],
-     {'stderr': "Using the --namespace option conflicts with specifying a "
-                "namespace",
+     {'stderr': ["Using --namespace option:",
+                 "conflicts with specifying namespace in INSTANCENAME:"],
       'rc': 1,
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
@@ -1664,8 +1665,8 @@ Instances: CIM_Foo
     ['INSTANCENAME with namespace, option -n with diff ns (error)',
      ['get', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
       '-n', 'test/cimv2'],
-     {'stderr': "Using the --namespace option conflicts with specifying a "
-                "namespace",
+     {'stderr': ["Using --namespace option:",
+                 "conflicts with specifying namespace in INSTANCENAME:"],
       'rc': 1,
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
@@ -1673,8 +1674,8 @@ Instances: CIM_Foo
     ['INSTANCENAME with namespace, options --key and --namespace (error)',
      ['get', 'root/cimv2:CIM_Foo', '--key', 'InstanceID=CIM_Foo1',
       '--namespace', 'root/cimv2'],
-     {'stderr': "Using the --namespace option conflicts with specifying a "
-                "namespace",
+     {'stderr': ["Using --namespace option:",
+                 "conflicts with specifying namespace in INSTANCENAME:"],
       'rc': 1,
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
@@ -1926,8 +1927,8 @@ Instances: CIM_Foo
     ['INSTANCENAME with namespace and with wildcard keybinding, '
      'option --namespace with same ns (error)',
      ['get', 'root/cimv2:CIM_Foo.?', '--namespace', 'root/cimv2'],
-     {'stderr': "Using the --namespace option conflicts with specifying a "
-                "namespace",
+     {'stderr': ["Using --namespace option:",
+                 "conflicts with specifying namespace in INSTANCENAME:"],
       'rc': 1,
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
@@ -1935,8 +1936,8 @@ Instances: CIM_Foo
     ['INSTANCENAME with namespace and with wildcard keybinding, '
      'option -n with same ns (error)',
      ['get', 'root/cimv2:CIM_Foo.?', '-n', 'root/cimv2'],
-     {'stderr': "Using the --namespace option conflicts with specifying a "
-                "namespace",
+     {'stderr': ["Using --namespace option:",
+                 "conflicts with specifying namespace in INSTANCENAME:"],
       'rc': 1,
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
@@ -1944,8 +1945,8 @@ Instances: CIM_Foo
     ['INSTANCENAME with namespace and with wildcard keybinding, '
      'option --namespace with diff ns (error)',
      ['get', 'root/cimv2:CIM_Foo.?', '--namespace', 'test/cimv2'],
-     {'stderr': "Using the --namespace option conflicts with specifying a "
-                "namespace",
+     {'stderr': ["Using --namespace option:",
+                 "conflicts with specifying namespace in INSTANCENAME:"],
       'rc': 1,
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
@@ -1953,8 +1954,8 @@ Instances: CIM_Foo
     ['INSTANCENAME with namespace and with wildcard keybinding, '
      'option -n with diff ns (error)',
      ['get', 'root/cimv2:CIM_Foo.?', '-n', 'test/cimv2'],
-     {'stderr': "Using the --namespace option conflicts with specifying a "
-                "namespace",
+     {'stderr': ["Using --namespace option:",
+                 "conflicts with specifying namespace in INSTANCENAME:"],
       'rc': 1,
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
@@ -3164,8 +3165,46 @@ InstanceID      IntegerProp
 
     # The following use interop ns to avoid warning about namespaces.
 
-    ['Verify instance command count CIM_* sorted, simple model, format table',
+    ['Verify instance command count CLASSNAME_GLOB CIM_* sorted, simple model',
      {'args': ['count', 'CIM_*', '--sort'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """Count of instances per class
++-------------+-----------------+---------+
+| Namespace   | Class           |   count |
+|-------------+-----------------+---------|
+| root/cimv2  | CIM_FooAssoc    |       1 |
+| root/cimv2  | CIM_FooRef1     |       1 |
+| root/cimv2  | CIM_FooRef2     |       1 |
+| root/cimv2  | CIM_Foo_sub_sub |       3 |
+| root/cimv2  | CIM_Foo_sub     |       4 |
+| root/cimv2  | CIM_Foo         |       5 |
++-------------+-----------------+---------+
+""",
+      'rc': 0,
+      'test': 'linesnows'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance command count CLASSNAME_GLOB * sort, format table',
+     {'args': ['count', '*', '--sort'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """Count of instances per class
++-------------+-----------------+---------+
+| Namespace   | Class           |   count |
+|-------------+-----------------+---------|
+| root/cimv2  | CIM_FooAssoc    |       1 |
+| root/cimv2  | CIM_FooRef1     |       1 |
+| root/cimv2  | CIM_FooRef2     |       1 |
+| root/cimv2  | CIM_Foo_sub_sub |       3 |
+| root/cimv2  | CIM_Foo_sub     |       4 |
+| root/cimv2  | CIM_Foo         |       5 |
++-------------+-----------------+---------+
+""",
+      'rc': 0,
+      'test': 'linesnows'},
+     SIMPLE_MOCK_FILE, OK],
+
+    ['Verify instance command count no CLASSNAME_GLOB sort, format table',
+     {'args': ['count', '--sort'],
       'general': ['--output-format', 'table',
                   '--default-namespace', 'interop']},
      {'stdout': """Count of instances per class
@@ -3206,18 +3245,17 @@ InstanceID      IntegerProp
 
     ['Verify instance command count CIM_*, notsorted simple model, fmt table',
      {'args': ['count', 'CIM_*'],
-      'general': ['--output-format', 'table',
-                  '--default-namespace', 'interop']},
+      'general': ['--output-format', 'table']},
      {'stdout': """Count of instances per class
 +-------------+-----------------+---------+
 | Namespace   | Class           |   count |
 |-------------+-----------------+---------|
-| interop     | CIM_Foo         |       5 |
-| interop     | CIM_FooAssoc    |       1 |
-| interop     | CIM_FooRef1     |       1 |
-| interop     | CIM_FooRef2     |       1 |
-| interop     | CIM_Foo_sub     |       4 |
-| interop     | CIM_Foo_sub_sub |       3 |
+| root/cimv2  | CIM_Foo         |       5 |
+| root/cimv2  | CIM_FooAssoc    |       1 |
+| root/cimv2  | CIM_FooRef1     |       1 |
+| root/cimv2  | CIM_FooRef2     |       1 |
+| root/cimv2  | CIM_Foo_sub     |       4 |
+| root/cimv2  | CIM_Foo_sub_sub |       3 |
 +-------------+-----------------+---------+
 """,
       'rc': 0,
@@ -3833,6 +3871,35 @@ root/cimv3 13 CIMInstanceName(s) returned
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
+    ['Verify instances (--no) enumerate from non default ns --summary ',
+     {'args': ['enumerate', 'CIM_Foo', '--no', '--summary',
+               '--namespace', 'root/cimv3']},
+     {'stdout': "13 CIMInstanceName(s) returned",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify instances enumerate from non default ns --no',
+     {'args': ['enumerate', 'CIM_Foo', '--no',
+               '--namespace', 'root/cimv3']},
+     {'stdout': """root/cimv3:CIM_Foo.InstanceID="CIM_Foo1"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo2"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo3"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo3-third-ns"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo30"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo31"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub1"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub2"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub3"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub4"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub1"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub2"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub3"
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
     ['Verify namesnames (--no) enumerate from two namespaces ',
      {'args': ['enumerate', 'CIM_Foo_Sub', '--no',
                '--namespace', 'root/cimv2,root/cimv3']},
@@ -3872,8 +3939,133 @@ root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub3"
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
+    # Get instance multiple request multiple namespaces tests
 
-    # instance references request
+    ['Verify instance get from two namespaces --key option',
+     {'args': ['get', 'CIM_Foo', '--key', 'InstanceID=CIM_Foo1',
+               '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': """#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify instance get from two namespaces --key option. table option',
+     {'args': ['get', 'CIM_Foo', '--key', 'InstanceID=CIM_Foo1',
+               '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """Instances: CIM_Foo
++-------------+--------------+---------------+
+| namespace   | InstanceID   |   IntegerProp |
+|-------------+--------------+---------------|
+| root/cimv2  | "CIM_Foo1"   |             1 |
+| root/cimv3  | "CIM_Foo1"   |             1 |
++-------------+--------------+---------------+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+
+    ['Verify instance get from two namespaces pick option.',
+     {'args': ['get', 'CIM_Foo.?',
+               '--namespace', 'root/cimv2,root/cimv3'],
+      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_PROMPT_0_FILE)}},
+     {'stdout': """#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify instance get from two namespaces pick option. prompt 12, ns # 2',
+     {'args': ['get', 'CIM_Foo.?',
+               '--namespace', 'root/cimv2,root/cimv3'],
+      'env': {MOCK_DEFINITION_ENVVAR:
+              GET_TEST_PATH_STR(MOCK_PROMPT_PICK_RESPONSE_12_FILE)}},
+     {'stdout': """#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify instance get from two namespaces full instance name',
+     {'args': ['get', 'CIM_Foo.InstanceID="CIM_Foo1"',
+               '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': """#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify instance get from ns in INSTANCEID, not default',
+     {'args': ['get', 'root/cimv3:CIM_Foo.InstanceID="CIM_Foo1"']},
+     {'stdout': """instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify instance get from ns in INSTANCEID, not default, bad ns',
+     {'args': ['get', 'root/NotExist:CIM_Foo.InstanceID="CIM_Foo1"']},
+     {'stderr': "CIMError: 3 (CIM_ERR_INVALID_NAMESPACE): Namespace does "
+                "not exist in CIM repository: 'root/NotExist'",
+      'rc': 1,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify instance get from two namespaces full instance name, fail ban ns',
+     {'args': ['get', 'CIM_Foo.InstanceID="CIM_Foo1"',
+               '--namespace', 'root/cimv2,root/DoesNotExist']},
+     {'stderr': "CIMError: 3 (CIM_ERR_INVALID_NAMESPACE): Namespace does "
+                "not exist in CIM repository: 'root/DoesNotExist'",
+      'rc': 1,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    # instance references request multiple namespaces
 
     ['Verify classnames references from two namespaces --summary',
      {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
@@ -3887,7 +4079,23 @@ root/cimv3 1 CIMInstanceName(s) returned
 
     ['Verify references names from two namespaces --summary, -o table',
      {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
-               '--no', '-s', '--namespace', 'root/cimv2,root/cimv3'],
+               '--summary', '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """Summary of CIMInstance(s) returned
++-------------+---------+-------------+
+| Namespace   |   Count | CIM Type    |
+|-------------+---------+-------------|
+| root/cimv2  |       1 | CIMInstance |
+| root/cimv3  |       1 | CIMInstance |
++-------------+---------+-------------+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify references names from two namespaces --summary, --no, -o table',
+     {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--no', '--summary', '--namespace', 'root/cimv2,root/cimv3'],
       'general': ['--output-format', 'table']},
      {'stdout': """Summary of CIMInstanceName(s) returned
 +-------------+---------+-----------------+
@@ -3900,6 +4108,31 @@ root/cimv3 1 CIMInstanceName(s) returned
       'rc': 0,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
+
+    ['Verify references from non-default namespace --names-only',
+     {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--namespace', 'root/cimv3'],
+      'general': ['--output-format', 'mof']},
+     {'stdout': """instance of CIM_FooAssoc {
+   Ref1 = "/root/cimv3:CIM_FooRef1.InstanceID=\\"CIM_FooRef11\\"";
+   Ref2 = "/root/cimv3:CIM_FooRef2.InstanceID=\\"CIM_FooRef21\\"";
+};
+         """,
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify references names from non-default namespace --names-only',
+     {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--names-only', '--namespace', 'root/cimv3'],
+      'general': ['--output-format', 'mof']},
+     {'stdout': '//FakedUrl:5988/root/cimv3:CIM_FooAssoc.Ref1="root/cimv3:'
+                'CIM_FooRef1.InstanceID=\\"CIM_FooRef11\\"",'
+                'Ref2="root/cimv3:CIM_FooRef2.InstanceID=\\"CIM_FooRef21\\""',
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
 
     # pylint: disable=line-too-long
     ['Verify  references names  from two namespaces --summary, -o table',
@@ -3955,7 +4188,7 @@ instance of CIM_FooAssoc {
 
     # instance associators request
 
-    ['Verify associators classnames from two namespaces --summary, -o table',
+    ['Verify associators instancenames from two namespaces --summary, -o table',
      {'args': ['associators', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
                '--no', '--summary', '--namespace', 'root/cimv2,root/cimv3'],
       'general': ['--output-format', 'table']},
@@ -3971,6 +4204,63 @@ instance of CIM_FooAssoc {
       'rc': 0,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
+
+    ['Verify associators names-only non-default namespace --summary, -o table',
+     {'args': ['associators', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--no', '--summary', '--namespace', 'root/cimv3'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """Summary of CIMInstanceName(s) returned
++---------+-----------------+
+|   Count | CIM Type        |
+|---------+-----------------|
+|       1 | CIMInstanceName |
++---------+-----------------+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify associators names-only non-default namespace --names-only mof',
+     {'args': ['associators', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--no', '--namespace', 'root/cimv3'],
+      'general': ['--output-format', 'mof']},
+     {'stdout':
+      '//FakedUrl:5988/root/cimv3:CIM_FooRef2.InstanceID="CIM_FooRef21"',
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+
+    ['Verify associators instances non-default namespace  -o table',
+     {'args': ['associators', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--namespace', 'root/cimv3'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """Instances: CIM_FooRef2
++----------------+
+| InstanceID     |
+|----------------|
+| "CIM_FooRef21" |
++----------------+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify associators names-only non-default namespaces -o table',
+     {'args': ['associators', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--no', '--namespace', 'root/cimv3'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """InstanceNames: CIM_FooRef2
++---------------+-------------+-------------+--------------+
+| host          | namespace   | class       | key=         |
+|               |             |             | InstanceID   |
+|---------------+-------------+-------------+--------------|
+| FakedUrl:5988 | root/cimv3  | CIM_FooRef2 | CIM_FooRef21 |
++---------------+-------------+-------------+--------------+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, RUN],
 
     # Test multi-namespace enum/get where there are no instances returned
 

--- a/tests/unit/pywbemcli/test_qualdecl_cmds.py
+++ b/tests/unit/pywbemcli/test_qualdecl_cmds.py
@@ -24,11 +24,13 @@ import pytest
 
 from .cli_test_extensions import CLITestsBase
 from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE, \
-    CMD_OPTION_NAMESPACE_HELP_LINE, CMD_OPTION_SUMMARY_HELP_LINE
+    CMD_OPTION_SUMMARY_HELP_LINE, \
+    CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE
 
 TEST_DIR = os.path.dirname(__file__)
 
 PYTHON_GE_38 = sys.version_info > (3, 8)
+THREE_NS_MOCK_FILE = 'simple_three_ns_mock_script.py'
 
 # A mof file that defines basic qualifier decls, classes, and instances
 # but not tied to the DMTF classes.
@@ -46,7 +48,7 @@ QD_HELP_LINES = [
 QD_ENUMERATE_HELP_LINES = [
     'Usage: pywbemcli [GENERAL-OPTIONS] qualifier enumerate [COMMAND-OPTIONS]',
     'List the qualifier declarations in a namespace.',
-    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE,
     CMD_OPTION_SUMMARY_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
@@ -55,7 +57,7 @@ QD_GET_HELP_LINES = [
     'Usage: pywbemcli [GENERAL-OPTIONS] qualifier get QUALIFIERNAME '
     '[COMMAND-OPTIONS]',
     "Get a qualifier declaration.",
-    CMD_OPTION_NAMESPACE_HELP_LINE,
+    CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE,
     CMD_OPTION_HELP_HELP_LINE,
 ]
 
@@ -167,6 +169,220 @@ QD_TBL_GET_OUT = """Qualifier Declarations
 |          |         |         |         | INDICATION  |                |
 +----------+---------+---------+---------+-------------+----------------+
 """
+
+# pylint enable=line_too_long
+QD_TBL_ENUM_MULTI_NS_OUT = """Qualifier Declarations
++-------------+------------------+---------+---------+---------+-------------+-----------------+
+| namespace   | Name             | Type    | Value   | Array   | Scopes      | Flavors         |
+|-------------+------------------+---------+---------+---------+-------------+-----------------|
+| root/cimv2  | Abstract         | boolean | False   | False   | CLASS       | EnableOverride  |
+|             |                  |         |         |         | ASSOCIATION | Restricted      |
+|             |                  |         |         |         | INDICATION  |                 |
+| root/cimv3  | Abstract         | boolean | False   | False   | CLASS       | EnableOverride  |
+|             |                  |         |         |         | ASSOCIATION | Restricted      |
+|             |                  |         |         |         | INDICATION  |                 |
+| root/cimv2  | Aggregate        | boolean | False   | False   | REFERENCE   | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv3  | Aggregate        | boolean | False   | False   | REFERENCE   | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv2  | Association      | boolean | False   | False   | ASSOCIATION | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv3  | Association      | boolean | False   | False   | ASSOCIATION | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv2  | Description      | string  |         | False   | ANY         | EnableOverride  |
+|             |                  |         |         |         |             | ToSubclass      |
+|             |                  |         |         |         |             | Translatable    |
+| root/cimv3  | Description      | string  |         | False   | ANY         | EnableOverride  |
+|             |                  |         |         |         |             | ToSubclass      |
+|             |                  |         |         |         |             | Translatable    |
+| root/cimv2  | EmbeddedInstance | string  |         | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | METHOD      | Restricted      |
+|             |                  |         |         |         | PARAMETER   |                 |
+| root/cimv3  | EmbeddedInstance | string  |         | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | METHOD      | Restricted      |
+|             |                  |         |         |         | PARAMETER   |                 |
+| root/cimv2  | EmbeddedObject   | boolean | False   | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | METHOD      | ToSubclass      |
+|             |                  |         |         |         | PARAMETER   |                 |
+| root/cimv3  | EmbeddedObject   | boolean | False   | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | METHOD      | ToSubclass      |
+|             |                  |         |         |         | PARAMETER   |                 |
+| root/cimv2  | In               | boolean | True    | False   | PARAMETER   | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv3  | In               | boolean | True    | False   | PARAMETER   | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv2  | Indication       | boolean | False   | False   | CLASS       | DisableOverride |
+|             |                  |         |         |         | INDICATION  | ToSubclass      |
+| root/cimv3  | Indication       | boolean | False   | False   | CLASS       | DisableOverride |
+|             |                  |         |         |         | INDICATION  | ToSubclass      |
+| root/cimv2  | Key              | boolean | False   | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | REFERENCE   | ToSubclass      |
+| root/cimv3  | Key              | boolean | False   | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | REFERENCE   | ToSubclass      |
+| root/cimv2  | Out              | boolean | False   | False   | PARAMETER   | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv3  | Out              | boolean | False   | False   | PARAMETER   | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv2  | Override         | string  |         | False   | PROPERTY    | EnableOverride  |
+|             |                  |         |         |         | REFERENCE   | Restricted      |
+|             |                  |         |         |         | METHOD      |                 |
+| root/cimv3  | Override         | string  |         | False   | PROPERTY    | EnableOverride  |
+|             |                  |         |         |         | REFERENCE   | Restricted      |
+|             |                  |         |         |         | METHOD      |                 |
+| root/cimv2  | Static           | boolean | False   | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | METHOD      | ToSubclass      |
+| root/cimv3  | Static           | boolean | False   | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | METHOD      | ToSubclass      |
++-------------+------------------+---------+---------+---------+-------------+-----------------+
+"""  # noqa: E501
+# pylint enable=line_too_long
+
+QD_MOF_ENUM_MULTINS_OUT = """#pragma namespace ("root/cimv2")
+Qualifier Abstract : boolean = false,
+    Scope(class, association, indication),
+    Flavor(EnableOverride, Restricted);
+
+#pragma namespace ("root/cimv2")
+Qualifier Aggregate : boolean = false,
+    Scope(reference),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv2")
+Qualifier Association : boolean = false,
+    Scope(association),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv2")
+Qualifier Description : string,
+    Scope(any),
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+#pragma namespace ("root/cimv2")
+Qualifier EmbeddedInstance : string,
+    Scope(property, method, parameter);
+
+#pragma namespace ("root/cimv2")
+Qualifier EmbeddedObject : boolean = false,
+    Scope(property, method, parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv2")
+Qualifier In : boolean = true,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv2")
+Qualifier Indication : boolean = false,
+    Scope(class, indication),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv2")
+Qualifier Key : boolean = false,
+    Scope(property, reference),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv2")
+Qualifier Out : boolean = false,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv2")
+Qualifier Override : string,
+    Scope(property, reference, method),
+    Flavor(EnableOverride, Restricted);
+
+#pragma namespace ("root/cimv2")
+Qualifier Static : boolean = false,
+    Scope(property, method),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier Abstract : boolean = false,
+    Scope(class, association, indication),
+    Flavor(EnableOverride, Restricted);
+
+#pragma namespace ("root/cimv3")
+Qualifier Aggregate : boolean = false,
+    Scope(reference),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier Association : boolean = false,
+    Scope(association),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier Description : string,
+    Scope(any),
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+#pragma namespace ("root/cimv3")
+Qualifier EmbeddedInstance : string,
+    Scope(property, method, parameter);
+
+#pragma namespace ("root/cimv3")
+Qualifier EmbeddedObject : boolean = false,
+    Scope(property, method, parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier In : boolean = true,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier Indication : boolean = false,
+    Scope(class, indication),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier Key : boolean = false,
+    Scope(property, reference),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier Out : boolean = false,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier Override : string,
+    Scope(property, reference, method),
+    Flavor(EnableOverride, Restricted);
+
+#pragma namespace ("root/cimv3")
+Qualifier Static : boolean = false,
+    Scope(property, method),
+    Flavor(DisableOverride, ToSubclass);
+
+"""
+# pylint enable=line_too_long
+QD_MOF_GET_MULTINS_OUT = """
+#pragma namespace ("root/cimv2")
+Qualifier Abstract : boolean = false,
+    Scope(class, association, indication),
+    Flavor(EnableOverride, Restricted);
+
+#pragma namespace ("root/cimv3")
+Qualifier Abstract : boolean = false,
+    Scope(class, association, indication),
+    Flavor(EnableOverride, Restricted);
+
+"""
+
+QD_TBL_GET_MULTINS_OUT = """Qualifier Declarations
++-------------+----------+---------+---------+---------+-------------+----------------+
+| namespace   | Name     | Type    | Value   | Array   | Scopes      | Flavors        |
+|-------------+----------+---------+---------+---------+-------------+----------------|
+| root/cimv2  | Abstract | boolean | False   | False   | CLASS       | EnableOverride |
+|             |          |         |         |         | ASSOCIATION | Restricted     |
+|             |          |         |         |         | INDICATION  |                |
+| root/cimv3  | Abstract | boolean | False   | False   | CLASS       | EnableOverride |
+|             |          |         |         |         | ASSOCIATION | Restricted     |
+|             |          |         |         |         | INDICATION  |                |
++-------------+----------+---------+---------+---------+-------------+----------------+
+"""  # noqa: E501
+# pylint enable=line_too_long
 
 # The following variables are used to control tests executed during
 # development of tests
@@ -374,12 +590,78 @@ TEST_CASES = [
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
 
-    # TODO: Add testcase for qualifier that is used, once usage checking has
-    #       been implemented.
+    #
+    #  Tests for multiple namespace enumerate
+    #
+    ['Verify qualifier command enumerate table, multiple ns',
+     {'args': ['enumerate', '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['-o', 'table']},
+     {'stdout': QD_TBL_ENUM_MULTI_NS_OUT,
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify qualifier command enumerate multiple ns MOF out',
+     {'args': ['enumerate', '--namespace', 'root/cimv2,root/cimv3'],
+      'general': []},
+     {'stdout': QD_MOF_ENUM_MULTINS_OUT,
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify qualifier command enumerate multiple ns  table output',
+     {'args': ['enumerate', '--namespace', 'root/cimv2,root/cimv3',
+               '--summary'],
+      'general': ['-o', 'table']},
+     {'stdout': """Summary of CIMQualifierDeclaration(s) returned
++-------------+---------+-------------------------+
+| Namespace   |   Count | CIM Type                |
+|-------------+---------+-------------------------|
+| root/cimv2  |      12 | CIMQualifierDeclaration |
+| root/cimv3  |      12 | CIMQualifierDeclaration |
++-------------+---------+-------------------------+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify qualifier command get table, multiple ns',
+     {'args': ['get', 'Abstract', '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['-o', 'table']},
+     {'stdout': QD_TBL_GET_MULTINS_OUT,
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify qualifier command get MOF out, multiple ns',
+     {'args': ['get', 'Abstract', '--namespace', 'root/cimv2,root/cimv3'],
+      'general': []},
+     {'stdout': QD_MOF_GET_MULTINS_OUT,
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify qualifier command get MOF out, multiple ns only in one ns',
+     {'args': ['get', 'EmbeddedObject', '--namespace', 'root/cimv2,interop'],
+      'general': []},
+     {'stderr': "CIMError: 6 (CIM_ERR_NOT_FOUND): Qualifier declaration "
+                "'EmbeddedObject' not found in namespace 'interop'.",
+      'rc': 1,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify qualifier command get MOF out, multiple ns not found',
+     {'args': ['get', 'Invalid_QD', '--namespace', 'root/cimv2,root/cimv3'],
+      'general': []},
+     {'stderr': "CIMError: 6 (CIM_ERR_NOT_FOUND): Qualifier "
+                "declaration 'Invalid_QD' not found in namespace 'root/cimv2'.",
+      'rc': 1,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
 ]
 
 
-class TestcmdQualifiers(CLITestsBase):
+class TestcmdQualifiers(CLITestsBase):  # pylint: disable=too-few-public-methods
     """
     Test all of the qualifiers command variations.
     """


### PR DESCRIPTION
NOTE:  waiting on M. Walker test but ready for review.

The instance get command with multiple namespaces (-n
root/cimv2,root/cimv3) and the .? flag to display namespaces caused an
exception.  However, this lead to realizing that we were only displaying
a single instance rather than the instances from each namespace.
Corrected those issues.

I did not create an issue since this is an issue with the code in a prior PR for the the current release and the code only exists for that release.
