### PR TITLE
1.0: Fixed install of incorrect certifi version on Python 2.7

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,8 @@
 # the minimum versions required in requirements.txt and dev-requirements.txt.
 
 
+-r requirements.txt
+
 # Direct dependencies:
 
 # Unit test (imports into testcases):

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -272,7 +272,7 @@ atomicwrites==1.2.1
 attrs==18.2.0; python_version <= '3.9'
 attrs==19.2.0; python_version >= '3.10'
 backports.functools-lru-cache==1.5; python_version < "3.3"
-certifi==2019.9.11
+certifi==2019.11.28
 chardet==3.0.2
 clint==0.5.1
 configparser==4.0.2; python_version < '3.2'


### PR DESCRIPTION
Rolls back PR #1212 into 1.0.1.