### PR TITLE
Refactor text for activate help subject

### DIFF
--- a/tests/unit/pywbemcli/test_help_cmd.py
+++ b/tests/unit/pywbemcli/test_help_cmd.py
@@ -23,8 +23,9 @@ import pytest
 
 from .cli_test_extensions import CLITestsBase
 
-DEFAULT_HELP_LINES = """Help subjects
-subject name    subject description
+DEFAULT_HELP_LINES = """
+Help Subjects:
+Subject name    Subject description
 --------------  ---------------------------------------------
 activate        Activating shell tab completion
 instancename    InstanceName parameter in instance cmd group


### PR DESCRIPTION
Fefactored the text for this help subject to remove repetition and make it shorter.

One minor code change, inserted EOL before the first line output so it is more visible on the terminal, in particular because it is more than 24 lines long.