### PR TITLE
add documentation and extensions for  shell completion

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -342,6 +342,23 @@ This documentation uses a few special terms to refer to Python types:
       can be persisted in a pywbem connection file and then referenced by
       name in future pywbemcli calls.
 
+   tab-completion
+      Also known as comand-line completion or autocompletion, is a feature where
+      the an underlying service fills in partially typed commands when the user
+      hits <TAB> or <TAB><TAB>. Tab-completion is available with pywbemcli
+      command line mode when a terminal shell that enables tab-completion is
+      being used (ex. bash, zsh) and tab-completion has been activated for
+      pywbemcli/pywbemlistener or when in the interactive mode.
+
+   auto-suggestion
+      Auto-suggestion is a way to propose input on the command line based on
+      the history of previous commands. The input is compared to the history
+      and when there is an entry in the history file with the given text the
+      proposed completion is show as gray text behind the current input.
+      Pressing the right arrow → or <CTRL-e> will insert this suggestion,
+      <ALT-f> will insert the first word of the suggestion.  This capability is
+      implemented only in the interactive mode of pywbemcli.
+
 
 .. _`Profile advertisement methodologies`:
 
@@ -351,12 +368,12 @@ Profile advertisement methodologies
 This section briefly explains the profile advertisement methodologies defined
 by DMTF. A full description can be found in :term:`DSP1033`.
 
