### PR TITLE
Add a new command that shows help subjects of general interest

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -48,6 +48,12 @@ Released: not yet
 
 * Increased the minimum version of pywbem to 1.6.0. (issue #1244)
 
+* Add a new command that will display text on subjects that have been defined
+  for the command.  This allows defining help for subjects that are not
+  specific to a particular command.  This is created specifically to
+  provide help for the setup to activate shell tab completion. The initial
+  subjects are repl and instancename
+
 **Cleanup:**
 
 * Use Ubuntu 20.04 for os target for some github CI tests because python setup

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -136,7 +136,7 @@ Help text for ``pywbemcli``:
       statistics    Command group for WBEM operation statistics.
       subscription  Command group to manage WBEM indication subscriptions.
       connection    Command group for WBEM connection definitions.
-      help          Show help message for interactive mode.
+      help          Show help for pywbemcli subjects.
       repl          Enter interactive mode (default).
 
 
@@ -941,9 +941,15 @@ Help text for ``pywbemcli help`` (see :ref:`help command`):
 
 ::
 
-    Usage: pywbemcli [GENERAL-OPTIONS] help
+    Usage: pywbemcli [GENERAL-OPTIONS] help CLASSNAME
 
-      Show help message for interactive mode.
+      Show help for pywbemcli subjects.
+
+      Show help for pywbemcli for specific pywbemcli subjects.
+
+      If there is no argument provided, outputs a list and summary of the existing help subjects.
+
+      If an argument is provided, it outputs the help for the subject(s) defined by the argument.
 
     Command Options:
       -h, --help  Show this help message.

--- a/pywbemtools/pywbemcli/__init__.py
+++ b/pywbemtools/pywbemcli/__init__.py
@@ -38,6 +38,7 @@ from ._cmd_connection import *        # noqa: F403,F401
 from ._cmd_profile import *           # noqa: F403,F401
 from ._cmd_statistics import *        # noqa: F403,F401
 from ._cmd_subscription import *      # noqa: F403,F401
+from ._cmd_help import *              # noqa: F403,F401
 
 from ._context_obj import *           # noqa: F403,F401
 from ._connection_repository import *   # noqa: F403,F401

--- a/pywbemtools/pywbemcli/_cmd_help.py
+++ b/pywbemtools/pywbemcli/_cmd_help.py
@@ -46,7 +46,11 @@ def help_subjects(ctx, subject):   # pylint: disable=unused-argument
     """
     Show help for pywbemcli subjects.
 
-    Show help for pywbemcli for specific pywbemcli subjects.
+    Show help for specific pywbemcli subjects.  This is in addition to the
+    help messages that are available with the -h or --help option for every
+    command group and command in pywbemcli. It helps document pywbemcli
+    subjects that are more general than specific commands and configuration
+    subjects that do not have specific commands
 
     If there is no argument provided, outputs a list and summary of the
     existing help subjects.
@@ -55,6 +59,9 @@ def help_subjects(ctx, subject):   # pylint: disable=unused-argument
     by the argument.
     """
     subjects = sorted(list(HELP_SUBJECTS_DICT.keys()))
+
+    # If there is no subject argument, output a table of all of the subjects and
+    # short descriptions.
 
     if not subject:
         # max_subject_len = len(max(subjects, key=len))
@@ -70,47 +77,49 @@ def help_subjects(ctx, subject):   # pylint: disable=unused-argument
 
         return
 
+    # If a subject exists, output the help for that subject
     if subject in HELP_SUBJECTS_DICT:
-        click.echo("{0} - {1}\n".format(subject,
-                                        HELP_SUBJECTS_DICT[subject][0]))
-        click.echo(HELP_SUBJECTS_DICT[subject][1])
+        click.echo("{0} - {1}\n{2}".
+                   format(subject,
+                          HELP_SUBJECTS_DICT[subject][0],
+                          HELP_SUBJECTS_DICT[subject][1]))
+    else:
+        raise click.ClickException("{} is not a subject in the subjects help".
+                                   format(subject))
 
 
-def repl_help_msg():
-    """
-    Return the repl help message. Duplicates message in pywbemcli.py because
-    of formatting.
-    """
-    return """
-The interactive (repl) mode is entered when pywbemcli is started without a
-command. General options may be defined on the command line.
+# FUTURE: Move this to new module along with repl command. Every cmd should
+#         be in separate module with its data.
+# pylint: disable=invalid-name
+repl_help_msg = """
+In the interactive mode pywbem returns control to a terminal. General
+options, commands, and command options may be entered. Pywbemcli remains in the
+interactive mode until terminated by <CTRL-D>, :q, :quit,  or :exit.
 
-In the interactive mode control is returned to the terminal and general options
-, commands, and command options may be entered. Pywbemcli remains in the
-interactive mode until terminated.
-
-General entered in the interactive mode are only active for the current
-command whereupon the original general options are restored.
+Pywbemcli enters interactive (repl) mode when started without a command.
+General options entered in the interactive mode are only active for the current
+command where upon the command line general options are restored.
 
 The prompt for the interactive mode is pywbemcli$
 
-In the interactive mode tab-completion <TAB> and autosuggestion help (suggest
-completions based on the pywbemcli history file) are active.
+Tab-completion <TAB> and autosuggestion help (suggest completions based on the
+pywbemcli history file) are always active in the interactive mode.
 
 The following can be entered in interactive (repl) mode:
 
   COMMAND                     Execute pywbemcli command COMMAND.
   !SHELL-CMD                  Execute shell command SHELL-CMD.
   <CTRL-D>, :q, :quit, :exit  Exit interactive mode.
-  <CTRL-r>  <search string>   To search the  command history file.
+  <CTRL-r>  <search string>   Search pywbemcli command history file.
                               Can be used with <UP>, <DOWN>
                               to display commands that match the search string.
                               Editing the search string updates the search.
-  <TAB>                       Tab completion (can be used anywhere).
+  <TAB>                       Tab completion (can be used anywhere on cmd line).
   -h, --help                  Show pywbemcli general help message, including a
                               list of pywbemcli commands.
   COMMAND --help              Show help message for pywbemcli command COMMAND.
-  help                        Show this help message.
+  help                        Show help subjects.
+  help repl                   Show help for the repl mode.
   :?, :h, :help               Show help message about interactive mode.
   <UP>, <DOWN>                Scroll through pwbemcli command history.
 
@@ -121,16 +130,26 @@ The following can be entered in interactive (repl) mode:
 Example:
    pywbemcli -n mock1
 
+   ... pywbemcli is now in the interactive mode
+
    pywbemcli$ class enumerate
       . . .  Returns classes enumerated.
+
+   pywbemcli$ class get blah
+      . . . Returns mof for class blah if it exists.
+
+   pywbemcli$ -v namespace list
+      . . . Gets namespaces for connection named mock1 but with verbose output
+
+      . . . Returns to non-verbose output for next command
    pywbemcli$
-"""
+"""  # pylint: enable=invalid-name
 
 
 # FUTURE: Other subjects: connection file, command structure, checkpointing
 # of mock server definition, arguments and options, etc.
 HELP_SUBJECTS_DICT = {
-    "repl": ("Using the repl command", repl_help_msg()),
+    "repl": ("Using the repl command", repl_help_msg),
     # 'activate': ("Activating shell tab completion",
     #             tab_completion_help_msg),
     'instancename': ('InstanceName parameter in instance cmd group',

--- a/pywbemtools/pywbemcli/_cmd_instance.py
+++ b/pywbemtools/pywbemcli/_cmd_instance.py
@@ -709,15 +709,9 @@ def instance_shrub(context, instancename, **options):
 #
 ####################################################################
 
+# Subject help used both in instance cmd group and in the help cmd
 
-def show_help_instancename():
-    """
-    Show the help message on how to specify an instance using INSTANCENAME
-    and the --key and --namespace options.
-    """
-    # Note: This help text has a fixed width since it is too complex to
-    # dynamically render it to a given width.
-    click.echo("""
+HELP_INSTANCENAME_MSG = """
 An instance path is specified using the INSTANCENAME argument and optionally the
 --key and --namespace options. It can be specified in three ways:
 
@@ -815,7 +809,18 @@ An instance path is specified using the INSTANCENAME argument and optionally the
      0: cimv2/test:TST_Person.FirstName="Albert",LastName="Einstein"
      1: cimv2/test:TST_Person.FirstName="Marie",LastName="Curie"
      Input integer between 0 and 1 or Ctrl-C to exit selection: _
-""")
+"""
+
+
+def show_help_instancename():
+    """
+    Show the help message on how to specify an instance using INSTANCENAME
+    and the --key and --namespace options.
+    """
+    # Note: This help text has a fixed width since it is too complex to
+    # dynamically render it to a given width.
+
+    click.echo(HELP_INSTANCENAME_MSG)
 
 
 def get_instancename(context, instancename, options, default_all_ns=False):

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -668,7 +668,6 @@ def cli(ctx, server, connection_name, default_namespace, user, password,
 
         https://pywbemtools.readthedocs.io/en/stable/
     """
-
     # Process cli options to validate options and produce resolved options,
     # i.e. the options with any defaults applied for non None options.
     # Produces new variables resolved... so that later tests can confirm that
@@ -976,37 +975,7 @@ def cli(ctx, server, connection_name, default_namespace, user, password,
             ctx.obj.pywbem_server.disconnect()
 
 
-@cli.command('help', options_metavar=GENERAL_OPTS_TXT)
-@add_options(help_option)
-@click.pass_context
-def repl_help(ctx):  # pylint: disable=unused-argument
-    """
-    Show help message for interactive mode.
-    """
-    click.echo("""
-The following can be entered in interactive mode:
-
-  COMMAND                     Execute pywbemcli command COMMAND.
-  !SHELL-CMD                  Execute shell command SHELL-CMD.
-  <CTRL-D>, :q, :quit, :exit  Exit interactive mode.
-  <CTRL-r>  <search string>   To search the  command history file.
-                              Can be used with <UP>, <DOWN>
-                              to display commands that match the search string.
-                              Editing the search string updates the search.
-  <TAB>                       Tab completion (can be used anywhere).
-  -h, --help                  Show pywbemcli general help message, including a
-                              list of pywbemcli commands.
-  COMMAND --help              Show help message for pywbemcli command COMMAND.
-  help                        Show this help message.
-  :?, :h, :help               Show help message about interactive mode.
-  <UP>, <DOWN>                Scroll through pwbemcli command history.
-
-  COMMAND: May be two words (class enumerate) for commands that are within
-  a group or a single word for special commands like `repl` that are not in
-  a group.
-""")
-
-
+# FUTURE: Move repl to its own module in pywbemcli.
 @cli.command('repl', options_metavar=GENERAL_OPTS_TXT)
 @add_options(help_option)
 @click.pass_context
@@ -1053,7 +1022,7 @@ def repl(ctx):
     if history_file.startswith('~'):
         history_file = os.path.expanduser(history_file)
 
-    click.echo("Enter 'help' for help, <CTRL-D> or ':q' "
+    click.echo("Enter 'help repl' for help, <CTRL-D> or ':q' "
                "to exit pywbemcli or <CTRL-r> to search history, ")
 
     prompt_kwargs = {

--- a/tests/end2endtest/test_errors.py
+++ b/tests/end2endtest/test_errors.py
@@ -66,5 +66,6 @@ stderr:
     assert rc == 0, details('rc')
     assert len(reswarn_lines) == 0, details('stderr', '0 ResourceWarning lines')
     assert len(out_lines) == 2, details('stdout', '2 stdout lines')
-    assert re.match(r"Enter 'help' for help", out_lines[0]), details('stdout')
+    assert re.match(r"Enter 'help repl' for help", out_lines[0]), \
+        details('stdout')
     assert re.match(r"OpenPegasus", out_lines[1]), details('stdout')

--- a/tests/unit/pywbemcli/test_general_options.py
+++ b/tests/unit/pywbemcli/test_general_options.py
@@ -176,7 +176,7 @@ GENERAL_HELP_LINES = [
       statistics  Command group for WBEM operation statistics.
       subscription  Command group to manage WBEM indication subscriptions.
       connection  Command group for WBEM connection definitions.
-      help        Show help message for interactive mode.
+      help        Show help for pywbemcli subjects.
       repl        Enter interactive mode (default)."""
 ]
 
@@ -222,27 +222,25 @@ Command Options:
 
 """  # noqa: E501
 
-INTERACTIVE_HELP = """
-The following can be entered in interactive mode:
 
-  COMMAND                     Execute pywbemcli command COMMAND.
-  !SHELL-CMD                  Execute shell command SHELL-CMD.
-  <CTRL-D>, :q, :quit, :exit  Exit interactive mode.
-  <CTRL-r>  <search string>   To search the  command history file.
-                              Can be used with <UP>, <DOWN>
-                              to display commands that match the search string.
-                              Editing the search string updates the search.
-  <TAB>                       Tab completion (can be used anywhere).
-  -h, --help                  Show pywbemcli general help message, including a
-                              list of pywbemcli commands.
-  COMMAND --help              Show help message for pywbemcli command COMMAND.
-  help                        Show this help message.
-  :?, :h, :help               Show help message about interactive mode.
-  <UP>, <DOWN>                Scroll through pwbemcli command history.
+SUBJECT_HELP = """Usage: pywbemcli [GENERAL-OPTIONS] help SUBJECT
 
-  COMMAND: May be two words (class enumerate) for commands that are within
-  a group or a single word for special commands like `repl` that are not in
-  a group.
+  Show help for pywbemcli subjects.
+
+  Show help for specific pywbemcli subjects.  This is in addition to the help
+  messages that are available with the -h or --help option for every command
+  group and command in pywbemcli. It helps document pywbemcli subjects that are
+  more general than specific commands and configuration subjects that do not
+  have specific commands
+
+  If there is no argument provided, outputs a list and summary of the existing
+  help subjects.
+
+  If an argument is provided, it outputs the help for the subject(s) defined by
+  the argument.
+
+Command Options:
+  -h, --help  Show this help message.
 """
 
 OK = True     # mark tests OK when they execute correctly
@@ -293,11 +291,11 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-    ['Verify help response (interactive help)).',
+    ['Verify help response (help command).',
      {'general': [],
       'cmdgrp': 'help',
-      'args': []},
-     {'stdout': INTERACTIVE_HELP,
+      'args': ['--help']},
+     {'stdout': SUBJECT_HELP,
       'rc': 0,
       'test': 'innows'},
      None, OK],

--- a/tests/unit/pywbemcli/test_help_cmd.py
+++ b/tests/unit/pywbemcli/test_help_cmd.py
@@ -1,0 +1,108 @@
+# (C) Copyright 2017 IBM Corp.
+# (C) Copyright 2017 Inova Development Inc.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test the help command that displays help text on specific pywbemcli
+subjects.
+
+"""
+
+import pytest
+
+from .cli_test_extensions import CLITestsBase
+
+DEFAULT_HELP_LINES = """Help subjects
+subject name    subject description
+--------------  --------------------------------------------
+instancename    InstanceName parameter in instance cmd group
+repl            Using the repl command
+"""
+REPL_HELP_LINES = [
+    'repl - Using the repl command',
+    'In the interactive mode pywbem returns control to a terminal. General'
+]
+
+# This is only a one line test becasuse it is also tested with instance cmds
+INSTANCENAME_HELP_LINES = [
+    "An instance path is specified using the INSTANCENAME argument and "
+]
+
+OK = True     # mark tests OK when they execute correctly
+RUN = True    # Mark OK = False and current test case being created RUN
+FAIL = False  # Any test currently FAILING or not tested yet
+SKIP = False
+
+
+TEST_CASES = [
+    # List of testcases.
+    # Each testcase is a list with the following items:
+    # * desc: Description of testcase.
+    # * inputs: String, or tuple/list of strings, or dict of 'env', 'args',
+    #     'general', and 'stdin'. See the 'inputs' parameter of
+    #     CLITestsBase.command_test() in cli_test_extensions.py for detailed
+    #     documentation.
+    # * exp_response: Dictionary of expected responses (stdout, stderr, rc) and
+    #     test definition (test: <testname>). See the 'exp_response' parameter
+    #     of CLITestsBase.command_test() in cli_test_extensions.py for
+    #     detailed documentation.
+    # * mock: None, name of file (.mof or .py), or list thereof.
+    # * condition: If True the test is executed, if 'pdb' the test breaks in the
+    #     the debugger, if 'verbose' print verbose messages, if False the test
+    #     is skipped.
+
+    ['Verify help command default response list of subjects',
+     {'subject': []},
+     {'stdout': DEFAULT_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify help command repl',
+     {'subject': ['repl']},
+     {'stdout': REPL_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify help command instancename',
+     {'subject': ['instancename']},
+     {'stdout': INSTANCENAME_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+]
+
+
+class TestHelpCmd(CLITestsBase):  # pylint: disable=too-few-pubic-methods
+    """
+    Test the general options including statistics,  --server,
+    --timeout, --use-pull, --pull-max-cnt, --output-format
+    """
+    @pytest.mark.parametrize(
+        "desc, inputs, exp_response, mock, condition", TEST_CASES)
+    def test_execute_pywbemcli(self, desc, inputs, exp_response, mock,
+                               condition):
+        # pylint: disable=unused-argument
+        """
+        Execute pybemcli with the defined input and test output.
+
+        """
+
+        command_group = 'help'
+
+        if inputs['subject']:
+            inputs = inputs['subject']
+        else:
+            inputs = []
+
+        self.command_test(desc, command_group, inputs, exp_response,
+                          None, condition)


### PR DESCRIPTION
Waiting on merge of pr #1274 to make a final change to this one.

This was created in response to request for a special help in pywbemcli for the shell tab completion functionality so the user did not have to go to the docs to understand how to activate the shell tab completion.

It includes a table that defines the help for any number of subjects and the command definition and and command action method to display either a list of the help subjects or the help for any given subject.

This replaces the help function for repl and make repl one of the subjects for this command.

Right now the help includes repl and instancename (instance command group)

This was originally part of the tab-completion pr but separated out to create smaller pr