### PR TITLE
Fix issue with instance table column ordering

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,11 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fix issue where "instance get" was not properly ordering the columns
+  of the table output for commands like "-o table instance get ... --pl p1,p2,p3".
+  The table was not being output in the same order as the list of properties in
+  the property list option. (see issue #1259)
+
 * Changed the development status of the Python package from "4 - Beta" to
   "5 - Production/Stable". This actually applies since version 1.1.0.
   (issue #1237)

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -1031,7 +1031,8 @@ def cmd_instance_get(context, instancename, options):
     property_list = resolve_propertylist(options['propertylist'])
 
     results = ResultsHandler(context, options, output_fmt, "instance",
-                             instancepath, instpath=instancepath)
+                             instancepath, instpath=instancepath,
+                             property_list=property_list)
 
     for ns in results:
         try:

--- a/tests/unit/pywbemcli/test_instance_cmds.py
+++ b/tests/unit/pywbemcli/test_instance_cmds.py
@@ -1738,6 +1738,38 @@ Instances: CIM_Foo
       'test': 'linesnows'},
      SIMPLE_MOCK_FILE, OK],
 
+    ['Table output with --propertylist correct column order',
+     {'args': ['get', 'TST_PERSON', '-k', 'name=Gabi',
+               '--pl', 'gender,likes,name'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """
+Instances: TST_Person
++------------+------------+--------+
+| gender     | likes      | name   |
+|------------+------------+--------|
+| 1 (female) | 2 (movies) | "Gabi" |
++------------+------------+--------+
+""",
+      'rc': 0,
+      'test': 'linesnows'},
+     ASSOC_MOCK_FILE, OK],
+
+    ['Table output with --propertylist correct column order test 2',
+     {'args': ['get', 'TST_PERSON', '-k', 'name=Gabi',
+               '--pl', 'name,gender,likes'],
+      'general': ['--output-format', 'table']},
+     {'stdout': """
+Instances: TST_Person
++--------+------------+------------+
+| name   | gender     | likes      |
+|--------+------------+------------|
+| "Gabi" | 1 (female) | 2 (movies) |
++--------+------------+------------+
+""",
+      'rc': 0,
+      'test': 'linesnows'},
+     ASSOC_MOCK_FILE, OK],
+
     ['INSTANCENAME with namespace, option --namespace with same ns (error)',
      ['get', 'root/cimv2:CIM_Foo.InstanceID="CIM_Foo1"',
       '--namespace', 'root/cimv2'],
@@ -3162,6 +3194,25 @@ InstanceID      IntegerProp
       'rc': 0,
       'test': 'linesnows'},
      ASSOC_MOCK_FILE, OK],
+
+    ['Verify instance associators with --pl in sorted order test 2',
+     {'args': ['associators', 'TST_Person.name="Mike"',
+               '--pl', 'Name,Likes,Gender'],
+      'general': ['--output-format', 'table']},
+     {'stdout': ["""Instances: TST_FamilyCollection
++----------------------+-----------+------------+------------+
+| classname            | name      | likes      | gender     |
+|----------------------+-----------+------------+------------|
+| TST_FamilyCollection | "Family2" |            |            |
+| TST_Person           | "Gabi"    | 2 (movies) | 1 (female) |
+| TST_Person           | "Sofi"    |            | 1 (female) |
++----------------------+-----------+------------+------------+
+"""],
+      'rc': 0,
+      'test': 'linesnows'},
+     ASSOC_MOCK_FILE, RUN],
+
+
 
     ['Verify instance associators with --pl in unsorted order',
      {'args': ['associators', 'TST_Person.name="Mike"',


### PR DESCRIPTION
Fix issue where -o table instance get was not correctly ordering the …table columns

When a property list is provided, pywbemcli is expected to order the columns in the table output in the same order as the order of properties in the --pl option.  This works for enumerate, etc. but not for the instance get command.  One option was missing from the call that sets up the display so that the propert_list option was not being passed to cim_object_display.

Corrected and tests added for proper ordering of the table columns.