### PR TITLE
1.2: Limits on use of urllib3 to < version 2.0.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -28,6 +28,16 @@ colorama>=0.4.5; python_version >= '3.5'
 importlib-metadata>=0.22,<5.0.0; python_version <= '3.7'
 importlib-metadata>=1.1.0; python_version >= '3.8'
 
+# urllib3 version < 2.0.0 required for python < 3.7
+urllib3>=1.25.9,<2.0.0; python_version == '2.7'
+urllib3>=1.25.9,<2.0.0;  python_version == '3.5'
+urllib3>=1.25.9,<2.0.0;  python_version == '3.6'
+# TODO: Following limits use of urllib3 <= 2.0  for python < 3.7 until issues
+# about upgrade resolved. Issue #1302 filed updates urllib3 to version 2.0.
+# Python <= 3.7 required for urllib3 <= 2.0.0
+urllib3>=1.25.9,<2.0.0; python_version >= '3.7' and python_version <= '3.9'
+urllib3>=1.26.5,<2.0.0; python_version >= '3.10'
+
 # more-itertools version 8.11 requires python 3.6, See issue #2796
 more-itertools>=4.0.0,!=8.11.0; python_version < '3.6'
 more-itertools>=4.0.0; python_version >= '3.6'
@@ -176,6 +186,9 @@ packaging>=17.0; python_version == '2.7'
 packaging>=17.0; python_version == '3.5'
 packaging>=21.0,<22.0; python_version >= '3.6'
 
+# urllib3 2.0 requires py>=3.7
+urllib3>=1.25.9,<2.0.0; python_version == '2.7' and python_version >= '3.5'
+urllib3>=1.26.5,<2.0.0; python_version >= '3.10'
 
 # Temporary workarounds on indirectly used packages:
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -160,7 +160,10 @@ requests==2.25.0; python_version >= '3.10'
 # decorator==4.0.11
 # yamlordereddictloader==0.4.0
 urllib3==1.25.9; python_version == '2.7'
-urllib3==1.25.9; python_version >= '3.5' and python_version <= '3.9'
+urllib3==1.25.9; python_version == '3.5'
+urllib3==1.25.9; python_version == '3.6'
+# urllib3 < 2.0.0 required for python < 3.7
+urllib3==1.25.9; python_version >= '3.7' and python_version <= '3.9'
 urllib3==1.26.5; python_version >= '3.10'
 
 # Direct dependencies for develop (must be consistent with dev-requirements.txt)

--- a/tests/unit/pywbemcli/test_pywbemcli_operations.py
+++ b/tests/unit/pywbemcli/test_pywbemcli_operations.py
@@ -48,6 +48,8 @@ PDB = "pdb"
 
 PYWBEM_VERSION = packaging.version.parse(pywbem.__version__)
 
+URLLIB3_VERSION = packaging.version.parse(urllib3.__version__)
+
 # Click (as of 7.1.2) raises UnsupportedOperation in click.echo() when
 # the pytest capsys fixture is used. That happens only on Windows.
 # See Click issue https://github.com/pallets/click/issues/1590. This
@@ -74,7 +76,8 @@ NEWSTYLE_SUPPORTED = sys.version_info[0:2] >= (3, 5)
 with warnings.catch_warnings():
     warnings.filterwarnings('error')
     try:
-        urllib3.Retry(method_whitelist={})
+        if URLLIB3_VERSION.release < (2):
+            urllib3.Retry(method_whitelist={})
     except (DeprecationWarning, TypeError):
         RETRY_DEPRECATION = PYWBEM_VERSION.release < (1, 1)
     else:


### PR DESCRIPTION
Rolls back PR #1303 into 1.2.1