### PR TITLE
Clarify usage of general options to be consistent with

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -323,6 +323,16 @@ This documentation uses a few special terms to refer to Python types:
       The subscription manager ID is a fixed string (``defaultpywbemcliSubMgr``)
       in pywbemcli
 
+   connection definition
+      The collection of parameters for a single pywbemcli connection to a
+      WBEM server. This includes server location (URI), user/security information for
+      the connection (user name and user password, certificates), pywbemcli connection
+      configuration parameters used by pywbem to execute the connection
+      including timeout, use of pull operations, etc. that are typically
+      defined in the pywbemcli general options. These connection definitions
+      can be persisted in a pywbem connection file and then referenced by
+      name in future pywbemcli calls.
+
 
 .. _`Profile advertisement methodologies`:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -47,6 +47,10 @@ Released: not yet
   namespaces are not shown if only a single or the default namespace is
   requested.  (see issues # 1058 and #1059)
 
+* Extended documentation to better document the use and characteristics
+  of the general options and the creation of the mock WBEM server
+  script (see issue #1190)
+
 **Cleanup:**
 
 * Extend use of general options in interactive mode to allow setting the

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -184,7 +184,6 @@ There are multiple types of tests in pywbemtools:
        $ tox                              # Run tests on all supported Python versions
        $ tox -e py27                      # Run tests on Python 2.7
 
-
 .. _`Disabling the spinner when debugging`:
 
 Disabling the spinner when debugging

--- a/docs/pywbemcli/cmdlineinterface.rst
+++ b/docs/pywbemcli/cmdlineinterface.rst
@@ -394,7 +394,8 @@ find other commands in the history containing the same string.
 
 .. index:: pair: interactive mode; history file
 
-The pywbemcli history is stored in the user home directory, ``~/.pywbemcli_history``.
+The pywbemcli history is stored in the user home directory. In linux systems this is
+, ``~/.pywbemcli_history`` and in windows systems TODO.
 
 .. index::
    pair: interactive mode; auto-suggestion
@@ -475,7 +476,7 @@ Pywbemcli terminates with one of the following program exit codes:
     error. This will mostly be caused by CIM errors returned by the server,
     but can also be caused by the pywbemcli code itself.
 
-  * Programming errors in mock Python scripts (see: :ref:`Mock support overview`);
+  * Programming errors in mock Python scripts (see: :ref:`Mock WBEM server overview`);
     the error message includes a Python traceback of the error.
 
 * **1 - Python traceback**: In such cases, pywbemcli terminates during its

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -2879,15 +2879,19 @@ implementations of WBEM servers such as the implementation of OpenPegasus.
 
 The ``connection`` command group includes commands that manage named connection
 definitions that are persisted in a :term:`connections file`.
-This allows maintaining multiple connection definitions and then using any
+This allows maintaining multiple connection :term:`connection definition`s and then using any
 one via the :ref:`--name general option`. Only a single connection is
 active (selected) at any point in time but the connection connection can
 be selected on the pywbemcli command line (:ref:`--name general option`) or
-changed within an interactive session using the :ref:`Connection select command`
+changed within an interactive session using the :ref:`Connection select command`.
 
 .. index:: pair: connections file; persistent connection attributes
 
-The attributes of each connection definition in the :term:`connections file` are:
+-- index: pair: connection definition, connection attributes
+
+.. index pair: connection attributes, persistent connection attributes
+
+The attributes of each :term:`connection definition` in the :term:`connections file` are:
 
 * **name** - name of the connection definition. See :ref:`--name general option`.
 * **server** - URL of the WBEM server, or None if the connection definition is
@@ -2897,6 +2901,8 @@ The attributes of each connection definition in the :term:`connections file` are
 * **password** - password for the WBEM server. See :ref:`--password general option`.
 * **use-pull** - determines whether the pull operations are to be used for
   the WBEM server. See :ref:`--use-pull general option`.
+* **pull-max-cnt** - integer that defines the maximum number of CIM instances the
+  WBEM server may return with a single pull Open or Pull request. See :ref:`--pull-max-cnt general option`.
 * **verify** - a boolean flag controlling whether the pywbem client verifies
   any certificate received from the WBEM server. See :ref:`--verify general option`.
 * **certfile** - path name of the server certificate file. See :ref:`--certfile general option`.
@@ -2928,7 +2934,7 @@ The commands in this group are:
 ``connection delete`` command
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``connection delete`` command deletes a connection definition from the
+The ``connection delete`` command deletes a :term:`connection definition` from the
 :term:`connections file`.
 
 The format of this command is:
@@ -3012,9 +3018,9 @@ See :ref:`pywbemcli connection export --help` for the exact help output of the c
 ``connection list`` command
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``connection list`` command lists the connection definitions in the
-:term:`connections file` and the current connection(if it has not been
-saved to the connections file).
+The ``connection list`` command lists the :term:`connection definition`
+definitions in the :term:`connections file` and the current connection (if it
+has not been saved to the connections file).
 
 
 The format of this command is:
@@ -3102,13 +3108,13 @@ See :ref:`pywbemcli connection list --help` for the exact help output of the com
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The ``connection save`` command saves the current connection in the
-:term:`connections file` as a connection definition with the name specified
+:term:`connections file` as a :term:`connection definition` with the name specified
 in the ``NAME`` argument.
 
 The format is:
     pywbemcli [GENERAL-OPTIONS] connection save ``NAME`` [COMMAND-OPTIONS]
 
-If a connection definition with that ``NAME`` already exists, it will be overwritten
+If a :term:`connection definition` with that ``NAME`` already exists, it will be overwritten
 without notice.
 
 This command includes an option (``set-default``) that sets the default
@@ -3144,19 +3150,19 @@ See :ref:`pywbemcli connection save --help` for the exact help output of the com
 .. index:: single: connection select command
 .. index:: pair: command; connection select
 
-The ``connection select`` command selects a connection definition from the
+The ``connection select`` command selects a :term:`connection definition` from the
 :term:`connections file` to become the :term:`current connection`.
 
 The command format is:
     pywbemcli [GENERAL-OPTIONS] connection select ``NAME`` [COMMAND-OPTIONS]
 
-If the ``NAME`` argument is specified, the connection definition with that name
-is selected. Otherwise, pywbemcl displays the list of connection definitions
-from the connections fileand prompts the user to pick one to be selected.
-If there is only a single connection, that connection is selected without the
-user request.
+If the ``NAME`` argument is specified, the :term:`connection definition` with
+that name is selected. Otherwise, pywbemcli displays the list of names of
+:term:`connection definition` entries from the connections file and prompts the
+user to pick one to be selected. If there is only a single connection, that
+connection is selected without the user request.
 
-If the ``--default``/``-d`` command option is set, the connection definition in
+If the ``--default``/``-d`` command option is set, the :term:`connection definition` in
 addition becomes the default connection, by marking it accordingly in the
 :term:`connections file`.
 
@@ -3216,7 +3222,7 @@ See :ref:`pywbemcli connection select --help` for the exact help output of the c
 .. index:: single: connection show command
 .. index:: pair: command; connection show
 
-The ``connection show`` command shows information about a connection definition:
+The ``connection show`` command shows information about a :term:`connection definition`:
 
 The command format is:
     pywbemcli [GENERAL-OPTIONS] connection show ``NAME`` [COMMAND-OPTIONS]
@@ -3224,7 +3230,7 @@ The command format is:
 * If ``NAME`` is ``?``, pywbemcli prompts the user to select one and shows
   the existing current connection. If there is only a single connection the
   user selection is bypassed.
-* If ``NAME`` is specified, show the connection definition with that name.
+* If ``NAME`` is specified, show the :term:`connection definition` with that name.
 * If ``NAME`` is not specified, show the existing current connection.
 
 .. code-block:: text
@@ -3311,16 +3317,16 @@ The command format is:
     pywbemcli [GENERAL-OPTIONS] connection set-default ``NAME`` [COMMAND-OPTIONS]
 
 The :term:`default-connection-name` attribute in the connection file allows a
-connection definition in a connections file to be loaded on startup without
+:term:`connection definition` in a connections file to be loaded on startup without
 using the :ref:`--name general option`. If pywbemcli is started without
 :ref:`--name general option`, :ref:`--server general option`, or
 :ref:`--mock-server general option`, the ``default-connection-name`` attribute
 is retrieved from the connections file if defined, and the value of this
-attribute used as the name of the connection definition set as current
+attribute used as the name of the :term:`connection definition` set as current
 connection.
 
-Thus, for example, if the default connection definition is ``mytests`` the
-connection definition for ``mytests`` is created each time pywbemcli is started
+Thus, for example, if the default :term:`connection definition` is ``mytests`` the
+:term:`connection definition` for ``mytests`` is created each time pywbemcli is started
 with no :ref:`--server general option`, :ref:`--mock-server general option` or
 the :ref:`--name general option`.
 

--- a/docs/pywbemcli/generaloptions.rst
+++ b/docs/pywbemcli/generaloptions.rst
@@ -5,19 +5,175 @@ Using the pywbemcli command line general options
 
 .. index:: single: general options
 
-.. _`Oveview of the general options`:
+.. _`Overview of the general options`:
+
+The following table is an overview of all of the pywbemcli general options with
+a cross-reference to a detailed definition of each opton
+
+
+.. list-table:: pywbemcli general options!
+   :widths: 20 20 20 20 20
+   :header-rows: 1
+
+   * - Option Name
+     - Function(1)
+     - Description
+     - Type
+     - Default Value
+
+   * - :ref:`--server <--server general option>`
+     - Server Definition
+     - Define server URI
+     - String
+     -
+
+   * - :ref:`--name <--name general option>`
+     - Sever Definition
+     - Get server definition by name
+     - String
+     -
+
+   * - :ref:`--mock-server <--mock-server general option>`
+     - Server Definition
+     - Define mock server
+     - String
+     -
+
+   * - :ref:`--user <--user general option>`
+     - Server Attribute
+     - Server user name
+     - String
+     -
+
+   * - :ref:`--password <--password general option>`
+     - Server Attribute
+     - Server user password
+     - String
+     -
+
+   * - :ref:`--use-pull <--use-pull general option>`
+     - Server attribute
+     - Use of pull Operations
+     - Choice
+     - either
+
+   * - :ref:`--pull-max-cnt <--pull-max-cnt general option>`
+     - Server attribute
+     - Max response size
+     - Integer
+     - 1000
+
+   * - :ref:`--certfile <--certfile general option>`
+     - Server attribute
+     - Define server cert
+     - String
+     -
+
+   * - :ref:`--keyfile <--keyfile general option>`
+     - Server attribute
+     - Define Table format
+     - String
+     -
+
+   * - :ref:`--timestats <--timestats general option>`
+     - Client attribute
+     - Control stats
+     - Boolean
+     -
+
+   * - :ref:`--log <--log general option>`
+     - Client attribute
+     - Control stats
+     - String
+     -
+
+   * - :ref:`--verify <--verify general option>`
+     - Client attribute
+     - Verify server cert
+     - Boolean
+     - True
+
+   * - :ref:`--ca-certs <--ca-certs general option>`
+     - Client blah
+     - Define Server ca certs
+     - String
+     -
+
+   * - :ref:`--timeout <--timeout general option>`
+     - Client attribute
+     - Timeout server request
+     - Integer (sec)
+     - 30 sec
+
+   * - :ref:`--default-namespace <--default-namespace general option>`
+     - Client attribute
+     - Connection default namespace
+     - String
+     - root/cimv2
+
+   * - :ref:`--output-format <--output-format general option>`
+     - Client attribute
+     - Define Table format
+     - Choice
+     - MOF
+
+   * - :ref:`--verbose <--verbose general option>`
+     - Client attribute
+     - Display processing details
+     - Boolean
+     - False
+
+   * - :ref:`--version <--version general option>`
+     - Client attribute
+     - Show pywbemtools version
+     -
+     -
+
+   * - :ref:`--warn <--warn general option>`
+     - Client attribute
+     - Control warnings
+     - Boolean
+     -
+
+   * - :ref:`--connections-file <--connections-file general option>`
+     - Client attribute
+     - Define file path
+     - String
+     - Default file
+
+   * - :ref:`--pdb <--pdb general option>`
+     - Client attribute
+     - Run with debugger
+     - Boolean
+     -
+
+   * - :ref:`--helo <--help general option>`
+     - Client attribute
+     - Show help
+     - String
+     -
+
+1. Server definitions and server attributes are attached to a :term:`connection definition`
+   and are used when defined for the current :term:`connection definition` in
+   the interactive mode.  Client attribute exist for the life of an interactive
+   session in the interactive mode. Thus --verbose entered on the command line
+   is used for all commands in the interactive mode.  --user entered on the
+   command line applies to the current server definition only.
 
 Overview of the general options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 General options define:
 
-* The connection to the WBEM server against which the pywbemcli commands are to be
-  executed (i.e url, default CIM namespace, security parameters, etc.)
-  or the alternative mock of a WBEM server.
-  See :ref:`Defining the WBEM server` for details.
+* The server definition (connection) to the WBEM server mock WBEM server
+  (i.e :term:`connection definition`)against which the pywbemcli commands are
+  targeted. See :ref:`Defining the WBEM server` for details.
+* Attributes of the WBEM server which is being targeted. This includes attributes
+  such as the user/password, certificates, etc. pull operations. These attributes
+  are attached to the current WBEM server connection definition and persisted with that
+  :term:`connection definition`.
 * Operation behavior of pywbemcli for requests; i.e. using the pull operations
-  vs the :term:`traditional operations`, or the client side timeout.
+  vs the :term:`traditional operations`, the client side timeout, etc..
   See :ref:`Controlling operation behavior and monitoring operations` for
   details.
 * Execution options to monitor the requests and responses (statistics keeping,
@@ -36,6 +192,7 @@ result in the ``simple`` table format:
 .. code-block:: text
 
     pywbemcli --output-format simple --server http://localhost qualifier enumerate
+
     Qualifier Declarations
     Name         Type     Value    Array    Scopes       Flavors
     -----------  -------  -------  -------  -----------  ---------------
@@ -51,7 +208,6 @@ once and retain their value throughout the execution of the interactive mode.
 General options defined in the command line may be overwritten by specifying
 them on interactive mode commands. The resulting new value is used only for
 that one command, and is not retained for subsequent interactive mode commands.
-
 
 In the following example, the :ref:`--output-format general option` is used
 on an interactive mode command to overwrite the default output format, and the
@@ -85,11 +241,57 @@ Defining the WBEM server
 The target WBEM server can be defined on the command line in several ways with
 the following arguments :
 
-1. Define connection information for a WBEM server by using the
-   :ref:`--server general option` that specifies the URL of the server.
+1. General options that define the WBEM server to be used.
+
+   The following 3 mutually exclusive general options define the WBEM server
+   that wil be the target of pywbem cli server-request commands (ex. class get
+   <class name).
+
+   * The :ref:`--server general option` defines the URI of a real WBEM server.
+     The attributes of the server used by pywbemcli are defined by the
+     connection characteristics general options (ex. --user, etc.)
+
+.. code-block:: text
+
+    pwybmcli -s http:myserver
+
+   * The :ref:`--name general option` defines the name of a :term:`connection definition`
+     in a :term:`connections file`. This name must have been previously created
+     by saving the name of a server definition with the :ref:`Command
+     connection save` command.
+
+.. code-block:: text
+
+    pwybmcli -n mytestserver connection show
+
+    defines the use of the previously defined connection ``mytestserver`` and
+    executes the pywbem command ``connection show``.
+
+   Connection definitions can be stored in a :term:`connections file`
+   and are managed with the :ref:`Connection command group`.
+
+   * The :ref:`--mock-server general option` defines a :ref:`Mock WBEM Server` that
+     is created upon pywbemcli startup.  The MOF or python files that are defined
+     with as values of the option define the characteristics of thes mock WBEM server
+     (The CIM objects that will be build in the mock environment and that can be
+     accesses as if they were a real WBEM server).
+
+     The mock WBEM server allows testing or demonstrating pywbemcli without
+     having access to a real WBEM server.
+
+.. code-block:: text
+
+    pwybmcli -m mytestmof.mof -m mytestscript.py class enumerate
+
+    defines the use of the pywbemcli mock WBEM server script ``myscript.py`` and
+    executes the pywbem command ``class enumerate`` to show the first level
+    of the class hiearchy class names in the default namespace.
+
+2. Define connection characteristics for a WBEM server by using the
 
    The following general options can be used for specifying additional
-   information for the connection:
+   information for the connection and become part of the :term:`connection definition`
+   (i.e. connection) for a WBEM server.
 
    * The :ref:`--default-namespace general option` defines the :term:`default namespace`
      to be used if a command does not specify a namespace.
@@ -99,6 +301,12 @@ the following arguments :
      authenticating with the WBEM server.
    * The :ref:`--verify general option` defines whether the client verifies
      certificates received from the WBEM server.
+   * The :ref:`--use-pull general option` defines whether pywbemcli issues
+     requests like ``instance enumerate`` as pull operations or as the traditional
+     operations. See :ref:`pywbem:Pull operations`.
+   * The :ref:`--pull-max-cnt general option` defines the maximum number of
+     instances the WBEM server can return in a single response to an Open or
+     Pull client request
    * The :ref:`--certfile general option` defines the client certificate file.
    * The :ref:`--keyfile general option` defines the client key file.
    * The :ref:`--ca-certs general option` defines a collection of certificates
@@ -106,18 +314,14 @@ the following arguments :
    * The :ref:`--timeout general option` defines the client side timeout
      for operations.
 
-2. Define a mock WBEM server by using the :ref:`--mock-server general option`.
+   NOTE: Not all of the above general options are used by the mock WBEM server.
+   Thus, since the mock WBEM server has no security layer, the ``--keyfile``,
+   ``--certfile``, and ``--ca-certs`` options will be rejected if a
+   mock WBEM server is specified
 
-   The mock WBEM server is part of pywbemcli and allows testing or
-   demonstrating pywbemcli without having access to a real WBEM server.
-   For details, see :ref:`Mock WBEM server support`.
-
-3. Refer to a persisted connection definition for either a WBEM server or
-   mock WBEM server by using the :ref:`--name general option` that
-   specifies the name of the connection definition.
-
-   Persisted connection definitions are stored in a :term:`connections file`
-   and are managed with the :ref:`Connection command group`.
+   A :term:`connection definition` can be named and persisted in a pywbemcli
+   :term:`connections file` identified by a connection name so that it can
+   be used by pywbem with the :ref:`--name general option`.
 
 
 .. _`Controlling operation behavior and monitoring operations`:
@@ -259,8 +463,8 @@ Examples for the argument value of this option include:
 """""""""""""""""""""""""
 
 The argument value of the ``--name``/``-n`` general option is a string that is
-the name of a connection definition in the :term:`connections file`.
-The parameters for this named connection definition will be loaded from the
+the name of a :term:`connection definition` in the :term:`connections file`.
+The parameters for this named :term:`connection definition` will be loaded from the
 :term:`connections file` to become the current WBEM connection in pywbemcli.
 
 In the interactive mode the connection is not actually established until a
@@ -270,7 +474,7 @@ This option is mutually exclusive with the :ref:`--server general option` and
 the :ref:`--mock-server general option` since each defines a connection to a
 WBEM server.
 
-The following example creates a connection definition named ``myserver``
+The following example creates a :term:`connection definition` named ``myserver``
 in the connections file, and then uses that connection to execute
 ``class get``:
 
@@ -475,7 +679,7 @@ part of the file defined by ``--certfile``.
 .. _`--ca-certs general option`:
 
 ``--ca-certs`` general option
-""""""""""""""""""""""""""""""
+"""""""""""""""""""""""""""""
 
 The argument value of the ``--ca-certs`` general option specifies which
 X.509 certificates are used on the client side for validating the X.509
@@ -554,9 +758,9 @@ section :ref:`Statistics command group` .
 """"""""""""""""""""""""""""""
 
 The argument value of the ``--use-pull``/``-u`` general option determines
-whether the pull operations or :term:`traditional operations` are used for the
-``instance enumerate``, ``instance references``, ``instance associators``
-and ``instance query`` commands. See
+whether the :ref:`pywbem:Pull Operations` or :term:`traditional operations` are
+used for the ``instance enumerate``, ``instance references``, ``instance
+associators`` and ``instance query`` commands. See
 :ref:`Pywbemcli and the DMTF pull operations` for more information on pull
 operations. The choices for the argument value are as follows:
 
@@ -564,7 +768,8 @@ operations. The choices for the argument value are as follows:
   support pull, the request will fail.
 * ``no`` - forces pywbemcli to try only the traditional non-pull operations.
 * ``either`` - (default) pywbem tries both; first pull operations and then
-  :term:`traditional operations`.
+  :term:`traditional operations`.  This is the recommended setting since it
+  will generate a valid response from any server.
 
 .. index:: triple: --pull-max-cnt; general options; pull-max-cnt
 
@@ -599,7 +804,7 @@ suffix ".mof" for MOF files and ".py" for Python scripts.
 When this option is used, the security options (ex. ``--user``) are irrelevant;
 they may be specified but are not used.
 
-See section :ref:`Mock WBEM server support` for information on the characteristics
+See section :ref:`Mock WBEM server` for information on the characteristics
 of the MOF and Python files that define a mock environment
 
 The following example creates a mock server with two files defining the mock
@@ -618,7 +823,7 @@ connection named ``mymockserver``:
 
     pywbemcli> connection save mymockserver
 
-See chapter :ref:`Mock WBEM server support` for more information on defining
+See chapter :ref:`Mock WBEM server` for more information on defining
 the files for a mock server.
 
 .. index:: triple: --output-format; general options; output-format
@@ -682,10 +887,10 @@ systems including Windows. See :func:`~py3:os.path.expanduser` for details.
 The actually used path name of the connections file is shown in the
 :ref:`connection list command`.
 
-The connection definitions in the connections file are managed with the
-commands in the :ref:`connection command group`.
+The :term:`connection definition` definitions in the connections file are
+managed with the commands in the :ref:`connection command group`.
 
-.. index:: triple: --pdb; general options; pdb
+.. index:: triple: --warn; general options; warn
 
 .. _`--warn general option`:
 
@@ -711,7 +916,7 @@ for details.
 The ``--pdb`` general option is a boolean option that enables debugging
 with the built-in pdb debugger.
 
-If debugging is enabled, execution of the pywbemcli command will pause just
+If debugging is enabled, execution of each pywbemcli command will pause just
 before the command within pywbemcli is executed, and the pdb debugger prompt
 will appear. See `pdb debugger commands`_ for details on how to operate the
 built-in pdb debugger.
@@ -736,7 +941,9 @@ command and the version of the pywbem package used by it, and then exits.
 """""""""""""""""""""""""
 
 The ``--help``/``-h`` general option displays help text which describes the
-command groups and general options, and then exits.
+command groups, commands,  and general options, and then exits. A specific
+help exists for each command group, and command and ``pywbemcli --help``
+presents the help on the general options
 
 .. index:: pair: environment variables; general options
 
@@ -744,6 +951,8 @@ command groups and general options, and then exits.
 
 Environment variables for general options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:: index:: pair: general options; environment variables
 
 Pywbemcli defines environment variables corresponding to its general options
 as follows:
@@ -836,12 +1045,16 @@ The DMTF specifications and pywbem includes two ways to execute the enumerate
 instance type operations (``Associators``, ``References``,
 ``EnumerateInstances``, ``ExecQuery``):
 
-* The :term:`traditional operations` (ex. ``EnumerateInstances``)
-* The pull operations (ex. ``OpenEnumerateInstances``, etc.)
+* The :term:`traditional operations` (ex. ``EnumerateInstances``) where the
+  WBEM server returns all of the response instances as a single response
+* The pull operations (ex. ``OpenEnumerateInstances``, etc.) where the
+  client and the server cooperate with client requests for Open... and subsequent
+  Pull... requests to return groups of response instances.
 
 Pywbem implements an overlay of the above two operations called the ``Iter..``
 operations where each ``Iter..`` operation executes either the traditional or
-pull operation depending on a parameter of the connection.
+pull operation depending on the :ref:`--use-pull general option` of the
+connection.
 
 While the pull operations may not be supported by all WBEM servers they can be
 significantly more efficient for large responses when they are available.

--- a/docs/pywbemcli/mock_support.rst
+++ b/docs/pywbemcli/mock_support.rst
@@ -1,117 +1,86 @@
 .. index:: pair: Mock WBEM server support; server mock
 
-.. _`Mock WBEM server support`:
+.. _`Mock WBEM server`:
 
-Mock WBEM server support
-========================
+Mock WBEM Server
+================
 
-.. _`Mock support overview`:
+.. _`Mock WBEM server overview`:
 
-Mock support overview
----------------------
+Mock WBEM server overview
+-------------------------
 
-Pywbemcli supports mocking a WBEM server with the
-:ref:`--mock-server general option`. This allows executing pywbemcli against a
-mock WBEM server that is automatically created in pywbemcli, rather than a real
+The pywbemcli implements an in-process Mock WBEM Server using the
+:ref:`pywbem:Mock WBEM server` that provides WBEM server responses to pywbmcli
+commands based on the definition of the CIM elements defined for the mock
 WBEM server.
 
-The ``--mock-server`` option is mutually exclusive with the
+Pywbemcli starts WBEM server when pywbemcli :ref:`--mock-server general option`
+is defined.  This option defines either a MOF file or Python script that
+defines a mock WBEM server environment that can include CIM namespaces, CIM
+classes, CIM instances, CIM qualifier declarations CIM instances, and CIM
+providers. This allows executing pywbemcli commands against the mock WBEM server
+that is created in pywbemcli rather than a real WBEM server.
+
+The :ref:`--mock-server general option` is mutually exclusive with the
 :ref:`--server general option` and :ref:`--name general option`, since each
-defines a WBEM server.
+defines a target WBEM server.
 
-The automatically created mock WBEM server has a in-memory repository for
-CIM objects (qualifier declarations, classes, and instances) and supports
-CIM namespaces. The operations performed against the mock WBEM server cause
-that mock repository to be inspected or manipulated accordingly.
+The created mock WBEM server has a in-memory repository for the
+CIM objects defined by the MOF/script (qualifier declarations, classes, and
+instances) and supports CIM namespaces. The operations performed against the
+mock WBEM server cause that mock repository to be inspected (ex. ``class
+enumerate``) or manipulated (ex.``instance create ....``) accordingly.
 
-The mock repository can be loaded with CIM objects from files specified as an
-argument to the ``--mock-server`` option. Each use of the option
-specifies one file path of such a file. The option may be used multiple times
-and each specified file is processed sequentially, in the sequence of the
-options on the command line.
+The mock repository can be defined and created with CIM objects from files
+specified as an argument to the :ref:`--mock-server general option`. Each use
+of the option specifies one file path. The option may be used
+multiple times and each specified file is processed sequentially, in the
+sequence of the options on the command line.
 
-The following types of files are supported for the ``--mock-server`` option:
+pywbemcli supports the following file types for the ``--mock-server`` option:
 
 .. index:: pair: MOF; server mock
 .. index:: pair: compile_string(); mock setup methods
 
 * **MOF files**: If the file extension is ``.mof``, the file is considered a
-  :term:`MOF` file. Pywbemcli compiles the MOF in the file and adds the
-  resulting CIM objects to the mock repository.
+  :term:`MOF` file and must be compilable with the :ref:`pywbem:MOF Compiler`
+  and the MOF syntax defined by the DMTF in :term:`DSP0004`. Pywbemcli compiles
+  the MOF in the file and adds the resulting CIM objects to the mock
+  repository.
 
-  The MOF file may define CIM qualifier declarations, CIM classes and CIM
-  instances.
+  The following is a very simple example that simply compiles two qualifier
+  declaration in a file ``qualdecls.mof`` and executes the command
+  ``qualifier enumerate``:
 
-  At this point, these CIM objects can be added to only one
-  :term:`CIM namespace` in the repository of the mock WBEM server, namely the
-  default namespace of the connection (see
-  :ref:`--default-namespace general option`).
+.. code-block:: text
+
+    pywbemcli -m qualdecl.mof qualifier enumerate
+
+    Qualifier Abstract : boolean = false,
+        Scope(class, association, indication),
+        Flavor(EnableOverride, Restricted);
+
+    Qualifier Aggregate : boolean = false,
+        Scope(reference),
+        Flavor(DisableOverride, ToSubclass);
+
+  The MOF file may define CIM namespaces (#pragma namespace ("user")), CIM
+  qualifier declarations, CIM classes and CIM instances.
+
+  Thus MOF files can create mocks of complete multi-namespace environments
+  including multiple namespaces, multiple classes, and instances including
+  complete association instances using the MOF compiler instance alias
+  construct.
 
   If a CIM object already exists in the repository, it is updated accordingly.
 
 .. index:: triple: Python files; server mock; add_cimobjects()
 
 * **Mock scripts**: If the file extension is ``.py``, the file is considered
-  a Python mock script.
-
-  Mock scripts can be used for any kind of setup of the mock WBEM server, for
-  example for creating namespaces, implementing and registering providers, or
-  adding CIM objects either from the corresponding Python objects or by
-  compiling MOF files or MOF strings.
-
-  Mock scripts support two approaches for passing the mock WBEM server they
-  should operate on:
-
-  * New-style: The mock script has a ``setup()`` function. This is the
-    recommended approach, but it is supported only on Python >=3.5. It enables
-    the mock environment of a connection definition to be cached.
-
-    New-style mock scripts are imported as a Python module into Python namespace
-    ``pywbemtools.pywbemcli.mockscripts.<mock-script-name>`` and their
-    ``setup()`` function is called. That function has the following interface:
-
-    .. code-block:: python
-
-        def setup(conn, server, verbose):
-            . . .
-
-    * ``conn`` (:class:`pywbem_mock.FakedWBEMConnection`):
-      This object provides a connection to the mock WBEM server. The methods
-      of this object can be used to create and modify CIM objects in the
-      mock repository and to register providers.
-
-    * ``server`` (:class:`pywbem.WBEMServer`):
-      This object is layered on top of the ``CONN`` object and provides access
-      to higher level features of the mock WBEM server, such as getting the
-      Interop namespace, adding namespaces, or building more complex objects
-      for the mock repository.
-
-    * ``verbose`` (bool):
-      A flag that contains the value of the boolean
-      :ref:`--verbose general option` of pywbemcli.
-
-  * Old-style: The mock script does not have a ``setup()`` function. This
-    approach is not recommended, but it is supported on all supported Python
-    versions. Using old-style mock scripts in a connection definition prevents
-    caching of its mock environment.
-
-    Old-style mock scripts are executed as Python scripts in Python namespace
-    ``__builtin__``, with the following Python global variables made available:
-
-    * ``CONN`` (:class:`pywbem_mock.FakedWBEMConnection`):
-      This object provides a connection to the mock WBEM server. The methods
-      of this object can be used to create and modify CIM objects in the
-      mock repository and to register providers.
-
-    * ``SERVER`` (:class:`pywbem.WBEMServer`):
-      This object is layered on top of the ``CONN`` object and provides access
-      to higher level features of the mock WBEM server, such as getting the
-      Interop namespace, adding namespaces, or building more complex objects
-      for the mock repository.
-
-    * ``VERBOSE`` (bool):
-      A flag that contains the value of the boolean
-      :ref:`--verbose general option` of pywbemcli.
+  a Python script and the script is executed as part of the startup of pywbemcli
+  in the command line mode or upon the first command executed that communicates
+  with a server in the interactive mode.
 
   Mock scripts can for example create Python objects of type
   :class:`~pywbem.CIMQualifierDeclaration`, :class:`~pywbem.CIMClass` and
@@ -119,14 +88,14 @@ The following types of files are supported for the ``--mock-server`` option:
   the mock repository via calls to
   :meth:`pywbem_mock.FakedWBEMConnection.add_cimobjects`.
 
-  Mock scripts can also implement user-defined providers
-  (see :ref:`pywbem:User-defined providers` in the pywbem documentation)
-  and register these providers with the mock WBEM server.
+  Mock scripts can also install user-defined providers (see
+  :ref:`pywbem:User-defined providers`) and register these providers with the
+  mock WBEM server (TODO).
 
-  Finally, mock scripts can be used to add or update CIM objects in the
-  CIM repository of the mock WBEM server. This is an alternative to
-  specifying MOF files, and can be used for example to parse files defining
-  the CIM objects for entire WBEM management profiles.
+  Finally, mock scripts can be used to add or update CIM objects in the mock
+  CIM repository. This is an alternative to specifying MOF files, and can be
+  used for example to parse files defining the CIM objects for entire WBEM
+  management profiles.
 
 It is possible to mix MOF files and mock scripts by specifying the
 :ref:`--mock-server general option` multiple times.
@@ -142,10 +111,18 @@ with the mock support. Since the mock support does not use HTTP(S), only the
     pair: MOF; server mock
 
 .. _`Creating files for the mock repository`:
-.. _`Setting up the mock WBEM server`:
+.. _`Setting up the mock WBEM server with a MOF file`:
 
-Setting up the mock WBEM server
--------------------------------
+Setting up the mock WBEM server with a MOF file
+-----------------------------------------------
+
+If the :ref:`--mock-server general option` defines a MOF file, The file
+most consist of DMTF MOF definitions of CIM qualifier declarations, CIM
+class definitions, and CIM instance definitions that are compiled by
+pywbemcli using the pywbem MOF compiler and installed in the mock
+cim repository before the first pywbemcli command that calls the server
+is executed.   CIM namespaces may be created (in addition to the
+default namespace) with the MOF namespace pragma command.
 
 The following is an example MOF file named ``tst_file.mof`` that defines some
 CIM qualifier declarations, a single CIM class, and a single CIM instance of
@@ -153,7 +130,7 @@ that class:
 
 .. code-block:: text
 
-    # Define some qualifiers
+    // Define some qualifier declarations
 
     Qualifier Description : string = null,
         Scope(any),
@@ -171,7 +148,7 @@ that class:
         Scope(parameter),
         Flavor(DisableOverride, ToSubclass);
 
-    # Define a class
+    // Define a class
 
        [Description ("Simple CIM Class")]
     class CIM_Foo {
@@ -189,7 +166,7 @@ that class:
         );
     };
 
-    # Define an instance of the class
+    // Define an instance of the class
 
     instance of CIM_Foo as $foo1 {
         InstanceID = "CIM_Foo1";
@@ -200,12 +177,377 @@ The pywbemcli command to use this MOF file for loading into a mock WBEM server,
 and then to enumerate its CIM class names is::
 
     $ pywbemcli --mock-server tst_file.mof class enumerate --names-only
+
     CIM_Foo
 
 
+.. _`Defining the mock WBEM server with a Python script`:
+
+Defining the mock WBEM server with a Python script
+--------------------------------------------------
+
+Creating a python script provides additional flexibility in defining mock
+environments over just installing MOF files including:
+
+1. The ability to install instance providers to control the processing of
+specific instance operations (create, modify, delete) on specific classes. This
+is similar to the definition of providers in WBEM servers such as OpenPegasus
+which process requests and generate responses to the client in the WBEM server
+for specific request types and CIM classes.  pywbem provides several prebuilt
+instance providers that can be installed with the setup script.
+
+2. The ability to install CIM qualifier declarations and CIM classes from
+   DMTF schemas rather than simply from local MOF files. See
+   :ref:`pywbem:Building a mocked CIM repository` rather than from local MOF
+   files.
+
+3. The ability to dynamically define and create CIM instances and in particular
+   instances of associations using both MOF and instances build from
+   pywbem cim objects ref:`pywbem.CIM objects`.
+
+A pywbem startup script can create many of the basic characteristics of a
+WBEM server including:
+
+1. Building the mock environment namespaces where the namespaces can be as simple
+   as just the connection default namespace or as complex as an environment
+   with an :term:`Interop namespace` and multiple other namespaces.
+2. Installing mock classes and qualifiers. This can be done by:
+
+   * Compiling a fixed set of classes and qualifier declarations defined in a
+     file or python string defining MOF.
+   * Compiling qualifier declarations and classes from a DMTF schema. The
+     following statements in a script installs qualifier declarations and CIM
+     classes, from the DMTF schema version 2.49.0 from the DMTF web site (if it
+     was not already on the local system compile the qualifier declarations
+     specified by the list of classnames).
+
+.. code-block::
+
+       VERBOSE = False
+       namespace = 'Interop'          # Namespace where qds and classes installed
+       schema_dir = '.'               # Directory where DMTF schema downloaded and expanded
+       DMTF_SCHEMA_VER = (2, 49, 0)   # defines DMTF schema version 2.49.0
+       schema_dir = schema_dir        # Directory where schema will be downloaded and installed
+       experimental-schema = True     # If True, DMTF experimental schema used
+
+       # Get and expand the schema.
+       schema = DMTFCIMSchema(DMTF_SCHEMA_VER,
+                              schema_dir,
+                              use_experimental=False,
+                              verbose=VERBOSE)
+       leaf_classes = ['CIM_ObjectManager', 'CIM_Namespace']
+
+       # Compile the qualifier declarations from the schema
+       # Compile the leaf classes and all classes on which they depend
+       conn.compile_schema_classes(
+                    leaf_classes,
+                    schema.schema_pragma_file,
+                    namespace=namespace,
+                verbose=VERBOSE)
+
+   These methods are documented in :ref:`pywbem.FakedWBEMConnection class`
+
+3. Installing/registering instance providers required for the mock.
+   Pywbemcli itself includes predefined providers for creating namespaces and
+   managing indication subscriptions that provide interfaces the same as most
+   WBEM servers.
+4. Installing CIM instances required for the mock environment by:
+
+   * Compiling MOF for the instances from a string or file
+   * Defining the instances with the pywbem.CIMInstance() class and installing
+     them .
+5. Registering dependent startup files used in the startup script using TODO
+   so that the mock WBEM server can be cached and restored
+   or recreated if any of the dependent files change.
+   Caching significantly increases the install speed of mock servers since
+   the CIM objects are already compiled and the repository created. The
+   pywbemcli method
+
+   The following is an example of registering dependent files including the
+   script file itself.
+
+.. code-block:: python
+
+    def register_dependents(conn, this_file_path, dependent_file_names):
+        """
+        Register a dependent file name with the pywbemcli dependent file api.
+        This insures that any change to a dependent file will cause the
+        script to be recompiled.
+        """
+        if isinstance(dependent_file_names, six.string_types):
+            dependent_file_names = [dependent_file_names]
+
+        for fn in dependent_file_names:
+            dep_path = os.path.join(os.path.dirname(this_file_path), fn)
+            conn.provider_dependent_registry.add_dependents(this_file_path,
+                                                        dep_path)
+
+    def _setup(conn, server, verbose):
+
+        . . .
+
+        if sys.version_info >= (3, 5):
+            this_file_path = __file__
+        else:
+            # Unfortunately, it does not seem to be possible to find the file path
+            # of the current script when it is executed using exec(), so we hard
+            # code the file path. This requires that the tests are run from the
+            # repo main directory.
+            this_file_path = 'tests/unit/pywbemcli/simple_interop_mock_script.py'
+            assert os.path.exists(this_file_path)
+
+    # Register the script file itself and any other files used in the script.
+    register_dependents(conn, this_file_path, <file-used-in-script>)
+
+6. Setting up the startup script interface from pywbemcli:
+
+   Mock scripts can be used for any kind of setup of the mock WBEM server, for
+   example for creating namespaces, implementing and registering providers, or
+   adding CIM objects either from the corresponding Python objects or by
+   compiling MOF files or MOF strings.
+
+   Mock scripts support two approaches for passing the mock WBEM server they
+   should operate on depending on the Python version:
+
+   * New-style(Python >=3.5): The mock script has a ``setup()`` function.  It enables
+     the mock environment of a connection definition to be cached.
+
+     New-style mock scripts are imported as a Python module into Python namespace
+     ``pywbemtools.pywbemcli.mockscripts.<mock-script-name>`` and their
+     ``setup()`` function is called. That function has the following interface:
+
+    .. code-block::
+
+        def setup(conn, server, verbose):
+
+     where:
+
+     * ``conn`` (:class:`pywbem_mock.FakedWBEMConnection`):
+       This object provides a connection to the mock WBEM server. The methods
+       of this object can be used to create and modify CIM objects in the
+       mock repository and to register providers.
+
+     * ``server`` (:class:`pywbem.WBEMServer`):
+       This object is layered on top of the ``CONN`` object and provides access
+       to higher level features of the mock WBEM server, such as getting the
+       Interop namespace, adding namespaces, or building more complex objects
+       for the mock repository.
+
+     * ``verbose`` (bool):
+       A flag that contains the value of the boolean
+       :ref:`--verbose general option` of pywbemcli.
+
+   * Old-style(all Python versions(*Deprecated*)):  The mock script does not have a
+     ``setup()`` function. This approach is not recommended, but it is supported
+     on all supported Python versions. Using old-style mock scripts in a
+     connection definition prevents caching of its mock environment.
+
+     Old-style mock scripts are executed as Python scripts in Python namespace
+     ``__builtin__``, with the following Python global variables made available:
+
+     * ``CONN`` (:class:`pywbem_mock.FakedWBEMConnection`):
+       This object provides a connection to the mock WBEM server. The methods
+       of this object can be used to create and modify CIM objects in the
+       mock repository and to register providers.
+
+     * ``SERVER`` (:class:`pywbem.WBEMServer`):
+       This object is layered on top of the ``CONN`` object and provides access
+       to higher level features of the mock WBEM server, such as getting the
+       Interop namespace, adding namespaces, or building more complex objects
+       for the mock repository.
+
+     * ``VERBOSE`` (bool):
+       A flag that contains the value of the boolean
+       :ref:`--verbose general option` of pywbemcli.
+
+Thus the structure of a setup script might be as shown in the following example
+that creates an :term:`Interop namespace`, CIM_Namespace and indication subscription
+providers, and MOF in the default_namespace from a MOF file.
+
+.. code-block:: python
+
+    def register_dependents(conn, this_file_path, dependent_file_names):
+        """
+        Register a dependent file name with the pywbemcli dependent file api.
+        This insures that any change to a dependent file will cause the
+        script to be recompiled.
+        """
+        if isinstance(dependent_file_names, six.string_types):
+            dependent_file_names = [dependent_file_names]
+
+        for fn in dependent_file_names:
+            dep_path = os.path.join(os.path.dirname(this_file_path), fn)
+            conn.provider_dependent_registry.add_dependents(this_file_path,
+                                                        dep_path)
+
+    def _setup(conn, server, verbose):
+
+        if sys.version_info >= (3, 5):
+            this_file_path = __file__
+        else:
+            # Unfortunately, it does not seem to be possible to find the file path
+            # of the current script when it is executed using exec(), so we hard
+            # code the file path. This requires that the tests are run from the
+            # repo main directory.
+            this_file_path = 'tests/unit/pywbemcli/simple_interop_mock_script.py'
+            assert os.path.exists(this_file_path)
+
+    # Prepare an Interop namespace and namespace provider a DMTF schema
+
+    INTEROP_NAMESPACE = 'interop'
+
+    interop_mof_file = 'mock_interop.mof'
+    if INTEROP_NAMESPACE not in conn.cimrepository.namespaces:
+        conn.add_namespace(INTEROP_NAMESPACE, verbose=verbose)
+
+    interop_mof_path = os.path.join(
+        os.path.dirname(this_file_path), interop_mof_file)
+    conn.compile_mof_file(interop_mof_path, namespace=INTEROP_NAMESPACE,
+                          verbose=verbose)
+    register_dependents(conn, this_file_path, interop_mof_file)
+
+    ns_provider = pywbem_mock.CIMNamespaceProvider(conn.cimrepository)
+    conn.register_provider(ns_provider, INTEROP_NAMESPACE, verbose=verbose)
+
+    # Add namespace-neutral MOF to the default namespace
+
+    mof_file = 'simple_mock_model.mof'
+    mof_path = os.path.join(os.path.dirname(this_file_path), mof_file)
+    conn.compile_mof_file(mof_path, namespace=None, verbose=verbose)
+    register_dependents(conn, this_file_path, mof_file)
+
+
+    # Interface from pywbemcli for both old and new interfaces
+
+    if sys.version_info >= (3, 5):
+        # New-style setup
+
+        # If the function is defined directly, it will be detected and refused
+        # by the check for setup() functions on Python <3.5, despite being defined
+        # only conditionally. The indirect approach with exec() addresses that.
+        # pylint: disable=exec-used
+        exec("""
+    def setup(conn, server, verbose):
+        _setup(conn, server, verbose)
+    """)
+
+    else:
+        # Old-style setup
+
+        global CONN  # pylint: disable=global-at-module-level
+        global SERVER  # pylint: disable=global-at-module-level
+        global VERBOSE  # pylint: disable=global-at-module-level
+
+        # pylint: disable=undefined-variable
+        _setup(CONN, SERVER, VERBOSE)  # noqa: F821
+
+Examples of pywbemcli startup python script
+-------------------------------------------
+
+Simple MOF based startup file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following is an example of the new-style version of mock script
+``tst_script.py`` that builds CIM classes and instances from pywbem CIM classes
+(:ref:`pywbem:CIM Objects`) representing the cim objects:
+
 .. index:: pair: add_cimobjects(); mock setup methods
 
-The following is an old-style mock script named ``tst_script.py`` that will add
+.. code-block:: python
+
+    from pywbem import CIMQualifierDeclaration, CIMQualifier, CIMClass, \
+        CIMProperty, CIMMethod, CIMParameter, CIMInstance, CIMInstanceName, Uint32
+
+    def setup(conn, server, verbose):
+        """Setup script for python >= version 3.5"""
+
+        # Define qualifier declarations using pywbem CIMQualifierDeclaration class
+
+        description_qd = CIMQualifierDeclaration(
+            'Description', type='string', value=None,
+            scopes=dict(ANY=True),
+            overridable=True, tosubclass=True, translatable=True)
+        in_qd = CIMQualifierDeclaration(
+            'In', type='boolean', value=True,
+            scopes=dict(PARAMETER=True),
+            overridable=False, tosubclass=True)
+        key_qd = CIMQualifierDeclaration(
+            'Key', type='boolean', value=False,
+            scopes=dict(PROPERTY=True, REFERENCE=True),
+            overridable=False, tosubclass=True)
+        out_qd = CIMQualifierDeclaration(
+            'Out', type='boolean', value=False,
+            scopes=dict(PARAMETER=True),
+            overridable=False, tosubclass=True)
+
+        # Define a class using pywbem CIMClass
+        foo_cl = CIMClass(
+            'CIM_Foo',
+            qualifiers=[
+                CIMQualifier('Description', 'Simple CIM Class'),
+            ],
+            properties=[
+                CIMProperty(
+                    'InstanceID', type='string', value=None,
+                    qualifiers=[
+                        CIMQualifier('Key', True),
+                        CIMQualifier('Description', 'This is a key property'),
+                    ],
+                    class_origin='CIM_Foo', propagated=False),
+                CIMProperty(
+                    'IntegerProp', type='uint32', value=None,
+                    qualifiers=[
+                        CIMQualifier('Key', True),
+                        CIMQualifier('Description', 'This is a uint32 property'),
+                    ],
+                    class_origin='CIM_Foo', propagated=False),
+            ],
+            methods=[
+                CIMMethod(
+                    'TestMethod', return_type='uint32',
+                    qualifiers=[
+                        CIMQualifier('Description',
+                                     'Method with one output parameter'),
+                    ],
+                    parameters=[
+                        CIMParameter(
+                            'OutputParam', type='string',
+                            qualifiers=[
+                                CIMQualifier('In', False),
+                                CIMQualifier('Out', True),
+                                CIMQualifier('Description', 'Output parameter'),
+                            ]),
+                    ],
+                    class_origin='CIM_Foo', propagated=False),
+            ]
+        )
+
+        # Define an instance of the class using pywbem CIMInstances.
+        # Note: The mock repository does not add an instance path, so it must be
+        # prepared upfront.
+        foo1 = CIMInstance(
+            'CIM_Foo',
+            path=CIMInstanceName(
+                'CIM_Foo', keybindings=dict(InstanceID="CIM_Foo1")),
+            properties=[
+                CIMProperty('InstanceID', value="CIM_Foo1"),
+                CIMProperty('IntegerProp', value=Uint32(1)),
+            ])
+
+        # Add the CIM objects to the mock repository
+        conn.add_cimobjects([
+            description_qd, in_qd, key_qd, out_qd,
+            foo_cl,
+            foo1,
+        ])
+
+        if verbose:
+            conn.display_repository()
+
+Example setup script old-style with MOF file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following is a  old-style(deprecated) mock script named ``tst_script.py`` that will add
 the same CIM objects as MOF file ``tst_file.mof`` to the mock repository using
 :meth:`~pywbem_mock.FakedWBEMConnection.add_cimobjects`. If the
 :ref:`--verbose general option` is set on the pywbemcli command line, the
@@ -310,97 +652,6 @@ mock repository will be displayed:
     if __name__ == '__builtin__':
         main()
 
-The following is the new-style version of mock script ``tst_script.py``:
-
-.. code-block:: python
-
-    from pywbem import CIMQualifierDeclaration, CIMQualifier, CIMClass, \
-        CIMProperty, CIMMethod, CIMParameter, CIMInstance, CIMInstanceName, Uint32
-
-
-    def setup(conn, server, verbose):
-
-        # Define some qualifier declarations
-        description_qd = CIMQualifierDeclaration(
-            'Description', type='string', value=None,
-            scopes=dict(ANY=True),
-            overridable=True, tosubclass=True, translatable=True)
-        in_qd = CIMQualifierDeclaration(
-            'In', type='boolean', value=True,
-            scopes=dict(PARAMETER=True),
-            overridable=False, tosubclass=True)
-        key_qd = CIMQualifierDeclaration(
-            'Key', type='boolean', value=False,
-            scopes=dict(PROPERTY=True, REFERENCE=True),
-            overridable=False, tosubclass=True)
-        out_qd = CIMQualifierDeclaration(
-            'Out', type='boolean', value=False,
-            scopes=dict(PARAMETER=True),
-            overridable=False, tosubclass=True)
-
-        # Define a class
-        foo_cl = CIMClass(
-            'CIM_Foo',
-            qualifiers=[
-                CIMQualifier('Description', 'Simple CIM Class'),
-            ],
-            properties=[
-                CIMProperty(
-                    'InstanceID', type='string', value=None,
-                    qualifiers=[
-                        CIMQualifier('Key', True),
-                        CIMQualifier('Description', 'This is a key property'),
-                    ],
-                    class_origin='CIM_Foo', propagated=False),
-                CIMProperty(
-                    'IntegerProp', type='uint32', value=None,
-                    qualifiers=[
-                        CIMQualifier('Key', True),
-                        CIMQualifier('Description', 'This is a uint32 property'),
-                    ],
-                    class_origin='CIM_Foo', propagated=False),
-            ],
-            methods=[
-                CIMMethod(
-                    'TestMethod', return_type='uint32',
-                    qualifiers=[
-                        CIMQualifier('Description',
-                                     'Method with one output parameter'),
-                    ],
-                    parameters=[
-                        CIMParameter(
-                            'OutputParam', type='string',
-                            qualifiers=[
-                                CIMQualifier('In', False),
-                                CIMQualifier('Out', True),
-                                CIMQualifier('Description', 'Output parameter'),
-                            ]),
-                    ],
-                    class_origin='CIM_Foo', propagated=False),
-            ]
-        )
-
-        # Define an instance of the class.
-        # Note: The mock repository does not add an instance path, so it must be
-        # prepared upfront.
-        foo1 = CIMInstance(
-            'CIM_Foo',
-            path=CIMInstanceName(
-                'CIM_Foo', keybindings=dict(InstanceID="CIM_Foo1")),
-            properties=[
-                CIMProperty('InstanceID', value="CIM_Foo1"),
-                CIMProperty('IntegerProp', value=Uint32(1)),
-            ])
-
-        # Add the CIM objects to the mock repository
-        conn.add_cimobjects([
-            description_qd, in_qd, key_qd, out_qd,
-            foo_cl,
-            foo1,
-        ])
-
-        if verbose:
-            conn.display_repository()
 
 The pywbemcli command to use this mock script, and then to enumerate its
 CIM class names is::
@@ -409,7 +660,7 @@ CIM class names is::
     CIM_Foo
 
 As you can see, adding CIM objects with a MOF file is more compact than
-doing that in a mock script, but of course the mock script can contain logic,
+doing that in a mock script, but the mock script can contain logic,
 and it allows defining providers.
 
 The following new-style mock script defines and registers a method provider
@@ -473,27 +724,68 @@ of the target CIM instance and returns that property in an output parameter
         conn.register_provider(provider, conn.default_namespace, verbose=verbose)
 
 
-.. _`Caching of mock WBEM servers`:
+The pywbemtools github tests/unit/pywbemcli directory includes several good
+examples of pywbemcli startup scripts that are used for testing including:
 
-Caching of mock WBEM servers
-----------------------------
+1. tests/unit/pywbemcli/simple_foo_mock_script.py that uses the default
+   namespace to create a simple but repository with classes and instances
+   defined in associated MOF files. See
 
-Pywbemcli automatically attempts to cache the mock WBEM server of a connection
-definition. If the connection definition specifies only MOF files and
-new-style mock scripts, that attempt will normally succeed. If it specifies
-any old-style mock script, or if any MOF file fails to compile, or if any
-mock script raises an exception, the mock WBEM server will not be cached.
+.. _a link: git://github.com/pywbem/pywbem.git/tests/unit/pywbemcli/simple_foo_mock_script.py
+
+2. simple_interop_mock_script.py - creates a mock server with interop
+   and user namespaces and installs the namespace provider. It uses local
+   MOF files to provide the qualifier declaration and class definitions.
+
+3. tests/unit/pywbemcli/testmock/wbemserver_mock_script.py which defines a
+   dictionary to build a mock server and uses the class in
+   tests/unit/pywbemcli/testmock/wbemserver_mock_script.py to build a
+   mock environment that can includes building multiple namespaces,
+   installing the namespace provider and subscription providers,
+   and installing sample profiles, central classes, and the
+   association classes for profile traversing.
+
+
+.. index:: pair: mock WBEM server ; cache mock WBEM server
+
+.. _`Caching mock WBEM servers connection definitions`:
+
+
+Caching mock WBEM servers connection definitions
+------------------------------------------------
+
+Pywbemcli automatically attempts to cache the contents of mock WBEM server
+definition when:
+
+1. the definition is saved (``connection save <name>``)
+2. command executed that uses the mock repository (ex. ``class enumerate --no``).
+
+Further, the connection will only be cached if:
+
+1. The setup script is the new-style mock script or a MOF file. The old style
+   setup script cannot be cached.
+2. The default connection file is used (i.e the
+   :ref:`--connections-file general option` is not used).
+3. The MOF compiles correctly and the setup script does not pass an exception
+   back to the caller.
+
+The advantage of caching the mock server definition is the speed of startup,
+in particular if the startup script compiles any classes and if the
+DMTF schema functions of pywbem are used to get CIM qualifier declaration and
+CIM class MOF.
 
 The following data from a mock WBEM server is cached:
 
-- its CIM repository
+- its CIM repository including namespaces defined, CIM qualifiers,
+  CIM classes, and CIM_instances
 - the content of the Python namespaces of its mock scripts (this includes for
   example the definition of any Python classes for the providers)
 - its registered providers
 - a list of dependent files registered by its mock scripts
 
 The caches for the connection definitions are maintained in the
-``.pywbemcli_mockcache`` directory in the user's home directory.
+``.pywbemcli_mockcache`` directory in the user's home directory in separate
+files with names of the form <quid>.<connection name>
 
 If a connection is used, pywbemcli verifies whether its mock WBEM server has been
 cached, and if so, whether the cache is up to date. If it is not up to date,


### PR DESCRIPTION
Clarify usage of general options to be consistent withthe general options design document.

1. Created a table of all the general options and clarified the grouping of the general options
2. Further documented the grouping of general options

Cleaned up the definition of what is a pywbemcli startup script.