### PR TITLE
Ks/container indications

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -48,6 +48,22 @@ Released: not yet
   requesting test indications from the wbem server and uses OpenPegasus 
   2.14.4 or greater. This change will allow end2end indication testing.
 
+* Fix issue where localhost was always assigned as the pywbemlistener bind
+  address. This limited the listener to only receiving indications from the
+  same system as the listener itself and only on the local network interface.
+  This change was part of extending the options to allow the user to define 
+  the bind address as part of the start and run commands. (see issue #1296)
+
+* Add pywbemlistener run/start command option --bind-addr to allow the user to
+  define a bind address to a listener. This replaces the use of the fixed
+  bind-address of localhost. This also changes the default bind address to
+  allow receiving indications on any local system network interrface and
+  not testing for the indication destination IP address. (see issue #1296)
+
+* Add an option to pywbemlistener to allow testing with a listener on a
+  different address/system than the system where pywbemlistener test is being
+  executed. This will allow testing across multiple systems.
+
 **Cleanup:**
 
 * Change to used safety-policy-file .safety-policy-yml to keep the safety issue

--- a/docs/pywbemlistener/cmdshelp.rst
+++ b/docs/pywbemlistener/cmdshelp.rst
@@ -175,6 +175,10 @@ Help text for ``pywbemlistener run`` (see :ref:`pywbemlistener run command`):
       -p, --port PORT              The port number the listener will open to receive indications. This can be any available
                                    port. Default: 25989
       -s, --scheme SCHEME          The scheme used by the listener (http, https). Default: https
+      -b, --bind-addr HOST         A host name or IP address to which this listener will be bound. Binding the listener
+                                   defines the indication destination host name or IP address for which this listener will
+                                   accept indications. The default accepts indications addressed to any network interfaces
+                                   on the listener system.
       -c, --certfile FILE          Path name of a PEM file containing the certificate that will be presented as a server
                                    certificate during SSL/TLS handshake. Required when using https. The file may in addition
                                    contain the private key of the certificate. Default: EnvVar PYWBEMLISTENER_CERTFILE, or
@@ -249,6 +253,10 @@ Help text for ``pywbemlistener start`` (see :ref:`pywbemlistener start command`)
       -p, --port PORT              The port number the listener will open to receive indications. This can be any available
                                    port. Default: 25989
       -s, --scheme SCHEME          The scheme used by the listener (http, https). Default: https
+      -b, --bind-addr HOST         A host name or IP address to which this listener will be bound. Binding the listener
+                                   defines the indication destination host name or IP address for which this listener will
+                                   accept indications. The default accepts indications addressed to any network interfaces
+                                   on the listener system.
       -c, --certfile FILE          Path name of a PEM file containing the certificate that will be presented as a server
                                    certificate during SSL/TLS handshake. Required when using https. The file may in addition
                                    contain the private key of the certificate. Default: EnvVar PYWBEMLISTENER_CERTFILE, or
@@ -321,6 +329,8 @@ Help text for ``pywbemlistener test`` (see :ref:`pywbemlistener test command`):
         pywbemlistener test lis1
 
     Command Options:
-      -c, --count INT  Count of test indications to send. Default: 1
-      -h, --help       Show this help message.
+      -c, --count INT      Count of test indications to send. Default: 1
+      -l, --listener HOST  Listener host name or IP address. The indications are sent to this host name or IP address.
+                           Default: localhost
+      -h, --help           Show this help message.
 

--- a/docs/pywbemlistener/commands.rst
+++ b/docs/pywbemlistener/commands.rst
@@ -45,11 +45,12 @@ Example:
 .. code-block:: text
 
     $ pywbemlistener list
-    +--------+--------+----------+-------+---------------------+
-    | Name   |   Port | Scheme   |   PID | Created             |
-    |--------+--------+----------+-------+---------------------|
-    | lis1   |  25989 | https    | 59327 | 2021-07-03 15:31:55 |
-    +--------+--------+----------+-------+---------------------+
+    +--------+--------+----------+-------------+--------+---------------------+
+    | Name   |   Port | Scheme   | Bind addr   |    PID | Created             |
+    |--------+--------+----------+-------------+--------+---------------------|
+    | lis1   |  25989 | http     | none        | 131870 | 2023-06-07 12:17:55 |
+    +--------+--------+----------+-------------+--------+---------------------+
+
 
 The ``-o, --output-format`` general option can be used to control the format of
 the table that is displayed, for example:
@@ -85,21 +86,23 @@ Example:
 .. code-block:: text
 
     $ pywbemlistener show lis1
-    +--------------------+---------------------------+
-    | Attribute          | Value                     |
-    |--------------------+---------------------------|
-    | Name               | lis1                      |
-    | Port               | 25989                     |
-    | Scheme             | https                     |
-    | Certificate file   | .../certs/server_cert.pem |
-    | Key file           | .../certs/server_key.pem  |
-    | Indication call    |                           |
-    | Indication display | False                     |
-    | Indication file    |                           |
-    | Log file           |                           |
-    | PID                | 59327                     |
-    | Created            | 2021-07-03 15:31:55       |
-    +--------------------+---------------------------+
+    +------------------+---------------------+
+    | Attribute        | Value               |
+    |------------------+---------------------|
+    | Name             | lis1                |
+    | Port             | 25989               |
+    | Scheme           | http                |
+    | Bind addr        | none                |
+    | Certificate file |                     |
+    | Key file         |                     |
+    | Indication call  |                     |
+    | Indication file  |                     |
+    | Log file         |                     |
+    | PID              | 131870              |
+    | Start PID        | 131868              |
+    | Created          | 2023-06-07 12:17:55 |
+    +------------------+---------------------+
+
 
 See :ref:`pywbemlistener show --help` for the exact help output of the command.
 
@@ -127,9 +130,23 @@ The previous example started a listener for HTTPS (the default) on the default
 port 25989. Because HTTPS was used, it was necessary to specify an X.509 server
 certificate and its key file.
 
-The port can be specified using the ``-p, --port`` option.
+The ``-p, --port`` option specifies the port on which the listener will
+receive indicaitons.
+
 The use of HTTP instead of the default HTTPS can be used by specifying it with
-the ``-s, --scheme`` option.
+the ``-s, --scheme`` option defines whether HTTP or HTTPS schema will be used
+as the bind url on which the listener is expecting indications. The default is
+HTTPS.
+
+The ``-b, --bind-addr`` option specifies that the listener will be bound to a
+single network interface and on linux systems, typically, to a single IP
+address on that interface. When a listener is bound to a single network
+interface/IP address it can receive indications only addressed to that network
+interface/IP address. Thus if the listener is bound to ``localhost`` (i.e. the
+local network interface) it will be able to only receive indications addressed
+to that network interface. The default when --bind-addr is not set is for the
+the listener to received indications addressed to any valid IPV4 or IPV6 IP
+address defined on the local system. (New in pywbemtools version 1.3.0).
 
 When the listener receives an indication, by default it drops it and does nothing
 else.
@@ -236,6 +253,14 @@ See :ref:`pywbemlistener stop --help` for the exact help output of the command.
 The ``pywbemlistener test`` command sends a test indication to a running WBEM
 indication listener on the local system.
 
+This command has two options:
+
+The ``-c, --count`` option that defines the number of indications to set where
+the default is to send a single indication.
+
+The ``-l, --listener`` option that defines a host name or IP address to which
+the indications will be sent.  The default ``--listener`` is ``localhost``.
+
 Example:
 
 .. code-block:: text
@@ -271,7 +296,16 @@ in a loop that never ends. It is possible to start this command in the
 background or even run it in the foreground, but it is not recommended that
 users do that directly. Instead, users should use the
 :ref:`pywbemlistener start command`, which starts the ``pywbemlistener run``
-command as a background process.
+command as a background process. Use the  ``pywbemlistener run`` command only
+when you need to have control over how exactly the process runs in the
+background.
+
+The argument and options for the run command are the same as for the
+``pywbemlistener start11 command.
+
+Note: The --start-pid option is needed because on Windows, the ``pywbemlistener
+  run`` command is not the direct child process of the `pywbemlistener start`
+  command starting it.
 
 See :ref:`pywbemlistener run --help` for the exact help output of the command.
 

--- a/tests/unit/pywbemlistener/test_list_cmd.py
+++ b/tests/unit/pywbemlistener/test_list_cmd.py
@@ -93,8 +93,8 @@ LIST_TESTCASES = [
         ),
         dict(
             stdout=[
-                r"^Name +Port +Scheme +PID +Created$",
-                r"^lis1 +50001 +http +[0-9]+ +[0-9\- :\.]+$",
+                r"^Name +Port +Scheme +Bind addr +PID +Created$",
+                r"^lis1 +50001 +http +none +[0-9]+ +[0-9\- :\.]+$",
             ],
             test='all',
         ),
@@ -107,13 +107,16 @@ LIST_TESTCASES = [
             listeners=[
                 ['lis1', '--scheme', 'http', '--port', '50001'],
                 ['lis2', '--scheme', 'http', '--port', '50002'],
+                ['lis3', '--scheme', 'http', '--port', '50003',
+                 '--bind-addr', 'localhost'],
             ]
         ),
         dict(
             stdout=[
-                r"^Name +Port +Scheme +PID +Created$",
-                r"^lis1 +50001 +http +[0-9]+ +[0-9\- :\.]+$",
-                r"^lis2 +50002 +http +[0-9]+ +[0-9\- :\.]+$",
+                r"^Name +Port +Scheme +Bind addr +PID +Created$",
+                r"^lis1 +50001 +http +none +[0-9]+ +[0-9\- :\.]+$",
+                r"^lis2 +50002 +http +none +[0-9]+ +[0-9\- :\.]+$",
+                r"^lis3 +50003 +http +localhost +[0-9]+ +[0-9\- :\.]+$",
             ],
             test='all',
         ),

--- a/tests/unit/pywbemlistener/test_run_cmd.py
+++ b/tests/unit/pywbemlistener/test_run_cmd.py
@@ -34,6 +34,7 @@ RUN_HELP_PATTERNS = [
     r"^Command Options:$",
     r"^ *-p, --port PORT ?",
     r"^ *-s, --scheme SCHEME ?",
+    r"^ *-b, --bind-addr HOST ?",
     r"^ *-c, --certfile FILE ?",
     r"^ *-k, --keyfile FILE ?",
     r"^ *--indi-call MODULE.FUNCTION ?",

--- a/tests/unit/pywbemlistener/test_show_cmd.py
+++ b/tests/unit/pywbemlistener/test_show_cmd.py
@@ -99,6 +99,36 @@ SHOW_TESTCASES = [
                 r"^Name +lis1$",
                 r"^Port +50001$",
                 r"^Scheme +http$",
+                r"^Bind addr +none",
+                r"^Certificate file *$",
+                r"^Key file *$",
+                r"^Indication call *$",
+                r"^Indication file *$",
+                r"^Log file *$",
+                r"^PID +[0-9]+$",
+                r"^Start PID +[0-9]+$",
+                r"^Created +[0-9\- :\.]+$",
+            ],
+            test='all',
+        ),
+        RUN_NOWIN,
+    ),
+    (
+        "Verify output of 'show' on existing listener with bind-addr set",
+        dict(
+            args=['-o', 'plain', 'show', 'lis1'],
+            listeners=[
+                ['lis1', '--scheme', 'http', '--port', '50001',
+                 '--bind-addr', 'localhost'],
+            ]
+        ),
+        dict(
+            stdout=[
+                r"^Attribute +Value$",
+                r"^Name +lis1$",
+                r"^Port +50001$",
+                r"^Scheme +http$",
+                r"^Bind addr +localhost",
                 r"^Certificate file *$",
                 r"^Key file *$",
                 r"^Indication call *$",

--- a/tests/unit/pywbemlistener/test_test_cmd.py
+++ b/tests/unit/pywbemlistener/test_test_cmd.py
@@ -31,6 +31,7 @@ TEST_HELP_PATTERNS = [
     r"\[COMMAND-OPTIONS\]$",
     r"^Command Options:$",
     r"^ *-c, --count INT ?",
+    r"^ *-l, --listener HOST?",
     r"^ *-h, --help ?",
 ]
 


### PR DESCRIPTION
Waiting on PR #1313

See commit message for details:

Fixes issue with pywbemlistener being bound to only "localhost" and adds an option to pywbemlistener start and run to allow the user to define the bind address for each listener created with the default value being 0.0.0.0 for which the listener will receive indications from any network interface and any host/ip address.

Adds new option to pywbemlistener test to define a host name/ip address to which indications will be sent rather than just sending them to localhost.
