### PR TITLE
Restrict some pkg versions in rtd-requirements to avoid missing bullets.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -81,10 +81,9 @@ docutils>=0.13.1; python_version >= '3.5' and python_version <= '3.9'
 docutils>=0.14; python_version >= '3.10'
 sphinx-git>=10.1.1
 GitPython>=2.1.1;
-sphinxcontrib-fulltoc>=1.2.0
 Pygments>=2.1.3; python_version == '2.7'
 Pygments>=2.7.4; python_version >= '3.5'
-sphinx-rtd-theme>=0.5.0
+sphinx-rtd-theme>=1.0.0
 # Babel 2.7.0 fixes an ImportError for MutableMapping which starts failing on Python 3.10
 Babel>=2.7.0
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -110,6 +110,9 @@ Released: not yet
 * Clarify the usage of the general options in the documentation.
   (see issue #1162)
 
+* Clean up issues in the docs where items in bullet lists do not show the
+  bullets Changes rtd-requirements to avoid suspect versions. (see issue #1218)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -188,11 +188,10 @@ docutils==0.13.1; python_version >= '3.5' and python_version <= '3.9'
 docutils==0.14; python_version >= '3.10'
 sphinx-git==10.1.1
 GitPython==2.1.1
-sphinxcontrib-fulltoc==1.2.0
 sphinxcontrib-websupport==1.1.2
 Pygments==2.1.3; python_version == '2.7'
 Pygments==2.7.4; python_version >= '3.5'
-sphinx-rtd-theme==0.5.0
+sphinx-rtd-theme==1.0.0
 Babel==2.7.0
 
 # PyLint (no imports, invoked via pylint script)

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -8,8 +8,7 @@ PyYAML>=3.13
 Sphinx>=1.7.6,<2.0.0; python_version == '2.7'
 Sphinx>=3.5.4,!=4.0.0; python_version >= '3.5'
 docutils>=0.13.1,<0.17; python_version == '2.7'
-# Issue #1218, bullets-list
-docutils>=0.13.1,<0.17; python_version >= '3.5'
+docutils>=0.13.1; python_version >= '3.5'
 sphinx-git>=10.1.1
 # Issue #1218, bullet-list failure with v 0.5.2
 sphinx-rtd-theme>0.5.2

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -8,7 +8,8 @@ PyYAML>=3.13
 Sphinx>=1.7.6,<2.0.0; python_version == '2.7'
 Sphinx>=3.5.4,!=4.0.0; python_version >= '3.5'
 docutils>=0.13.1,<0.17; python_version == '2.7'
-docutils>=0.13.1; python_version >= '3.5'
+docutils>=0.13.1; python_version >= '3.5' and python_version <= '3.9'
+docutils>=0.14; python_version >= '3.10'
 sphinx-git>=10.1.1
 # Issue #1218, bullet-list failure with v 0.5.2
-sphinx-rtd-theme>0.5.2
+sphinx-rtd-theme>=1.0.0

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -8,6 +8,8 @@ PyYAML>=3.13
 Sphinx>=1.7.6,<2.0.0; python_version == '2.7'
 Sphinx>=3.5.4,!=4.0.0; python_version >= '3.5'
 docutils>=0.13.1,<0.17; python_version == '2.7'
-docutils>=0.13.1; python_version >= '3.5'
+# Issue #1218, bullets-list
+docutils>=0.13.1,<0.17; python_version >= '3.5'
 sphinx-git>=10.1.1
-sphinxcontrib-fulltoc>=1.2.0
+# Issue #1218, bullet-list failure with v 0.5.2
+sphinx-rtd-theme>0.5.2


### PR DESCRIPTION
The documentation output is not including the bullets in bullet lists. It prints the lists as if they were separate paragraphs.  Since the other instance of this were tied to specific issues of sphinx-rtd-theme and docutils, we bypassed the specific package versions.

**Note**: it is not sure this resolves the problem and we will not know until it is merged to master but seems logical and in accord with the bugs documented by docutils and sphinx-rtd-theme.

NOTE: This does not modify the version in dev-requirements.txt because these work correctly.