### PR TITLE
Fix issues from Nov 2022 security issue changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,9 @@ test_log_file := test_$(python_version_fn).log
 # - 50571 dparse (user safety) 0.4.1 -> 0.5.2, 0.5.1 -> 0.5.2.  ReDos issue
 # - 50885 Pygments 2.7.4 cannot be used on Python 2.7
 # - 50886 Pygments 2.7.4 cannot be used on Python 2.7
-
+# - 51499 Wheel CVE fix in version 0.38.0 yanked after release
+# - 51358 Safety, before 2.2.0 uses dparse with issue, python 2.7 max is 1.9.0
+# - 51457 py - Latest release has this safety issue i.e. <=1.11.0
 safety_ignore_opts := \
 	-i 38100 \
 	-i 38834 \
@@ -346,6 +348,9 @@ safety_ignore_opts := \
 	-i 50571 \
 	-i 50885 \
 	-i 50886 \
+	-i 51499 \
+	-i 51358 \
+	-i 51457 \
 
 ifdef TESTCASES
   pytest_opts := $(TESTOPTS) -k $(TESTCASES)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -53,12 +53,6 @@ dparse>=0.4.1,<0.5.0; python_version == '2.7'
 dparse>=0.5.2; python_version == '3.5'
 # ver 0.6.2 min requirement by safety 2.2.0
 dparse>=0.6.2; python_version >= '3.6'
-# Safety requires Click>=8.0.2.
-# Repeat the Click requirements from
-# requirements.txt. to keep them in sync.
-Click>=7.1.1,<8.0; python_version <= '3.5'
-# Safety package requires click 8.0.2 minimum
-# Click>=8.0.2; python_version >= '3.6'
 
 # PyYAML is also pulled in by dparse and python-coveralls
 # PyYAML 5.3 fixed narrow build error on Python 2.7

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -53,12 +53,12 @@ dparse>=0.4.1,<0.5.0; python_version == '2.7'
 dparse>=0.5.2; python_version == '3.5'
 # ver 0.6.2 min requirement by safety 2.2.0
 dparse>=0.6.2; python_version >= '3.6'
-# Safety requires Click>6.0 and the upgrade strategy 'eager' causes Click to be
-# upgraded to 8.0.0, unless we repeat the Click requirements from
-# requirements.txt. Keep them in sync.
+# Safety requires Click>=8.0.2.
+# Repeat the Click requirements from
+# requirements.txt. to keep them in sync.
 Click>=7.1.1,<8.0; python_version <= '3.5'
 # Safety package requires click 8.0.2 minimum
-Click>=8.0.2; python_version >= '3.6'
+# Click>=8.0.2; python_version >= '3.6'
 
 # PyYAML is also pulled in by dparse and python-coveralls
 # PyYAML 5.3 fixed narrow build error on Python 2.7

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -45,16 +45,20 @@ coveralls>=2.1.2,<3.0.0; python_version >= '3.5'
 # Safety CI by pyup.io
 # safety 1.9.0 removed support for Python 2.7 (and now also enforces that)
 safety>=1.8.7,<1.9.0; python_version == '2.7'
-safety>=1.9.0; python_version >= '3.5'
+safety>=1.9.0,<2.0.0; python_version == '3.5'
+safety>=2.2.0; python_version >= '3.6'
 # dparse 0.5.0 has an infinite recursion issue on Python 2.7,
 #   see https://github.com/pyupio/dparse/issues/46
 dparse>=0.4.1,<0.5.0; python_version == '2.7'
-dparse>=0.5.2; python_version >= '3.5'
+dparse>=0.5.2; python_version == '3.5'
+# ver 0.6.2 min requirement by safety 2.2.0
+dparse>=0.6.2; python_version >= '3.6'
 # Safety requires Click>6.0 and the upgrade strategy 'eager' causes Click to be
 # upgraded to 8.0.0, unless we repeat the Click requirements from
 # requirements.txt. Keep them in sync.
 Click>=7.1.1,<8.0; python_version <= '3.5'
-Click>=8.0.1; python_version >= '3.6'
+# Safety package requires click 8.0.2 minimum
+Click>=8.0.2; python_version >= '3.6'
 
 # PyYAML is also pulled in by dparse and python-coveralls
 # PyYAML 5.3 fixed narrow build error on Python 2.7

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -49,16 +49,16 @@ Released: not yet
 * Increased minimum version of Click to 8.0.1 on Python >= 3.6 to prepare for
   new features. Adjusted testcases accordingly.
 
