### PR TITLE
Add a new command that displays pywbemtools documentation.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -54,6 +54,9 @@ Released: not yet
   provide help for the setup to activate shell tab completion. The initial
   subjects are repl and instancename
 
+* Add a new command to pywbemcli that calls the current system default web
+  browser to view the pywbemtools public documentation.
+
 **Cleanup:**
 
 * Use Ubuntu 20.04 for os target for some github CI tests because python setup

--- a/docs/pywbemcli/cmdlineinterface.rst
+++ b/docs/pywbemcli/cmdlineinterface.rst
@@ -457,6 +457,9 @@ mode.  Then it attempts to modify the user and password to their default values
 of None and execute the class enumerate again.  This command would be executed
 without using the user and password because they have been reset for that command.
 
+A summary of help can be viewed by entering ``help repl`` when in the
+interactive mode.
+
 .. code-block:: text
 
     pywbemcli -s https:blah --user fred --pasword blah

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -42,7 +42,8 @@ The command groups are:
 * :ref:`Connection command group` - Command group for WBEM connection definitions.
 
 The individual commands (no command group) are:
-* :ref:`help command` - Show help message for interactive mode.
+* :ref:`help command` - Show help for particular pywbemcli subjects
+* :ref:`doc command` - Issue request to web browser to load pywbemcli documentation
 * :ref:`repl command` - Enter interactive mode (default).
 
 
@@ -4775,33 +4776,37 @@ search.
     single: help command
     pair: help; command
 
-The ``help`` command provides information on special commands and controls
-that can be executed in the :ref:`interactive mode` including:
+The ``help`` command provides information on a number of subjects where the
+extra help might be needed on pywbemcli: This includes subjects like
 
-* executing shell commands,
-* exiting pywbemcli,
-* getting help on commands,
-* viewing interactive mode command history.
+* commands in the repl(interactive mode,
+* activating the shell tab-completion,
+
 
 This is different from the ``--help`` option that provides information on
 command groups, and commands.
 
 .. code-block:: text
 
-    $ pywbemcli help
+    Help subjects
+    subject name    subject description
+    --------------  --------------------------------------------
+    instancename    InstanceName parameter in instance cmd group
+    repl            Using the repl command
 
-    The following can be entered in interactive mode:
+The help for each subject is retrieved by entering the subject name for
+the subject of interest as the argument to the help command:
 
-      <pywbemcli-cmd>             Execute pywbemcli command <pywbemcli-cmd>.
-      !<shell-cmd>                Execute shell command <shell-cmd>.
+Thus, for example:
 
-      <CTRL-D>, :q, :quit, :exit  Exit interactive mode.
+.. code-block:: text
 
-      <TAB>                       Tab completion (can be used anywhere).
-      -h, --help                  Show pywbemcli general help message, including a
-                                  list of pywbemcli commands.
-      <pywbemcli-cmd> --help      Show help message for pywbemcli command
-                                  <pywbemcli-cmd>.
-      help                        Show this help message.
-      :?, :h, :help               Show help message about interactive mode.
-      <up-arrow, down-arrow>      View pwbemcli command history:
+    $ pywbemcli help repl
+      . . . returns help on the interactive and commands available in that mode
+
+    in the interactive mode:
+
+    pywbemcli> help repl
+      . . . returns help on the interactive and commands available in that mode
+
+

--- a/pywbemtools/pywbemcli/__init__.py
+++ b/pywbemtools/pywbemcli/__init__.py
@@ -39,6 +39,7 @@ from ._cmd_profile import *           # noqa: F403,F401
 from ._cmd_statistics import *        # noqa: F403,F401
 from ._cmd_subscription import *      # noqa: F403,F401
 from ._cmd_help import *              # noqa: F403,F401
+from ._cmd_docs import *              # noqa: F403,F401
 
 from ._context_obj import *           # noqa: F403,F401
 from ._connection_repository import *   # noqa: F403,F401

--- a/pywbemtools/pywbemcli/_cmd_docs.py
+++ b/pywbemtools/pywbemcli/_cmd_docs.py
@@ -1,0 +1,48 @@
+# (C) Copyright 2023 IBM Corp.
+# (C) Copyright 2023 Inova Development Inc.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Click Command definition for a docs command that calls a web browser with
+the uri of the pywbemcli documentation.
+"""
+
+from __future__ import absolute_import, print_function
+
+import webbrowser
+import click
+
+from .._click_extensions import GENERAL_OPTS_TXT
+
+from .pywbemcli import cli
+from .._options import add_options, help_option
+
+
+@cli.command('docs', options_metavar=GENERAL_OPTS_TXT)
+@add_options(help_option)
+@click.pass_context
+def help_docs(ctx):   # pylint: disable=unused-argument
+    """
+    Get pywbemtools documentation in web browser.
+
+    EXPERIMENTAL
+
+    Calls the current default web browser to display the current stable
+    pywbemtools documentation in a new window.
+    """
+    docs_uri = "https://pywbemtools.readthedocs.io/en/stable/"
+    try:
+        webbrowser.open_new(docs_uri)
+    except webbrowser.Error as we:
+        raise click.ClickException("Web Browser failed {}".format(we))

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -404,7 +404,7 @@ def _create_server_instance(
 # pylint: disable=bad-continuation
 # PywbemtoolsTopGroup sets order commands listed in help output
 @click.group(invoke_without_command=True, cls=PywbemtoolsTopGroup,
-             move_to_end=('connection', 'help', 'repl'),
+             move_to_end=('connection', 'help', 'repl', 'docs'),
              context_settings=CONTEXT_SETTINGS,
              options_metavar=GENERAL_OPTS_TXT,
              subcommand_metavar=SUBCMD_HELP_TXT)

--- a/tests/unit/pywbemcli/test_general_options.py
+++ b/tests/unit/pywbemcli/test_general_options.py
@@ -176,6 +176,7 @@ GENERAL_HELP_LINES = [
       statistics  Command group for WBEM operation statistics.
       subscription  Command group to manage WBEM indication subscriptions.
       connection  Command group for WBEM connection definitions.
+      docs        Get pywbemtools documentation in web browser.
       help        Show help for pywbemcli subjects.
       repl        Enter interactive mode (default)."""
 ]


### PR DESCRIPTION
Adds a new command, docs with no options or arguments that calls the current system default web browser in a new window with the url of the current pywbemtools ReadTheDocs documentation and immediately returns control to the user.

This uses a package (webbrowser) that is part of python since at least python 2.7.18 (based on python documentation.

I marked this experimental in the help allowed no choices because despite the fact that the python webbrowser module has a number of options like picking the web browser these options appear to be problematic.  Further, we really have no way of testing this other than to manually execute the command; we are not sure that it really started a web browser from any tests.

When the user executes this command the pywbemtools ReadTheDocs stable should appear in a new window of the default webbrowser.

I added this since it would appear that it is a way to make the documentation available to the user without them going back to github web pages, etc. to find the url for the documentation.

DISCUSSION: Is this logical and is it logical for this version of pywbemtools????

Co-authored-by: kschopmeyer <k.schopmeyerwork@gmail.com>