### PR TITLE
 Clarified packages needed to issues reported by safety (split out Ubuntu/Python version issue into separate PR)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ test_log_file := test_$(python_version_fn).log
 # - 50571 dparse (user safety) 0.4.1 -> 0.5.2, 0.5.1 -> 0.5.2.  ReDos issue
 # - 50885 Pygments 2.7.4 cannot be used on Python 2.7
 # - 50886 Pygments 2.7.4 cannot be used on Python 2.7
-# - 51499 Wheel CVE fix in version 0.38.0 yanked after release
+# - 51499 Wheel CVE fix in version 0.38.1 fixes; cannnot be used on python 2.7
 # - 51358 Safety, before 2.2.0 uses dparse with issue, python 2.7 max is 1.9.0
 # - 51457 py - Latest release has this safety issue i.e. <=1.11.0
 safety_ignore_opts := \

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -175,10 +175,12 @@ coveralls==2.1.2; python_version >= '3.5'
 safety==1.8.7; python_version == '2.7'
 # version 2. not compatible with python 3.5
 safety==1.9.0; python_version == '3.5'
+# safety 2.2.0 resolves safety issue #51358
 safety==2.2.0; python_version >= '3.6'
+
 dparse==0.4.1; python_version == '2.7'
 dparse==0.5.2; python_version == '3.5'
-#  version 0.6.2 required by safety 2.2.0
+#  dparse version 0.6.2 required by safety 2.2.0
 dparse==0.6.2; python_version >= '3.6'
 # Tox
 tox==2.5.0


### PR DESCRIPTION
CI tests using  ubuntu.latest (which recently was updated to ubuntu 22.04)  return an error for some tests where the os is ubuntu.latest because this version of python and/or the github action setup-python do not support python <= 3.6. This pr modifies the matrix for the github to define use of ubuntu 20.04 for tests that define use of python version <= 3.6.

