### PR TITLE
Fix issue where instance shrub fails tests with tabulate 0.9.0

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -96,6 +96,10 @@ Released: not yet
   classes and as of pywbem 1.5.0 that limitation is enforces.  (see issue
   #1203)
 
+* Modify instance shrub command to only display the classname of the
+  association class (i.e. reference_class). Even with multi namespace
+  environments the reference class must be in the target namespace.
+
 
 **Known issues:**
 

--- a/tests/unit/pywbemcli/test_instance_cmds.py
+++ b/tests/unit/pywbemcli/test_instance_cmds.py
@@ -732,13 +732,13 @@ SIMPLE_SHRUB_TREE = """TST_Person.name="Mike"
 
 SIMPLE_SHRUB_FULLPATH_TREE = """root/cimv2:TST_Person.name="Mike"
  +-- parent(Role)
- |   +-- //FakedUrl:5988/root/cimv2:TST_Lineage(AssocClass)
+ |   +-- TST_Lineage(AssocClass)
  |       +-- child(ResultRole)
  |           +-- TST_Person(ResultClass)(2 insts)
  |               +-- //FakedUrl:5988/root/cimv2:TST_Person.name="Gabi"
  |               +-- //FakedUrl:5988/root/cimv2:TST_Person.name="Sofi"
  +-- member(Role)
-     +-- //FakedUrl:5988/root/cimv2:TST_MemberOfFamilyCollection(AssocClass)
+     +-- TST_MemberOfFamilyCollection(AssocClass)
          +-- family(ResultRole)
              +-- TST_FamilyCollection(ResultClass)(1 insts)
                  +-- //FakedUrl:5988/root/cimv2:TST_FamilyCollection.name="Family2"
@@ -806,22 +806,22 @@ COMPLEX_SHRUB_TABLE = [
 COMPLEX_SHRUB_FULLPATH_TABLE = [
     'Shrub of root/cimv2:TST_EP.InstanceID=1: paths',
     'Role       AssocClass    ResultRole    ResultClass    Assoc Inst paths',
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        Target        TST_EP         //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=2(refinst:0)',  # noqa E501
+    'Initiator  TST_A3        Target        TST_EP         //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=2(refinst:0)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=5(refinst:1)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=7(refinst:2)',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        Target        TST_EP         //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=2(refinst:0)',  # noqa E501
+    'Initiator  TST_A3        Target        TST_EP         //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=2(refinst:0)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=5(refinst:1)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=7(refinst:2)',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        Target        TST_EP         //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=2(refinst:0)',  # noqa E501
+    'Initiator  TST_A3        Target        TST_EP         //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=2(refinst:0)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=5(refinst:1)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_EP.InstanceID=7(refinst:2)',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        LogicalUnit   TST_LD         //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=3(refinst:0)',  # noqa E501
+    'Initiator  TST_A3        LogicalUnit   TST_LD         //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=3(refinst:0)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=6(refinst:1)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=8(refinst:2)',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        LogicalUnit   TST_LD         //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=3(refinst:0)',  # noqa E501
+    'Initiator  TST_A3        LogicalUnit   TST_LD         //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=3(refinst:0)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=6(refinst:1)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=8(refinst:2)',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3        LogicalUnit   TST_LD         //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=3(refinst:0)',  # noqa E501
+    'Initiator  TST_A3        LogicalUnit   TST_LD         //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=3(refinst:0)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=6(refinst:1)',  # noqa E501
     '                                                      //FakedUrl:5988/root/cimv2:TST_LD.InstanceID=8(refinst:2)']  # noqa E501
 # pylint: enable=line-too-long
@@ -840,12 +840,12 @@ COMPLEX_SHRUB_TABLE_SUMMARY = [
 COMPLEX_SHRUB_FULLPATH_TABLE_SUMMARY = [
     'Shrub of root/cimv2:TST_EP.InstanceID=1: summary',
     'Role       AssocClass    ResultRole    ResultClass      Assoc Inst Count',
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   Target        TST_EP  3',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   Target        TST_EP  3',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   Target        TST_EP  3',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   LogicalUnit   TST_LD  3',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   LogicalUnit   TST_LD  3',  # noqa E501
-    'Initiator  //FakedUrl:5988/root/cimv2:TST_A3   LogicalUnit   TST_LD  3']  # noqa E501
+    'Initiator  TST_A3   Target        TST_EP  3',  # noqa E501
+    'Initiator  TST_A3   Target        TST_EP  3',  # noqa E501
+    'Initiator  TST_A3   Target        TST_EP  3',  # noqa E501
+    'Initiator  TST_A3   LogicalUnit   TST_LD  3',  # noqa E501
+    'Initiator  TST_A3   LogicalUnit   TST_LD  3',  # noqa E501
+    'Initiator  TST_A3   LogicalUnit   TST_LD  3']  # noqa E501
 # pylint: enable=line-too-long
 
 COMPLEX_SHRUB_TREE = [
@@ -880,13 +880,13 @@ SIMPLE_SHRUB_TABLE1 = [
 SIMPLE_SHRUB_FULLPATH_TABLE1 = [
     'Shrub of root/cimv2:TST_Person.name="Mike": paths',
     'Role    AssocClass ResultRole    ResultClass  Assoc Inst paths',
-    'parent  //FakedUrl:5988/root/cimv2:TST_Lineage child TST_Person //FakedUrl:5988/',  # noqa E501
+    'parent  TST_Lineage child TST_Person //FakedUrl:5988/',  # noqa E501
     'root/cimv2:TST_Person.',
     'name="Gabi"',
     '//FakedUrl:5988/',
     'root/cimv2:TST_Person.',
     'name="Sofi"',
-    'member  //FakedUrl:5988/root/cimv2:TST_MemberOfFamilyCollection  family TST_FamilyCollection  //FakedUrl:5988/',  # noqa E501
+    'member  TST_MemberOfFamilyCollection  family TST_FamilyCollection  //FakedUrl:5988/',  # noqa E501
     'root/cimv2:TST_FamilyCollection.',
     'name="Family2"']
 # pylint: enable=line-too-long


### PR DESCRIPTION
Fixed issue where tabulate update to 0.9.0 causes failure of tests.

Issue was a partly backward compatible new limitation by tabulate and an issue with shrub code where we were sending CIMClassName object to tabulate for the association classname  rather than just the classname string

Further it became obvious that we we were displaying more than we need to with the associator class entry in the table which was sending the whole CIMClassname to display rather than just classname.

Changed to only send classname string to display for both table and tree output.

This required changing a number of tests that were displaying the whole URL for the CIMClassName element representing the associator class.

**NOTE:** We did not make this command multi-namespace so if we were to make it multinamespace we would probably want to add the namespace to the association class in the output.

Fixed a number of tests to match output and moved one piece of code to a local method.