### PR TITLE
Ignore security issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,6 +302,9 @@ test_log_file := test_$(python_version_fn).log
 # - 50571 dparse (user safety) 0.4.1 -> 0.5.2, 0.5.1 -> 0.5.2.  ReDos issue
 # - 50885 Pygments 2.7.4 cannot be used on Python 2.7
 # - 50886 Pygments 2.7.4 cannot be used on Python 2.7
+# - 51159 cryptography  v 39.0.0 drops support for C library "LibreSSL" < 3.4
+# - 50885 pygments Lexer infinite loop in versions Pygments versions 1.5 to 2.7.3
+# - 50886 pygments regular expressions vulnerable to ReDos, versions >=1.1,<2.7.4
 
 safety_ignore_opts := \
 	-i 38100 \
@@ -346,6 +349,8 @@ safety_ignore_opts := \
 	-i 50571 \
 	-i 50885 \
 	-i 50886 \
+
+#	-i 51159 \
 
 ifdef TESTCASES
   pytest_opts := $(TESTOPTS) -k $(TESTCASES)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -90,6 +90,9 @@ Released: not yet
 * Fixed tests that fail because XML output of classes and qualifier declarations
   return attributes not ordered before python version 3.8. (see issue #1173).
 
+* Added new entries to Makefile security ignore list for new security
+  issues issued in in September and October 2022 for pywbemclisupport tools
+
 
 **Known issues:**
 


### PR DESCRIPTION
Bypass security issues for"

1. cryptography < 39.0.0

It is development support so I added to the ignore list. This was before rebase to use PR #1199

| REPORT                                                                       |
| checked 238 packages, using default DB                                       |
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID       |
+============================+===========+==========================+==========+
| cryptography               | 3.3       | <39.0.0                  | 51159    |
+==============================================================================+
| Cryptography 39.0.0 drops support for C library "LibreSSL" < 3.4, as these   |
| versions are not receiving security support anymore.                         |
+==============================================================================+
| cryptography               | 3.2.1     | <39.0.0                  | 51159    |
+==============================================================================+
| Cryptography 39.0.0 drops support for C library "LibreSSL" < 3.4, as these   |
| versions are not receiving security support anymore.                         |
+==============================================================================+
| cryptography               | 3.4.7     | <39.0.0                  | 51159    |
+==============================================================================+
| Cryptography 39.0.0 drops support for C library "LibreSSL" < 3.4, as these   |
| versions are not receiving security support anymore.                         |
+==============================================================================+