### PR TITLE
Issue #1273 - Refine use of pylint use-dict-literal

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -183,8 +183,6 @@ confidence=
 #       any code issues we will ignore this warning.
 # Note: "consider-using-set-comprehension" not allowed in python 2.6 so we
 #       ignore it as long as we are using 2.7
-# Note: "use-dict-literal" ignore for now because it is only a speed issue
-#       with the dict() and it is used extensively throughout code
 disable=I0011, bad-option-value,
         too-many-locals, too-many-branches, too-many-statements,
         too-many-lines, too-many-public-methods,
@@ -193,7 +191,7 @@ disable=I0011, bad-option-value,
         locally-enabled, superfluous-parens, useless-object-inheritance,
         consider-using-set-comprehension, unnecessary-pass, useless-return,
         raise-missing-from, super-with-arguments, redundant-u-string-prefix,
-        consider-using-f-string, use-dict-literal
+        consider-using-f-string
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pywbemtools/pywbemcli/_pywbemcli_operations.py
+++ b/pywbemtools/pywbemcli/_pywbemcli_operations.py
@@ -600,11 +600,10 @@ class BuildMockenvMixin(object):
         # We construct a single object, because the CIM repository is
         # referenced from each provider, and pickle properly handles
         # multiple references to the same object.
-        mockenv = dict(
-            cimrepository=self.cimrepository,
-            # pylint: disable=protected-access
-            provider_registry=self._provider_registry,
-        )
+        mockenv = {"cimrepository": self.cimrepository,
+                   # pylint: disable=protected-access
+                   "provider_registry": self._provider_registry}
+
         with io.open(mockenv_pickle_file, 'wb') as fp:
             pickle.dump(mockenv, fp)
 

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -100,14 +100,13 @@ OUTPUT_FORMATS_OPTION.append("")
 #
 # Context variables passed to click
 #
-CONTEXT_SETTINGS = dict(
+CONTEXT_SETTINGS = {
 
     # Enable -h as additional help option:
-    help_option_names=['-h', '--help'],
+    "help_option_names": ['-h', '--help'],
 
     # Default the output width properly:
-    terminal_width=get_terminal_width(),
-)
+    "terminal_width": get_terminal_width()}
 
 
 ###########################################################################

--- a/pywbemtools/pywbemlistener/_cmd_listener.py
+++ b/pywbemtools/pywbemlistener/_cmd_listener.py
@@ -715,13 +715,11 @@ def format_indication(indication, host, indi_format=None):
         pass
     tz = dt.tzname() or ''
     i_mof = indication.tomof().replace('\n', ' ')
-    format_kwargs = dict(
-        dt=dt,
-        tz=tz,
-        h=host,
-        i_mof=i_mof,
-        i=indication,
-    )
+    format_kwargs = {"dt": dt,
+                     "tz": tz,
+                     "h": host,
+                     "i_mof": i_mof,
+                     "i": indication}
     if indi_format is None:
         indi_format = DEFAULT_INDI_FORMAT
     indi_str = indi_format.format(**format_kwargs)
@@ -1210,7 +1208,7 @@ def cmd_listener_start(context, name, options):
 
     prepare_startup_completion()
 
-    popen_kwargs = dict(shell=False)
+    popen_kwargs = {"shell": False}
     if six.PY3:
         popen_kwargs['start_new_session'] = True
 

--- a/pywbemtools/pywbemlistener/pywbemlistener.py
+++ b/pywbemtools/pywbemlistener/pywbemlistener.py
@@ -39,14 +39,14 @@ __all__ = ['cli']
 #
 # Context variables passed to click
 #
-CONTEXT_SETTINGS = dict(
+
+CONTEXT_SETTINGS = {
 
     # Enable -h as additional help option:
-    help_option_names=['-h', '--help'],
+    "help_option_names": ['-h', '--help'],
 
     # Default the output width properly:
-    terminal_width=get_terminal_width(),
-)
+    "terminal_width": get_terminal_width()}
 
 
 ############################################################################

