### PR TITLE
Ks/#1191 shrub cmd duplicates the components of display

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -31,6 +31,12 @@ Released: not yet
 
 * Fixed new formatting issues raised by flake8 5.0.
 
+* Fixed issue where the instance shrub command duplicated the results instances
+  tree in cases where there was an inter-namespace association and displayed
+  the complete ClassName of the association class rather than just the
+  class name. (see issue #1191)
+
+
 **Enhancements:**
 
 * Increased minimum version of Click to 8.0.1 on Python >= 3.6 to prepare for

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -82,7 +82,7 @@ Help text for ``pywbemcli``:
                                       file. Use "" to set default in interactive mode.Default: EnvVar PYWBEMCLI_KEYFILE, or
                                       none.
       -t, --timeout INT               Client-side timeout (seconds) on data read for operations with the WBEM server. This
-                                      integer is the timeout for a single server request. Pywbem retries reads 2 times so
+                                      integer is the timeout for a single server request. Pywbem retries reads 0 times so
                                       the delay for read timeout failure may be multiple times the timeout value.Default:
                                       EnvVar PYWBEMCLI_TIMEOUT, or 30. Min/max:   [0<=x<=300]
       -U, --use-pull [yes|no|either]  Determines whether pull operations are used for operations with the WBEM server that

--- a/tests/unit/pywbemcli/test_instance_cmds.py
+++ b/tests/unit/pywbemcli/test_instance_cmds.py
@@ -587,13 +587,13 @@ SIMPLE_SHRUB_FULLPATH_TREE = """root/cimv2:TST_Person.name="Mike"
  +-- parent(Role)
  |   +-- //FakedUrl:5988/root/cimv2:TST_Lineage(AssocClass)
  |       +-- child(ResultRole)
- |           +-- //FakedUrl:5988/root/cimv2:TST_Person(ResultClass)(2 insts)
+ |           +-- TST_Person(ResultClass)(2 insts)
  |               +-- //FakedUrl:5988/root/cimv2:TST_Person.name="Gabi"
  |               +-- //FakedUrl:5988/root/cimv2:TST_Person.name="Sofi"
  +-- member(Role)
      +-- //FakedUrl:5988/root/cimv2:TST_MemberOfFamilyCollection(AssocClass)
          +-- family(ResultRole)
-             +-- //FakedUrl:5988/root/cimv2:TST_FamilyCollection(ResultClass)(1 insts)
+             +-- TST_FamilyCollection(ResultClass)(1 insts)
                  +-- //FakedUrl:5988/root/cimv2:TST_FamilyCollection.name="Family2"
 """  # noqa: E501
 
@@ -659,22 +659,22 @@ COMPLEX_SHRUB_TABLE = [
 COMPLEX_SHRUB_FULLPATH_TABLE = [
     'Shrub of root/cimv2:TST_EP.InstanceID=1: paths',
     'Role       AssocClass    ResultRole    ResultClass    Assoc Inst paths',
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        Target        //FakedUrl:5988/root/cimv2:TST_EP         //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=2(refinst:0)',  # noqa E501
+    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        Target        TST_EP         //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=2(refinst:0)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=5(refinst:1)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=7(refinst:2)',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        Target        //FakedUrl:5988/root/cimv2:TST_EP         //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=2(refinst:0)',  # noqa E501
+    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        Target        TST_EP         //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=2(refinst:0)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=5(refinst:1)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=7(refinst:2)',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        Target        //FakedUrl:5988/root/cimv2:TST_EP         //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=2(refinst:0)',  # noqa E501
+    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        Target        TST_EP         //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=2(refinst:0)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=5(refinst:1)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=7(refinst:2)',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        LogicalUnit   //FakedUrl:5988/root/cimv2:TST_LD         //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=3(refinst:0)',  # noqa E501
+    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        LogicalUnit   TST_LD         //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=3(refinst:0)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=6(refinst:1)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=8(refinst:2)',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        LogicalUnit   //FakedUrl:5988/root/cimv2:TST_LD         //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=3(refinst:0)',  # noqa E501
+    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        LogicalUnit   TST_LD         //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=3(refinst:0)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=6(refinst:1)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=8(refinst:2)',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        LogicalUnit   //FakedUrl:5988/root/cimv2:TST_LD         //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=3(refinst:0)',  # noqa E501
+    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        LogicalUnit   TST_LD         //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=3(refinst:0)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=6(refinst:1)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=8(refinst:2)']  # noqa E501
 # pylint: enable=line-too-long
@@ -693,12 +693,12 @@ COMPLEX_SHRUB_TABLE_SUMMARY = [
 COMPLEX_SHRUB_FULLPATH_TABLE_SUMMARY = [
     'Shrub of root/cimv2:TST_EP.InstanceID=1: summary',
     'Role       AssocClass    ResultRole    ResultClass      Assoc Inst Count',
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   Target        //FakedUrl:5988/root/cimv2:TST_EP  3',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   Target        //FakedUrl:5988/root/cimv2:TST_EP  3',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   Target        //FakedUrl:5988/root/cimv2:TST_EP  3',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   LogicalUnit   //FakedUrl:5988/root/cimv2:TST_LD  3',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   LogicalUnit   //FakedUrl:5988/root/cimv2:TST_LD  3',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   LogicalUnit   //FakedUrl:5988/root/cimv2:TST_LD  3']  # noqa E501
+    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   Target        TST_EP  3',  # noqa E501
+    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   Target        TST_EP  3',  # noqa E501
+    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   Target        TST_EP  3',  # noqa E501
+    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   LogicalUnit   TST_LD  3',  # noqa E501
+    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   LogicalUnit   TST_LD  3',  # noqa E501
+    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   LogicalUnit   TST_LD  3']  # noqa E501
 # pylint: enable=line-too-long
 
 COMPLEX_SHRUB_TREE = [
@@ -732,12 +732,15 @@ SIMPLE_SHRUB_TABLE1 = [
 # pylint: disable=line-too-long
 SIMPLE_SHRUB_FULLPATH_TABLE1 = [
     'Shrub of root/cimv2:TST_Person.name="Mike": paths',
-    'Role   AssocClass ResultRole ResultClass Assoc Inst paths',
-    'parent //FakedUrl:5988/root/cimv2:TST_Lineage  child  //FakedUrl:5988/root/cimv2:TST_Person',  # noqa: E501
-    '//FakedUrl:5988/root/cimv2:TST_Person.name="Sofi"',
-    '//FakedUrl:5988/root/cimv2:TST_Person.name="Gabi"',
-    'member //FakedUrl:5988/root/cimv2:TST_MemberOfFamilyCollection  family   //FakedUrl:5988/root/cimv2:TST_FamilyCollection',  # noqa: E501
-    '//FakedUrl:5988/root/cimv2:TST_FamilyCollection.',
+    'Role    AssocClass ResultRole    ResultClass  Assoc Inst paths',
+    'parent  //FakedUrl:5988/root/cimv2:TST_Lineage child TST_Person //FakedUrl:5988/',  # noqa E501
+    'root/cimv2:TST_Person.',
+    'name="Gabi"',
+    '//FakedUrl:5988/',
+    'root/cimv2:TST_Person.',
+    'name="Sofi"',
+    'member  //FakedUrl:5988/root/cimv2:TST_MemberOfFamilyCollection  family TST_FamilyCollection  //FakedUrl:5988/',  # noqa E501
+    'root/cimv2:TST_FamilyCollection.',
     'name="Family2"']
 # pylint: enable=line-too-long
 
@@ -1286,7 +1289,6 @@ Instances: TST_Person
      {'args': ['enumerate', 'CIM_Namespace', '-n', 'interop'],
       'general': ['-o', 'simple']},
      {'stdout': ["Instances: CIM_Namespace",
-
                  "CreationClassName    Name    ObjectManagerCreatio "
                  "ObjectManagerName SystemCreationClassN SystemName",
 
@@ -3636,6 +3638,21 @@ interop      TST_PersonExp        4
       'test': 'innows'},
      ASSOC_MOCK_FILE, OK],
 
+    ['Verify instance command shrub, simple tree with --result-role option1',
+     ['shrub', 'TST_Person.name="Mike"', '--result-role', 'child'],
+     {'stdout': SIMPLE_SHRUB_TREE_RESULT_CLASS,
+      'rc': 0,
+      'test': 'innows'},
+     ASSOC_MOCK_FILE, OK],
+
+
+    ['Verify instance command shrub, simple tree with --result-role option2',
+     ['shrub', 'TST_Person.name="Mike"', '--result-role', 'CHILD'],
+     {'stdout': SIMPLE_SHRUB_TREE_RESULT_CLASS,
+      'rc': 0,
+      'test': 'innows'},
+     ASSOC_MOCK_FILE, OK],
+
     ['Verify instance command shrub, simple tree with --result-class option1',
      ['shrub', 'TST_Person.name="Mike"', '--result-class', 'TST_Person'],
      {'stdout': SIMPLE_SHRUB_TREE_RESULT_CLASS,
@@ -3643,7 +3660,7 @@ interop      TST_PersonExp        4
       'test': 'innows'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance command shrub, simple tree with --assoc-class option2',
+    ['Verify instance command shrub, simple tree with --result-class option2',
      ['shrub', 'TST_Person.name="Mike"', '--result-class', 'tst_person'],
      {'stdout': SIMPLE_SHRUB_TREE_RESULT_CLASS,
       'rc': 0,
@@ -3758,7 +3775,7 @@ interop      TST_PersonExp        4
       'test': 'innows'},
      ASSOC_MOCK_FILE, OK],
 
-    ['Verify instance command shrub, with reduced terminal width to trigger path folding',  # noqa E501
+    ['Verify instance command shrub, with reduced terminal width to trigger path folding and --fullpath',  # noqa E501
      {'args': ['shrub', 'root/cimv2:TST_Person.name="Mike"', '--fullpath'],
       'general': ['--output-format', 'plain'],
       'env': {'PYWBEMTOOLS_TERMWIDTH': '80'}},

--- a/tests/unit/pywbemcli/testmock/wbemserver_mock_class.py
+++ b/tests/unit/pywbemcli/testmock/wbemserver_mock_class.py
@@ -382,7 +382,7 @@ class WbemServerMock(object):
             if er.status_code != CIM_ERR_ALREADY_EXISTS:
                 pass
 
-        # Compile the leaf classes into the CIM repositor
+        # Compile the leaf classes into the CIM repository
         # This test not required to use the class in the test environment.
         # However, if it is ever used as template for code that could
         # execute on pywbem version 0.x, this test is required.


### PR DESCRIPTION
Fixes issue where an instance shrub with inter-namespace association duplicates the display of the output instances and also shows the ResultClass element as a full CIMClassName rather than simple string class name.

The issue was caused by the fact that we were using the python CIMClassname ranther that the string class name to define the association class in the build of the shrub tree.  This meant that when that class existed in multiple namespaces both were included in the display.  Fixed by using only the class name string.

This also added more tests of the shrub.

Update by Andy: PR #2909 has been merged.