-These methodologies describe how a client can discover the central instances
-of a management profile. Discovering the :term:`central instances` through a
-:term:`management profile` is the recommended approach for clients, over simply enumerating a CIM
-class of choice. The reason is that this approach enables clients to work
-seamlessly with different server implementations, even when they have
-implemented a different set of management profiles.
+These methodologies describe how a client can discover the central instances of
+a management profile. Discovering the :term:`central instances` through a
+:term:`management profile` is the recommended approach for clients, over simply
+enumerating a CIM class of choice. The reason is that this approach enables
+clients to work seamlessly with different server implementations, even when
+they have implemented a different set of management profiles.
 
 The DMTF defines three profile advertisement methodologies in :term:`DSP1033`:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -48,7 +48,7 @@ Released: not yet
 
 * Increased the minimum version of pywbem to 1.6.0. (issue #1244)
 
-* Add a new command that will display text on subjects that have been defined
+* Add a new command that will display help on subjects that have been defined
   for the command.  This allows defining help for subjects that are not
   specific to a particular command.  This is created specifically to
   provide help for the setup to activate shell tab completion. The initial
@@ -56,6 +56,20 @@ Released: not yet
 
 * Add a new command to pywbemcli that calls the current system default web
   browser to view the pywbemtools public documentation.
+
+* Added documentation defining activation of tab-complation in shells.
+  Tab-completion must be activated by the user before the <TAB> can be used
+  in cmd mode to complete the terminal input of command and option names. (see
+  issue #1158)
+
+* Add specific tab-completion for the values of the general option --name and
+  command arguments/names values that look up connection name to enable
+  tab_completion for Click 8 and ignore it for Click 7. Modify general options
+  --mock-server, --connection-file, --keyfile, --certfile that are for files to
+  use the click.Path type which enables tab-completion. Modify --use-pull
+  choice general option to allow the "" choice. so that tab-completion is
+  automatically enabled. (See issue #487)
+
 
 **Cleanup:**
 

--- a/docs/pywbemcli/cmdlineinterface.rst
+++ b/docs/pywbemcli/cmdlineinterface.rst
@@ -27,13 +27,19 @@ within the pywbemtools package.
 
 Pywbemcli provides a command line interface(CLI) interaction with WBEM servers.
 
-The command line can contain the following components:
+The pywbemcli command is invoked with a command  and arguments/options:
+
+.. code-block:: text
+
+    $ pywbemcli [GENERAL-OPTIONS] COMMAND [COMMAND-OPTIONS] [ARGS]
+
+Where the components are:
 
 The pywbemcli command is invoked with a command and arguments/options:
 
 .. code-block:: text
 
-    $ pywbemcli [GENERAL-OPTIONS] COMMAND [COMMAND-OPTIONS] [ARGUMENTSS]
+    $ pywbemcli [GENERAL-OPTIONS] COMMAND [COMMAND-OPTIONS] [ARGUMENTS]
     or
     $ pywbemcli [GENERAL-OPTIONS] COMMAND [ARGUMENTS] [COMMAND-OPTIONS]
 
@@ -58,7 +64,7 @@ Where the components are:
 
 .. index:: pair: command arguments; command components
 
-* **ARGUMENTSS** - Arguments may be defineda specific command. Arguments
+* **ARGUMENTS** - Arguments may be defineda specific command. Arguments
   are not individually
   documented in the help and do not have preceeding dashes. In pywbemcli
   arguments are only used in commands. There are no general arguments.
@@ -76,17 +82,17 @@ do not begin with ``-``.
 
 .. index:: pair: command groups; command interface
 
-Command groups are named after the objects the commands operate on
+Command groups are generally named after the objects the commands operate on
 (ex. ``class``, ``instance``, ``qualifier``, ``server``, ``connection``,
 ``namespace``, etc.). Executing:
 
 .. code-block:: text
 
    $ pywbemcli --help
-   ...
+
    Commands:
      class       Command group for CIM classes.
-   ...
+     ...
 
 
 returns the list of command groups under the title `Commands`.
@@ -94,6 +100,9 @@ returns the list of command groups under the title `Commands`.
 Commands are named after actions on these objects
 (ex. ``get``, ``create``, ``delete``). The list of commands for each group
 is displayed with the command `pywbemcli <group name> --help`.
+
+The list of commands for each group
+is listed with the command `pywbemcli <group name> --help`.
 
 For example, the command:
 
@@ -106,12 +115,67 @@ the MOF output format. The option ``--output-format`` is a general option
 and ``--namespace`` is a command option.
 
 .. index::
-   pair: tab-completion; auto-completion
+   pair: tab-completion; auto-suggestion
    single: auto-suggestion
 
-Pywbemcli supports several modes of tab-completion, auto-completion suggestions
-depending on whether it is in command or interactive mode. This is detailed
-in the following sections.
+Pywbemcli supports  :term:`tab-completion` and :term:`auto-suggestion`
+depending on whether it is in command mode or interactive mode.
+
+  * :ref:`interactive mode` - both tab-completion and auto-suggestion are always
+    available.
+  * :ref:`command mode` - tab-completion is available with some command shells
+    and only when activated for the shell type.  Auto-suggestion is not
+    available.
+
+Tab-completion is available in pywbemcli for:
+    * All comand group and command names
+    * All option names
+    * At least the following general options values:
+        * --name
+        * --mock-server - The completion uses the default connection file
+          unless the --connection-file general option has already been defined
+          for an alternate connection file on the command line.
+        * --connection-file
+        * --keyfile
+        * --certfile
+        * --use-pull
+        * --output-format
+    * At least the following command arguments
+        * help <subject-argument>
+    * At least the following command options
+        * Subscription <command> --owned / -- permanent option
+
+Tab-completion for option/argument values only works for pywbemcli running with
+Python version greater than 3.5. If pywbemcli is running on Python 3.5 or 2.7,
+option values has no support for tab-completion. Nothing happens if <TAB> is
+hit while entering an option value. However, the tab-completion of other
+command line syntax elements is supported.
+
+
+.. code-block:: text
+
+    $ pywbemcli --<TAB><TAB>
+    ... <shows the general options to select from>
+
+    $ pywbemcli <TAB><TAB>
+    ... <shows the command groups to select from>
+
+    $ pywbemcli clas<TAB>
+    ... completes the command group class
+
+    $ pywbemcli class <TAB><TAB>
+    ... <shows the class commands to select from>
+
+    $ pywbemcli -n moc <TAB><TAB>  (Only only with Python 3)
+    ... returns connection names in the default connection file that start
+    ... with moc
+
+Tab-completion for ``pywbemcli`` is used like any other tab-completion by
+hitting <TAB> or <TAB><TAB> where completion is possible. Generally <TAB>
+returns a complete response completion if there is only one available while
+<TAB><TAB> returns a list if there are multiple possible completions but the
+exact behavior depends on the shell and any number of shell flags, extensions
+that are particular to each shell.
 
 .. index::
     pair: Modes of operation; Command mode
@@ -161,41 +225,13 @@ WBEM server on ``localhost``:
 
 .. index::
    pair: tab-completion; command mode
-   pair: auto-completion; command mode
+   pair: auto-suggestion; command mode
 
-In command mode, tab completion is also supported for some command shells, but
-must be enabled specifically for each shell.
+In command mode, tab-completion is supported for some command shells (ex. bash,
+zsh), but must be activated specifically for each command line shell type.
+Section :ref:"Activating shell tab-completion" documents the mechanisms for
+activating shell completion.
 
-.. index::
-   pair: command mode; bash
-
-For example, with a bash shell, enter the following to enable tab completion of
-pywbemcli:
-
-.. code-block:: text
-
-    $ eval "$(_PYWBEMCLI_COMPLETE=source pywbemcli)"
-
-Bash tab completion for ``pywbemcli`` is used like any other bash tab
-completion:
-
-.. code-block:: text
-
-    $ pywbemcli --<TAB><TAB>
-    ... <shows the general options to select from>
-
-    $ pywbemcli <TAB><TAB>
-    ... <shows the command groups to select from>
-
-    $ pywbemcli class <TAB><TAB>
-    ... <shows the class commands to select from>
-
-Pywbemcli uses the Python
-`click package <https://click.palletsprojects.com/en/8.x/>`_
-for its command line handling. See
-`Bash Complete in the Click documentation <https://click.palletsprojects.com/en/8.x/bashcomplete/>`_
-for additional features of the Bash tab completion of pywbemcli. This includes
-information on how to enable the auto complete on the command line.
 
 
 .. index:: pair: interactive mode; command modes
@@ -210,6 +246,9 @@ In interactive mode (also known as :term:`REPL` mode), pywbem provides an
 interactive shell environment that allows typing pywbemcli commands, internal
 commands (for operating the pywbemcli shell), and external commands (that are
 executed in the standard shell of the user).
+
+The pywbemcli shell uses the prompt ``pywbemcli>``. The cursor is shown in
+the examples as an underscore (``_``) in the following examples in this document.
 
 This pywbemcli shell is started when the ``pywbemcli`` command is invoked
 without specifying any command group or command:
@@ -226,9 +265,6 @@ command:
 
     $ pywbemcli [GENERAL-OPTIONS] repl
     pywbemcli> _
-
-The pywbemcli shell uses the prompt ``pywbemcli>``. The cursor is shown in
-the examples above as an underscore (``_``).
 
 The commands and options that can be typed in the pywbemcli shell are the rest
 of the command line that would follow the ``pywbemcli`` command in
@@ -363,14 +399,17 @@ example:
 
 .. index::
    pair: tab-completion; interactive mode
-   pair: auto-completion; interactive mode
+   pair: auto-suggestion; interactive mode
 
-The pywbemcli shell in the interactive mode supports popup help text while for
-commands, arguments, and options typing, where the valid choices are shown
-based upon what was typed so far, and where an item from the popup list can be
-picked with <TAB> or with the cursor keys. It can be used to select from the
-list of general options. In the following examples, an underscore ``_`` is
-shown as the cursor:
+The pywbemcli shell in the interactive mode always supports tab-completion and
+usually with popup help text for commands, arguments, and options typing, where
+the valid choices are shown based upon what was typed so far, and where an item
+from the popup list can be picked with <TAB> or with the cursor keys. It can be
+used to select from the list of general options. Interacitve
+mode tab-completion may differ from command mode tab-completion because the
+support is provided by a python package and not the shell. The following
+examples show interactive mode tab-completion; an
+underscore ``_`` is shown as the cursor:
 
 .. code-block:: text
 
@@ -383,10 +422,80 @@ shown as the cursor:
     pywbemcli> cl_
                   class
 
+Interactive mode uses a combination of tab-completion and auto-suggestion  for
+aut completion which are both always active:
+
+  * :term:`tab-completion` - In this mode, a single <TAB> enables the display of
+    available completion possibilities for command groups, commands, options
+    and selected option values.
+  * :term:`auto-suggestion` - The pywbemcli interactive mode also supports
+    automated parameter suggestions based on the pywbemcli history file which
+    works with the tab-completion described above. The input is compared to
+    the history and when there is another entry starting with the given text,
+    the completion will be shown as gray text behind the current input.
+    Pressing the right arrow → or <CTRL>-e will insert this suggestion.
+
+
+General options can be entered in the interactive mode but they generally only
+apply to the current command defined in the same command input as the general
+option.  Thus, to modify the output format for a particular command, enter the
+--output-format general option before the command.  The following command
+sets the output format to ``table`` before executing the command and then
+restores it to the original value.:
+
+.. code-block:: text
+
+    pywbemcli> --output-format table instance enumerate CIM_Foo
+
+A particular difference between general options in the interactive mode and
+the command line mode is the ability to set general options back to their
+default value in the interactive mode.   In the command mode this is not
+required.  However, in the interactive mode, it could be useful to reset a
+general option to its default value for a command.  Thus, if the log was set
+on startup (--log all), it could be disabled for a command or the user name
+(--user) could be set back to None.  However, normally the default value is
+only set by not including that general option with the command line input
+
+To reset selected string type general options in the interactive, the string
+value of ``""`` (an empty string) is provided as the value which causes pywbemcli
+to set the default value of that general option.
+
+The following code defines a server with ``--user`` and ``--password`` in interactive
+mode.  Then it attempts to modify the user and password to their default values
+of None and execute the class enumerate again.  This command would be executed
+without using the user and password because they have been reset for that command.
+
+The following is an example of tab-completion when the next expected element is
+an option; a single <TAB> enables the display of available completion possibilities:
+
+.. code-block:: text
+
+    pywbemcli> class enumerate <TAB>
+     --di                   Include the complete subclass hierarchy of the requested classes in the result set. Default: Do not include sub...
+     --deep-inheritance     Include the complete subclass hierarchy of the requested classes in the result set. Default: Do not include sub...
+     --lo                   Do not include superclass properties and methods in the returned class(es). Default: Include superclass propert...
+     --local-only           Do not include superclass properties and methods in the returned class(es). Default: Include superclass propert...
+     --nq                   Do not include qualifiers in the returned class(es). Default: Include qualifiers.
+     --no-qualifiers        Do not include qualifiers in the returned class(es). Default: Include qualifiers.
+     --ico                  Include class origin information in the returned class(es). Default: Do not include class origin information.
+
+Example of auto suggestion:
+
+.. code-block:: text
+
+    pywbemcli> cl
+       The command line shows the proposed command grayed out based on that
+       command being previously executed as depicted below. The <TAB> can be
+       used to modify what is selected.
+    pywbemcli> class get PG_TestElement -n test/static
+
+
 .. index:: pair: command history; interactive mode
 
-The pywbemcli shell supports history across multiple invocations of the shell
-using <UP_ARROW>, <DOWN-ARROW> to step through the history line by line.
+The pywbemcli shell supports commandhistory across multiple invocations of the shell
+using <UP_ARROW>, <DOWN-ARROW> to step through the history line by line. The
+pywbem interactive mode history file is separate from any shell history
+files and is used only by pywbemcli.
 
 .. index::
    single: command history; search
@@ -417,45 +526,6 @@ find other commands in the history containing the same string.
 
 The pywbemcli history is stored in the user home directory on linux systems.
 
-.. index::
-   pair: interactive mode; auto-suggestion
-
-The pywbemcli interactive mode also supports automated parameter suggestions based on
-the pywbemcli history file which works with the auto completion described
-above. The input is compared to the history and when there is another entry
-starting with the given text, the completion will be shown as gray text behind
-the current input. Pressing the right arrow → or c-e will insert this
-suggestion.
-
-General options can be entered in the interactive mode but they generally only
-apply to the current command defined in the same command input as the general
-option.  Thus, to modify the output format for a particular command, enter the
---output-format general option before the command.  The following command
-sets the output format to ``table`` before executing the command and then
-restores it to the original value.:
-
-
-.. code-block:: text
-
-    pywbemcli> --output-format table instance enumerate CIM_Foo
-
-A particular difference between general options in the interactive mode and
-the command line mode is the ability to set general options back to their
-default value in the interactive mode.   In the command mode this is not
-required.  However, in the interactive mode, it could be useful to reset a
-general option to its default value for a command.  Thus, if the log was set
-on startup (--log all), it could be disabled for a command or the user name
-(--user) could be set back to None.  However, normally the default value is
-only set by not including that general option with the command line input
-
-To reset selected string type general options in the interactive, the string
-value of ``""`` (an empty string) is provided as the value which causes pywbemcli
-to set the default value of that general option.
-
-The following code defines a server with ``--user`` and ``--password`` in interactive
-mode.  Then it attempts to modify the user and password to their default values
-of None and execute the class enumerate again.  This command would be executed
-without using the user and password because they have been reset for that command.
 
 A summary of help can be viewed by entering ``help repl`` when in the
 interactive mode.
@@ -532,3 +602,193 @@ Pywbemcli terminates with one of the following program exit codes:
 
   If this happens for a command entered in interactive mode, the pywbemcli shell
   is not terminated; only the command that displayed the help is terminated.
+
+
+.. _`Activating shell tab-completion`:
+
+Activating shell tab-completion
+-------------------------------
+
+.. index:: tab-completion
+.. index:: Activating tab-completion
+
+In order to activate shell completion for the shells where pywbemcli supports
+shell completion , you need to informthe shell that completion is available
+for pywbemcli, and how.  The general way this works is through a magic
+environment variable called _<PROG_NAME>PYWBEMCLI_COMPLETE and a callback from
+the shell defined by the value of that variable (ex ``bash_source``).
+
+Pywbemcli includes tab-completion capability for all commands which is:
+
+* Always enabled in the :ref:`Interactive mode`. **NOTE:** Currently the
+  tab-completion of values and arguments is NOT available in the interactive
+  mode.
+* Enabled in the :ref:`command mode` when shell tab-completion is activated
+  and only with the selected shells:
+
+  * **bash shell** - (bash version 4.4 or greater). not all Linux implementations
+    include the bash_complete addon so that the user may be required to install
+    the add-on. A simple test with a utility like ``ls`` will indicate if
+    tab-completion is available  in bash(ex. enter ``ls <TAB>`` to test for the
+    existence of the bash_complet addon).
+  * **zsh shell** - Tab-completion is available for all versions of zsh but
+    may need to be activated in the zsh config file. Furthermore there are two
+    different completion systems for zsh.
+  * **fish shell** - Available for all versions of this shell.
+
+Once tab-completion is activated for pywbemcli, hitting <TAB> or <TAB><TAB> initiates
+tab-completion for command names, option names, and some option values which
+attempts to return the completion of the string where <TAB> was entered. If
+there are multiple possible completions, some shells return the list and others
+do nothing until a second <TAB> is entered.
+
+
+Generally activation of pywbemcli involves the following but with different
+formats for each shell type:
+
+1. Getting from pywbemcli the body of a complete script for the shell type to be
+   activated. This is done by executing a shell statement of form
+   ``_PYWBEMCLI_COMPLETE=bash_source pywbemcli`` which causes the shell completion
+   functionality to call pywbemcli to return the complete script it maintains
+   for bash tab-completion.
+2. Notifying the shell of this completion script by:
+   * notifying the shell with a shell  ``eval`` statement
+   * or saving the script to a complete scriptfile and notifying the shell later by
+   sourcing the resulting complete script file.
+
+Since much of the logic of activating shell tab-completion for pywbemcli is
+based on the shell completion logic in the Click package, that package also
+provides documentation on the activation process. Search for "python Click
+shell completion" in a web browser.
+
+Activation with eval statement
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following table shows the eval statement for the shells that pywbemcli
+supports for tab-completion that would be added to a shell startup file defined
+in table:ref:`tab-complete-eval-statement`. The shell command assigns a value
+to the variable _PYWBEMCLI_COMPLETE and calls back to pywbemcli with the
+variable value and other environment variables set by the shell; pywbemcli
+returns with a string containing the shell complete script. Thus, for bash:
+
+  _COMPLETE_PYWBEMCLI=bash_source pywbemcli
+
+.. _tab-complete-eval-statement:
+
+.. table:: Eval statement and proposed startup shell startup file to use for several shells
+
+  ======  =======================================  =============================================================
+  Shell   File to insert eval statement            Eval command
+  ======  =======================================  =============================================================
+  bash    ~/.bashrc                                eval "$(_PYWBEMCLI_COMPLETE=bash_source pywbemcli)"
+  zsh     ~/.zshrc                                 eval "$(_PYWBEMCLI_COMPLETE=zsh_source pywbemcli)"
+  fish    ~/.config/fish/completions/foo-bar.fish  eval (env _PYWBEMCLI_COMPLETE=fish_source pywbemcli)
+  ======  =======================================  =============================================================
+
+**NOTE:** the variable value (ex. bash_source) must have the two words reversed
+if tab-completion is to be activated with Python 2.7 or Python 3.5 (ex.
+source_bash)
+
+The above method may be difficult when virtual the location of the pywbemcli
+executable is not in the path (ex. when pywbemcli is in a virtual environment)
+since the eval statement initiates a callback to the pywbemcli. Also it can
+slow down terminal startup because pywbemcli must be called on each terminal
+startup to get the completion script definition.
+
+Activation by creating a complete script file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An alternative is to create a complete script file using the same statement
+(ex. ``_PYWBEMCLI_COMPLETE=bash_source pywbemcli``) but saving the resulting
+script in a file.  A file containing shell commands is created that defines the
+completion and completion activation and the tab-completion is then activated
+by sourcing that file (ex. ``source ~/.pywbemcli-complete.bash``).
+
+.. _shell-completion-script:
+
+.. table:: Creation of the complete script file as the tab-completion initialization
+   :name: shell-completion-script
+
+  =====  ==========================================================================
+  Shell  Script
+  =====  ==========================================================================
+  bash   _PYWBEMCLI_COMPLETE=bash_source pywbemcli > ~/.pywbemcli-complete.bash
+  zsh    _PYWBEMCLI_COMPLETE=zsh_source pywbemcli > ~/.pywbemcli-complete.zsh
+  fish   _PYWBEMCLI_COMPLETE=fish_source pywbemcli > ~/.config/fish/completions/pywbemcli.fish
+  =====  ==========================================================================
+
+**NOTE:** the variable value (ex. bash_source) must have the two words reversed
+if tab-completion is to be activated with Python 2.7 or Python 3.5 (ex.
+source_bash)
+
+Tab-completion activation must then be completed completed by sourcing the
+complete script file for example as follows:
+
+.. code-block:: text
+
+    $ source  ~/.pywbemcli-complete.bash
+
+Redo this source statement every time a terminal window is started by, for example:
+
+* including this activation statement in a terminal startup script (ex. in .bashrc)
+* including this activation as part of a virtula environment startup
+* or simply by executing the script itself(ex. ``source  ~/.pywbemcli-complete.bash``).
+
+Thus, for bash, pywbemcli can be activated by inserting the following
+evaluation script into .bashrc if pywbemcli is executable whenever the terminal
+is started:
+
+.. code-block::
+
+    eval "$(_PYWBEMCLI_COMPLETE=bash_source pywbemcli)"
+
+or by creating a completion file one time as follows:
+
+.. code-block::
+
+    # Execute once when pywbemcli is in the path:
+
+    PYWBEMCLII_COMPLETE=bash_source pywbemcli > ~/.pywbemcli-complete.bash
+
+    # Source the resulting file each time a terminal is started
+    source  ~/.pywbemcli-complete.bash
+
+
+Testing that pywbemcli tab-completion is activated
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The tab-completion activation of pywbemcli can be tested in a terminal by
+simply entering part of a known pywbemcli command and using the <TAB> to
+request completion. The example below shows testing:
+
+.. code-block:: text
+
+   $ pywbemcli clas<TAB>
+
+   This should complete the class statement (i.e. expand cmd line to
+   ``pywbemcli class``).
+
+Each shell type has one or more commands to determine the state of
+tab-completion for a particular application.  In bash it is the builtin command
+``complete`` used both to define the tab-completion for a particular command
+and to list which commands have been activated.
+
+Executing the bash builtin ``complete -p pywbemcli`` command should return the
+a line that defines the completion for pywbemcli as follows:
+
+.. code-block:: text
+
+    $ complete -p pywbemcli       < ------------ This returns the following
+
+    complete -o nosort -F _pywbemcli_completion pywbemcli
+
+Zsh has corresponding commands depending on the version of completion and the
+use of the bashcompinit plugin.
+
+Removing shell tab-completion activation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Bash: The command ``complete -r pywbemcli`` removes the tab-completion for
+pywbemcli.
+
+Zsh: TODO

--- a/docs/pywbemcli/cmdlineinterface.rst
+++ b/docs/pywbemcli/cmdlineinterface.rst
@@ -350,8 +350,8 @@ information for external and internal commands:
 .. index:: pair: interactive mode; exit
 
 In addition to using one of the internal exit commands shown in the help text
-above, you can also exit the pywbemcli shell by typing `Ctrl-D` (on Linux,
-OS-X and UNIX-like environments on Windows), or `Ctrl-C` (on native Windows).
+above, you can also exit the pywbemcli shell by typing <Ctrl-D> (on Linux,
+OS-X and UNIX-like environments on Windows), or <Ctrl-C> (on native Windows).
 
 .. index:: pair: interactive mode; --help
 
@@ -433,7 +433,7 @@ aut completion which are both always active:
     works with the tab-completion described above. The input is compared to
     the history and when there is another entry starting with the given text,
     the completion will be shown as gray text behind the current input.
-    Pressing the right arrow → or <CTRL>-e will insert this suggestion.
+    Pressing the right arrow → or <CTRL-e> will insert this suggestion.
 
 
 General options can be entered in the interactive mode but they generally only

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -941,11 +941,13 @@ Help text for ``pywbemcli help`` (see :ref:`help command`):
 
 ::
 
-    Usage: pywbemcli [GENERAL-OPTIONS] help CLASSNAME
+    Usage: pywbemcli [GENERAL-OPTIONS] help SUBJECT
 
       Show help for pywbemcli subjects.
 
-      Show help for pywbemcli for specific pywbemcli subjects.
+      Show help for specific pywbemcli subjects.  This is in addition to the help messages that are available with the -h or
+      --help option for every command group and command in pywbemcli. It helps document pywbemcli subjects that are more
+      general than specific commands and configuration subjects that do not have specific commands
 
       If there is no argument provided, outputs a list and summary of the existing help subjects.
 
@@ -1983,11 +1985,26 @@ Help text for ``pywbemcli repl`` (see :ref:`repl command`):
       Enter the interactive mode where pywbemcli commands can be entered interactively. The prompt is changed to
       'pywbemcli>'.
 
+      <COMMAND> <COMMAND OPTIONS> - Execute pywbemcli command COMMAND
+
+      <GENERAL_OPTIONS> <COMMAND> <COMMAND_OPTIONS> - Execute command with general options.  General options set here exist
+      only for the current command.
+
+      -h, --help - Show pywbemcli general help message, including a                               list of pywbemcli
+      commands. COMMAND -h, --help - Show help message for pywbemcli command COMMAND.
+
+      !SHELL-CMD - Execute shell command SHELL-CMD
+
+      Pywbemcli termination - <CTRL-D>, :q, :quit, :exit
+
       Command history is supported. The command history is stored in a file ~/.pywbemcli_history.
 
-      Pywbemcli may be terminated from this mode by entering <CTRL-D>, :q, :quit, :exit
+      <UP>, <DOWN> - Scroll through pwbemcli command history.
 
-      In the repl mode, <CTRL-r> man be used to initiate an interactive search of the history file.
+      <CTRL-r> <search string> - initiate an interactive search of the pywbemcli history file. Can be used with <UP>, <DOWN>
+      to display commands that match the search string. Editing the search string updates the search.
+
+      <TAB> - tab completion for current command line (can be used anywhere in command)
 
       Interactive mode also includes an autosuggest feature that makes suggestions from the command history as the command
       the user types in the command and options.

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -136,6 +136,7 @@ Help text for ``pywbemcli``:
       statistics    Command group for WBEM operation statistics.
       subscription  Command group to manage WBEM indication subscriptions.
       connection    Command group for WBEM connection definitions.
+      docs          Get pywbemtools documentation in web browser.
       help          Show help for pywbemcli subjects.
       repl          Enter interactive mode (default).
 
@@ -927,6 +928,30 @@ Help text for ``pywbemcli connection test`` (see :ref:`connection test command`)
       --test-pull  If set, the connection is tested to determine if theDMTF defined pull operations (ex.
                    OpenEnumerateInstancesare implemented since these are optional.
       -h, --help   Show this help message.
+
+
+.. _`pywbemcli docs --help`:
+
+pywbemcli docs --help
+---------------------
+
+
+
+Help text for ``pywbemcli docs`` (see :ref:`docs command`):
+
+
+::
+
+    Usage: pywbemcli [GENERAL-OPTIONS] docs
+
+      Get pywbemtools documentation in web browser.
+
+      EXPERIMENTAL
+
+      Calls the current default web browser to display the current stable pywbemtools documentation in a new window.
+
+    Command Options:
+      -h, --help  Show this help message.
 
 
 .. _`pywbemcli help --help`:

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -43,7 +43,7 @@ The command groups are:
 
 The individual commands (no command group) are:
 * :ref:`help command` - Show help for particular pywbemcli subjects
-* :ref:`doc command` - Issue request to web browser to load pywbemcli documentation
+* :ref:`docs command` - Issue request to web browser to load pywbemcli documentation
 * :ref:`repl command` - Enter interactive mode (default).
 
 
@@ -4808,5 +4808,25 @@ Thus, for example:
 
     pywbemcli> help repl
       . . . returns help on the interactive and commands available in that mode
+
+.. index::
+    pair: help; command
+
+.. _`docs command`:
+
+``docs`` command
+----------------
+
+.. index::
+    single: docs command
+    pair: docs; command
+
+The ``docs`` command provides a simple way to access the pywbemtools
+documentation  publically available on the WEB.  This command calls the
+system default WEB browser with the URL of the pywbemtools documentation
+to open a new browser window with the top level page of that documentation and
+immediatly terminates or returns to the repl command line.
+
+This is ``experimental`` as of pywbemtools 1.2.0.
 
 

--- a/docs/pywbemcli/generaloptions.rst
+++ b/docs/pywbemcli/generaloptions.rst
@@ -1824,7 +1824,7 @@ or:
 .. code-block:: text
 
     $ pywbemcli connection delete
-    Select a connection or CTRL_C to abort.
+    Select a connection or <CTRL-C> to abort.
     0: Ronald
     1: testconn
     Input integer between 0 and 1 or Ctrl-C to exit selection: 0

--- a/pywbemtools/_click_extensions.py
+++ b/pywbemtools/_click_extensions.py
@@ -191,11 +191,42 @@ def pywbemtools_format_options(self, ctx, formatter):
             formatter.write_dl(opts)
 
 
+class TabCompleteArgument(click.Argument):
+    """
+    click.argument subclass to be used wherever shell_complete is part of the
+    attributes. Removes the shell_complete attribute if Click version less that
+    version 8 since it is not defined for Click 7
+    """
+    def __init__(self, *args, **kwargs):
+        # Remove the shell_complete option which is not defined in click 7
+        if CLICK_VERSION[0] < 8:
+            kwargs.pop('shell_complete', [])
+
+        super(TabCompleteArgument, self).__init__(*args, **kwargs)
+
+
+class TabCompleteOption(click.Option):
+    """
+    click.Option subclass to override Option for any option that sets the
+    shell_complete attribute. If click version 7, remove the click8 only
+    attribute since that attribute does not exist in Click 7
+    """
+    def __init__(self, *args, **kwargs):
+        """
+        Remove shell_complete option and pass other args and kwargs to
+        superclass
+        """
+        # Remove the shell_complete option which is not defined in click 7
+        if CLICK_VERSION[0] < 8:
+            kwargs.pop('shell_complete', [])
+        super(TabCompleteOption, self).__init__(*args, **kwargs)
+
+
 # The following MutuallyExclusiveOption originated with a number of
 # discussions on stack overflow and a github gist at
 # https://gist.github.com/stanchan/bce1c2d030c76fe9223b5ff6ad0f03db
 
-class MutuallyExclusiveOption(click.Option):
+class MutuallyExclusiveOption(TabCompleteOption):
     """
     This class subclasses Click option to allow defining mutually exclusive
     options.

--- a/pywbemtools/_click_extensions.py
+++ b/pywbemtools/_click_extensions.py
@@ -122,7 +122,7 @@ class PywbemtoolsTopGroup(click.Group):
         on Windows, when using Click 8.0.1 or higher (that is the version which
         introduced this argument).
         """
-        if CLICK_VERSION >= (8, 0, 1):
+        if CLICK_VERSION[0] >= 8:
             kwargs = dict(kwargs)
             kwargs['windows_expand_args'] = False
         return self.main(*args, **kwargs)

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -42,10 +42,13 @@ from ._common import pick_one_from_list, pywbem_error_exception, \
 from ._connection_repository import ConnectionsFileError
 from ._context_obj import ContextObj
 from .._click_extensions import PywbemtoolsGroup, PywbemtoolsCommand, \
-    CMD_OPTS_TXT, GENERAL_OPTS_TXT, SUBCMD_HELP_TXT
+    CMD_OPTS_TXT, GENERAL_OPTS_TXT, SUBCMD_HELP_TXT, TabCompleteArgument
+
 from .._options import add_options, help_option
 from .._output_formatting import output_format_is_table, \
     validate_output_format, format_table, fold_strings
+
+from .pywbemcli import connection_name_complete
 
 # Issue 224 - Exception in prompt-toolkit with python 2.7. Caused because
 # with prompt-toolkit 2 + the completer requires unicode and click_repl not
@@ -151,7 +154,9 @@ def connection_show(context, name, **options):
 
 @connection_group.command('delete', cls=PywbemtoolsCommand,
                           options_metavar=CMD_OPTS_TXT)
-@click.argument('name', type=str, metavar='NAME', required=False)
+@click.argument('name', type=str, metavar='NAME', required=False,
+                shell_complete=connection_name_complete,
+                cls=TabCompleteArgument)
 @add_options(help_option)
 @click.pass_obj
 def connection_delete(context, name):

--- a/pywbemtools/pywbemcli/_cmd_help.py
+++ b/pywbemtools/pywbemcli/_cmd_help.py
@@ -37,7 +37,7 @@ from .._output_formatting import validate_output_format, format_table
 # FUTURE: add the tab-completion function for the subject argument
 
 
-def help_option_subject_shell_complete(ctx, param, incomplete):
+def help_arg_subject_shell_complete(ctx, param, incomplete):
     # pylint: disable=unused-argument
     """
     Shell complete function for the help subjects argument.  This function is
@@ -55,7 +55,7 @@ def help_option_subject_shell_complete(ctx, param, incomplete):
 @click.argument('subject', type=str,
                 metavar='SUBJECT',
                 cls=TabCompleteArgument,
-                shell_complete=help_option_subject_shell_complete,
+                shell_complete=help_arg_subject_shell_complete,
                 required=False)  # pylint: disable=no-member
 @add_options(help_option)
 @click.pass_context
@@ -101,7 +101,8 @@ def help_subjects(ctx, subject):   # pylint: disable=unused-argument
                           HELP_SUBJECTS_DICT[subject][0],
                           HELP_SUBJECTS_DICT[subject][1]))
     else:
-        raise click.ClickException("{} is not a subject in the subjects help".
+        raise click.ClickException("'{}' is not a valid help subject. "
+                                   "Try 'help' for list of subjects.".
                                    format(subject))
 
 

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -23,8 +23,9 @@ from __future__ import absolute_import, print_function
 import os
 import io
 import sys
-import traceback
 import warnings
+import traceback
+import six
 import click
 import click_repl
 from prompt_toolkit.history import FileHistory
@@ -58,7 +59,7 @@ from .._click_extensions import PywbemtoolsTopGroup, GENERAL_OPTS_TXT, \
 from .._utils import pywbemtools_warn, get_terminal_width, \
     CONNECTIONS_FILENAME, DEFAULT_CONNECTIONS_FILE
 from .._options import add_options, help_option
-from .._output_formatting import OUTPUT_FORMAT_GROUPS
+from .._output_formatting import OUTPUT_FORMAT_GROUPS, OUTPUT_FORMATS
 
 
 __all__ = ['cli']
@@ -69,12 +70,19 @@ DEFAULT_DEFINITION_NAME = "not-saved"
 
 # Defaults for some options
 DEFAULT_VERIFY = True  # The default is to verify
+
+# definition of use_pull options
+USE_PULL_OPTIONS = ('yes', 'no', 'either')
 DEFAULT_PULL_CHOICE = 'either'
 USE_PULL_CHOICE = {'either': None, 'yes': True, 'no': False, 'default': None}
 
 # Save for general opiton log parameter from the interactive
 # command before the current command in some cases.
 PREV_LOG_OPTION = None
+
+# OUTPUT_FORMATS must be
+OUTPUT_FORMATS_OPTION = list(OUTPUT_FORMATS)
+OUTPUT_FORMATS_OPTION.append("")
 
 #
 # Context variables passed to click
@@ -88,9 +96,101 @@ CONTEXT_SETTINGS = dict(
     terminal_width=get_terminal_width(),
 )
 
+
 ###########################################################################
 #
-# Support functions for the the cli(...) function
+# Debug support for shell completion functions.  Allows capturing
+# information during shell tab completion to a debug file.
+#
+###########################################################################
+
+# The following functions are support for testing completion functions where
+# functions like print cannot easily be used.
+
+def disp_ctx_params(ctx, param, incomplete, verbose=False):
+    """
+    Display parameters used in the call to a completion function
+    """
+    if verbose:
+        shell_debug_str("ctx attrs:{0}\nparam:  {1}\n incomplete:  {2}".
+                        format(get_ctx_attrs(ctx), param, incomplete))
+
+
+def shell_debug_str(strng):
+    """
+    Print the string in strng to the file debug.txt. Used in debugging
+    click completion functionality
+    """
+    if six.PY2:
+        # pylint: disable=unspecified-encoding
+        with open('debug.txt', 'a') as f:
+            print("{}".format(strng), file=f)
+    else:
+        with open('debug.txt', 'a', encoding='utf-8') as f:
+            print("{}".format(strng), file=f, flush=True)
+
+
+def get_ctx_attrs(ctx):
+    """
+    Write to the file debug.txt the ctx, param, and incomplete if verbose
+    is True. This is used to debug the completion functions since the terminal
+    is already in use as a result of the tab.
+    """
+    attrs = vars(ctx)
+    return '{0}'.format(
+        '\n  '.join('{0}: {1}'.format(i, v) for (i, v) in
+                    sorted(attrs.items())))
+
+
+###########################################################################
+#
+#  Tab completion methods to support tab-completion of options and parameters
+#   with click > 8.0. Tab completion for click < 8.0 exists only for
+#  commands and command groups but not for options and parameters. The
+#  shell-complete attribute did not exist in Click 7.
+#
+###########################################################################
+
+
+def connection_name_complete(ctx, param, incomplete):
+    # pylint: disable=unused-argument
+    """
+    Shell complete function for the general option --name.  This function is
+    called if <TAB> is entered from terminal as part of the value of the
+    --name general option.  It returns all entries in connection table that
+    starte with the string in incomplete.
+    """
+    connections_file = \
+        ctx.params['connections_file'] or DEFAULT_CONNECTIONS_FILE
+    # Output to stderr since terminal is not available because this only
+    # occurs when shell <TAB> entered to start tab-completion
+    try:
+        connections_repo = ConnectionRepository(connections_file)
+        if not connections_repo.file_exists():
+            # Abort does not allow a message and FileError does not abort.
+            # Maybe only solution is message in return since abort gets us
+            # nowhere
+            return "ERROR: Connetion file {} does not exist Aborting". \
+                format(connections_file)
+
+        # Returns list of click CompletionItems from list of keys in
+        # the repository. This never gets called with Click vers lt 8
+        # so the fact the shell_completion does not exist does not matter
+        # pylint: disable=no-member
+        return [
+            click.shell_completion.CompletionItem(name) for name in
+            connections_repo if name.startswith(incomplete)]
+
+    except ConnectionsFileError as cfe:
+        click.echo('Fatal error: {0}: {1}'.
+                   format(cfe.__class__.__name__, cfe),
+                   err=True)
+        raise click.Abort()
+
+
+###########################################################################
+#
+# cli option support functions
 #
 ###########################################################################
 
@@ -408,10 +508,14 @@ def _create_server_instance(
              context_settings=CONTEXT_SETTINGS,
              options_metavar=GENERAL_OPTS_TXT,
              subcommand_metavar=SUBCMD_HELP_TXT)
-@click.option('-n', '--name', 'connection_name', type=str, metavar='NAME',
+@click.option('-n', '--name', 'connection_name',
+              type=str,
+              metavar='NAME',
               cls=MutuallyExclusiveOption,
               mutually_exclusive=["server", 'mock-server'],
               show_mutually_exclusive=False,
+              # shell_complete is ignored with Python 2, See. click changes.
+              shell_complete=connection_name_complete,
               # defaulted in code
               envvar=PYWBEMCLI_NAME_ENVVAR,
               help=u'Use the WBEM server defined by the WBEM connection '
@@ -420,7 +524,9 @@ def _create_server_instance(
                    u'--mock-server options, since each defines a WBEM server. '
                    u'Default: EnvVar {ev}, or none.'.
                    format(ev=PYWBEMCLI_NAME_ENVVAR))
-@click.option('-m', '--mock-server', type=str, multiple=True, metavar="FILE",
+@click.option('-m', '--mock-server', multiple=True,
+              type=click.Path(exists=True, dir_okay=False),
+              metavar="FILE",
               # defaulted in code
               cls=MutuallyExclusiveOption,
               mutually_exclusive=["server", 'name'],
@@ -475,7 +581,9 @@ def _create_server_instance(
                    u'handshake. If --no-verify client bypasses verification. '
                    u'Default: EnvVar {ev}, or "--verify".'.
                    format(ev=PYWBEMCLI_VERIFY_ENVVAR))
-@click.option('--ca-certs', type=str, metavar="CACERTS",
+@click.option('--ca-certs',
+              type=str,
+              metavar="CACERTS",
               default=None,  # defaulted in code
               envvar=PYWBEMCLI_CA_CERTS_ENVVAR,
               help=u'Certificates used to validate the certificate presented '
@@ -490,7 +598,10 @@ def _create_server_instance(
                    u'directory from from a system defined list of directories '
                    u'(pywbem before 1.0).'.
                    format(ev=PYWBEMCLI_CA_CERTS_ENVVAR))
-@click.option('-c', '--certfile', type=str, metavar="FILE",
+@click.option('-c', '--certfile',
+              # Ignore missing file. Issue caught in cim_operations
+              type=click.Path(exists=False, dir_okay=False),
+              metavar="FILE",
               # defaulted in code
               envvar=PYWBEMCLI_CERTFILE_ENVVAR,
               help=u'Path name of a PEM file containing a X.509 client '
@@ -500,7 +611,10 @@ def _create_server_instance(
                    u'default in interactive mode. '
                    u'Default: EnvVar {ev}, or none.'.
                    format(ev=PYWBEMCLI_CERTFILE_ENVVAR))
-@click.option('-k', '--keyfile', type=str, metavar='FILE',
+@click.option('-k', '--keyfile',
+              # Ignore missing file. Issue caught later
+              type=click.Path(exists=False, dir_okay=False),
+              metavar='FILE',
               # defaulted in code
               envvar=PYWBEMCLI_KEYFILE_ENVVAR,
               help=u'Path name of a PEM file containing a X.509 private key '
@@ -522,7 +636,7 @@ def _create_server_instance(
                    u'Default: EnvVar {ev}, or {default}. Min/max: '.
                    format(rt=HTTP_READ_RETRIES, ev=PYWBEMCLI_TIMEOUT_ENVVAR,
                           default=DEFAULT_CONNECTION_TIMEOUT))
-@click.option('-U', '--use-pull', type=click.Choice(['yes', 'no', 'either']),
+@click.option('-U', '--use-pull', type=click.Choice(USE_PULL_OPTIONS),
               # defaulted in code
               envvar=PYWBEMCLI_USE_PULL_ENVVAR,
               help=u'Determines whether pull operations are used for '
@@ -564,6 +678,7 @@ def _create_server_instance(
                           default=DEFAULT_NAMESPACE))
 @click.option('-o', '--output-format', metavar='FORMAT',
               default=None,  # There is no default value
+              type=click.Choice(OUTPUT_FORMATS_OPTION),
               help=u'Output format for the command result. '
                    u'The default and allowed output formats are command '
                    u'specific. '
@@ -602,6 +717,7 @@ def _create_server_instance(
               u'Default: False.')
 @click.option('-C', '--connections-file', metavar='FILE PATH',
               default=None,  # default value set in cli function
+              type=click.Path(dir_okay=False),   # file may not exist yet
               envvar=PYWBEMCLI_CONNECTIONS_FILE_ENVVAR,
               # Keep help text in sync with connections file definitions in
               # _connection_repository.py:
@@ -755,7 +871,8 @@ def cli(ctx, server, connection_name, default_namespace, user, password,
         if connections_file:
             connections_repo = ConnectionRepository(connections_file, verbose)
         elif connections_file == "":
-            connections_repo = DEFAULT_CONNECTIONS_FILE
+            connections_repo = ConnectionRepository(DEFAULT_CONNECTIONS_FILE,
+                                                    verbose)
         else:
             connections_repo = ctx.obj.connections_repo
 

--- a/tests/unit/pywbemcli/cli_test_extensions.py
+++ b/tests/unit/pywbemcli/cli_test_extensions.py
@@ -58,7 +58,7 @@ class CLITestsBase(object):
           desc (:term:`string`):
             Description of the test
 
-          command_grp (:term:`string`):
+          command_grp (:term:`string` or None):
             Pywbemcli command group for this test. This is the first level of
             the command, e.g. 'class' or 'instance'.
 
@@ -269,7 +269,8 @@ class CLITestsBase(object):
                     .format(mock_files)
 
         if not stdin:
-            cmd_line.append(command_grp)
+            if command_grp:
+                cmd_line.append(command_grp)
 
         if local_args:
             cmd_line.extend(local_args)

--- a/tests/unit/pywbemcli/test_general_options.py
+++ b/tests/unit/pywbemcli/test_general_options.py
@@ -570,10 +570,9 @@ TEST_CASES = [
      {'general': ['--mock-server', 'invalidfilename.mof'],
       'cmdgrp': 'connection',
       'args': ['show']},
-     {'stderr': ['Error: Mock file ',
-                 'invalidfilename.mof',
-                 ' does not exist'],
-      'rc': 1,
+     {'stderr': "Invalid value for '-m' / '--mock-server': "
+                "File 'invalidfilename.mof' does not exist.",
+      'rc': 2,
       'test': 'innows'},
      None, OK],
 
@@ -581,10 +580,9 @@ TEST_CASES = [
      {'general': ['--mock-server', 'invalidfilename.mofx'],
       'cmdgrp': 'connection',
       'args': ['show']},
-     {'stderr': ['Mock file ',
-                 'invalidfilename.mofx',
-                 ' has invalid suffix'],
-      'rc': 1,
+     {'stderr': "Invalid value for '-m' / '--mock-server': File " \
+                "'invalidfilename.mofx' does not exist.",
+      'rc': 2,
       'test': 'innows'},
      None, OK],
 
@@ -716,10 +714,9 @@ TEST_CASES = [
      {'general': ['--mock-server', 'fred'],
       'cmdgrp': 'connection',
       'args': ['show']},
-     {'stderr': ['Error: Mock file',
-                 'fred',
-                 'has invalid suffix'],
-      'rc': 1,
+     {'stderr': ["Invalid value for", "'-m' / '--mock-server'", "File",
+                 "'fred'", "does not exist."],
+      'rc': 2,
       'test': 'innows'},
      None, OK],
 
@@ -1417,7 +1414,7 @@ TEST_CASES = [
 
      None, OK],
 
-    ['Verify  misc general options with "" value reset the option to None',
+    ['Verify  misc general options with value "" resetting the option to None',
      {'general': ['--server', 'http://blah',
                   '--default-namespace', 'root/blah',
                   '--user', 'fred',
@@ -1430,11 +1427,11 @@ TEST_CASES = [
       'stdin': ['--log "" --output-format "" connection show'],
       'cmdgrp': None},
      # Test for user and password with no values
-     # NOTE: We cannot really test --log, --output-format changes
+     # NOTE: We cannot really test --log, changes
      {'stdout': ['default-namespace  root/blah'],
       'rc': 0,
       'test': 'innows'},
-     None, OK],
+     None, RUN],
 
     # NOTE: Other tests for --log option in interactive mode in test_log_option
 
@@ -1770,6 +1767,7 @@ realsvr2  http://realsvr2  root/cim5    fred           90  False                
 
 
 class TestGeneralOptions(CLITestsBase):
+    # pylint: disable=too-few-public-methods
     """
     Test the general options including statistics,  --server,
     --timeout, --use-pull, --pull-max-cnt, --output-format

--- a/tests/unit/pywbemcli/test_help_cmd.py
+++ b/tests/unit/pywbemcli/test_help_cmd.py
@@ -25,10 +25,13 @@ from .cli_test_extensions import CLITestsBase
 
 DEFAULT_HELP_LINES = """Help subjects
 subject name    subject description
---------------  --------------------------------------------
+--------------  ---------------------------------------------
+activate        Activating shell tab completion
 instancename    InstanceName parameter in instance cmd group
 repl            Using the repl command
+tab-completion  Where tab completion is provided by pywbemcli
 """
+
 REPL_HELP_LINES = [
     'repl - Using the repl command',
     'In the interactive mode pywbem returns control to a terminal. General'
@@ -38,6 +41,15 @@ REPL_HELP_LINES = [
 INSTANCENAME_HELP_LINES = [
     "An instance path is specified using the INSTANCENAME argument and "
 ]
+
+TABCOMPLETION_HELP_LINES = [
+    "Tab completion is always available in the interactive mode (see help repl)"
+]
+
+ACTIVATE_HELP_LINES = [
+    "Pywbemcli includes tab-completion capability for all commands for certain"
+]
+
 
 OK = True     # mark tests OK when they execute correctly
 RUN = True    # Mark OK = False and current test case being created RUN
@@ -79,6 +91,13 @@ TEST_CASES = [
      {'stdout': INSTANCENAME_HELP_LINES,
       'test': 'innows'},
      None, OK],
+
+    ['Verify help command tab-completion',
+     {'subject': ['tab-completion']},
+     {'stdout': TABCOMPLETION_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
 ]
 
 

--- a/tests/unit/pywbemcli/test_help_cmd.py
+++ b/tests/unit/pywbemcli/test_help_cmd.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 """
 Test the help command that displays help text on specific pywbemcli
-subjects.
+subjects. This command is not part of any command group.
 
 """
 
@@ -58,7 +58,7 @@ SKIP = False
 
 
 TEST_CASES = [
-    # List of testcases.
+    # List of testcases for test help <subject>.
     # Each testcase is a list with the following items:
     # * desc: Description of testcase.
     # * inputs: String, or tuple/list of strings, or dict of 'env', 'args',
@@ -75,53 +75,58 @@ TEST_CASES = [
     #     is skipped.
 
     ['Verify help command default response list of subjects',
-     {'subject': []},
+     {'args': ['help'], },
      {'stdout': DEFAULT_HELP_LINES,
       'test': 'innows'},
-     None, OK],
+     None, RUN],
 
     ['Verify help command repl',
-     {'subject': ['repl']},
+     {'args': ['help', 'repl']},
      {'stdout': REPL_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     ['Verify help command instancename',
-     {'subject': ['instancename']},
+     {'args': ['help', 'instancename']},
      {'stdout': INSTANCENAME_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
     ['Verify help command tab-completion',
-     {'subject': ['tab-completion']},
+     {'args': ['help', 'tab-completion']},
      {'stdout': TABCOMPLETION_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify help command tab-completion',
+     {'args': ['help', 'blah']},
+     {'stderr': ["'blah' is not a valid help subject."],
+      'rc': 1,
       'test': 'innows'},
      None, OK],
 
 ]
 
 
-class TestHelpCmd(CLITestsBase):  # pylint: disable=too-few-pubic-methods
+class TestCmdHelp(CLITestsBase):  # pylint: disable=too-few-public-methods
     """
     Test the general options including statistics,  --server,
     --timeout, --use-pull, --pull-max-cnt, --output-format
     """
+
+    command_group = None
+
     @pytest.mark.parametrize(
         "desc, inputs, exp_response, mock, condition", TEST_CASES)
-    def test_execute_pywbemcli(self, desc, inputs, exp_response, mock,
-                               condition):
-        # pylint: disable=unused-argument
+    def test_help_cmd(self, desc, inputs, exp_response, mock, condition):
         """
-        Execute pybemcli with the defined input and test output.
+        Common test method for those commands and options in the
+        class command that can be tested.  This includes:
 
+          * Subcommands like help that do not require access to a server
+
+          * Subcommands that can be tested with a single execution of a
+            pywbemcli command.
         """
-
-        command_group = 'help'
-
-        if inputs['subject']:
-            inputs = inputs['subject']
-        else:
-            inputs = []
-
-        self.command_test(desc, command_group, inputs, exp_response,
-                          None, condition)
+        self.command_test(desc, self.command_group, inputs, exp_response,
+                          mock, condition, verbose=True)

--- a/tests/unit/pywbemcli/test_tabcompletion_unit.py
+++ b/tests/unit/pywbemcli/test_tabcompletion_unit.py
@@ -1,0 +1,287 @@
+# (C) Copyright 2023 IBM Corp.
+# (C) Copyright 2023 Inova Development Inc.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the completer functions implemented in pywbemcli.
+"""
+
+from __future__ import absolute_import, print_function
+
+import os
+import io
+import packaging.version
+import pytest
+import click
+
+
+from pywbemtools.pywbemcli._cmd_help import help_arg_subject_shell_complete
+from pywbemtools.pywbemcli.pywbemcli import connection_name_complete
+# pylint: disable=relative-beyond-top-level
+from ..pytest_extensions import simplified_test_function
+# pylint: enable=relative-beyond-top-level
+
+# Click version as a tuple. Used to control tab-completion features
+CLICK_VERSION = packaging.version.parse(click.__version__).release
+# boolean True if click version 8 or greater.
+CLICK_V_8 = CLICK_VERSION[0] >= 8
+
+
+TEST_CONNECTION_YAML = """connection_definitions:
+    testconn:
+        name: testconn
+        server: http://blah
+        user: fred
+        password: fred
+        default-namespace: root/cimv2
+        timeout: 30
+        use-pull: null
+        pull-max-cnt: 1000
+        verify: true
+        certfile: cert1.pem
+        keyfile: null
+        ca-certs: null
+        mock-server: []
+    tmp1:
+        name: tmp1
+        server: null
+        user: null
+        password: null
+        default-namespace: root/cimv2
+        timeout: 30
+        use-pull: null
+        pull-max-cnt: 1000
+        verify: true
+        certfile: null
+        keyfile: null
+        ca-certs: null
+        mock-server:
+        - temp_mock_model.mof
+default_connection_name: null
+"""
+
+SCRIPT_DIR = os.path.dirname(__file__)
+CONNECTION_REPO_TEST_FILE_PATH = os.path.join(SCRIPT_DIR,
+                                              'tst_tabcompletion.yaml')
+
+
+@pytest.fixture(scope='function', autouse=True)
+def remove_connections_file():
+    """Remove the test connection file before and after each test"""
+
+    if os.path.isfile(CONNECTION_REPO_TEST_FILE_PATH):
+        os.remove(CONNECTION_REPO_TEST_FILE_PATH)
+    yield
+    if os.path.isfile(CONNECTION_REPO_TEST_FILE_PATH):
+        os.remove(CONNECTION_REPO_TEST_FILE_PATH)
+
+
+OK = True     # mark tests OK when they execute correctly
+RUN = True    # Mark OK = False and current test case being created RUN
+FAIL = False  # Any test currently FAILING or not tested yet
+SKIP = False  # mark tests that are to be skipped.
+
+
+TESTCASES_CONNECTION_NAME_COMPLETE = [
+    # Testcases for pywbemcli.connection_name_complete()
+    #
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * kwargs: Keyword arguments for the test function:
+    #   * ctx: Value of connection file or None
+    #   * yaml: string containing yaml to put into file
+    #   * file_exists: boolean defining whether test expects file to exist
+    #   * incomplete; the incomplete value for the connection name
+    #   * ext_rtn; list of connection names to be returned
+    # * exp_exc_types: Expected exception type(s), or None.
+    # * exp_warn_types: Expected warning type(s), or None.
+    # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
+
+    ('Verify with connections file, valid incomplete completes name',
+     dict(ctx=CONNECTION_REPO_TEST_FILE_PATH,
+          yaml=TEST_CONNECTION_YAML,
+          file=CONNECTION_REPO_TEST_FILE_PATH,
+          file_exists=True,
+          incomplete="testco",
+          exp_rtn=["testconn"]),
+     None, None, OK),
+
+    ('Verify with connections file, invalid incomplete returns empty list',
+     dict(ctx=CONNECTION_REPO_TEST_FILE_PATH,
+          yaml=TEST_CONNECTION_YAML,
+          file=CONNECTION_REPO_TEST_FILE_PATH,
+          file_exists=True,
+          incomplete="mock",
+          exp_rtn=[]),
+     None, None, OK),
+
+    ('Verify with connections file, complete is complete returns name',
+     dict(ctx=CONNECTION_REPO_TEST_FILE_PATH,
+          yaml=TEST_CONNECTION_YAML,
+          file=CONNECTION_REPO_TEST_FILE_PATH,
+          file_exists=True,
+          incomplete="testconn",
+          exp_rtn=["testconn"]),
+     None, None, OK),
+
+    ('Verify with connections file, single char incomplete returns name',
+     dict(ctx=CONNECTION_REPO_TEST_FILE_PATH,
+          yaml=TEST_CONNECTION_YAML,
+          file=CONNECTION_REPO_TEST_FILE_PATH,
+          file_exists=True,
+          incomplete="t",
+          exp_rtn=["testconn", 'tmp1']),
+     None, None, OK),
+
+    ('Verify with connections file, empty incomplete incomplete returns name',
+     dict(ctx=CONNECTION_REPO_TEST_FILE_PATH,
+          yaml=TEST_CONNECTION_YAML,
+          file=CONNECTION_REPO_TEST_FILE_PATH,
+          file_exists=True,
+          incomplete="",
+          exp_rtn=["testconn", 'tmp1']),
+     None, None, OK),
+
+    ('Verify with connections file, incomplete too big fails',
+     dict(ctx=CONNECTION_REPO_TEST_FILE_PATH,
+          yaml=TEST_CONNECTION_YAML,
+          file=CONNECTION_REPO_TEST_FILE_PATH,
+          file_exists=True,
+          incomplete="testconnextra",
+          exp_rtn=[]),
+     None, None, OK),
+
+    ('Verify with  invalid connections file, generates exception',
+     dict(ctx="CONNECTION_REPO_TEST_FILE_PATH",
+          yaml=TEST_CONNECTION_YAML,
+          file=CONNECTION_REPO_TEST_FILE_PATH,
+          file_exists=False,
+          incomplete="",
+          exp_rtn=["testconn", 'tmp1']),
+     click.ClickException, None, CLICK_V_8),
+
+    # Needs click version as condition to avoid unwanted exception because
+    # of the exception expected.
+    ('Verify with  invalid connections file, generates exception',
+     dict(ctx="CONNECTION_REPO_TEST_FILE_PATH",
+          yaml=TEST_CONNECTION_YAML,
+          file=None,
+          file_exists=False,
+          incomplete="",
+          exp_rtn=[]),
+     click.ClickException, None, CLICK_V_8),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_CONNECTION_NAME_COMPLETE)
+@simplified_test_function
+def test_connection_name_complete(testcase, ctx, yaml, file, file_exists,
+                                  incomplete, exp_rtn):
+    """
+    Test function for connection_name_complete() function
+    """
+    # Ignore the test for Click  version 7
+    if not CLICK_V_8:
+        return
+
+    # Create a fake click context object that contains param "connections_file"
+    class ClickContextMock(object):  # pylint: disable=too-few-public-methods
+        """ Create a mock click context object containing param attribute """
+        def __init__(self):
+            self.params = {"connections_file": None}
+
+    # Setup to emulate the params in click ctx
+    context = ClickContextMock()
+    context.params = {"connections_file": ctx}
+
+    # Conditionally create connections file by writing YAML text to the file
+    if file_exists:
+        if yaml:
+            with io.open(file, "w", encoding='utf-8') as repo_file:
+                repo_file.write(yaml)
+
+    param = None  # The method being tested ignores param
+
+    rtn_items = connection_name_complete(context, param, incomplete)
+
+    # Ensure that exceptions raised in the remainder of this function
+    # are not mistaken as expected exceptions
+    assert testcase.exp_exc_types is None
+
+    act_rtn_values = [item.value for item in rtn_items]
+    assert act_rtn_values == exp_rtn
+
+
+TESTCASES_HELP_ARG_SUBJECT_SHELL_COMPLETE = [
+    # Testcases for _cmd_help.help_arg_subject_shell_complete()
+    #
+    # Each list item is a testcase tuple with these items:
+    # * desc: Short testcase description.
+    # * kwargs: Keyword arguments for the test function:
+    #   * incomplete = string representing the incomplete subject name
+    #   * exp_rtn: expected function return.
+    # * exp_exc_types: Expected exception type(s), or None.
+    # * exp_warn_types: Expected warning type(s), or None.
+    # * condition: Boolean condition for testcase to run, or 'pdb' for debugger
+
+    ('Verify correct completion with last character missing',
+     dict(incomplete="act",
+          exp_rtn=["activate"]),
+     None, None, OK),
+
+    ('Verify correct completion with complete input',
+     dict(incomplete="activate",
+          exp_rtn=["activate"]),
+     None, None, OK),
+
+    ('Verify correct whe incomplete is empty.',
+     dict(incomplete="",
+          exp_rtn=["repl", "activate", "instancename", "tab-completion"]),
+     None, None, OK),
+
+    ('Verify empty rtn when invalid incomplete input, i.e. no match',
+     dict(incomplete="blah", exp_rtn=[]),
+     None, None, OK),
+]
+
+
+@pytest.mark.parametrize(
+    "desc, kwargs, exp_exc_types, exp_warn_types, condition",
+    TESTCASES_HELP_ARG_SUBJECT_SHELL_COMPLETE)
+@simplified_test_function
+def test_help_arg_subject_shell_complete(testcase, incomplete, exp_rtn):
+    """
+    Test function for help_arg_subject_shell_complete() function. Note that
+    the parameters ctx and param are not used by the function being tested
+    """
+    # Ignore the test for Click  version lt 8
+    if CLICK_VERSION[0] < 8:
+        return
+
+    # The code to be tested
+    # ctx and param not used by the complete function.
+    ctx = None
+    param = None
+    # Note: Must return a list of click CompletionItem object.
+    rtn_items = help_arg_subject_shell_complete(ctx, param, incomplete)
+
+    # Ensure that exceptions raised in the remainder of this function
+    # are not mistaken as expected exceptions
+    assert testcase.exp_exc_types is None
+
+    act_rtn_values = [item.value for item in rtn_items]
+    assert act_rtn_values == exp_rtn

--- a/tools/click_help_capture.py
+++ b/tools/click_help_capture.py
@@ -216,7 +216,7 @@ def create_help_cmd_list(script_cmd, script_name):
             if script_name == 'pywbemcli':
                 if level == 0:
                     line = 'Help text for ``{}``:'.format(script_name)
-                elif level == 1 and name not in ('repl', 'help'):
+                elif level == 1 and name not in ('repl', 'help', 'docs'):
                     line = 'Help text for ``{}`` (see :ref:`{} command ' \
                     'group`):'.format(command, name)
                 else:


### PR DESCRIPTION
See commits for PR details

adds :
1. tab-completion documentation  DONE
2. new command for help-subjects of which only activate repl, and instancename exist now,   Done
3.completion functions for shell-tab completion for  --name value,--mock-server values, and help <subject  Done, tested manually
4. value completion for --mock-server and --connection-file work but we added no special code since the dir function is part
of the standard click script Done Note that these functions are unit tested but their use is limited to click gt version 8 (i.e. python
gt 3.5.
5. Unit tests for the new completion functions for --name general option and help <subject> subject argument.
6. Zsh basic documentation for tab completion.  
7. Extended test of help command to cover extra case.  Note: This required one word change to cli_test_extensions to account for command with no command-group.


NOT DONE

31 testing with fish shell not started.  I propose we not even try it for this release, just leave it in as supported because click takes care of the differences. 
2. Add something to pywbemlistener to define tab-completion. Probably just a reference to the documentation in pywbemcli. Separate Issue #1278.  This means simply moving the existing tab-completion documentation to the common documentation and changing it so references to pywbemcli are generalized to be either pywbemcli or pywbemlistener.