--- a/tests/unit/pywbemcli/test_class_cmds.py
+++ b/tests/unit/pywbemcli/test_class_cmds.py
@@ -42,6 +42,8 @@ from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
     CMD_OPTION_SUBCLASSOF_FILTER_HELP_LINE, \
     CMD_OPTION_LEAFCLASSES_FILTER_HELP_LINE
 
+# pylint: disable=use-dict-literal
+
 _PYWBEM_VERSION = parse_version(pywbem_version)
 # pywbem 1.0.0 or later
 PYWBEM_1_0_0 = _PYWBEM_VERSION.release >= (1, 0, 0)

--- a/tests/unit/pywbemcli/test_common.py
+++ b/tests/unit/pywbemcli/test_common.py
@@ -50,6 +50,8 @@ from pywbemtools.pywbemcli._common import parse_wbemuri_str, \
 from .cli_test_extensions import setup_mock_connection
 from ..pytest_extensions import simplified_test_function
 
+# pylint: disable=use-dict-literal
+
 # from tests.unit.utils import assert_lines
 
 OK = True     # mark tests OK when they execute correctly

--- a/tests/unit/pywbemcli/test_connection_cmds.py
+++ b/tests/unit/pywbemcli/test_connection_cmds.py
@@ -31,6 +31,8 @@ from pywbemtools._utils import CONNECTIONS_FILENAME
 from .cli_test_extensions import CLITestsBase
 from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
 
+# pylint: disable=use-dict-literal
+
 SCRIPT_DIR = os.path.dirname(__file__)
 
 # A mof file that defines basic qualifier decls, classes, and instances

--- a/tests/unit/pywbemcli/test_connection_repository.py
+++ b/tests/unit/pywbemcli/test_connection_repository.py
@@ -39,6 +39,8 @@ from pywbemtools.pywbemcli._pywbem_server import PywbemServer
 
 from ..pytest_extensions import simplified_test_function
 
+# pylint: disable=use-dict-literal
+
 # Click (as of 7.1.2) raises UnsupportedOperation in click.echo() when
 # the pytest capsys fixture is used. That happens only on Windows.
 # See Click issue https://github.com/pallets/click/issues/1590. This

--- a/tests/unit/pywbemcli/test_context_obj.py
+++ b/tests/unit/pywbemcli/test_context_obj.py
@@ -23,6 +23,8 @@ from __future__ import absolute_import, print_function
 from pywbemtools.pywbemcli._context_obj import ContextObj
 from pywbemtools.pywbemcli._pywbem_server import PywbemServer
 
+# pylint: disable=use-dict-literal
+
 
 def test_ContextObj_init():
     """

--- a/tests/unit/pywbemcli/test_display_cimobjects.py
+++ b/tests/unit/pywbemcli/test_display_cimobjects.py
@@ -42,6 +42,8 @@ from pywbemtools._output_formatting import DEFAULT_MAX_CELL_WIDTH
 
 from ..pytest_extensions import simplified_test_function
 
+# pylint: disable=use-dict-literal
+
 OK = True    # mark tests OK when they execute correctly
 RUN = True    # Mark OK = False and current test case being created RUN
 FAIL = False  # Any test currently FAILING or not tested yet

--- a/tests/unit/pywbemcli/test_general_options.py
+++ b/tests/unit/pywbemcli/test_general_options.py
@@ -33,6 +33,8 @@ from .cli_test_extensions import CLITestsBase, PYWBEM_0, PYWBEM_1
 from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
 from ..utils import CLICK_VERSION
 
+# pylint: disable=use-dict-literal
+
 TEST_DIR = os.path.dirname(__file__)
 
 # Test connections file used in some testcases

--- a/tests/unit/pywbemcli/test_help_cmd.py
+++ b/tests/unit/pywbemcli/test_help_cmd.py
@@ -16,12 +16,13 @@
 """
 Test the help command that displays help text on specific pywbemcli
 subjects. This command is not part of any command group.
-
 """
 
 import pytest
 
 from .cli_test_extensions import CLITestsBase
+
+# pylint: disable=use-dict-literal
 
 DEFAULT_HELP_LINES = """
 Help Subjects:
