### PR TITLE
Ks/extend help subjects arg processing

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -52,7 +52,7 @@ Released: not yet
   for the command.  This allows defining help for subjects that are not
   specific to a particular command.  This is created specifically to
   provide help for the setup to activate shell tab completion. The initial
-  subjects are repl and instancename
+  subjects are repl and instancename.
 
 * Add a new command to pywbemcli that calls the current system default web
   browser to view the pywbemtools public documentation.

--- a/pywbemtools/pywbemcli/_cmd_help.py
+++ b/pywbemtools/pywbemcli/_cmd_help.py
@@ -75,6 +75,13 @@ def help_subjects(ctx, subject):   # pylint: disable=unused-argument
     If an argument is provided, it outputs the help for the subject(s) defined
     by the argument.
     """
+    def display_complete_subject(subject):
+        """Display the subject with key subject"""
+        click.echo("{0} - {1}\n{2}".
+                   format(subject,
+                          HELP_SUBJECTS_DICT[subject][0],
+                          HELP_SUBJECTS_DICT[subject][1]))
+
     subjects = sorted(list(HELP_SUBJECTS_DICT.keys()))
 
     # If there is no subject argument, output a table of all of the subjects and
@@ -94,12 +101,23 @@ def help_subjects(ctx, subject):   # pylint: disable=unused-argument
 
         return
 
-    # If a subject exists, output the help for that subject
+    # If a subject text exists, output the help for that subject
     if subject in HELP_SUBJECTS_DICT:
-        click.echo("{0} - {1}\n{2}".
-                   format(subject,
-                          HELP_SUBJECTS_DICT[subject][0],
-                          HELP_SUBJECTS_DICT[subject][1]))
+        display_complete_subject(subject)
+
+    # Try search for single subject exists that matches startswith
+    subjects = HELP_SUBJECTS_DICT.keys()
+    partial_subjects = [subj for subj in subjects
+                        if subj.startswith(subject)]
+
+    # Return if startswith matches a single subject
+    if len(partial_subjects) == 1:
+        display_complete_subject(partial_subjects[0])
+
+    # If multiple matches, multiple possible subjects, rtn msg
+    elif len(partial_subjects) > 1:
+        click.echo("Multiple possible subjects {}".
+                   format(', '.join(subjects)))
     else:
         raise click.ClickException("'{}' is not a valid help subject. "
                                    "Try 'help' for list of subjects.".
@@ -186,7 +204,7 @@ requires that that pywbemcli is available:
           ~/.config/fish/completions/pywbemcli.fish
 
 Once the completion script file is created, pywbemcli tab-completion can be
-activated by sourcing this script (ex ``source ~/.pywbemcli-complete.bash``)
+activated by sourcing this script (ex ''source ~/.pywbemcli-complete.bash'')
 This does not actually call pywbemcli.  This can be done a number of
 different means, for example:
 
@@ -195,7 +213,6 @@ different means, for example:
 * Manually executing the sourcing statement when required.
 '''
 # pylint: enable=invalid-name
-
 
 # FUTURE: Move this to new module along with repl command. Every cmd should
 #         be in separate module with its data.

--- a/tests/unit/pywbemcli/test_help_cmd.py
+++ b/tests/unit/pywbemcli/test_help_cmd.py
@@ -58,13 +58,12 @@ SKIP = False
 
 
 TEST_CASES = [
-    # List of testcases for test help <subject>.
+    # List of testcases for command help <subject>.
     # Each testcase is a list with the following items:
     # * desc: Description of testcase.
-    # * inputs: String, or tuple/list of strings, or dict of 'env', 'args',
-    #     'general', and 'stdin'. See the 'inputs' parameter of
-    #     CLITestsBase.command_test() in cli_test_extensions.py for detailed
-    #     documentation.
+    # * inputs:
+    # * inputs.subject: argument (i.e. subject for the help command)
+    # *
     # * exp_response: Dictionary of expected responses (stdout, stderr, rc) and
     #     test definition (test: <testname>). See the 'exp_response' parameter
     #     of CLITestsBase.command_test() in cli_test_extensions.py for
@@ -80,31 +79,36 @@ TEST_CASES = [
       'test': 'innows'},
      None, RUN],
 
-    ['Verify help command repl',
+    ['Verify help command  arg repl',
      {'args': ['help', 'repl']},
      {'stdout': REPL_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify help command instancename',
+    ['Verify help command  arg instancename',
      {'args': ['help', 'instancename']},
      {'stdout': INSTANCENAME_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify help command tab-completion',
+    ['Verify help command arg tab-completion',
      {'args': ['help', 'tab-completion']},
      {'stdout': TABCOMPLETION_HELP_LINES,
       'test': 'innows'},
      None, OK],
 
-    ['Verify help command tab-completion',
+    ['Verify help command arg tab-completion unique partial input',
+     {'args': ['help', 'tab-c']},
+     {'stdout': TABCOMPLETION_HELP_LINES,
+      'test': 'innows'},
+     None, OK],
+
+    ['Verify help command arg tab-completion',
      {'args': ['help', 'blah']},
      {'stderr': ["'blah' is not a valid help subject."],
       'rc': 1,
       'test': 'innows'},
      None, OK],
-
 ]
 
 


### PR DESCRIPTION
This pr based on PR #1247, tab-completion changes.

Minor change to allow inputting a partial subject name and having if displayed if the partial name in a unique startswith match to the subject keys.   Thus the user would be able to type in pywbemcli help activate or pyebemcli help act.  If multiples keys satisfy
startswith, a list of possible keys is displayed