-* Extended class and instance enumerate/get/associators/references to allow
-  getting the objects from multiple namespaces with a single request.  This
-  extends the command option --namespace to allow multiple namespaces for
-  these commands using either comma-separated format
-  (ex. --namespace root/cimv2,root/cimv3) or multiple definitions of the option
-  (ex. --namespace root/cimv2 --namespace root/cimv3) The display of results
-  have been extended to include the namespace name for the objects in all
-  of the output formats if multiple namespaces are used. As before, the
-  namespaces are not shown if only a single or the default namespace is
-  requested.(see issues #1058 and #1059)
+* Extended class/instance enumerate/get/associators/references and qualifier
+  enumerate to allow getting the objects from multiple namespaces with a single
+  request.  This extends the command option --namespace to allow multiple
+  namespaces for these commands using either comma-separated format (ex.
+  --namespace root/cimv2,root/cimv3) or multiple definitions of the option (ex.
+  --namespace root/cimv2 --namespace root/cimv3) The display of results have
+  been extended to include the namespace name for the objects in all of the
+  output formats if multiple namespaces are used. As before, the namespaces are
+  not shown if only a single or the default namespace is requested.(see issues
+  #1058 and #1059)
 
 * Add a new option (--object-order) to class and instance
   enumerate/get/associators/references and qualifier enumerate/get to reorder
@@ -112,6 +112,9 @@ Released: not yet
 
 * Clean up issues in the docs where items in bullet lists do not show the
   bullets Changes rtd-requirements to avoid suspect versions. (see issue #1218)
+
+* Update to requirements files for new Nov 2022 security issues with wheel,
+  safety, and py. (see PR # 1627)
 
 **Known issues:**
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -252,6 +252,10 @@ pkginfo==1.4.2
 # Address issue that pyparsing 3.0.0b2 gets installed on py27 (used by packaging)
 pyparsing==2.3.1
 
+packaging==17.0; python_version == '2.7'
+packaging==17.0; python_version == '3.5'
+packaging==21.0; python_version >= '3.6'
+
 # Indirect dependencies for develop (not in dev-requirements.txt)
 
 bleach==3.3.0; python_version == '2.7'
@@ -288,7 +292,6 @@ linecache2==1.0.0
 MarkupSafe==1.1.0
 mistune==0.8.1
 more-itertools==5.0.0
-packaging==17.0
 pandocfilters==1.4.1
 pathlib2==2.2.1
 pbr==1.8.0

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -89,6 +89,7 @@ setuptools==39.0.1; python_version <= '3.6'
 setuptools==40.6.0; python_version == '3.7'
 setuptools==41.5.0; python_version >= '3.8' and python_version <= '3.9'
 setuptools==49.0.0; python_version >= '3.10'
+# Minimum should be set to 0.38.0 when that version released. Issue #1228
 wheel==0.30.0; python_version <= '3.6'
 wheel==0.32.0; python_version == '3.7'
 wheel==0.33.5; python_version >= '3.8'
@@ -107,7 +108,8 @@ nocasedict==1.0.1
 six==1.14.0; python_version <= '3.9'
 six==1.16.0; python_version >= '3.10'
 Click==7.1.1; python_version <= '3.5'
-Click==8.0.1; python_version >= '3.6'
+# Safety package requires click 8.0.2 minimum
+Click==8.0.2; python_version >= '3.6'
 click-spinner==0.1.8
 click-repl==0.1.6; python_version <= '3.5'
 click-repl==0.2; python_version >= '3.6'
@@ -171,10 +173,13 @@ coveralls==2.1.2; python_version >= '3.5'
 
 # Safety CI by pyup.io
 safety==1.8.7; python_version == '2.7'
-safety==1.9.0; python_version >= '3.5'
+# version 2. not compatible with python 3.5
+safety==1.9.0; python_version == '3.5'
+safety==2.2.0; python_version >= '3.6'
 dparse==0.4.1; python_version == '2.7'
-dparse==0.5.2; python_version >= '3.5'
-
+dparse==0.5.2; python_version == '3.5'
+#  version 0.6.2 required by safety 2.2.0
+dparse==0.6.2; python_version >= '3.6'
 # Tox
 tox==2.5.0
 # tox 3.17 requires six>=1.14.0
@@ -290,7 +295,7 @@ pbr==1.8.0
 pexpect==4.2.1
 pickleshare==0.7.4
 ptyprocess==0.5.1
-py==1.10.0
+py==1.11.0
 pytz==2016.10; python_version <= '3.9'
 pytz==2019.1; python_version >= '3.10'
 pyzmq==16.0.4

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -84,7 +84,7 @@
 # * pip 20.2 introduced a new resolver whose backtracking had issues that were resolved only in 21.2.2.
 # * pip>=21.0 is needed for the cryptography package on Windows on GitHub Actions.
 pip==10.0.1; python_version <= '3.5'
-pip==21.2.2; python_version >= '3.6'
+pip==21.3; python_version >= '3.6'
 setuptools==39.0.1; python_version <= '3.6'
 setuptools==40.6.0; python_version == '3.7'
 setuptools==41.5.0; python_version >= '3.8' and python_version <= '3.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,9 @@ PyYAML>=5.3.1; python_version == '2.7'
 PyYAML>=5.3.1; python_version >= '3.5'
 
 yamlloader>=0.5.5
-packaging>=17.0
+packaging>=17.0; python_version == '2.7'
+packaging>=17.0; python_version == '3.5'
+packaging>=21.0; python_version >= '3.6'
 
 # See issue #822 about issue in mock 4.0.3.
 mock>=3.0.0,<4.0.0; python_version < '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ six>=1.14.0; python_version <= '3.9'
 six>=1.16.0; python_version >= '3.10'
 # Click 7.0 has issue #1231 on Windows which we circumvent in the test code
 # Click 7.1 has a bug with output capturing
-# Click 8.0 is incompatible with pywbemcli. See issues #816 (python 2.7 not
+# Click 8.0 is incompatible with python <3.0. See issues #816 (python 2.7 not
 #     supported) and #819 (click-repl incompatible)
 # The Click requirements were copied into dev-requirements.txt in order not to
 # have the safety package upgrade it. Keep them in sync.

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,8 @@ six>=1.16.0; python_version >= '3.10'
 # The Click requirements were copied into dev-requirements.txt in order not to
 # have the safety package upgrade it. Keep them in sync.
 Click>=7.1.1,<8.0; python_version <= '3.5'
-Click>=8.0.1; python_version >= '3.6'
+# Safety package requires click 8.0.2 minimum
+Click>=8.0.2; python_version >= '3.6'
 click-spinner>=0.1.8
 # click-repl 0.2 is needed for compatibility with Click 8.0.
 click-repl>=0.1.6; python_version <= '3.5'


### PR DESCRIPTION
See commit message for details of changes

**NOTE:** Removed review needed because there is an issue with the build for python 3.10, ubuntu, minimum (test / test (ubuntu-latest, 3.10, minimum) and the development setup step hundreds of times too long (hours in place of seconds) when I finally killed that step.  In a previous test it was in the development setup step for over an hour and not completed where all other tests completed the development setup step in about 30 seconds.    Issue tied to pip issuing the following message for each item:

```

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking



```
NOTE: Same issue occurs with local test using python 3.9 in local test of develop with PACKAGE_LEVEL=minimum.



The following is the safety table output defining the current safety issues from 1 November:

` ` `
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID        |
+============================+===========+==========================+==========+
| wheel                      | 0.30.0    | <0.38.0                  | 51499    |
+==============================================================================+
| Wheel 0.38.0 fixes a potential DoS attack via the 'WHEEL_INFO_RE'
regular    |
| expression.
                                                                  |
+==============================================================================+
| wheel                      | 0.32.0    | <0.38.0                  | 51499    |
+==============================================================================+
| Wheel 0.38.0 fixes a potential DoS attack via the 'WHEEL_INFO_RE'
regular    |
| expression.
                                                                  |
+==============================================================================+
| wheel                      | 0.33.5    | <0.38.0                  |
51499    |
+==============================================================================+
| Wheel 0.38.0 fixes a potential DoS attack via the 'WHEEL_INFO_RE'
regular    |
| expression.
                                                                  |
+==============================================================================+
| safety                     | 1.8.7     | <2.2.0                   | 51358    |
+==============================================================================+
| Safety 2.2.0 updates its dependency 'dparse' to include a security
fix.      |
+==============================================================================+
| safety                     | 1.9.0     | <2.2.0                   | 51358    |
+==============================================================================+
| Safety 2.2.0 updates its dependency 'dparse' to include a security
fix.      |
+==============================================================================+
| py                         | 1.10.0    | <=1.11.0                 | 51457    |
+==============================================================================+
| Py throughout 1.11.0 allows remote attackers to conduct a ReDoS
(Regular     |
| expression Denial of Service) attack via a Subversion repository with
        |
| crafted info data, because the InfoSvnCommand argument is mishandled.
        |
| https://github.com/pytest-dev/py/issues/287
                                  |
+==============================================================================