### PR TITLE
Fix issue in test module wbemserver_moc_class.py

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -90,6 +90,12 @@ Released: not yet
 * Fixed tests that fail because XML output of classes and qualifier declarations
   return attributes not ordered before python version 3.8. (see issue #1173).
 
+* Modify tests/unit/pywbemcli/wbemserver_mock_class.py to remove the
+  CIMInstanceName host lement used in creating a ProfileImplements instance.  That
+  element of CIMInstanceName is not allowed on Create instance of association
+  classes and as of pywbem 1.5.0 that limitation is enforces.  (see issue
+  #1203)
+
 
 **Known issues:**
 

--- a/tests/unit/pywbemcli/testmock/wbemserver_mock_class.py
+++ b/tests/unit/pywbemcli/testmock/wbemserver_mock_class.py
@@ -324,7 +324,6 @@ class WbemServerMock(object):
                 central_inst_path = CIMInstanceName(
                     item[1][0],
                     keybindings=item[1][1],
-                    host=conn.host,
                     namespace=ns)
                 prof_insts = self.wbem_server.get_selected_profiles(
                     registered_org=profile_name[0],


### PR DESCRIPTION
There is a case in this code where an instance is created of an association but the path for one of the references includes the host element in CIMInstanceName object. Documented in isue #1203 and fixed in pywbem issue #2920

This was invalid but only with pywbem 1.5.0 is that validated. Not setting the host element allows passing tests with pywbem 1.5.0