### PR TITLE
Modify github actions test to use ubuntu-20.04 for Python 3.5,3.6 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,20 +33,77 @@ jobs:
       id: select_matrix
       # Select full matrix when scheduled or when releasing, and normal matrix
       # otherwise. The matrix is defined as a JSON string.
+      # This This technique documented in:
+      #    https://stackoverflow.com/questions/65384420/how-to-make-a-github-action-matrix-element-conditional
       # TODO: Find a way to define this with less escapes.
+      # NOTE: ubuntu-20.04 is used for Python 3.5+3.6 because ubuntu-latest no longer supports them. See issue #1245.
       run: |
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\", \"windows-latest\" ], \
             \"python-version\": [ \"2.7\", \"3.5\", \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ], \
+            \"exclude\": [ \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"minimum\" \
+              } \
+            ], \
+            \"include\": [ \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"minimum\" \
+              } \
+            ] \
           }" >> $GITHUB_OUTPUT; \
         else \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\" ], \
-            \"python-version\": [ \"2.7\", \"3.5\", \"3.10\" ], \
+            \"python-version\": [ \"2.7\", \"3.10\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"include\": [ \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.5\", \
+                \"package_level\": \"minimum\" \
+              }, \
               { \
                 \"os\": \"macos-latest\", \
                 \"python-version\": \"2.7\", \
@@ -97,11 +154,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Create local cache directory for Docker images
-      if: ${{ matrix.os in ('ubuntu-latest', 'ubuntu-20.04') }}
+      if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04' }}
       run: |
         mkdir -p ${{ env.DOCKER_CACHE_DIR }}
     - name: Set up caching for local Docker image cache directory
-      if: ${{ matrix.os in ('ubuntu-latest', 'ubuntu-20.04') }}
+      if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04' }}
       uses: actions/cache@v1
       with:
         path: ${{ env.DOCKER_CACHE_DIR }}
@@ -109,7 +166,7 @@ jobs:
         restore-keys: |
           docker-cache-
     - name: Get WBEM server image from Docker Hub or local Docker image cache
-      if: ${{ matrix.os in ('ubuntu-latest', 'ubuntu-20.04') }}
+      if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04' }}
       run: |
         if [[ ! -f ${{ env.DOCKER_CACHE_DIR }}/${{ env.TEST_SERVER_IMAGE_TAR }} ]]; then \
           echo "Pulling image from Docker Hub"; \
@@ -186,7 +243,7 @@ jobs:
       run: |
         make test
     - name: Run end2end test with WBEM server Docker image
-      if: ${{ matrix.os in ('ubuntu-latest', 'ubuntu-20.04') }}
+      if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04' }}
       env:
         PACKAGE_LEVEL: ${{ matrix.package_level }}
         # Uses TEST_SERVER_IMAGE variable

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,10 @@ Released: not yet
 
 **Cleanup:**
 
+* Use Ubuntu 20.04 for os target for some github CI tests because python setup
+  action does not include Python 3.5 and 3.6 for ubuntu 22.04 (i.e ubuntu-latest as
+  of Nov 2022) which causes scheduled test failure.  See issue #1245
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
For details, see the commit message.
This splits off the ubuntu-20.04 fixes from Karl's PR #1246 