### PR TITLE
1.2: Fixed coveralls issues with KeyError and HTTP 422 Unprocessable Entity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -292,6 +292,9 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_PARALLEL: true
         COVERALLS_FLAG_NAME: "${{ matrix.os }},${{ matrix.python-version }},${{ matrix.package_level }}"
+        COVERALLS_SERVICE_NAME: github
+        COVERALLS_SERVICE_JOB_ID: "${{ github.run_id }}"
+        COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
       run: |
         coveralls
     - name: Run installtest
@@ -311,5 +314,6 @@ jobs:
     - name: Send coverage finish to coveralls.io
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
       run: |
         coveralls --finish

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -41,7 +41,7 @@ coverage>=5.0
 pytest-cov>=2.7.0
 # coveralls 2.0 has removed support for Python 2.7
 git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
-coveralls>=2.1.2,<3.0.0; python_version >= '3.5'
+coveralls>=3.3.0; python_version >= '3.5'
 
 # Safety CI by pyup.io
 # safety 1.9.0 removed support for Python 2.7 (and now also enforces that)
@@ -56,7 +56,7 @@ dparse>=0.5.2; python_version == '3.5'
 # ver 0.6.2 min requirement by safety 2.2.0
 dparse>=0.6.2; python_version >= '3.6'
 
-# PyYAML is also pulled in by dparse and python-coveralls
+# PyYAML is also pulled in by dparse
 # PyYAML 5.3 fixed narrow build error on Python 2.7
 # PyYAML 5.3.1 addressed issue 38100 reported by safety
 # PyYAML 5.2 addressed issue 38639 reported by safety

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -16,6 +16,8 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed coveralls issues with KeyError and HTTP 422 Unprocessable Entity.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -132,7 +132,7 @@ tabulate==0.8.2; python_version <= '3.9'
 tabulate==0.8.8; python_version >= '3.10'
 prompt-toolkit==1.0.15; python_version == '2.7'
 prompt-toolkit==2.0.1; python_version >= '3.5'
-# PyYAML is also pulled in by dparse and python-coveralls
+# PyYAML is also pulled in by dparse
 PyYAML==5.3.1; python_version == '2.7'
 PyYAML==5.3.1; python_version >= '3.5' and python_version <= '3.9'
 PyYAML==5.4.1; python_version >= '3.10'
@@ -183,7 +183,7 @@ coverage==5.0; python_version == '2.7' or python_version >= '3.5'
 pytest-cov==2.7.0; python_version == '2.7' or python_version >= '3.5'
 # Links are not allowed in constraint files - minimum ensured by dev-requirements.txt:
 # git+https://github.com/andy-maier/coveralls-python.git@andy/add-py27#egg=coveralls; python_version == '2.7'
-coveralls==2.1.2; python_version >= '3.5'
+coveralls==3.3.0; python_version >= '3.5'
 
 # Safety CI by pyup.io
 safety==1.8.7; python_version == '2.7'


### PR DESCRIPTION
Rolls back PR #1297 into 1.2.1.