### PR TITLE
Add .safety-policy.yaml file.

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -1,0 +1,79 @@
+# Safety policy file
+# For documentation, see https://docs.pyup.io/docs/safety-20-policy-file
+
+# Configuration for the 'safety check' command
+security:
+
+    # Ignore certain severities.
+    # A number between 0 and 10, with the following significant values:
+    # - 9: ignore all vulnerabilities except CRITICAL severity
+    # - 7: ignore all vulnerabilities except CRITICAL & HIGH severity
+    # - 4: ignore all vulnerabilities except CRITICAL, HIGH & MEDIUM severity
+    ignore-cvss-severity-below: 0
+
+    # Ignore unknown severities.
+    # Should be set to False.
+    ignore-cvss-unknown-severity: False
+
+    # List of specific vulnerabilities to ignore.
+    # {id}:                 # vulnerability ID
+    #     reason: {text}    # optional: Reason for ignoring it. Will be reported in the Safety reports
+    #     expires: {date}   # optional: Date when this ignore will expire
+    ignore-vulnerabilities:
+        37504:
+            reason: Fixed Twine version requires Python>=3.6 and is used there
+        38330:
+            reason: Fixed Sphinx version requires Python>=3.5 and is used there
+        39611:
+            reason: PyYAML full_load method or FullLoader is not used
+        39621:
+            reason: Fixed Pylint version requires Python>=3.6 and is used there
+        40291:
+            reason: Pip, found in;10.0.1, affected; <19.2, Fixed Pip version requires Python>=3.6 and is used there
+        42559:
+            reason: Fixed Pip version requires Python>=3.6 and is used there; Pip is not shipped with this package
+        43975:
+            reason: Fixed Urllib3 versions are excluded by requests
+        45185:
+            reason: Fixed Pylint version requires Python>=3.6.2 and is used there
+        45775:
+            reason: Fixed Sphinx version requires Python>=3.5 and is used there
+        47833:
+            reason: Fixed Click version requires Python>=3.6 and is used there
+        50885:
+            reason: Fixed Pygments version requires Python>=3.5 and is used there
+        50886:
+            reason: Fixed Pygments version requires Python>=3.5 and is used there
+        51457:
+            reason: Py package is not yet fixed (latest version 1.11.0)
+            expires: 2023-06-30
+        51499:
+            reason: Fixed Wheel version requires Python>=3.7 and is used there; Risk is on Pypi side
+        52322:
+            reason: Fixed GitPython version requires Python>=3.7 and is used there
+        52365:
+            reason: Fixed Certifi version requires Python>=3.6 and is used there
+        52495:
+            reason: Fixed Setuptools version requires Python>=3.7 and is used there; Risk is on Pypi side
+        52518:
+            reason: Fixed GitPython version requires Python>=3.7 and is used there
+        38765:
+            reason: Pip, found in; 10.0.1, affected; <19.2, Python 2.7 requires this version
+        37765:
+            reason: Psutil, found in; 5.6.5, affected; <=5.6.5,
+        51358:
+            reason: Safety, found in; 1.8.7, affected; <2.2.0,
+        50571:
+            reason: Dparse, found in; 0.4.1, affected; <0.5.2,
+        42203:
+            reason: Babel, found in; 2.7.0, affected; <2.9.1
+        52510:
+            reason: Future, found in; 0.18.2; affected; <=0.18.2
+        39525:
+            reason: Jinja2, found in; 2.8.1, affected; <2.11.3
+        54679:
+            reason: Jinja2, found in; 2.8.1, affected; <2.10.1
+
+
+    # Continue with exit code 0 when vulnerabilities are found.
+    continue-on-vulnerability-error: False

--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,9 @@ pylint_opts := --disable=fixme --ignore=$(pylint_ignore)
 # Flake8 config file
 flake8_rc_file := .flake8
 
+# Safety policy file
+safety_policy_file := .safety-policy.yml
+
 # Python source files to be checked by PyLint and Flake8
 py_src_files := \
     setup.py \
