### PR TITLE
Improve the help message for repl

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -63,6 +63,8 @@ Released: not yet
   overlybroadexceptions to prefix names with builtins. 3. Fixed issue found
   by new usless-exception warning. (raise not part of statement)
 
+* Improve the help description for repl.  It was not complete.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -1017,14 +1017,32 @@ def repl(ctx):
     Enter the interactive mode where pywbemcli commands can be entered
     interactively. The prompt is changed to 'pywbemcli>'.
 
+    <COMMAND> <COMMAND OPTIONS> - Execute pywbemcli command COMMAND
+
+    <GENERAL_OPTIONS> <COMMAND> <COMMAND_OPTIONS> - Execute command with
+    general options.  General options set here exist only for the current
+    command.
+
+    -h, --help - Show pywbemcli general help message, including a
+                                  list of pywbemcli commands.
+    COMMAND -h, --help - Show help message for pywbemcli command COMMAND.
+
+    !SHELL-CMD - Execute shell command SHELL-CMD
+
+    Pywbemcli termination - <CTRL-D>, :q, :quit, :exit
+
     Command history is supported. The command history is stored in a file
     ~/.pywbemcli_history.
 
-    Pywbemcli may be terminated from this mode by entering
-    <CTRL-D>, :q, :quit, :exit
+    <UP>, <DOWN> - Scroll through pwbemcli command history.
 
-    In the repl mode, <CTRL-r> man be used to initiate an interactive
-    search of the history file.
+    <CTRL-r> <search string> - initiate an interactive
+    search of the pywbemcli history file. Can be used with <UP>, <DOWN>
+    to display commands that match the search string.
+    Editing the search string updates the search.
+
+    <TAB> - tab completion for current command line
+    (can be used anywhere in command)
 
     Interactive mode also includes an autosuggest feature that makes
     suggestions from the command history as the command the user types in the

--- a/tests/unit/pywbemcli/test_general_options.py
+++ b/tests/unit/pywbemcli/test_general_options.py
@@ -185,16 +185,37 @@ REPL_HELP = """Usage: pywbemcli [GENERAL-OPTIONS] repl
 
   Enter interactive mode (default).
 
-  Enter the interactive mode where pywbemcli commands can be entered interactively. The prompt is changed to 'pywbemcli>'.
+  Enter the interactive mode where pywbemcli commands can be entered
+  interactively. The prompt is changed to 'pywbemcli>'.
 
-  Command history is supported. The command history is stored in a file ~/.pywbemcli_history.
+  <COMMAND> <COMMAND OPTIONS> - Execute pywbemcli command COMMAND
 
-  Pywbemcli may be terminated from this mode by entering <CTRL-D>, :q, :quit, :exit
+  <GENERAL_OPTIONS> <COMMAND> <COMMAND_OPTIONS> - Execute command with general
+  options.  General options set here exist only for the current command.
 
-  In the repl mode, <CTRL-r> man be used to initiate an interactive search of the history file.
+  -h, --help - Show pywbemcli general help message, including a
+  list of pywbemcli commands. COMMAND -h, --help - Show help message for
+  pywbemcli command COMMAND.
 
-  Interactive mode also includes an autosuggest feature that makes suggestions from the command history as the command the user types in the
-  command and options.
+  !SHELL-CMD - Execute shell command SHELL-CMD
+
+  Pywbemcli termination - <CTRL-D>, :q, :quit, :exit
+
+  Command history is supported. The command history is stored in a file
+  ~/.pywbemcli_history.
+
+  <UP>, <DOWN> - Scroll through pwbemcli command history.
+
+  <CTRL-r> <search string> - initiate an interactive search of the pywbemcli
+  history file. Can be used with <UP>, <DOWN> to display commands that match the
+  search string. Editing the search string updates the search.
+
+  <TAB> - tab completion for current command line (can be used anywhere in
+  command)
+
+  Interactive mode also includes an autosuggest feature that makes suggestions
+  from the command history as the command the user types in the command and
+  options.
 
 Command Options:
   -h, --help  Show this help message.


### PR DESCRIPTION
While redocumenting the repl help message as part of adding the help subject for PR #1272  it became apparent that the original help message was incomplete.

This required putting the new help message text into the test_general_options.py also for testing.