@@ -134,4 +135,4 @@ class TestCmdHelp(CLITestsBase):  # pylint: disable=too-few-public-methods
             pywbemcli command.
         """
         self.command_test(desc, self.command_group, inputs, exp_response,
-                          mock, condition, verbose=True)
+                          mock, condition)

--- a/tests/unit/pywbemcli/test_instance_cmds.py
+++ b/tests/unit/pywbemcli/test_instance_cmds.py
@@ -45,6 +45,8 @@ from .common_options_help_lines import CMD_OPTION_NAMES_ONLY_HELP_LINE, \
     CMD_OPTION_LEAFCLASSES_FILTER_HELP_LINE, \
     CMD_OPTION_SHOW_NULL_HELP_LINE
 
+# pylint: disable=use-dict-literal
+
 
 _PYWBEM_VERSION = parse_version(pywbem_version)
 # pywbem 1.0.0 or later

--- a/tests/unit/pywbemcli/test_log_option.py
+++ b/tests/unit/pywbemcli/test_log_option.py
@@ -24,6 +24,8 @@ import pytest
 
 from .cli_test_extensions import CLITestsBase
 
+# pylint: disable=use-dict-literal
+
 TEST_DIR = os.path.dirname(__file__)
 
 SIMPLE_MOCK_MODEL_FILE = 'simple_mock_model.mof'

--- a/tests/unit/pywbemcli/test_misc_errors.py
+++ b/tests/unit/pywbemcli/test_misc_errors.py
@@ -21,6 +21,8 @@ import pytest
 
 from .cli_test_extensions import CLITestsBase
 
+# pylint: disable=use-dict-literal
+
 SCRIPT_DIR = os.path.dirname(__file__)
 SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
 SIMPLE_MOCK_FILE_PATH = os.path.join(SCRIPT_DIR, SIMPLE_MOCK_FILE)

--- a/tests/unit/pywbemcli/test_namespace_cmds.py
+++ b/tests/unit/pywbemcli/test_namespace_cmds.py
@@ -23,6 +23,7 @@ import pytest
 from .cli_test_extensions import CLITestsBase
 from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
 
+# pylint: disable=use-dict-literal
 
 # The mock files used for testing
 TEST_INTEROP_MOCK_FILE = 'simple_interop_mock_script.py'

--- a/tests/unit/pywbemcli/test_namespace_creation.py
+++ b/tests/unit/pywbemcli/test_namespace_creation.py
@@ -20,6 +20,7 @@ import pytest
 
 from .cli_test_extensions import CLITestsBase
 
+# pylint: disable=use-dict-literal
 
 # Mock environment #1: Namespace-neutral MOF, no Interop namespace
 MOCK1_MOF_FILE = 'simple_mock_model.mof'

--- a/tests/unit/pywbemcli/test_profile_cmds.py
+++ b/tests/unit/pywbemcli/test_profile_cmds.py
@@ -25,6 +25,8 @@ import pytest
 from .cli_test_extensions import CLITestsBase
 from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
 
+# pylint: disable=use-dict-literal
+
 TEST_DIR = os.path.dirname(__file__)
 
 # A mof file that defines basic qualifier decls, classes, and instances

--- a/tests/unit/pywbemcli/test_python_tell.py
+++ b/tests/unit/pywbemcli/test_python_tell.py
@@ -14,6 +14,8 @@ import os
 import io
 import pytest
 
+# pylint: disable=use-dict-literal
+
 
 @pytest.fixture()
 def file_path():

--- a/tests/unit/pywbemcli/test_pywbem_server.py
+++ b/tests/unit/pywbemcli/test_pywbem_server.py
@@ -28,6 +28,8 @@ from pywbemtools.pywbemcli._pywbem_server import PywbemServer
 
 from tests.unit.pytest_extensions import simplified_test_function
 
+# pylint: disable=use-dict-literal
+
 OK = True
 RUN = True
 FAIL = False

--- a/tests/unit/pywbemcli/test_pywbemcli_operations.py
+++ b/tests/unit/pywbemcli/test_pywbemcli_operations.py
@@ -40,6 +40,8 @@ from pywbemtools.pywbemcli.mockscripts import DeprecatedSetupWarning, \
 from ..pytest_extensions import simplified_test_function
 from ..utils import captured_output
 
+# pylint: disable=use-dict-literal
+
 OK = True
 FAIL = False
 PDB = "pdb"

--- a/tests/unit/pywbemcli/test_qualdecl_cmds.py
+++ b/tests/unit/pywbemcli/test_qualdecl_cmds.py
@@ -27,6 +27,8 @@ from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE, \
     CMD_OPTION_SUMMARY_HELP_LINE, \
     CMD_OPTION_MULTIPLE_NAMESPACE_DFLT_CONN_HELP_LINE
 
+# pylint: disable=use-dict-literal
+
 TEST_DIR = os.path.dirname(__file__)
 
 PYTHON_GE_38 = sys.version_info > (3, 8)

--- a/tests/unit/pywbemcli/test_server_cmds.py
+++ b/tests/unit/pywbemcli/test_server_cmds.py
@@ -25,6 +25,8 @@ import pytest
 from .cli_test_extensions import CLITestsBase
 from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
 
+# pylint: disable=use-dict-literal
+
 TEST_DIR = os.path.dirname(__file__)
 
 # A mof file that defines basic qualifier decls, classes, and instances

--- a/tests/unit/pywbemcli/test_statistics_cmds.py
+++ b/tests/unit/pywbemcli/test_statistics_cmds.py
@@ -26,6 +26,8 @@ from .cli_test_extensions import CLITestsBase
 
 from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
 
+# pylint: disable=use-dict-literal
+
 TEST_DIR = os.path.dirname(__file__)
 SIMPLE_MOCK_FILE = 'simple_mock_model.mof'
 SIMPLE_MOCK_FILE_PATH = os.path.join(TEST_DIR, SIMPLE_MOCK_FILE)

--- a/tests/unit/pywbemcli/test_subscription_cmds.py
+++ b/tests/unit/pywbemcli/test_subscription_cmds.py
@@ -37,6 +37,8 @@ import pytest
 from .cli_test_extensions import CLITestsBase
 from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
 
+# pylint: disable=use-dict-literal
+
 TEST_DIR = os.path.dirname(__file__)
 TEST_DIR_REL = os.path.relpath(TEST_DIR)
 

--- a/tests/unit/pywbemcli/test_tabcompletion_unit.py
+++ b/tests/unit/pywbemcli/test_tabcompletion_unit.py
@@ -37,6 +37,8 @@ from pywbemtools.pywbemcli.pywbemcli import connection_name_completer
 from ..pytest_extensions import simplified_test_function
 # pylint: enable=relative-beyond-top-level
 
+# pylint: disable=use-dict-literal
+
 # Click version as a tuple. Used to control tab-completion features
 CLICK_VERSION = packaging.version.parse(click.__version__).release
 # boolean True if click version 8 or greater.

--- a/tests/unit/pywbemlistener/test_general_options.py
+++ b/tests/unit/pywbemlistener/test_general_options.py
@@ -27,6 +27,8 @@ import pytest
 
 from .cli_test_extensions import pywbemlistener_test, RUN
 
+# pylint: disable=use-dict-literal
+
 # Output patterns for 'pywbemlistener --help'
 HELP_PATTERNS = [
     r"^Usage: pywbemlistener \[GENERAL-OPTIONS\] COMMAND \[ARGS\] "

--- a/tests/unit/pywbemlistener/test_list_cmd.py
+++ b/tests/unit/pywbemlistener/test_list_cmd.py
@@ -23,6 +23,8 @@ import pytest
 
 from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NOWIN
 
+# pylint: disable=use-dict-literal
+
 # Output patterns for 'pywbemlistener list --help'
 LIST_HELP_PATTERNS = [
     r"^Usage: pywbemlistener \[GENERAL-OPTIONS\] list \[COMMAND-OPTIONS\]$",

--- a/tests/unit/pywbemlistener/test_run_cmd.py
+++ b/tests/unit/pywbemlistener/test_run_cmd.py
@@ -25,6 +25,8 @@ from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NOWIN
 from .test_start_cmd import START_HELP_CALL_PATTERNS, \
     START_HELP_FORMAT_PATTERNS
 
+# pylint: disable=use-dict-literal
+
 # Output patterns for 'pywbemlistener run --help'
 RUN_HELP_PATTERNS = [
     r"^Usage: pywbemlistener \[GENERAL-OPTIONS\] run NAME "

--- a/tests/unit/pywbemlistener/test_show_cmd.py
+++ b/tests/unit/pywbemlistener/test_show_cmd.py
@@ -23,6 +23,8 @@ import pytest
 
 from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NOWIN
 
+# pylint: disable=use-dict-literal
+
 # Output patterns for 'pywbemlistener show --help'
 SHOW_HELP_PATTERNS = [
     r"^Usage: pywbemlistener \[GENERAL-OPTIONS\] show NAME "

--- a/tests/unit/pywbemlistener/test_start_cmd.py
+++ b/tests/unit/pywbemlistener/test_start_cmd.py
@@ -24,6 +24,7 @@ import pytest
 from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NOWIN
 from ..utils import CLICK_VERSION
 
+# pylint: disable=use-dict-literal
 
 # Default indication format (must be in sync with actual default format)
 DEFAULT_INDI_FORMAT = '{dt} {h} {i_mof}'

--- a/tests/unit/pywbemlistener/test_stop_cmd.py
+++ b/tests/unit/pywbemlistener/test_stop_cmd.py
@@ -23,6 +23,8 @@ import pytest
 
 from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NOWIN
 
+# pylint: disable=use-dict-literal
+
 # Output patterns for 'pywbemlistener stop --help'
 STOP_HELP_PATTERNS = [
     r"^Usage: pywbemlistener \[GENERAL-OPTIONS\] stop NAME "

--- a/tests/unit/pywbemlistener/test_tabcompletion_unit.py
+++ b/tests/unit/pywbemlistener/test_tabcompletion_unit.py
@@ -36,6 +36,8 @@ from ..pytest_extensions import simplified_test_function
 from .cli_test_extensions import ensure_no_listeners, start_listeners, \
     RUN, RUN_NOWIN
 
+# pylint: disable=use-dict-literal
+
 # Click version as a tuple. Used to control tab-completion features
 CLICK_VERSION = packaging.version.parse(click.__version__).release
 # boolean True if click version 8 or greater.

--- a/tests/unit/pywbemlistener/test_test_cmd.py
+++ b/tests/unit/pywbemlistener/test_test_cmd.py
@@ -23,6 +23,8 @@ import pytest
 
 from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NOWIN
 
+# pylint: disable=use-dict-literal
+
 # Output patterns for 'pywbemlistener list --help'
 TEST_HELP_PATTERNS = [
     r"^Usage: pywbemlistener \[GENERAL-OPTIONS\] test NAME "

--- a/tests/unit/test_output_formatting.py
+++ b/tests/unit/test_output_formatting.py
@@ -37,6 +37,8 @@ from pywbemtools._output_formatting import validate_output_format, \
 
 from .pytest_extensions import simplified_test_function
 
+# pylint: disable=use-dict-literal
+
 _PYWBEM_VERSION = parse_version(__version__)
 # pywbem 1.0.0 (dev, beta, final) or later
 PYWBEM_1_0_0 = _PYWBEM_VERSION.release >= (1, 0, 0)

--- a/tests/unit/test_tableformat.py
+++ b/tests/unit/test_tableformat.py
@@ -29,6 +29,7 @@ import pytest
 
 from pywbemtools._output_formatting import format_table, fold_strings
 
+# pylint: disable=use-dict-literal
 
 # A simple table
 TABLE1_HEADERS = ['col1', 'col2', 'col3']

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -31,6 +31,7 @@ import pywbemtools._utils
 
 from .pytest_extensions import simplified_test_function
 
+# pylint: disable=use-dict-literal
 
 TESTCASES_ENSURE_BYTES = [
 


### PR DESCRIPTION
Fix pylint definitons so that we test all code in for use-literal-dict but put ignore in all tests where it is happening.
