### PR TITLE
Fix issue where --pl option rtns error with poor explanation.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -21,6 +21,8 @@ Released: not yet
 * Changed the development status of the Python package from "4 - Beta" to
   "5 - Production/Stable". This actually applies since version 1.1.0.
   (issue #1237)
+* Fix minor issue where if user input --pl "a, b, c" they would get strange
+  error.  Now fails with error stating that space not allowed in property list.
 
 **Enhancements:**
 

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -1264,6 +1264,7 @@ def cmd_instance_enumerate(context, classname, options):
     """
     conn = context.pywbem_server.conn
     output_fmt = validate_output_format(context.output_format, ['CIM', 'TABLE'])
+    breakpoint()
 
     property_list = resolve_propertylist(options['propertylist'])
 

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -1264,7 +1264,6 @@ def cmd_instance_enumerate(context, classname, options):
     """
     conn = context.pywbem_server.conn
     output_fmt = validate_output_format(context.output_format, ['CIM', 'TABLE'])
-    breakpoint()
 
     property_list = resolve_propertylist(options['propertylist'])
 

--- a/pywbemtools/pywbemcli/_common.py
+++ b/pywbemtools/pywbemcli/_common.py
@@ -88,11 +88,15 @@ def resolve_propertylist(propertylist):
     if len(propertylist) == 1 and not propertylist[0]:
         propertylist = []
 
-    # expand any comma separated entries in the list
+    # Expand any comma separated entries in the list
     else:
         pl = []
         for item in propertylist:
             if ',' in item:
+                if ' ' in item:
+                    raise click.ClickException(
+                        "Spaces not allowed in comma-separated PropertyList: {}"
+                        .format(','.join(propertylist)))
                 pl.extend(item.split(','))
             else:
                 pl.append(item)

--- a/tests/unit/pywbemcli/test_common.py
+++ b/tests/unit/pywbemcli/test_common.py
@@ -602,33 +602,37 @@ TESTCASES_RESOLVE_PROPERTYLIST = [
 
     ('Verify simple property list with 2 entries',
      dict(pl_str=("abc,def",), exp_pl=['abc', 'def']),
-     None, None, True),
+     None, None, OK),
 
     ('Verify propertylist with single property entry',
      dict(pl_str=("abc",), exp_pl=['abc']),
-     None, None, True),
+     None, None, OK),
 
     ('Verify multiple properties',
      dict(pl_str=("abc", "def"), exp_pl=['abc', 'def']),
-     None, None, True),
+     None, None, OK),
 
-    ('Verify multiple properties and both multiple in on option and multiple '
+    ('Verify multiple properties and both multiple in one option and multiple '
      'options.',
      dict(pl_str=None, exp_pl=None),
-     None, None, True),
+     None, None, OK),
 
     ('Verify multiple properties and both multiple in on option and multiple '
      'options.',
      dict(pl_str=("ab", "def", "xyz,rst"), exp_pl=['ab', 'def', 'xyz', 'rst']),
-     None, None, True),
+     None, None, OK),
 
     ('Verify empty propertylist',
-     dict(pl_str=("",), exp_pl=[]),
-     None, None, False),
+     dict(pl_str=(""), exp_pl=None),
+     None, None, OK),
 
-    ('Verify empty propertylist',
-     dict(pl_str=(""), exp_pl=[]),
-     None, None, False),
+    ('Verify propertylist with commas and spaces fails',
+     dict(pl_str=("a, b,c",), exp_pl=[]),
+     click.ClickException, None, OK),
+
+    ('Verify propertylist with commas and spaces fails',
+     dict(pl_str=("a, b,c", "abc"), exp_pl=[]),
+     click.ClickException, None, OK),
 ]
 
 


### PR DESCRIPTION
In the case where the user inputs a property list )--pl) with the definition as a comma separated list a,b,c but with quotes around the list and a space "a, b,c"" catches and reports the exact error.