### PR TITLE
pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -161,8 +161,9 @@ pipdeptree>=2.2.0
 #   not yet have proper dependency handling, so we do not install pip-check-reqs
 #   on Python 2.7.
 # pip-check-reqs 2.3.2 is needed to have proper support for pip<=21.3.
+# pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11.
 pip-check-reqs>=2.3.2; python_version >= '3.5' and python_version <= '3.10'
-pip-check-reqs>=2.4.0; python_version >= '3.11'
+pip-check-reqs>=2.4.3; python_version >= '3.11'
 
 # safety 2.3.5 started pinning packaging to <22.0 and requires >=21.0
 packaging>=17.0; python_version == '2.7'

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -276,7 +276,7 @@ pkginfo==1.4.2
 # Package dependency management tools
 pipdeptree==2.2.0
 pip-check-reqs==2.3.2; python_version >= '3.5' and python_version <= '3.10'
-pip-check-reqs==2.4.0; python_version >= '3.11'
+pip-check-reqs==2.4.3; python_version >= '3.11'
 
 # pyzmq is used (at least?) by jupyter.
 #pyzmq==16.0.4


### PR DESCRIPTION
No review needed.