@@ -253,113 +256,6 @@ py_src_files := \
 
 # Test log
 test_log_file := test_$(python_version_fn).log
-
-# Issues reported by safety command that are ignored.
-# Package upgrade strategy due to reported safety issues:
-# - For packages that are direct or indirect runtime requirements, upgrade
-#   the package version only if possible w.r.t. the supported environments and
-#   if the issue affects pywbem, and add to the ignore list otherwise.
-# - For packages that are direct or indirect development or test requirements,
-#   upgrade the package version only if possible w.r.t. the supported
-#   environments and add to the ignore list otherwise.
-# Current safety ignore list, with reasons:
-# Runtime dependencies:
-# - 38100: PyYAML on py34 cannot be upgraded; no issue since PyYAML FullLoader is not used
-# - 38834: urllib3 on py34 cannot be upgraded -> remains an issue on py34
-# Development and test dependencies:
-# - 38765: We want to test install with minimum pip versions.
-# - 38892: lxml cannot be upgraded on py34; no issue since HTML Cleaner of lxml is not used
-# - 38224: pylint cannot be upgraded on py27+py34
-# - 37504: twine cannot be upgraded on py34
-# - 37765: psutil cannot be upgraded on PyPy
-# - 38107: bleach cannot be upgraded on py34
-# - 38330: Sphinx cannot be upgraded on py27+py34
-# - 38546: Bleach
-# - 39194: lxml cannot be upgraded on py34; no issue since HTML Cleaner of lxml is not used
-# - 39195: lxml cannot be upgraded on py34; no issue since output file paths do not come from untrusted sources
-# - 39462: The CVE for tornado will be replaced by a CVE for Python, see https://github.com/tornadoweb/tornado/issues/2981
-# - 39611: PyYAML cannot be upgraded on py34+py35; We are not using the FullLoader.
-# - 39621: Pylint cannot be upgraded on py27+py34
-# - 39525: Jinja2 cannot be upgraded on py34
-# - 40072: lxml HTML cleaner in lxml 4.6.3 no longer includes the HTML5 'formaction'
-# - 38932: cryptography cannot be upgraded to 3.2 on py34
-# - 39252: cryptography cannot be upgraded to 3.3 on py34+py35
-# - 39606: cryptography cannot be upgraded to 3.3.2 on py34+py35
-# - 40291: pip cannot be upgraded to 21.1 py<3.6
-# - 40380..40386: notebook issues fixed in 6.1.5 which would prevent using notebook on py2
-# - 42218: pip <21.1 - unicode separators in git references
-# - 42253: Notebook, before 5.7.1 allows XSS via untrusted notebook
-# - 42254: Notebook before 5.7.2, allows XSS via crafted directory name
-# - 42293: babel, before 2.9.1 CVS-2021-42771, Bable.locale issue
-# - 42297: Bleach before 3.11, a mutation XSS afects user calling bleach.clean
-# - 42298: Bleach before 3.12, mutation XSS affects bleach.clean
-# - 42559 pip, before 21.1 CVE-2021-3572
-# - 43975: urllib3 before 1.26.5 CVE-2021-33503, not important for pywbemtools
-# - 45775 Sphinx 3.0.4 updates jQuery version, cannot upgrade Sphinx on py27
-# - 47833 Click 8.0.0 uses 'mkstemp()', cannot upgrade Click due to incompatibilities
-# - 45185 Pylint 2.13.0 fixes crash with doc_params ext, cannot upgrade on py27/35
-# - SEPT 2022
-# - 50571 dparse (user safety) 0.4.1 -> 0.5.2, 0.5.1 -> 0.5.2.  ReDos issue
-# - 50885 Pygments 2.7.4 cannot be used on Python 2.7
-# - 50886 Pygments 2.7.4 cannot be used on Python 2.7
-# - 51499 Wheel CVE fix in version 0.38.1 fixes; cannnot be used on python 2.7
-# - 51358 Safety, before 2.2.0 uses dparse with issue, python 2.7 max is 1.9.0
-# - 51457 py - Latest release has this safety issue i.e. <=1.11.0
-# - 52322 GitPython - max version for python 2.7 is < 3.0.0
-# - 52510 future - new min >0.18.2 - No new version released Jan 2023. Issue #2976
-# - 52518 GitPython - Python 2.7 uses version 2.1.1
-# - 52365 certifi - 2020.4,5,1 max python 2.7, 22.5.1.18.1 max python 3.5
-safety_ignore_opts := \
-	-i 38100 \
-	-i 38834 \
-	-i 38765 \
-	-i 38892 \
-	-i 38224 \
-	-i 37504 \
-	-i 37765 \
-	-i 38107 \
-	-i 38330 \
-	-i 38546 \
-	-i 39194 \
-	-i 39195 \
-	-i 39462 \
-	-i 39611 \
-	-i 39621 \
-	-i 39525 \
-	-i 40072 \
-	-i 38932 \
-	-i 39252 \
-	-i 39606 \
-	-i 40291 \
-	-i 40380 \
-	-i 40381 \
-	-i 40382 \
-	-i 40383 \
-	-i 40384 \
-	-i 40385 \
-	-i 40386 \
-	-i 42218 \
-	-i 42253 \
-	-i 42254 \
-	-i 42203 \
-	-i 42297 \
-	-i 42298 \
-	-i 42559 \
-	-i 43975 \
-	-i 45775 \
-	-i 47833 \
-	-i 45185 \
-	-i 50571 \
-	-i 50885 \
-	-i 50886 \
-	-i 51499 \
-	-i 51358 \
-	-i 51457 \
-	-i 52322 \
-	-i 52495 \
-	-i 52510 \
-	-i 52518 \
-	-i 52365 \
 
 ifdef TESTCASES
   pytest_opts := $(TESTOPTS) -k $(TESTCASES)
