### PR TITLE
Alternate requirements for november security issue fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,9 @@ test_log_file := test_$(python_version_fn).log
 # - 50571 dparse (user safety) 0.4.1 -> 0.5.2, 0.5.1 -> 0.5.2.  ReDos issue
 # - 50885 Pygments 2.7.4 cannot be used on Python 2.7
 # - 50886 Pygments 2.7.4 cannot be used on Python 2.7
-
+# - 51499 Wheel CVE fix in version 0.38.0 yanked after release
+# - 51358 Safety, before 2.2.0 uses dparse with issue, python 2.7 max is 1.9.0
+# - 51457 py - Latest release has this safety issue i.e. <=1.11.0
 safety_ignore_opts := \
 	-i 38100 \
 	-i 38834 \
@@ -346,6 +348,9 @@ safety_ignore_opts := \
 	-i 50571 \
 	-i 50885 \
 	-i 50886 \
+	-i 51499 \
+	-i 51358 \
+	-i 51457 \
 
 ifdef TESTCASES
   pytest_opts := $(TESTOPTS) -k $(TESTCASES)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -45,7 +45,7 @@ coveralls>=2.1.2,<3.0.0; python_version >= '3.5'
 # Safety CI by pyup.io
 # safety 1.9.0 removed support for Python 2.7 (and now also enforces that)
 safety>=1.8.7,<1.9.0; python_version == '2.7'
-safety>=1.9.0; python_version >= '3.5'
+safety>=1.9.0,<2.2.0; python_version >= '3.5'
 # dparse 0.5.0 has an infinite recursion issue on Python 2.7,
 #   see https://github.com/pyupio/dparse/issues/46
 dparse>=0.4.1,<0.5.0; python_version == '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ six>=1.14.0; python_version <= '3.9'
 six>=1.16.0; python_version >= '3.10'
 # Click 7.0 has issue #1231 on Windows which we circumvent in the test code
 # Click 7.1 has a bug with output capturing
-# Click 8.0 is incompatible with pywbemcli. See issues #816 (python 2.7 not
+# Click 8.0 is incompatible with  python <3.0.. See issues #816 (python 2.7 not
 #     supported) and #819 (click-repl incompatible)
 # The Click requirements were copied into dev-requirements.txt in order not to
 # have the safety package upgrade it. Keep them in sync.


### PR DESCRIPTION
This pr:

1. Sets ignore for the new security issues

   * wheel  - There is no new version that corrects the security issue
   * safety - There is a new version that passes the security issue but  causes other issues
   * py -- There is no new version that corrects the security issue