### PR TITLE
Set limit in requirements.txt to not use click-repl 0.3.0

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,10 @@ Released: not yet
 
 * Fixed coveralls issues with KeyError and HTTP 422 Unprocessable Entity.
 
+* Disallow the use of the click_repl version 3.0 because it cannot
+  process general options and causes a significant number of CLI tests to
+  fail. (issue #1312)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,9 @@ Click>=7.1.1,<8.0; python_version == '2.7'
 Click>=8.0.2; python_version >= '3.6'
 click-spinner>=0.1.8
 # click-repl 0.2 is needed for compatibility with Click 8.0.
-click-repl>=0.1.6; python_version == '2.7'
-click-repl>=0.2; python_version >= '3.6'
+# click-repl version 3.0 causes test failures. See issue #1312
+click-repl>=0.1.6,<0.3.0; python_version == '2.7'
+click-repl>=0.2,<0.3.0; python_version >= '3.6'
 asciitree>=0.3.3
 # tabulate 0.8.8 fixes ImportError on Python 3.10.
 tabulate>=0.8.2; python_version <= '3.9'


### PR DESCRIPTION
This new version of click-repl was released 3 days ago and breaks almost 100 of our tests because it does not support the use of general options in the interactive mode.

See issue #1312. Issue also filed with click_repl

rollback needed because:

a. This version of click_repl totally untested by us so not at all sure whether we need to add tests to cover autocomplete.
b.  It completely disallows use of general options in the interactive mode which cause significant issues in our CI tests and removes a capability that users may have been using on a regular basis.