### PR TITLE
Add object ordering to multi-namespace requests to allow ordering by object name

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,7 +36,7 @@ Released: not yet
 * Increased minimum version of Click to 8.0.1 on Python >= 3.6 to prepare for
   new features. Adjusted testcases accordingly.
 
-  Extended class and instance enumerate/get/associators/references to allow
+* Extended class and instance enumerate/get/associators/references to allow
   getting the objects from multiple namespaces with a single request.  This
   extends the command option --namespace to allow multiple namespaces for
   these commands using either comma-separated format
@@ -45,7 +45,13 @@ Released: not yet
   have been extended to include the namespace name for the objects in all
   of the output formats if multiple namespaces are used. As before, the
   namespaces are not shown if only a single or the default namespace is
-  requested.  (see issues # 1058 and #1059)
+  requested.(see issues #1058 and #1059)
+
+* Add a new option (--object-order) to class and instance
+  enumerate/get/associators/references and qualifier enumerate/get to reorder
+  the command results displays by the object name rather than the default of
+  namespace name. This allows the user to more easily compare the objects
+  themselves in different namespaces. (see issues #1058 and #1059)
 
 **Cleanup:**
 

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -231,6 +231,8 @@ Help text for ``pywbemcli class associators`` (see :ref:`class associators comma
       -n, --namespace NAMESPACE(s)    Namespace(s) to use for this command, instead of the default connection namespace. May
                                       be specified multiple times using either the option multiple times and/or comma
                                       separated list. Default: connection default namespace.
+      --object-order                  Order the objects by object before namespace. Only applies when multiple namespaces
+                                      defined.
       -s, --summary                   Show only a summary (count) of the objects.
       -h, --help                      Show this help message.
 
@@ -354,6 +356,8 @@ Help text for ``pywbemcli class enumerate`` (see :ref:`class enumerate command`)
       --subclass-of CLASSNAME         Filter the returned classes to return only classes that are a subclass of the option
                                       value.
       --leaf-classes                  Filter the returned classes to return only leaf (classes; classes with no subclass.
+      --object-order                  Order the objects by object before namespace. Only applies when multiple namespaces
+                                      defined.
       -h, --help                      Show this help message.
 
 
@@ -558,6 +562,8 @@ Help text for ``pywbemcli class references`` (see :ref:`class references command
       -n, --namespace NAMESPACE(s)    Namespace(s) to use for this command, instead of the default connection namespace. May
                                       be specified multiple times using either the option multiple times and/or comma
                                       separated list. Default: connection default namespace.
+      --object-order                  Order the objects by object before namespace. Only applies when multiple namespaces
+                                      defined.
       -s, --summary                   Show only a summary (count) of the objects.
       -h, --help                      Show this help message.
 
@@ -1053,6 +1059,8 @@ Help text for ``pywbemcli instance associators`` (see :ref:`instance associators
                                       Null property are displayed
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
                                       --namespace options.
+      --object-order                  Order the objects by object before namespace. Only applies when multiple namespaces
+                                      defined.
       -h, --help                      Show this help message.
 
 
@@ -1262,6 +1270,8 @@ Help text for ``pywbemcli instance enumerate`` (see :ref:`instance enumerate com
       --show-null                     In the TABLE output formats, show properties with no value (i.e. Null) in all of the
                                       instances to be displayed. Otherwise only properties at least one instance has a non-
                                       Null property are displayed
+      --object-order                  Order the objects by object before namespace. Only applies when multiple namespaces
+                                      defined.
       -h, --help                      Show this help message.
 
 
@@ -1306,6 +1316,8 @@ Help text for ``pywbemcli instance get`` (see :ref:`instance get command`):
       -n, --namespace NAMESPACE(s)    Namespace(s) to use for this command, instead of the default connection namespace. May
                                       be specified multiple times using either the option multiple times and/or comma
                                       separated list. Default: connection default namespace.
+      --object-order                  Order the objects by object before namespace. Only applies when multiple namespaces
+                                      defined.
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
                                       --namespace options.
       --show-null                     In the TABLE output formats, show properties with no value (i.e. Null) in all of the
@@ -1502,6 +1514,8 @@ Help text for ``pywbemcli instance references`` (see :ref:`instance references c
                                       The filter query language to be used with --filter-query. Default: DMTF:FQL.
       --hi, --help-instancename       Show help message for specifying INSTANCENAME including use of the --key and
                                       --namespace options.
+      --object-order                  Order the objects by object before namespace. Only applies when multiple namespaces
+                                      defined.
       -h, --help                      Show this help message.
 
 
@@ -1908,6 +1922,8 @@ Help text for ``pywbemcli qualifier enumerate`` (see :ref:`qualifier enumerate c
       -n, --namespace NAMESPACE(s)  Namespace(s) to use for this command, instead of the default connection namespace. May
                                     be specified multiple times using either the option multiple times and/or comma
                                     separated list. Default: connection default namespace.
+      --object-order                Order the objects by object before namespace. Only applies when multiple namespaces
+                                    defined.
       -s, --summary                 Show only a summary (count) of the objects.
       -h, --help                    Show this help message.
 
@@ -1937,6 +1953,8 @@ Help text for ``pywbemcli qualifier get`` (see :ref:`qualifier get command`):
       -n, --namespace NAMESPACE(s)  Namespace(s) to use for this command, instead of the default connection namespace. May
                                     be specified multiple times using either the option multiple times and/or comma
                                     separated list. Default: connection default namespace.
+      --object-order                Order the objects by object before namespace. Only applies when multiple namespaces
+                                    defined.
       -h, --help                    Show this help message.
 
 

--- a/docs/pywbemcli/features.rst
+++ b/docs/pywbemcli/features.rst
@@ -491,7 +491,7 @@ the root classes).
 
 
 .. index::
-    pair: namespace; multiple namespaces
+    pair: namespace; multiple namespace commands
     pair: --namespace option; command option --namespace
 
 .. _`Using multiple namespaces with server requests`:
@@ -509,7 +509,7 @@ Generally the CIM/XML commands defined by the DMTF execute operations on a singl
 is a request to the WBEM server to return instances of of <classname> from
 namespace ``interop``.
 
-However, pywbemcli expands this to allow some requests to be executed against
+However, pywbemcli expands this in version 1.1.0  to allow some requests to be executed against
 multiple namespaces in a single request.  This was done primarily to allow
 viewing CIM objects in the server across namespaces (ex. comparing classes
 or instances between namespaces).
@@ -517,25 +517,34 @@ or instances between namespaces).
 The commands ``enumerate``, ``get``, ``associators``, and ``references`` for
 the command groups ``class`` and ``instance`` and the ``enumerate`` and ``get``
 for the command group qualifiers allow issuing requests on multiple namespaces
-in a single pywbemcli command. Multiple namespace for a command is defined with
+in a single pywbemcli command. Multiple namespaces for a command is defined with
 the ``--namespace`` option by defining the set of namespaces to be included
 rather than just a single namespace. If the ``default-namespace`` is not
 defined is the connection default namespace.
 
-The responses are displayed in the same form as with a single namespace except
-that the namespace is included for each type of display to allow the user to
-determine which data is in which namespace.  With MOF, the namespace appears as
+Thus, the requests below command pywbecli to make a request for each of the
+namespaces interop and root/comv2 and to present the results of both requests
+in a single response.
+
+    class enumerate CIM_ManagedElement -n interop, root/cimve
+    class enumerate CIM_ManagedElement -s interop -n root/cimv2 
+
+The responses are displayed in the same form as for a single namespace except
+that the namespace is included for each type of output format to allow the user to
+determine which object is in which namespace.  With MOF, the namespace appears as
 a MOF namespace pragma (commented because not all WBEM server compilers honor the
-namespace pragma). With tables, a namespace column is included.
+namespace pragma). With tables, a namespace column is included in the table.
+
+The order of the objects displayed in responses is controlled by a command
+options ``--object-order``.  The default order is to order the objects by
+namespace but defining this option allows modifying the order to display
+objects ordered by object name which allows comparing objects between namespaces.
 
 For example:
 
 .. code-block:: text
 
     # pywbemcli instance enumerate CIM_Door --namespace root/cimv2,root/cimv3
-
-    # pywbemcli instance get CIM_Subscription.? --namespace root/cimv2 --namespace root/cimv3
-
 
 return the instances of CIM_Door from two namespaces root/cimv2 and root/cimv3.
 

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -488,6 +488,153 @@ def class_tree(context, classname, **options):
 ####################################################################
 
 
+def handle_multi_ns_exc(exc, ns_names, results, ns, target_object,
+                        obj_type=None):
+    """
+    Handle CIM_Error exceptions from multi-namespace requests.  This method
+    processes an exception from a server request methods and determines if
+    the processing will continue for other namespaces or terminate with an
+    exception. If one of the listed CIMError status codes in being processed,
+    it allows the processing to continue but issues a warning message.
+
+    If all namespaces in the ns_names list have been processed and there
+    are no valid responses in the ns_names list, it raises the error shown
+    by exc.
+
+    Parameters:
+      exc (Exception):
+        The exception caught and being processed being processed.
+
+      ns_names (list of :term:`string`):
+        The list of namespaces being processed by the request
+
+      results (:class:`NocaseDict`):
+        Dictionary of results generated
+
+      ns (:term:`string`):
+        The namespace being processed
+
+      target_object (:term:`string` or CIMInstanceName,):
+        The request target object that caused the exception or None
+
+      obj_type (:term:`string`):
+        Optionsl string defining the type of object that is the target/source.
+        Inserted into warning message.
+    """
+    # If not one of the following status codes, terminate with Click exception
+    if exc.status_code not in (CIM_ERR_NOT_FOUND,
+                               CIM_ERR_INVALID_CLASS,
+                               CIM_ERR_INVALID_NAMESPACE,
+                               CIM_ERR_INVALID_PARAMETER):
+        raise pywbem_error_exception(exc)
+
+    # Otherwise If all commands complete, and none were successful generate
+    #  exception. Otherwise generate a warning message.
+
+    # Add the current namespace to the results with empty results list.
+    # This is important because display_cimobjects depends on list of all
+    # namespaces for formatting.
+    results[ns] = []
+
+    # If all returns were in error, terminate with exception
+    if len(ns_names) == len(results) and not any(results.values()):
+        raise pywbem_error_exception(exc)
+
+    if obj_type is None:
+        obj_type = "class:" if isinstance(target_object, six.string_types) \
+            else "instance:"
+
+    warning_msg("Error: '{0}' {1} '{2}' in namespace: '{3}'. "
+                "Exception: {4}\n".format(exc.status_code_name, obj_type,
+                                          target_object, ns, exc))
+
+
+def get_namespaces(context, namespaces, default_all_ns=False):
+    """
+    Returns either the namespaces defined in --namespaces parameter or if
+    namespaces is empty, either all of the namespaces available in the server or
+    the value None depending on the value of the parameter default_all_ns.
+
+    Processes either single namespace string, single string containing
+    multiple comma-separated,namespace definitions  or combination of string
+    and tuple.
+
+    This allows a single processor for the namespace option that returns
+    namespace or default in a form that matches the type of namespaces
+    (tuple, list) or (string, string)
+
+    Parameters:
+
+      context context (:class:`ContextObj` provided with command)
+
+      namespaces (tuple of :term:`string` or :term:`string`)
+        tuple of strings where each string is one or more namespace names.
+        Any single string can contain one or multiple namespaces by
+        comma-separating the namespace names.
+
+      default_all_ns (:class:`py:bool`):
+        Boolean that determines return value if namespaces is None or []:
+          True: Return all namespaces in server
+          False: Return default namespace for current conn (default)
+
+    Returns:
+        If namespaces is a tuple, returns list of namespaces with
+        comma-separated strings separated into single items in the list
+        If namespaces is string, returns the single namespace string
+        if namespaces is None, returns None if default_all_ns is False
+        or all namespaces in environment if default_all_ns is True
+
+    Raises:
+        CIMError if status code not CIM_ERR_NOT_FOUND
+    """
+    def get_default_ns(default_ns):
+        return default_ns if not isinstance(namespaces, tuple) else [default_ns]
+
+    # Return the provided namespace(s) by expanding each entry that has
+    # comma-separated values add adding those without comma
+
+    ns_names = []
+    if namespaces:
+        if isinstance(namespaces, tuple):
+            for ns in namespaces:
+                ns_names.extend(ns.split(','))
+            return ns_names
+        return namespaces
+
+    # If default input param is None, return the default namespace.
+    # We set the default namespace here rather than None (where the request
+    # would get the default namespace) because the find command
+    # attempts to build a dict with namespace and None fails
+    conn = context.pywbem_server.conn
+    default_ns = conn.default_namespace
+    assert default_all_ns is not None
+    if default_all_ns is False:
+        return get_default_ns(default_ns)
+
+    # Otherwise get all namespaces from server
+    wbem_server = context.pywbem_server.wbem_server
+    try:
+        assert isinstance(namespaces, tuple)
+        ns_names = wbem_server.namespaces
+        ns_names.sort()
+        return ns_names
+
+    except ModelError:
+        return get_default_ns(default_ns)
+
+    except CIMError as ce:
+        # Allow processing to continue if no interop namespace
+        if ce.status_code == CIM_ERR_NOT_FOUND:
+            warning_msg('{}. Using default_namespace {}.'
+                        .format(ce, conn.default_namespace))
+            return get_default_ns(default_ns)
+        raise click.ClickException('Failed to find namespaces. Exception: {} '
+                                   .format(ce))
+
+    except Error as er:
+        raise pywbem_error_exception(er)
+
+
 def get_classnames_in_namespaces(context, options, namespaces, classname_glob):
     """
     Get the classnames of all classes in the namespaces parameter that
@@ -662,7 +809,6 @@ def cmd_class_references(context, classname, options):
                              classname)
 
     for ns in results:
-        try:
             cln = CIMClassName(classname, namespace=ns)
             if options['names_only']:
                 results.add(conn.ReferenceNames(
@@ -703,7 +849,6 @@ def cmd_class_associators(context, classname, options):
                              classname)
 
     for ns in results:
-        try:
             cln = CIMClassName(classname, namespace=ns)
             if options['names_only']:
                 results.add(conn.AssociatorNames(
@@ -732,6 +877,9 @@ def cmd_class_associators(context, classname, options):
             raise pywbem_error_exception(er)
 
     results.display()
+
+    display_cim_objects(context, results, output_format,
+                        summary=options['summary'])
 
 
 def cmd_class_find(context, classname_glob, options):

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -39,7 +39,8 @@ from ._display_cimobjects import display_cim_objects
 from ._common_options import propertylist_option, names_only_option, \
     include_classorigin_instance_option, namespace_option, summary_option, \
     verify_option, multiple_namespaces_option_dflt_all, \
-    multiple_namespaces_option_dflt_conn, class_filter_options
+    multiple_namespaces_option_dflt_conn, class_filter_options, \
+    object_order_option
 
 from ._cimvalueformatter import mof_escaped
 
@@ -213,6 +214,7 @@ def instance_group():
 @add_options(filter_query_option)
 @add_options(filter_query_language_option)
 @add_options(show_null_option)
+@add_options(object_order_option)
 @add_options(help_option)
 @click.pass_obj
 def instance_enumerate(context, classname, **options):
@@ -251,6 +253,7 @@ def instance_enumerate(context, classname, **options):
 @add_options(propertylist_option)
 @add_options(keybinding_key_option)
 @add_options(multiple_namespaces_option_dflt_conn)
+@add_options(object_order_option)
 @add_options(help_instancename_option)
 @add_options(show_null_option)
 @add_options(help_option)
@@ -414,6 +417,7 @@ def instance_modify(context, instancename, **options):
 @add_options(filter_query_language_option)
 @add_options(show_null_option)
 @add_options(help_instancename_option)
+@add_options(object_order_option)
 @add_options(help_option)
 @click.pass_obj
 def instance_associators(context, instancename, **options):
@@ -468,6 +472,7 @@ def instance_associators(context, instancename, **options):
 @add_options(show_null_option)
 @add_options(filter_query_language_option)
 @add_options(help_instancename_option)
+@add_options(object_order_option)
 @add_options(help_option)
 @click.pass_obj
 def instance_references(context, instancename, **options):
@@ -1240,12 +1245,8 @@ def enumerate_instances(conn, context, options, namespace, classname,
             raise er
         raise pywbem_error_exception(er)
 
-<<<<<<< HEAD
     # Exception from Enumerate and the FilterQuery.  This exception would
     # apply  to all namespaces so just terminate.
-=======
-    # Exception from Enumerate
->>>>>>> Fix issue #1184 - Multiple namespace commands with errors
     except ValueError as ve:
         raise click.ClickException(
             'Instance enumerate failed because FilterQuery not allowed with '
@@ -1345,6 +1346,7 @@ def cmd_instance_references(context, instancename, options):
                 .format(context.pywbem_server.use_pull, ve.__class__.__name__,
                         ve))
     results.display()
+
 
 def cmd_instance_associators(context, instancename, options):
     """

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -1240,8 +1240,12 @@ def enumerate_instances(conn, context, options, namespace, classname,
             raise er
         raise pywbem_error_exception(er)
 
+<<<<<<< HEAD
     # Exception from Enumerate and the FilterQuery.  This exception would
     # apply  to all namespaces so just terminate.
+=======
+    # Exception from Enumerate
+>>>>>>> Fix issue #1184 - Multiple namespace commands with errors
     except ValueError as ve:
         raise click.ClickException(
             'Instance enumerate failed because FilterQuery not allowed with '
@@ -1341,7 +1345,6 @@ def cmd_instance_references(context, instancename, options):
                 .format(context.pywbem_server.use_pull, ve.__class__.__name__,
                         ve))
     results.display()
-
 
 def cmd_instance_associators(context, instancename, options):
     """

--- a/pywbemtools/pywbemcli/_cmd_qualifier.py
+++ b/pywbemtools/pywbemcli/_cmd_qualifier.py
@@ -31,7 +31,7 @@ from ._common import sort_cimobjects, pywbem_error_exception
 
 from ._common_cmd_functions import ResultsHandler
 from ._common_options import namespace_option, summary_option, \
-    multiple_namespaces_option_dflt_conn
+    multiple_namespaces_option_dflt_conn, object_order_option
 from .._click_extensions import PywbemtoolsGroup, PywbemtoolsCommand, \
     CMD_OPTS_TXT, GENERAL_OPTS_TXT, SUBCMD_HELP_TXT
 from .._options import add_options, help_option
@@ -66,6 +66,7 @@ def qualifier_group():
 @click.argument('qualifiername', type=str, metavar='QUALIFIERNAME',
                 required=True,)
 @add_options(multiple_namespaces_option_dflt_conn)
+@add_options(object_order_option)
 @add_options(help_option)
 @click.pass_obj
 def qualifier_get(context, qualifiername, **options):
@@ -112,6 +113,7 @@ def qualifier_delete(context, qualifiername, **options):
 @qualifier_group.command('enumerate', cls=PywbemtoolsCommand,
                          options_metavar=CMD_OPTS_TXT)
 @add_options(multiple_namespaces_option_dflt_conn)
+@add_options(object_order_option)
 @add_options(summary_option)
 @add_options(help_option)
 @click.pass_obj
@@ -199,4 +201,3 @@ def cmd_qualifier_enumerate(context, options):
             raise pywbem_error_exception(er)
 
     results.display()
-

--- a/pywbemtools/pywbemcli/_cmd_qualifier.py
+++ b/pywbemtools/pywbemcli/_cmd_qualifier.py
@@ -199,3 +199,4 @@ def cmd_qualifier_enumerate(context, options):
             raise pywbem_error_exception(er)
 
     results.display()
+

--- a/pywbemtools/pywbemcli/_common_cmd_functions.py
+++ b/pywbemtools/pywbemcli/_common_cmd_functions.py
@@ -114,7 +114,7 @@ class ResultsHandler(object):
 
         self.results = NocaseDict()
 
-        # set the requested namespaces into the results dictionary
+        # Set the requested namespaces into the results dictionary
         for ns in self.ns_names:
             self.results[ns] = None
 
@@ -189,11 +189,13 @@ class ResultsHandler(object):
         """
         summary = self.options.get('summary', None)
         ignore_null = not self.options.get('show_null', None)
+        object_order = self.options.get("object_order", None)
 
         display_cim_objects(self.context, self.results, self.output_format,
                             summary=summary,
                             ignore_null_properties=ignore_null,
-                            property_list=self.property_list)
+                            property_list=self.property_list,
+                            object_order=object_order)
 
         if self.result_errors:
             if any(self.result_errors.values()):

--- a/pywbemtools/pywbemcli/_common_options.py
+++ b/pywbemtools/pywbemcli/_common_options.py
@@ -102,6 +102,12 @@ verify_option = [
                       u'Default: Do not prompt for confirmation.'),
 ]
 
+object_order_option = [
+    click.option('--object-order', is_flag=True, required=False,
+                 help=u'Order the objects by object before namespace. Only '
+                      u'applies when multiple namespaces defined.'),
+]
+
 class_filter_options = [
     click.option('--association/--no-association',
                  default=None,

--- a/pywbemtools/pywbemcli/_display_cimobjects.py
+++ b/pywbemtools/pywbemcli/_display_cimobjects.py
@@ -192,6 +192,14 @@ def display_cim_objects(context, cim_objects, output_format, summary=False,
                     _display_one_cim_object(
                         context, obj, output_format, property_list,
                         quote_strings, ignore_null_properties, namespace=ns)
+            if not isinstance(ns_objects, list):
+                ns_objects = [ns_objects]
+            ns_objects = sort_cimobjects(ns_objects)
+
+            for obj in ns_objects:
+                _display_one_cim_object(
+                    context, obj, output_format, property_list, quote_strings,
+                    ignore_null_properties, namespace=ns)
         return
 
     # If not NocaseDict, it is list or single object. Sort by classname and

--- a/tests/unit/pywbemcli/test_class_cmds.py
+++ b/tests/unit/pywbemcli/test_class_cmds.py
@@ -612,7 +612,7 @@ CIMFOO_SUB_SUB_NO_QUALS_XML = """<CLASS NAME="CIM_Foo_sub_sub" SUPERCLASS="CIM_F
 """  # noqa E501
 # pylint: enable=line-too-long
 
-OK = True     # mark tests OK when they execute correctly
+OK = True    # mark tests OK when they execute correctly
 RUN = True    # Mark OK = False and current test case being created RUN
 FAIL = False  # Any test currently FAILING or not tested yet
 
@@ -1311,7 +1311,6 @@ TEST_CASES = [
      {'stderr': ["namespace:root/cimv2", "CIM_ERR_INVALID_CLASS",
                  "Description:The class 'InvalidClassname' defined by "
                  "'ClassName' parameter does not exist in namespace "
-                 "'root/cimv2'"],
       'rc': 1,
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],

--- a/tests/unit/pywbemcli/test_class_cmds.py
+++ b/tests/unit/pywbemcli/test_class_cmds.py
@@ -612,7 +612,518 @@ CIMFOO_SUB_SUB_NO_QUALS_XML = """<CLASS NAME="CIM_Foo_sub_sub" SUPERCLASS="CIM_F
 """  # noqa E501
 # pylint: enable=line-too-long
 
-OK = True    # mark tests OK when they execute correctly
+ENUMERATE_CLASS_2_NAMESPACE = """
+#pragma namespace ("root/cimv2")
+   [Description ( "Subclass of CIM_Foo" )]
+class CIM_Foo_sub : CIM_Foo {
+
+   string cimfoo_sub;
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   string InstanceID;
+
+      [Description ( "This is Uint32 property." )]
+   uint32 IntegerProp;
+
+      [Description ( "Embedded instance property" ),
+       EmbeddedInstance ( "CIM_FooEmb3" )]
+   string cimfoo_emb3;
+
+      [Description ( "Method with in and out parameters" )]
+   uint32 Fuzzy(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_FooRef1 REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue);
+
+      [Description ( "Static method with in and out parameters" ),
+       Static ( true )]
+   uint32 FuzzyStatic(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_Foo REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue,
+         [IN ( true ),
+          Description ( "Embedded instance parameter" ),
+          EmbeddedInstance ( "CIM_FooEmb1" )]
+      string cimfoo_emb1);
+
+      [Description ( "Method with no parameters but embedded instance return" ),
+       EmbeddedInstance ( "CIM_FooEmb2" )]
+   string DeleteNothing();
+
+};
+
+#pragma namespace ("root/cimv2")
+class CIM_Foo_sub2 : CIM_Foo {
+
+   string cimfoo_sub2;
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   string InstanceID;
+
+      [Description ( "This is Uint32 property." )]
+   uint32 IntegerProp;
+
+      [Description ( "Embedded instance property" ),
+       EmbeddedInstance ( "CIM_FooEmb3" )]
+   string cimfoo_emb3;
+
+      [Description ( "Method with in and out parameters" )]
+   uint32 Fuzzy(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_FooRef1 REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue);
+
+      [Description ( "Static method with in and out parameters" ),
+       Static ( true )]
+   uint32 FuzzyStatic(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_Foo REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue,
+         [IN ( true ),
+          Description ( "Embedded instance parameter" ),
+          EmbeddedInstance ( "CIM_FooEmb1" )]
+      string cimfoo_emb1);
+
+      [Description ( "Method with no parameters but embedded instance return" ),
+       EmbeddedInstance ( "CIM_FooEmb2" )]
+   string DeleteNothing();
+
+};
+
+#pragma namespace ("root/cimv3")
+   [Description ( "Subclass of CIM_Foo" )]
+class CIM_Foo_sub : CIM_Foo {
+
+   string cimfoo_sub;
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   string InstanceID;
+
+      [Description ( "This is Uint32 property." )]
+   uint32 IntegerProp;
+
+      [Description ( "Embedded instance property" ),
+       EmbeddedInstance ( "CIM_FooEmb3" )]
+   string cimfoo_emb3;
+
+      [Description ( "Method with in and out parameters" )]
+   uint32 Fuzzy(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_FooRef1 REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue);
+
+      [Description ( "Static method with in and out parameters" ),
+       Static ( true )]
+   uint32 FuzzyStatic(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_Foo REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue,
+         [IN ( true ),
+          Description ( "Embedded instance parameter" ),
+          EmbeddedInstance ( "CIM_FooEmb1" )]
+      string cimfoo_emb1);
+
+      [Description ( "Method with no parameters but embedded instance return" ),
+       EmbeddedInstance ( "CIM_FooEmb2" )]
+   string DeleteNothing();
+
+};
+
+#pragma namespace ("root/cimv3")
+class CIM_Foo_sub2 : CIM_Foo {
+
+   string cimfoo_sub2;
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   string InstanceID;
+
+      [Description ( "This is Uint32 property." )]
+   uint32 IntegerProp;
+
+      [Description ( "Embedded instance property" ),
+       EmbeddedInstance ( "CIM_FooEmb3" )]
+   string cimfoo_emb3;
+
+      [Description ( "Method with in and out parameters" )]
+   uint32 Fuzzy(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_FooRef1 REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue);
+
+      [Description ( "Static method with in and out parameters" ),
+       Static ( true )]
+   uint32 FuzzyStatic(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_Foo REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue,
+         [IN ( true ),
+          Description ( "Embedded instance parameter" ),
+          EmbeddedInstance ( "CIM_FooEmb1" )]
+      string cimfoo_emb1);
+
+      [Description ( "Method with no parameters but embedded instance return" ),
+       EmbeddedInstance ( "CIM_FooEmb2" )]
+   string DeleteNothing();
+};
+"""
+
+ENUMERATE_CLASS_2_NAMESPACE_OBJECT_ORDER = """#pragma namespace ("root/cimv2")
+   [Description ( "Subclass of CIM_Foo" )]
+class CIM_Foo_sub : CIM_Foo {
+
+   string cimfoo_sub;
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   string InstanceID;
+
+      [Description ( "This is Uint32 property." )]
+   uint32 IntegerProp;
+
+      [Description ( "Embedded instance property" ),
+       EmbeddedInstance ( "CIM_FooEmb3" )]
+   string cimfoo_emb3;
+
+      [Description ( "Method with in and out parameters" )]
+   uint32 Fuzzy(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_FooRef1 REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue);
+
+      [Description ( "Static method with in and out parameters" ),
+       Static ( true )]
+   uint32 FuzzyStatic(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_Foo REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue,
+         [IN ( true ),
+          Description ( "Embedded instance parameter" ),
+          EmbeddedInstance ( "CIM_FooEmb1" )]
+      string cimfoo_emb1);
+
+      [Description ( "Method with no parameters but embedded instance return" ),
+       EmbeddedInstance ( "CIM_FooEmb2" )]
+   string DeleteNothing();
+
+};
+
+#pragma namespace ("root/cimv3")
+   [Description ( "Subclass of CIM_Foo" )]
+class CIM_Foo_sub : CIM_Foo {
+
+   string cimfoo_sub;
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   string InstanceID;
+
+      [Description ( "This is Uint32 property." )]
+   uint32 IntegerProp;
+
+      [Description ( "Embedded instance property" ),
+       EmbeddedInstance ( "CIM_FooEmb3" )]
+   string cimfoo_emb3;
+
+      [Description ( "Method with in and out parameters" )]
+   uint32 Fuzzy(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_FooRef1 REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue);
+
+      [Description ( "Static method with in and out parameters" ),
+       Static ( true )]
+   uint32 FuzzyStatic(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_Foo REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue,
+         [IN ( true ),
+          Description ( "Embedded instance parameter" ),
+          EmbeddedInstance ( "CIM_FooEmb1" )]
+      string cimfoo_emb1);
+
+      [Description ( "Method with no parameters but embedded instance return" ),
+       EmbeddedInstance ( "CIM_FooEmb2" )]
+   string DeleteNothing();
+
+};
+
+#pragma namespace ("root/cimv2")
+class CIM_Foo_sub2 : CIM_Foo {
+
+   string cimfoo_sub2;
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   string InstanceID;
+
+      [Description ( "This is Uint32 property." )]
+   uint32 IntegerProp;
+
+      [Description ( "Embedded instance property" ),
+       EmbeddedInstance ( "CIM_FooEmb3" )]
+   string cimfoo_emb3;
+
+      [Description ( "Method with in and out parameters" )]
+   uint32 Fuzzy(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_FooRef1 REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue);
+
+      [Description ( "Static method with in and out parameters" ),
+       Static ( true )]
+   uint32 FuzzyStatic(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_Foo REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue,
+         [IN ( true ),
+          Description ( "Embedded instance parameter" ),
+          EmbeddedInstance ( "CIM_FooEmb1" )]
+      string cimfoo_emb1);
+
+      [Description ( "Method with no parameters but embedded instance return" ),
+       EmbeddedInstance ( "CIM_FooEmb2" )]
+   string DeleteNothing();
+
+};
+
+#pragma namespace ("root/cimv3")
+class CIM_Foo_sub2 : CIM_Foo {
+
+   string cimfoo_sub2;
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   string InstanceID;
+
+      [Description ( "This is Uint32 property." )]
+   uint32 IntegerProp;
+
+      [Description ( "Embedded instance property" ),
+       EmbeddedInstance ( "CIM_FooEmb3" )]
+   string cimfoo_emb3;
+
+      [Description ( "Method with in and out parameters" )]
+   uint32 Fuzzy(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_FooRef1 REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue);
+
+      [Description ( "Static method with in and out parameters" ),
+       Static ( true )]
+   uint32 FuzzyStatic(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_Foo REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue,
+         [IN ( true ),
+          Description ( "Embedded instance parameter" ),
+          EmbeddedInstance ( "CIM_FooEmb1" )]
+      string cimfoo_emb1);
+
+      [Description ( "Method with no parameters but embedded instance return" ),
+       EmbeddedInstance ( "CIM_FooEmb2" )]
+   string DeleteNothing();
+
+};
+
+"""
+
+OK = True     # mark tests OK when they execute correctly
 RUN = True    # Mark OK = False and current test case being created RUN
 FAIL = False  # Any test currently FAILING or not tested yet
 
@@ -1310,7 +1821,7 @@ TEST_CASES = [
      ['enumerate', 'InvalidClassname'],
      {'stderr': ["namespace:root/cimv2", "CIM_ERR_INVALID_CLASS",
                  "Description:The class 'InvalidClassname' defined by "
-                 "'ClassName' parameter does not exist in namespace "
+                 "'ClassName' parameter does not exist in namespace "],
       'rc': 1,
       'test': 'innows'},
      SIMPLE_MOCK_FILE, OK],
@@ -1926,8 +2437,13 @@ TEST_CASES = [
     ['Verify class command enumerate with --leaf-classes & --subclass-of',
      ['enumerate', '--di', '--no', '--leaf-classes', '--subclass-of',
       'TST_Person'],
-     {'stdout': ['TST_PersonClsDep', 'TST_PersonDep', 'TST_PersonExp'
-                 'TST_PersonExpProperty', 'TST_PersonPropDep', 'TST_PersonSub'],
+     {'stdout': """TST_PersonClsDep
+TST_PersonDep
+TST_PersonExp
+TST_PersonExpProperty
+TST_PersonPropDep
+TST_PersonSub
+""",
       'test': 'innows'},
      QUALIFIER_FILTER_MODEL, OK],
 
@@ -2686,9 +3202,130 @@ TEST_CASES = [
 
     ['Verify class get from two namespaces. single namespace/comma option',
      {'args': ['get', 'CIM_Foo', '--namespace', 'root/cimv2,root/cimv3']},
-     {'stdout': ['#pragma namespace ("root/cimv2")',
-                 '#pragma namespace ("root/cimv3")',
-                 'CIM_Foo {'],
+     {'stdout': ["""#pragma namespace ("root/cimv2")
+   [Description ( "Simple CIM Class" )]
+class CIM_Foo {
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   string InstanceID;
+
+      [Description ( "This is Uint32 property." )]
+   uint32 IntegerProp;
+
+      [Description ( "Embedded instance property" ),
+       EmbeddedInstance ( "CIM_FooEmb3" )]
+   string cimfoo_emb3;
+
+      [Description ( "Method with in and out parameters" )]
+   uint32 Fuzzy(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_FooRef1 REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue);
+
+      [Description ( "Static method with in and out parameters" ),
+       Static ( true )]
+   uint32 FuzzyStatic(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_Foo REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue,
+         [IN ( true ),
+          Description ( "Embedded instance parameter" ),
+          EmbeddedInstance ( "CIM_FooEmb1" )]
+      string cimfoo_emb1);
+
+      [Description ( "Method with no parameters but embedded instance return" ),
+       EmbeddedInstance ( "CIM_FooEmb2" )]
+   string DeleteNothing();
+
+};
+
+#pragma namespace ("root/cimv3")
+   [Description ( "Simple CIM Class" )]
+class CIM_Foo {
+
+      [Key ( true ),
+       Description ( "This is key property." )]
+   string InstanceID;
+
+      [Description ( "This is Uint32 property." )]
+   uint32 IntegerProp;
+
+      [Description ( "Embedded instance property" ),
+       EmbeddedInstance ( "CIM_FooEmb3" )]
+   string cimfoo_emb3;
+
+      [Description ( "Method with in and out parameters" )]
+   uint32 Fuzzy(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_FooRef1 REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue);
+
+      [Description ( "Static method with in and out parameters" ),
+       Static ( true )]
+   uint32 FuzzyStatic(
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Define data to be returned in output parameter" )]
+      string TestInOutParameter,
+         [IN ( true ),
+          OUT ( true ),
+          Description ( "Test of ref in/out parameter" )]
+      CIM_Foo REF TestRef,
+         [IN ( false ),
+          OUT ( true ),
+          Description ( "Rtns method name if exists on input" )]
+      string OutputParam,
+         [IN ( true ),
+          Description ( "Defines return value if provided." )]
+      uint32 OutputRtnValue,
+         [IN ( true ),
+          Description ( "Embedded instance parameter" ),
+          EmbeddedInstance ( "CIM_FooEmb1" )]
+      string cimfoo_emb1);
+
+      [Description ( "Method with no parameters but embedded instance return" ),
+       EmbeddedInstance ( "CIM_FooEmb2" )]
+   string DeleteNothing();
+
+};
+"""],
       'rc': 0,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
@@ -2730,18 +3367,24 @@ TEST_CASES = [
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
-    ['Verify class enumerate from two namespaces multiple namespace option,'
-     ' no classname',
-     {'args': ['enumerate', '--namespace', 'root/cimv2',
-               '--namespace', 'root/cimv3']},
-     {'stdout': ['#pragma namespace ("root/cimv2")',
-                 '#pragma namespace ("root/cimv3")',
-                 'class CIM_Foo {'],
+    ['Verify class enumerate two namespaces CIM_Foo',
+     {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': [ENUMERATE_CLASS_2_NAMESPACE],
       'rc': 0,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
-    ['Verify class enumerate from two namespaces, CIM_Foo',
+
+
+    ['Verify class enumerate two namespaces CIM_Foo --object-order',
+     {'args': ['enumerate', 'CIM_Foo', '-n', 'root/cimv2,root/cimv3',
+               '--object-order']},
+     {'stdout': [ENUMERATE_CLASS_2_NAMESPACE_OBJECT_ORDER],
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify class enumerate from two namespaces, CIM_Foo comma separted',
      {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/cimv2,root/cimv3']},
      {'stdout': ['#pragma namespace ("root/cimv2")',
                  '#pragma namespace ("root/cimv3")',
@@ -2753,8 +3396,9 @@ TEST_CASES = [
     ['Verify class enumerate from two namespaces summary',
      {'args': ['enumerate', 'CIM_Foo', '--summary',
                '--namespace', 'root/cimv2,root/cimv3']},
-     {'stdout': ['root/cimv2 2 CIMClass(s) returned',
-                 'root/cimv3 2 CIMClass(s) returned'],
+     {'stdout': ["""root/cimv2 2 CIMClass(s) returned
+root/cimv3 2 CIMClass(s) returned
+"""],
       'rc': 0,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
@@ -2798,6 +3442,19 @@ root/cimv3:CIM_Foo_sub2
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
+    ['Verify classnames (--no) enumerate from two namespaces --object-order',
+     {'args': ['enumerate', 'CIM_Foo', '--no', '--object-order',
+               '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': """
+root/cimv2:CIM_Foo_sub
+root/cimv3:CIM_Foo_sub
+root/cimv2:CIM_Foo_sub2
+root/cimv3:CIM_Foo_sub2
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
     ['Verify classnames enumerate from two namespaces --no --summary, -o table',
      {'args': ['enumerate', 'CIM_Foo', '--no', '--summary',
                '--namespace', 'root/cimv2,root/cimv3'],
@@ -2828,6 +3485,40 @@ root/cimv3:CIM_Foo_sub2
                'root/cimv3,root/cimv2']},
      {'stderr': ["namespace:root/cimv3", "CIMError:CIM_ERR_INVALID_CLASS"],
       'rc': 1,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify class enumerate --no from three namespaces',
+     {'args': ['enumerate', '--no', '-n', 'root/cimv2,root/cimv3,interop']},
+     {'stdout': """root/cimv2:CIM_BaseEmb
+root/cimv2:CIM_BaseRef
+root/cimv2:CIM_Foo
+root/cimv2:CIM_FooAssoc
+root/cimv3:CIM_BaseEmb
+root/cimv3:CIM_BaseRef
+root/cimv3:CIM_Foo
+root/cimv3:CIM_FooAssoc
+interop:CIM_Namespace
+interop:CIM_ObjectManager
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify class enumerate --no from three namespaces different ns order',
+     {'args': ['enumerate', '--no', '-n', 'root/cimv3,root/cimv2,interop']},
+     {'stdout': """root/cimv3:CIM_BaseEmb
+root/cimv3:CIM_BaseRef
+root/cimv3:CIM_Foo
+root/cimv3:CIM_FooAssoc
+root/cimv2:CIM_BaseEmb
+root/cimv2:CIM_BaseRef
+root/cimv2:CIM_Foo
+root/cimv2:CIM_FooAssoc
+interop:CIM_Namespace
+interop:CIM_ObjectManager
+""",
+      'rc': 0,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
@@ -2870,6 +3561,8 @@ class CIM_FooAssoc {
       'rc': 0,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
+
+    # TODO: Add tests for reference and reference --no with object-order
 
     ['Verify references classname (--no) from two namespaces',
      {'args': ['references', 'CIM_FooRef1', '--no',
@@ -2947,6 +3640,8 @@ class CIM_FooRef2 : CIM_BaseRef {
       'rc': 0,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
+
+    # TODO: Add test for associators and associator names with object-order.
 
     # pylint: disable=line-too-long
     ['Verify associators from two namespaces xml output',

--- a/tests/unit/pywbemcli/test_instance_cmds.py
+++ b/tests/unit/pywbemcli/test_instance_cmds.py
@@ -501,6 +501,153 @@ instance of CIM_Foo_sub_sub {
 };
 """
 
+MULTIPLE_NS_ENUM_INST_RTN_OBJECT_ORDER = """#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo1";
+   IntegerProp = 1;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo2";
+   IntegerProp = 2;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo2";
+   IntegerProp = 2;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo3";
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo3";
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo30";
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo30";
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo31";
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo31";
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub1";
+   IntegerProp = 4;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub1";
+   IntegerProp = 4;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub2";
+   IntegerProp = 5;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub2";
+   IntegerProp = 5;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub3";
+   IntegerProp = 6;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub3";
+   IntegerProp = 6;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub4";
+   IntegerProp = 7;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo_sub {
+   InstanceID = "CIM_Foo_sub4";
+   IntegerProp = 7;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo_sub_sub {
+   InstanceID = "CIM_Foo_sub_sub1";
+   IntegerProp = 8;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo_sub_sub {
+   InstanceID = "CIM_Foo_sub_sub1";
+   IntegerProp = 8;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo_sub_sub {
+   InstanceID = "CIM_Foo_sub_sub2";
+   IntegerProp = 9;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo_sub_sub {
+   InstanceID = "CIM_Foo_sub_sub2";
+   IntegerProp = 9;
+};
+
+#pragma namespace ("root/cimv2")
+instance of CIM_Foo_sub_sub {
+   InstanceID = "CIM_Foo_sub_sub3";
+   IntegerProp = 10;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo_sub_sub {
+   InstanceID = "CIM_Foo_sub_sub3";
+   IntegerProp = 10;
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_Foo {
+   InstanceID = "CIM_Foo3-third-ns";
+   IntegerProp = 3;
+};
+
+"""
+
+
 GET_INSTANCE_ALL_TYPES = """instance of PyWBEM_AllTypes {
    InstanceId = "test_instance";
    scalBool = true;
@@ -767,9 +914,6 @@ TEST_CASES = [
     # * condition: If True the test is executed, if 'pdb' the test breaks in the
     #     the debugger, if 'verbose' print verbose messages, if False the test
     #     is skipped.
-
-    #
-    #   instance --help
     #
     ['Verify instance command --help response',
      '--help',
@@ -1234,8 +1378,8 @@ Instances: PyWBEM_AllTypes
       'test': 'linesnows'},
      ALLTYPES_MOCK_FILE, OK],
 
-    ['Verify instance command enumerate of TST_Person shows value-mapped '
-     'properties in table output',
+    ['Verify instance enumerate TST_Person shows value-mapped properties in '
+     'table output',
      {'args': ['enumerate', 'TST_Person', '--pl', 'name,gender,likes'],
       'general': ['--output-format', 'table']},
      {'stdout': """
@@ -1258,7 +1402,7 @@ Instances: TST_Person
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance command enumerate of TST_Person honors property list '
+    ['Verify instance command enumerate TST_Person property list order'
      'order in table output',
      {'args': ['enumerate', 'TST_Person', '--pl', 'Name,Likes,Gender'],
       'general': ['--output-format', 'table']},
@@ -3849,9 +3993,223 @@ instance of CIM_Foo {
     # Enumerate request
     #
 
-    ['Verify instance enumerate from two namespaces, CIM_Foo',
+    ['Verify instance enumerate from two namespaces, CIM_Foo mof out',
      {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/cimv2,root/cimv3']},
      {'stdout': MULTIPLE_NS_ENUM_INST_RTN,
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify instance enumerate from two namespaces, CIM_Foo table out',
+     {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """Instances: CIM_Foo
++-------------+---------------------+---------------+
+| namespace   | InstanceID          | IntegerProp   |
+|-------------+---------------------+---------------|
+| root/cimv2  | "CIM_Foo1"          | 1             |
+| root/cimv2  | "CIM_Foo2"          | 2             |
+| root/cimv2  | "CIM_Foo3"          |               |
+| root/cimv2  | "CIM_Foo30"         |               |
+| root/cimv2  | "CIM_Foo31"         |               |
+| root/cimv2  | "CIM_Foo_sub1"      | 4             |
+| root/cimv2  | "CIM_Foo_sub2"      | 5             |
+| root/cimv2  | "CIM_Foo_sub3"      | 6             |
+| root/cimv2  | "CIM_Foo_sub4"      | 7             |
+| root/cimv2  | "CIM_Foo_sub_sub1"  | 8             |
+| root/cimv2  | "CIM_Foo_sub_sub2"  | 9             |
+| root/cimv2  | "CIM_Foo_sub_sub3"  | 10            |
+| root/cimv3  | "CIM_Foo1"          | 1             |
+| root/cimv3  | "CIM_Foo2"          | 2             |
+| root/cimv3  | "CIM_Foo3"          |               |
+| root/cimv3  | "CIM_Foo3-third-ns" | 3             |
+| root/cimv3  | "CIM_Foo30"         |               |
+| root/cimv3  | "CIM_Foo31"         |               |
+| root/cimv3  | "CIM_Foo_sub1"      | 4             |
+| root/cimv3  | "CIM_Foo_sub2"      | 5             |
+| root/cimv3  | "CIM_Foo_sub3"      | 6             |
+| root/cimv3  | "CIM_Foo_sub4"      | 7             |
+| root/cimv3  | "CIM_Foo_sub_sub1"  | 8             |
+| root/cimv3  | "CIM_Foo_sub_sub2"  | 9             |
+| root/cimv3  | "CIM_Foo_sub_sub3"  | 10            |
++-------------+---------------------+---------------+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify instance enumerate from two ns, CIM_Foo mof out --object-order',
+     {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/cimv2,root/cimv3',
+               '--object-order']},
+     {'stdout': MULTIPLE_NS_ENUM_INST_RTN_OBJECT_ORDER,
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify instance enumerate from two ns, CIM_Foo tbl out --object-order',
+     {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/cimv2,root/cimv3',
+               '--object-order'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """Instances: CIM_Foo
++-------------+---------------------+---------------+
+| namespace   | InstanceID          | IntegerProp   |
+|-------------+---------------------+---------------|
+| root/cimv2  | "CIM_Foo1"          | 1             |
+| root/cimv3  | "CIM_Foo1"          | 1             |
+| root/cimv2  | "CIM_Foo2"          | 2             |
+| root/cimv3  | "CIM_Foo2"          | 2             |
+| root/cimv2  | "CIM_Foo3"          |               |
+| root/cimv3  | "CIM_Foo3"          |               |
+| root/cimv2  | "CIM_Foo30"         |               |
+| root/cimv3  | "CIM_Foo30"         |               |
+| root/cimv2  | "CIM_Foo31"         |               |
+| root/cimv3  | "CIM_Foo31"         |               |
+| root/cimv2  | "CIM_Foo_sub1"      | 4             |
+| root/cimv3  | "CIM_Foo_sub1"      | 4             |
+| root/cimv2  | "CIM_Foo_sub2"      | 5             |
+| root/cimv3  | "CIM_Foo_sub2"      | 5             |
+| root/cimv2  | "CIM_Foo_sub3"      | 6             |
+| root/cimv3  | "CIM_Foo_sub3"      | 6             |
+| root/cimv2  | "CIM_Foo_sub4"      | 7             |
+| root/cimv3  | "CIM_Foo_sub4"      | 7             |
+| root/cimv2  | "CIM_Foo_sub_sub1"  | 8             |
+| root/cimv3  | "CIM_Foo_sub_sub1"  | 8             |
+| root/cimv2  | "CIM_Foo_sub_sub2"  | 9             |
+| root/cimv3  | "CIM_Foo_sub_sub2"  | 9             |
+| root/cimv2  | "CIM_Foo_sub_sub3"  | 10            |
+| root/cimv3  | "CIM_Foo_sub_sub3"  | 10            |
+| root/cimv3  | "CIM_Foo3-third-ns" | 3             |
++-------------+---------------------+---------------+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify instance enumerate from 2 namespaces, CIM_Foo mof out names-only',
+     {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/cimv2,root/cimv3',
+               '--names-only']},
+     {'stdout': """root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"
+root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"
+root/cimv2:CIM_Foo.InstanceID="CIM_Foo3"
+root/cimv2:CIM_Foo.InstanceID="CIM_Foo30"
+root/cimv2:CIM_Foo.InstanceID="CIM_Foo31"
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub1"
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub2"
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub3"
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub4"
+root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub1"
+root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub2"
+root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub3"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo1"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo2"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo3"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo3-third-ns"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo30"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo31"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub1"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub2"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub3"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub4"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub1"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub2"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub3"
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify instance enumerate 2 ns, CIM_Foo mof out --no, --object-order',
+     {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/cimv2,root/cimv3',
+               '--no', '--object-order']},
+     {'stdout': """root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo1"
+root/cimv2:CIM_Foo.InstanceID="CIM_Foo2"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo2"
+root/cimv2:CIM_Foo.InstanceID="CIM_Foo3"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo3"
+root/cimv2:CIM_Foo.InstanceID="CIM_Foo30"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo30"
+root/cimv2:CIM_Foo.InstanceID="CIM_Foo31"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo31"
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub1"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub1"
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub2"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub2"
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub3"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub3"
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub4"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub4"
+root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub1"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub1"
+root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub2"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub2"
+root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub3"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub3"
+root/cimv3:CIM_Foo.InstanceID="CIM_Foo3-third-ns"
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify instance enumerate names two ns, CIM_Foo tbl out --object-order',
+     {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/cimv2,root/cimv3',
+               '--object-order', '--names-only'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """InstanceNames: CIM_Foo
++--------+-------------+-----------------+-------------------+
+| host   | namespace   | class           | key=              |
+|        |             |                 | InstanceID        |
+|--------+-------------+-----------------+-------------------|
+|        | root/cimv2  | CIM_Foo         | CIM_Foo1          |
+|        | root/cimv3  | CIM_Foo         | CIM_Foo1          |
+|        | root/cimv2  | CIM_Foo         | CIM_Foo2          |
+|        | root/cimv3  | CIM_Foo         | CIM_Foo2          |
+|        | root/cimv2  | CIM_Foo         | CIM_Foo3          |
+|        | root/cimv3  | CIM_Foo         | CIM_Foo3          |
+|        | root/cimv2  | CIM_Foo         | CIM_Foo30         |
+|        | root/cimv3  | CIM_Foo         | CIM_Foo30         |
+|        | root/cimv2  | CIM_Foo         | CIM_Foo31         |
+|        | root/cimv3  | CIM_Foo         | CIM_Foo31         |
+|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub1      |
+|        | root/cimv3  | CIM_Foo_sub     | CIM_Foo_sub1      |
+|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub2      |
+|        | root/cimv3  | CIM_Foo_sub     | CIM_Foo_sub2      |
+|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub3      |
+|        | root/cimv3  | CIM_Foo_sub     | CIM_Foo_sub3      |
+|        | root/cimv2  | CIM_Foo_sub     | CIM_Foo_sub4      |
+|        | root/cimv3  | CIM_Foo_sub     | CIM_Foo_sub4      |
+|        | root/cimv2  | CIM_Foo_sub_sub | CIM_Foo_sub_sub1  |
+|        | root/cimv3  | CIM_Foo_sub_sub | CIM_Foo_sub_sub1  |
+|        | root/cimv2  | CIM_Foo_sub_sub | CIM_Foo_sub_sub2  |
+|        | root/cimv3  | CIM_Foo_sub_sub | CIM_Foo_sub_sub2  |
+|        | root/cimv2  | CIM_Foo_sub_sub | CIM_Foo_sub_sub3  |
+|        | root/cimv3  | CIM_Foo_sub_sub | CIM_Foo_sub_sub3  |
+|        | root/cimv3  | CIM_Foo         | CIM_Foo3-third-ns |
++--------+-------------+-----------------+-------------------+
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify instance enumerate from 2 namespaces, CIM_Foo_Sub mof --no',
+     {'args': ['enumerate', 'CIM_Foo_Sub', '--no',
+               '--namespace', 'root/cimv2,root/cimv3']},
+     {'stdout': """
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub1"
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub2"
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub3"
+root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub4"
+root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub1"
+root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub2"
+root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub3"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub1"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub2"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub3"
+root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub4"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub1"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub2"
+root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub3"
+""",
       'rc': 0,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
@@ -3865,7 +4223,7 @@ instance of CIM_Foo {
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
-    ['Verify instance enumerate from two namespaces summary, --summary, table',
+    ['Verify instance enumerate from two namespaces summary  table',
      {'args': ['enumerate', 'CIM_Foo', '--summary',
                '--namespace', 'root/cimv2,root/cimv3'],
       'general': ['--output-format', 'table']},
@@ -3908,29 +4266,6 @@ root/cimv3:CIM_Foo.InstanceID="CIM_Foo3"
 root/cimv3:CIM_Foo.InstanceID="CIM_Foo3-third-ns"
 root/cimv3:CIM_Foo.InstanceID="CIM_Foo30"
 root/cimv3:CIM_Foo.InstanceID="CIM_Foo31"
-root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub1"
-root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub2"
-root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub3"
-root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub4"
-root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub1"
-root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub2"
-root/cimv3:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub3"
-""",
-      'rc': 0,
-      'test': 'innows'},
-     THREE_NS_MOCK_FILE, OK],
-
-    ['Verify namesnames (--no) enumerate from two namespaces ',
-     {'args': ['enumerate', 'CIM_Foo_Sub', '--no',
-               '--namespace', 'root/cimv2,root/cimv3']},
-     {'stdout': """
-root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub1"
-root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub2"
-root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub3"
-root/cimv2:CIM_Foo_sub.InstanceID="CIM_Foo_sub4"
-root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub1"
-root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub2"
-root/cimv2:CIM_Foo_sub_sub.InstanceID="CIM_Foo_sub_sub3"
 root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub1"
 root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub2"
 root/cimv3:CIM_Foo_sub.InstanceID="CIM_Foo_sub3"
@@ -4135,7 +4470,7 @@ root/cimv3 1 CIMInstanceName(s) returned
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
-    ['Verify references from non-default namespace --names-only',
+    ['Verify references from non-default namespace',
      {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
                '--namespace', 'root/cimv3'],
       'general': ['--output-format', 'mof']},
@@ -4148,6 +4483,47 @@ root/cimv3 1 CIMInstanceName(s) returned
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
+    ['Verify references from 2 ns. shows same reference from both',
+     {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--namespace', 'root/cimv2,root/cimv3'],
+      'general': ['--output-format', 'mof']},
+     {'stdout': """#pragma namespace ("root/cimv2")
+instance of CIM_FooAssoc {
+   Ref1 = "/root/cimv2:CIM_FooRef1.InstanceID=\\"CIM_FooRef11\\"";
+   Ref2 = "/root/cimv2:CIM_FooRef2.InstanceID=\\"CIM_FooRef21\\"";
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_FooAssoc {
+   Ref1 = "/root/cimv3:CIM_FooRef1.InstanceID=\\"CIM_FooRef11\\"";
+   Ref2 = "/root/cimv3:CIM_FooRef2.InstanceID=\\"CIM_FooRef21\\"";
+};
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify references from 2 ns. shows --object-order',
+     {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
+               '--namespace', 'root/cimv2,root/cimv3', '--object-order'],
+      'general': ['--output-format', 'mof']},
+     {'stdout': """#pragma namespace ("root/cimv2")
+instance of CIM_FooAssoc {
+   Ref1 = "/root/cimv2:CIM_FooRef1.InstanceID=\\"CIM_FooRef11\\"";
+   Ref2 = "/root/cimv2:CIM_FooRef2.InstanceID=\\"CIM_FooRef21\\"";
+};
+
+#pragma namespace ("root/cimv3")
+instance of CIM_FooAssoc {
+   Ref1 = "/root/cimv3:CIM_FooRef1.InstanceID=\\"CIM_FooRef11\\"";
+   Ref2 = "/root/cimv3:CIM_FooRef2.InstanceID=\\"CIM_FooRef21\\"";
+};
+""",
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    # The following demonstrates that the references are bidirectional
     ['Verify references names from non-default namespace --names-only',
      {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
                '--names-only', '--namespace', 'root/cimv3'],
@@ -4159,9 +4535,8 @@ root/cimv3 1 CIMInstanceName(s) returned
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
-
     # pylint: disable=line-too-long
-    ['Verify  references names  from two namespaces --summary, -o table',
+    ['Verify  references names  from two namespaces -o table',
      {'args': ['references', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
                '--no', '--namespace', 'root/cimv2,root/cimv3'],
       'general': ['--output-format', 'table']},
@@ -4306,31 +4681,19 @@ instance of CIM_FooAssoc {
 
     ['Verify instance enumerate from two namespaces, CIM_Foo one ns bad',
      {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/cimv2,root/INV']},
-<<<<<<< HEAD
      {'stderr': ['namespace:root/INV', 'CIMError:CIM_ERR_INVALID_NAMESPACE'],
-=======
-     {'stderr': ['Warning', 'CIM_ERR_INVALID_NAMESPACE', 'root/INV'],
->>>>>>> Fix issue #1184 - Multiple namespace commands with errors
       'stdout': ['#pragma namespace ("root/cimv2")',
                  "instance of CIM_Foo {",
                  'InstanceID = "CIM_Foo1";',
                  'IntegerProp = 1;'],
-<<<<<<< HEAD
       'rc': 1,
-=======
-      'rc': 0,
->>>>>>> Fix issue #1184 - Multiple namespace commands with errors
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
     ['Verify instance enumerate from one namespace, ns bad',
      {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/INV']},
-<<<<<<< HEAD
      {'stderr': ["namespace:root/INV", "CIMError:CIM_ERR_INVALID_NAMESPACE",
                  "CIMError: 3 (CIM_ERR_INVALID_NAMESPACE):"],
-=======
-     {'stderr': ["CIMError: 3 (CIM_ERR_INVALID_NAMESPACE):"],
->>>>>>> Fix issue #1184 - Multiple namespace commands with errors
       'rc': 1,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
@@ -4338,13 +4701,8 @@ instance of CIM_FooAssoc {
     ['Verify instance enumerate from two namespaces, Invalid Classname',
      {'args': ['enumerate', 'CIM_Foox', '--namespace',
                'root/cimv2,root/cimv3']},
-<<<<<<< HEAD
      {'stderr': ["namespace:root/cimv2", "CIMError:CIM_ERR_INVALID_CLASS",
                  "namespace:root/cimv3"],
-=======
-     {'stderr': ["CIMError: 5 (CIM_ERR_INVALID_CLASS)", 'CIM_Foox'],
-
->>>>>>> Fix issue #1184 - Multiple namespace commands with errors
       'rc': 1,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
@@ -4361,12 +4719,8 @@ instance of CIM_FooAssoc {
 | root/INV    |       0 | CIMInstance |
 +-------------+---------+-------------+
 """,
-<<<<<<< HEAD
       'stderr': ["namespace:root/INV", "CIM_ERR_INVALID_NAMESPACE"],
       'rc': 1,
-=======
-      'rc': 0,
->>>>>>> Fix issue #1184 - Multiple namespace commands with errors
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
@@ -4378,12 +4732,8 @@ instance of CIM_FooAssoc {
                  'InstanceID = "CIM_Foo1";',
                  "IntegerProp = 1;",
                  "};"],
-<<<<<<< HEAD
       'stderr': ["namespace:root/DoesNotExist"],
       'rc': 1,
-=======
-      'stderr': ['Warning', "balh"],
->>>>>>> Fix issue #1184 - Multiple namespace commands with errors
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
@@ -4399,21 +4749,14 @@ instance of CIM_FooAssoc {
     ['Verify instance get from two namespaces, invalid instance',
      {'args': ['get', 'CIM_Foo', '--key', 'InstanceID=INVALID',
                '--namespace', 'root/cimv2,root/cimv3']},
-<<<<<<< HEAD
      {'stderr': ["namespace:root/cimv2", "CIMError:CIM_ERR_NOT_FOUND",
                  "namespace:root/cimv3", "CIMError:CIM_ERR_NOT_FOUND",
-=======
-     {'stderr': ["WARNING: Error: 'CIM_ERR_NOT_FOUND'",
->>>>>>> Fix issue #1184 - Multiple namespace commands with errors
                  "CIMError: 6 (CIM_ERR_NOT_FOUND):"],
       'rc': 1,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
-<<<<<<< HEAD
     # pylint: disable=line-too-long
-=======
->>>>>>> Fix issue #1184 - Multiple namespace commands with errors
     ['Verify associators names-only non-default namespaces -o table, invalid '
      'ns',
      {'args': ['associators', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
@@ -4427,7 +4770,6 @@ instance of CIM_FooAssoc {
 | FakedUrl:5988 | root/cimv3  | CIM_FooRef2 | CIM_FooRef21 |
 +---------------+-------------+-------------+--------------+
 """,
-<<<<<<< HEAD
       'stderr': """Request Response Errors for Target: (class) root/Invalid:CIM_FooRef1.InstanceID="CIM_FooRef11"
 +--------------+---------------------------+------------------------------------------------------------+
 | namespace    | CIMError                  | Description                                                |
@@ -4440,13 +4782,6 @@ Error: Errors encountered on 1 server request(s)
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
     # pylint: enable=line-too-long
-=======
-      'stderr': ["Error: 'CIM_ERR_INVALID_NAMESPACE'", "'root/Invalid'",
-                 "'root/Invalid:CIM_FooRef1.InstanceID=\"CIM_FooRef11\"'"],
-      'rc': 0,
-      'test': 'innows'},
-     THREE_NS_MOCK_FILE, OK],
->>>>>>> Fix issue #1184 - Multiple namespace commands with errors
 
     # Test multi-namespace enum/get where there are no instances returned
 

--- a/tests/unit/pywbemcli/test_instance_cmds.py
+++ b/tests/unit/pywbemcli/test_instance_cmds.py
@@ -4306,19 +4306,31 @@ instance of CIM_FooAssoc {
 
     ['Verify instance enumerate from two namespaces, CIM_Foo one ns bad',
      {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/cimv2,root/INV']},
+<<<<<<< HEAD
      {'stderr': ['namespace:root/INV', 'CIMError:CIM_ERR_INVALID_NAMESPACE'],
+=======
+     {'stderr': ['Warning', 'CIM_ERR_INVALID_NAMESPACE', 'root/INV'],
+>>>>>>> Fix issue #1184 - Multiple namespace commands with errors
       'stdout': ['#pragma namespace ("root/cimv2")',
                  "instance of CIM_Foo {",
                  'InstanceID = "CIM_Foo1";',
                  'IntegerProp = 1;'],
+<<<<<<< HEAD
       'rc': 1,
+=======
+      'rc': 0,
+>>>>>>> Fix issue #1184 - Multiple namespace commands with errors
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
     ['Verify instance enumerate from one namespace, ns bad',
      {'args': ['enumerate', 'CIM_Foo', '--namespace', 'root/INV']},
+<<<<<<< HEAD
      {'stderr': ["namespace:root/INV", "CIMError:CIM_ERR_INVALID_NAMESPACE",
                  "CIMError: 3 (CIM_ERR_INVALID_NAMESPACE):"],
+=======
+     {'stderr': ["CIMError: 3 (CIM_ERR_INVALID_NAMESPACE):"],
+>>>>>>> Fix issue #1184 - Multiple namespace commands with errors
       'rc': 1,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
@@ -4326,8 +4338,13 @@ instance of CIM_FooAssoc {
     ['Verify instance enumerate from two namespaces, Invalid Classname',
      {'args': ['enumerate', 'CIM_Foox', '--namespace',
                'root/cimv2,root/cimv3']},
+<<<<<<< HEAD
      {'stderr': ["namespace:root/cimv2", "CIMError:CIM_ERR_INVALID_CLASS",
                  "namespace:root/cimv3"],
+=======
+     {'stderr': ["CIMError: 5 (CIM_ERR_INVALID_CLASS)", 'CIM_Foox'],
+
+>>>>>>> Fix issue #1184 - Multiple namespace commands with errors
       'rc': 1,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
@@ -4344,8 +4361,12 @@ instance of CIM_FooAssoc {
 | root/INV    |       0 | CIMInstance |
 +-------------+---------+-------------+
 """,
+<<<<<<< HEAD
       'stderr': ["namespace:root/INV", "CIM_ERR_INVALID_NAMESPACE"],
       'rc': 1,
+=======
+      'rc': 0,
+>>>>>>> Fix issue #1184 - Multiple namespace commands with errors
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
@@ -4357,8 +4378,12 @@ instance of CIM_FooAssoc {
                  'InstanceID = "CIM_Foo1";',
                  "IntegerProp = 1;",
                  "};"],
+<<<<<<< HEAD
       'stderr': ["namespace:root/DoesNotExist"],
       'rc': 1,
+=======
+      'stderr': ['Warning', "balh"],
+>>>>>>> Fix issue #1184 - Multiple namespace commands with errors
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
@@ -4374,14 +4399,21 @@ instance of CIM_FooAssoc {
     ['Verify instance get from two namespaces, invalid instance',
      {'args': ['get', 'CIM_Foo', '--key', 'InstanceID=INVALID',
                '--namespace', 'root/cimv2,root/cimv3']},
+<<<<<<< HEAD
      {'stderr': ["namespace:root/cimv2", "CIMError:CIM_ERR_NOT_FOUND",
                  "namespace:root/cimv3", "CIMError:CIM_ERR_NOT_FOUND",
+=======
+     {'stderr': ["WARNING: Error: 'CIM_ERR_NOT_FOUND'",
+>>>>>>> Fix issue #1184 - Multiple namespace commands with errors
                  "CIMError: 6 (CIM_ERR_NOT_FOUND):"],
       'rc': 1,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
+<<<<<<< HEAD
     # pylint: disable=line-too-long
+=======
+>>>>>>> Fix issue #1184 - Multiple namespace commands with errors
     ['Verify associators names-only non-default namespaces -o table, invalid '
      'ns',
      {'args': ['associators', 'CIM_FooRef1', '--key', 'InstanceID=CIM_FooRef11',
@@ -4395,6 +4427,7 @@ instance of CIM_FooAssoc {
 | FakedUrl:5988 | root/cimv3  | CIM_FooRef2 | CIM_FooRef21 |
 +---------------+-------------+-------------+--------------+
 """,
+<<<<<<< HEAD
       'stderr': """Request Response Errors for Target: (class) root/Invalid:CIM_FooRef1.InstanceID="CIM_FooRef11"
 +--------------+---------------------------+------------------------------------------------------------+
 | namespace    | CIMError                  | Description                                                |
@@ -4407,6 +4440,13 @@ Error: Errors encountered on 1 server request(s)
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
     # pylint: enable=line-too-long
+=======
+      'stderr': ["Error: 'CIM_ERR_INVALID_NAMESPACE'", "'root/Invalid'",
+                 "'root/Invalid:CIM_FooRef1.InstanceID=\"CIM_FooRef11\"'"],
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+>>>>>>> Fix issue #1184 - Multiple namespace commands with errors
 
     # Test multi-namespace enum/get where there are no instances returned
 

--- a/tests/unit/pywbemcli/test_qualdecl_cmds.py
+++ b/tests/unit/pywbemcli/test_qualdecl_cmds.py
@@ -178,6 +178,72 @@ QD_TBL_ENUM_MULTI_NS_OUT = """Qualifier Declarations
 | root/cimv2  | Abstract         | boolean | False   | False   | CLASS       | EnableOverride  |
 |             |                  |         |         |         | ASSOCIATION | Restricted      |
 |             |                  |         |         |         | INDICATION  |                 |
+| root/cimv2  | Aggregate        | boolean | False   | False   | REFERENCE   | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv2  | Association      | boolean | False   | False   | ASSOCIATION | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv2  | Description      | string  |         | False   | ANY         | EnableOverride  |
+|             |                  |         |         |         |             | ToSubclass      |
+|             |                  |         |         |         |             | Translatable    |
+| root/cimv2  | EmbeddedInstance | string  |         | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | METHOD      | Restricted      |
+|             |                  |         |         |         | PARAMETER   |                 |
+| root/cimv2  | EmbeddedObject   | boolean | False   | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | METHOD      | ToSubclass      |
+|             |                  |         |         |         | PARAMETER   |                 |
+| root/cimv2  | In               | boolean | True    | False   | PARAMETER   | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv2  | Indication       | boolean | False   | False   | CLASS       | DisableOverride |
+|             |                  |         |         |         | INDICATION  | ToSubclass      |
+| root/cimv2  | Key              | boolean | False   | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | REFERENCE   | ToSubclass      |
+| root/cimv2  | Out              | boolean | False   | False   | PARAMETER   | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv2  | Override         | string  |         | False   | PROPERTY    | EnableOverride  |
+|             |                  |         |         |         | REFERENCE   | Restricted      |
+|             |                  |         |         |         | METHOD      |                 |
+| root/cimv2  | Static           | boolean | False   | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | METHOD      | ToSubclass      |
+| root/cimv3  | Abstract         | boolean | False   | False   | CLASS       | EnableOverride  |
+|             |                  |         |         |         | ASSOCIATION | Restricted      |
+|             |                  |         |         |         | INDICATION  |                 |
+| root/cimv3  | Aggregate        | boolean | False   | False   | REFERENCE   | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv3  | Association      | boolean | False   | False   | ASSOCIATION | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv3  | Description      | string  |         | False   | ANY         | EnableOverride  |
+|             |                  |         |         |         |             | ToSubclass      |
+|             |                  |         |         |         |             | Translatable    |
+| root/cimv3  | EmbeddedInstance | string  |         | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | METHOD      | Restricted      |
+|             |                  |         |         |         | PARAMETER   |                 |
+| root/cimv3  | EmbeddedObject   | boolean | False   | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | METHOD      | ToSubclass      |
+|             |                  |         |         |         | PARAMETER   |                 |
+| root/cimv3  | In               | boolean | True    | False   | PARAMETER   | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv3  | Indication       | boolean | False   | False   | CLASS       | DisableOverride |
+|             |                  |         |         |         | INDICATION  | ToSubclass      |
+| root/cimv3  | Key              | boolean | False   | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | REFERENCE   | ToSubclass      |
+| root/cimv3  | Out              | boolean | False   | False   | PARAMETER   | DisableOverride |
+|             |                  |         |         |         |             | ToSubclass      |
+| root/cimv3  | Override         | string  |         | False   | PROPERTY    | EnableOverride  |
+|             |                  |         |         |         | REFERENCE   | Restricted      |
+|             |                  |         |         |         | METHOD      |                 |
+| root/cimv3  | Static           | boolean | False   | False   | PROPERTY    | DisableOverride |
+|             |                  |         |         |         | METHOD      | ToSubclass      |
++-------------+------------------+---------+---------+---------+-------------+-----------------+
+"""  # noqa: E501
+
+
+QD_TBL_ENUM_MULTI_NS_OUT_OBJECT_ORDER = """Qualifier Declarations
++-------------+------------------+---------+---------+---------+-------------+-----------------+
+| namespace   | Name             | Type    | Value   | Array   | Scopes      | Flavors         |
+|-------------+------------------+---------+---------+---------+-------------+-----------------|
+| root/cimv2  | Abstract         | boolean | False   | False   | CLASS       | EnableOverride  |
+|             |                  |         |         |         | ASSOCIATION | Restricted      |
+|             |                  |         |         |         | INDICATION  |                 |
 | root/cimv3  | Abstract         | boolean | False   | False   | CLASS       | EnableOverride  |
 |             |                  |         |         |         | ASSOCIATION | Restricted      |
 |             |                  |         |         |         | INDICATION  |                 |
@@ -367,6 +433,126 @@ Qualifier Abstract : boolean = false,
 Qualifier Abstract : boolean = false,
     Scope(class, association, indication),
     Flavor(EnableOverride, Restricted);
+
+"""
+
+QD_MOF_ENUM_MULTINS_OUT_OBJECT_ORDER = """#pragma namespace ("root/cimv2")
+Qualifier Abstract : boolean = false,
+    Scope(class, association, indication),
+    Flavor(EnableOverride, Restricted);
+
+#pragma namespace ("root/cimv3")
+Qualifier Abstract : boolean = false,
+    Scope(class, association, indication),
+    Flavor(EnableOverride, Restricted);
+
+#pragma namespace ("root/cimv2")
+Qualifier Aggregate : boolean = false,
+    Scope(reference),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier Aggregate : boolean = false,
+    Scope(reference),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv2")
+Qualifier Association : boolean = false,
+    Scope(association),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier Association : boolean = false,
+    Scope(association),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv2")
+Qualifier Description : string,
+    Scope(any),
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+#pragma namespace ("root/cimv3")
+Qualifier Description : string,
+    Scope(any),
+    Flavor(EnableOverride, ToSubclass, Translatable);
+
+#pragma namespace ("root/cimv2")
+Qualifier EmbeddedInstance : string,
+    Scope(property, method, parameter);
+
+#pragma namespace ("root/cimv3")
+Qualifier EmbeddedInstance : string,
+    Scope(property, method, parameter);
+
+#pragma namespace ("root/cimv2")
+Qualifier EmbeddedObject : boolean = false,
+    Scope(property, method, parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier EmbeddedObject : boolean = false,
+    Scope(property, method, parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv2")
+Qualifier In : boolean = true,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier In : boolean = true,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv2")
+Qualifier Indication : boolean = false,
+    Scope(class, indication),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier Indication : boolean = false,
+    Scope(class, indication),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv2")
+Qualifier Key : boolean = false,
+    Scope(property, reference),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier Key : boolean = false,
+    Scope(property, reference),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv2")
+Qualifier Out : boolean = false,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier Out : boolean = false,
+    Scope(parameter),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv2")
+Qualifier Override : string,
+    Scope(property, reference, method),
+    Flavor(EnableOverride, Restricted);
+
+#pragma namespace ("root/cimv3")
+Qualifier Override : string,
+    Scope(property, reference, method),
+    Flavor(EnableOverride, Restricted);
+
+#pragma namespace ("root/cimv2")
+Qualifier Static : boolean = false,
+    Scope(property, method),
+    Flavor(DisableOverride, ToSubclass);
+
+#pragma namespace ("root/cimv3")
+Qualifier Static : boolean = false,
+    Scope(property, method),
+    Flavor(DisableOverride, ToSubclass);
 
 """
 
@@ -601,10 +787,28 @@ TEST_CASES = [
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],
 
+    ['Verify qualifier command enumerate table, multiple ns',
+     {'args': ['enumerate', '--namespace', 'root/cimv2,root/cimv3',
+               '--object-order'],
+      'general': ['-o', 'table']},
+     {'stdout': QD_TBL_ENUM_MULTI_NS_OUT_OBJECT_ORDER,
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
     ['Verify qualifier command enumerate multiple ns MOF out',
      {'args': ['enumerate', '--namespace', 'root/cimv2,root/cimv3'],
       'general': []},
      {'stdout': QD_MOF_ENUM_MULTINS_OUT,
+      'rc': 0,
+      'test': 'innows'},
+     THREE_NS_MOCK_FILE, OK],
+
+    ['Verify qualifier command enumerate multiple ns MOF out',
+     {'args': ['enumerate', '--namespace', 'root/cimv2,root/cimv3',
+               '--object-order'],
+      'general': []},
+     {'stdout': QD_MOF_ENUM_MULTINS_OUT_OBJECT_ORDER,
       'rc': 0,
       'test': 'innows'},
      THREE_NS_MOCK_FILE, OK],


### PR DESCRIPTION
Add option to sort the output for the class/instance/qualifier enumerate/get/associator/reference commands from the default order of namespace, object id to order the output by object id first so that objects can be compared between namespaces.

See the commit for more information