### PR TITLE
Set new safety issue into ignore list for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,8 @@ test_log_file := test_$(python_version_fn).log
 # - 45775 Sphinx 3.0.4 updates jQuery version, cannot upgrade Sphinx on py27
 # - 47833 Click 8.0.0 uses 'mkstemp()', cannot upgrade Click due to incompatibilities
 # - 45185 Pylint 2.13.0 fixes crash with doc_params ext, cannot upgrade on py27/35
+# - SEPT 2022
+# - 50571 dparse (user safety) 0.4.1 -> 0.5.2, 0.5.1 -> 0.5.2.  ReDos issue
 
 safety_ignore_opts := \
 	-i 38100 \
@@ -339,6 +341,7 @@ safety_ignore_opts := \
 	-i 45775 \
 	-i 47833 \
 	-i 45185 \
+	-i 50571 \
 
 ifdef TESTCASES
   pytest_opts := $(TESTOPTS) -k $(TESTCASES)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -43,7 +43,7 @@ safety>=1.9.0; python_version >= '3.5'
 # dparse 0.5.0 has an infinite recursion issue on Python 2.7,
 #   see https://github.com/pyupio/dparse/issues/46
 dparse>=0.4.1,<0.5.0; python_version == '2.7'
-dparse>=0.5.1; python_version >= '3.5'
+dparse>=0.5.2; python_version >= '3.5'
 # Safety requires Click>6.0 and the upgrade strategy 'eager' causes Click to be
 # upgraded to 8.0.0, unless we repeat the Click requirements from
 # requirements.txt. Keep them in sync.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -171,7 +171,7 @@ coveralls==2.1.2; python_version >= '3.5'
 safety==1.8.7; python_version == '2.7'
 safety==1.9.0; python_version >= '3.5'
 dparse==0.4.1; python_version == '2.7'
-dparse==0.5.1; python_version >= '3.5'
+dparse==0.5.2; python_version >= '3.5'
 
 # Tox
 tox==2.5.0


### PR DESCRIPTION
Adds new issue on dparse (used by safety) to Makefile security issues.

Note: This is a test issue, not code issue so I took shortest path to
keep CI running.

Fails on Python 2.7 & 3.5 latest and on all minimum tests.

safety issue # 400 filed in github
https://github.com/pyupio/safety/issues/400

```

| REPORT
                                                                       |
| checked 160 packages, using free DB (updated once a month)
                   |
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID
       |
+============================+===========+==========================+==========+
| dparse                     | 0.4.1     | <0.5.2                   |
50571    |
+==============================================================================+
| Dparse 0.5.2 fixes a possible ReDoS vulnerability.
                           |
|
https://github.com/pyupio/dparse/commit/8c990170bbd6c0cf212f1151e90254865560
|
| 62d5

|
+==============================================================================+
| dparse                     | 0.5.1     | <0.5.2                   |
50571    |
+==============================================================================+
| Dparse 0.5.2 fixes a possible ReDoS vulnerability.
                           |
|
https://github.com/pyupio/dparse/commit/8c990170bbd6c0cf212f1151e90254865560
|
| 62d5

|
+==============================================================================+

```