@@ -764,11 +660,20 @@ flake8_$(pymn).done: Makefile develop_$(pymn).done $(flake8_rc_file) $(py_src_fi
 	@echo "Makefile: Done running Flake8"
 
 safety_$(pymn).done: Makefile develop_$(pymn).done minimum-constraints.txt
+# Python 2.7 and 3.5 safety do not support the policy file
+ifeq ($(python_m_version),2)
+	@echo "Makefile: Warning: Skipping Safety on Python $(python_version)" >&2
+else
+ifeq ($(python_mn_version),3.5)
+	@echo "Makefile: Warning: Skipping Safety on Python $(python_version)" >&2
+else
 	@echo "Makefile: Running pyup.io safety check"
 	-$(call RM_FUNC,$@)
-	safety check -r minimum-constraints.txt --full-report $(safety_ignore_opts)
+	safety check --policy-file $(safety_policy_file) -r minimum-constraints.txt --full-report
 	echo "done" >$@
 	@echo "Makefile: Done running pyup.io safety check"
+endif
+endif
 
 todo_$(pymn).done: Makefile develop_$(pymn).done $(pylint_rc_file) $(py_src_files)
 ifeq ($(python_m_version),2)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -28,12 +28,12 @@ colorama>=0.4.5; python_version >= '3.5'
 importlib-metadata>=0.22,<5.0.0; python_version <= '3.7'
 importlib-metadata>=1.1.0; python_version >= '3.8'
 
-# urllib3 version < 2.0.0 required for python < 3.7
+# urllib3 < 2.0.0 required for python < 3.7
 urllib3>=1.25.9,<2.0.0; python_version == '2.7'
 urllib3>=1.25.9,<2.0.0;  python_version == '3.5'
 urllib3>=1.25.9,<2.0.0;  python_version == '3.6'
 # TODO: Following limits use of urllib3 <= 2.0  for python < 3.7 until issues
-# about upgrade resolved. Issue #1302 filed updates urllib3 to version 2.0.
+# about upgrade resolved. Issue #1302 updates urllib3 to version 2.0.
 # Python <= 3.7 required for urllib3 <= 2.0.0
 urllib3>=1.25.9,<2.0.0; python_version >= '3.7' and python_version <= '3.9'
 urllib3>=1.26.5,<2.0.0; python_version >= '3.10'
@@ -101,7 +101,9 @@ Pygments>=2.1.3; python_version == '2.7'
 Pygments>=2.7.4; python_version >= '3.5'
 sphinx-rtd-theme>=1.0.0
 # Babel 2.7.0 fixes an ImportError for MutableMapping which starts failing on Python 3.10
-Babel>=2.7.0
+Babel>=2.7.0; python_version == '2.7'
+# Safety issue #42203 affected < 2.9.1
+Babel>=2.9.1; python_version >= '3.5'
 
 # PyLint (no imports, invoked via pylint script)
 # Pylint requires astroid
@@ -209,3 +211,5 @@ urllib3>=1.26.5,<2.0.0; python_version >= '3.10'
 # otherwise indirect dependency.
 Jinja2>=2.8.1; python_version == '2.7'
 Jinja2>=2.8.1; python_version >= '3.5'
+# Safety issue #51358, affected <2.2
+Jinja2>=2.10.2; python_version >= '3.10'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -24,6 +24,13 @@ Released: not yet
 
 **Cleanup:**
 
+* Change to used safety-policy-file .safety-policy-yml to keep the safety issue
+  ignore list in place of the list in the Makefile.
+
+* Add several new safety ignore entries into .safety-policy.yml from the
+  new issues that were added to list May 2023.
+
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -139,7 +139,8 @@ PyYAML==5.4.1; python_version >= '3.10'
 yamlloader==0.5.5
 mock==3.0.0
 toposort==1.6
-psutil==5.5.0; python_version <= '3.9'
+# safety issue # 37765 affected <=5.6.5,
+psutil==5.6.5; python_version <= '3.9'
 psutil==5.8.0; python_version >= '3.10'
 
 # Virtualenv
@@ -220,7 +221,9 @@ sphinxcontrib-websupport==1.1.2
 Pygments==2.1.3; python_version == '2.7'
 Pygments==2.7.4; python_version >= '3.5'
 sphinx-rtd-theme==1.0.0
-Babel==2.7.0
+Babel==2.7.0; python_version == '2.7'
+# Safety issue #42203  affected < 2.9.1
+Babel==2.9.1; python_version >= '3.5'
 
 # PyLint (no imports, invoked via pylint script)
 pylint==2.5.2; python_version == '3.5'
@@ -301,7 +304,8 @@ docopt==0.6.1
 enum34==1.1.6; python_version == "2.7"
 filelock==3.0.0
 functools32==3.2.3.post2; python_version < "3.2"
-future==0.18.2
+# Safety issue #52510 affected <=0.18.2
+future==0.18.3
 futures==3.3.0; python_version < "3.2"
 # gitdb2 is a mirror Pypi name for certain gitdb versions.
 gitdb2==2.0.0; python_version == '2.7'
@@ -312,6 +316,7 @@ html5lib==0.999999999
 idna==2.5
 imagesize==0.7.1
 Jinja2==2.8.1; python_version <= '3.9'
+# Safety issue #51358, affected <2.2
 Jinja2==2.10.2; python_version >= '3.10'
 jsonschema==2.6.0
 keyring==18.0.0


### PR DESCRIPTION
Based on PR # 3002, urllib3 version limit PR to pass tests. Waiting on commit of that PR

Add a safety policy file (.safety_policy.yaml) to replace the list of safety-ignores in the Makefile. This file based on the file in pywbem.

Update the safety ignore entries to account for the new safety issues introduced in May 2023

Note: the safety issue 52510, on Future module was removed from the ignore list since the new version (0.18.3) of that package that fixes the issue has been released in January 2023.  (pywbem issue #2976)

This pr includes changes to both minimum-constraints.txt and dev-requirements.txt to reflect the new safety issues.

NOTE: We  modified the minimum-constraints.txt and, etc. to further separate out the requirements that are specific for python 2.7 and 3.5 in to individual statements in many cases to maybe make it easier when we get to removing requirements for these python versions.