### PR TITLE
Update docker Pegasus docker image used in pywbemtools tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ endif
 # Docker image for end2end tests.
 # Keep the version in sync with the test.yml workflow.
 ifndef TEST_SERVER_IMAGE
-  TEST_SERVER_IMAGE := kschopmeyer/openpegasus-server:0.1.1
+  TEST_SERVER_IMAGE := kschopmeyer/openpegasus-server:0.1.2
 endif
 
 # Determine OS platform make runs on.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -88,6 +88,8 @@ Released: not yet
 
 * Improve the help description for repl.  It was not complete.
 
+* Update Pegasus docker image version to 0.1.2
+
 **Known issues:**
 
 * See `list of open issues`_.


### PR DESCRIPTION
Update docker image from 0.1.1 to 0.1.2.  The new image is functionally equivalent but much smaller and so faster to install.  One line change in Makefile and this docker image already being used by pywbem