### PR TITLE
Attempt to fix bullet issue on RTD by pinning docutils

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -77,12 +77,13 @@ Sphinx>=1.7.6,<2.0.0; python_version == '2.7'
 Sphinx>=3.5.4,!=4.0.0; python_version >= '3.5' and python_version <= '3.9'
 Sphinx>=4.2.0; python_version >= '3.10'
 docutils>=0.13.1,<0.17; python_version == '2.7'
-docutils>=0.13.1; python_version >= '3.5' and python_version <= '3.9'
-docutils>=0.14; python_version >= '3.10'
+docutils>=0.13.1,<0.17; python_version >= '3.5' and python_version <= '3.9'
+docutils>=0.14,<0.17; python_version >= '3.10'
 sphinx-git>=10.1.1
 GitPython>=2.1.1;
 Pygments>=2.1.3; python_version == '2.7'
 Pygments>=2.7.4; python_version >= '3.5'
+# Issue #1218, bullet-list failure with v 0.5.2
 sphinx-rtd-theme>=1.0.0
 # Babel 2.7.0 fixes an ImportError for MutableMapping which starts failing on Python 3.10
 Babel>=2.7.0

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -5,11 +5,16 @@ six>=1.14.0
 ply>=3.10
 PyYAML>=3.13
 # M2Crypto>=0.30.1  # we cannot install M2Crypto because RTD does not have Swig
+
 Sphinx>=1.7.6,<2.0.0; python_version == '2.7'
-Sphinx>=3.5.4,!=4.0.0; python_version >= '3.5'
+Sphinx>=3.5.4,!=4.0.0; python_version >= '3.5' and python_version <= '3.9'
+Sphinx>=4.2.0; python_version >= '3.10'
 docutils>=0.13.1,<0.17; python_version == '2.7'
-docutils>=0.13.1; python_version >= '3.5' and python_version <= '3.9'
-docutils>=0.14; python_version >= '3.10'
+docutils>=0.13.1,<0.17; python_version >= '3.5' and python_version <= '3.9'
+docutils>=0.14,<0.17; python_version >= '3.10'
 sphinx-git>=10.1.1
+GitPython>=2.1.1;
+Pygments>=2.1.3; python_version == '2.7'
+Pygments>=2.7.4; python_version >= '3.5'
 # Issue #1218, bullet-list failure with v 0.5.2
 sphinx-rtd-theme>=1.0.0


### PR DESCRIPTION
Details:

* Pinned docutils to <0.17 also for recent Python 3.x versions, see https://stackoverflow.com/a/68008428/1424462

* Made rtd-requirements.txt more consistent with dev-requirements.txt by adding Pygments and changed Sphinx reqs.

Signed-off-by: Andreas Maier <andreas.r.maier@gmx.de>