### PR TITLE
Ks/add end2end indications test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,9 @@ on:
 env:
   # WBEM server image on Docker Hub as repository:tag.
   # Keep the version in sync with the Makefile.
-  TEST_SERVER_IMAGE: kschopmeyer/openpegasus-server:0.1.1
+  TEST_SERVER_IMAGE: kschopmeyer/openpegasus-server:0.1.3
   # Base file name of local tarball created from WBEM server image
-  TEST_SERVER_IMAGE_TAR: openpegasus-server:0.1.1.tar.gz
+  TEST_SERVER_IMAGE_TAR: openpegasus-server:0.1.3.tar.gz
   # Local Docker image cache directory
   DOCKER_CACHE_DIR: ~/docker-cache
 

--- a/tests/end2endtest/test_indications.py
+++ b/tests/end2endtest/test_indications.py
@@ -1,0 +1,309 @@
+# Copyright 2023 IBM Corp. All Rights Reserved.
+# Copyright 2023 Inova Development All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test subscription command group commands. This test creates indication filters,
+listener destinations, and subscriptions, requests indications from an
+Open Pegasus server, confirms the correct number of indications sent and, and
+removes the subscription from the server.  If fails if the requested number
+of indications not received.  The test may be repeated by calling
+execute_indication_test(...) multiple times.
+
+"""
+
+from __future__ import absolute_import, print_function
+
+import socket
+import os
+import sys
+import time
+
+from pytest import skip
+
+# pylint: disable=unused-import
+from .utils import server_url, validate_namespace_exists, \
+    validate_indication_profile, validate_required_classes, \
+    create_indication_subscription, remove_subscription, \
+    exec_pywbemcli_cmd   # noqa: F401
+# pylint: enable=unused-import
+
+from ..unit.utils import execute_command
+
+
+def exec_pywbemlistener_cmd(request_params, expected_rc=0, ignore_stderr=False,
+                            verbose=False):
+    """
+    Execute a pywbemlistener request with the list of parameters provided in
+    request_params and assert if rc != 0. When ignore_stderr is set, the test
+    ignores values in the stderr returned.
+
+    If expected_rc == 0
+        Returns stdout if rc = 0 or asserts if rc != 0
+    if expected_rc != 0
+        Returns stderr if expected_rc == rc or asserts if expected_rc != rc
+
+    Allows code where a non-zero stderr is returned when
+    rc == 0. the ingore_stderr parameter allows bypassing this.
+    """
+    if verbose:
+        print("Exec_listener_cmd {}".format(request_params))
+    rc, stdout, stderr = execute_command('pywbemlistener', request_params)
+    if verbose:
+        print("Listener startup result rc={}, stderr={}".format(rc, stderr))
+
+    if expected_rc == 0:
+        assert rc == 0, "pywbemlistener failed: params={}, rc={}, stderr={}" \
+                        .format(request_params, rc, stderr)
+        if not ignore_stderr:
+            assert stderr == '', \
+                "pywbemlistener stderr={}, rc={}".format(stderr, rc)
+        return stdout
+
+    # expected rc not 0
+    assert rc == expected_rc, "pywbemlistener failed: params={} failed " \
+                              "rc={}, stderr={} " \
+                              .format(request_params, rc, stderr)
+    return stderr
+
+
+def execute_indication_test(
+        svr_url, ind_dest_scheme, ind_dest_addr,
+        listener_scheme, listener_bind_addr, listener_port,
+        indication_send_count, verbose):  # pylint: disable=redefined-outer-name
+    """
+    Execute the indication test with the parameters provided. The test includes
+    creating the subscription, creating the listener, requesting a defined
+    number of indications from the WBEM server, waiting for the indications to
+    be received, and removing the subscription.
+
+    The verbose flag adds a number of console outputs as the test proceeds.
+    """
+    if verbose:
+        print("Test for ind_dest_scheme={}, ind_dest_addr={}, "
+              "listener_scheme={}, listener_bind_addr{}, listener_port={}".
+              format(ind_dest_scheme, ind_dest_addr, listener_scheme,
+                     listener_bind_addr, listener_port))
+    filter_id = 'ofilter1'
+    dest_id = 'odest1'
+    test_result = None
+
+    source_namespaces = 'test/TestProvider'
+    query = 'SELECT * from Test_IndicationProviderClass'
+
+    if verbose:
+        print("Create subscription. svr_url={} "
+              "ind_dest_scheme={}, ind_dest_addr={}, listener_port={}, "
+              "destid={}, filterid={}, query={}, source_namespaces={}".
+              format(svr_url, ind_dest_scheme, ind_dest_addr,
+                     listener_port, dest_id, filter_id, query,
+                     source_namespaces))
+
+    create_indication_subscription(
+        svr_url, ind_dest_scheme, ind_dest_addr,
+        listener_port, dest_id, filter_id, query, source_namespaces)
+
+    # Create listener that writes to a file
+    listener_name = 'lis1-end2endtest'
+    if verbose:
+        print("Create listener named {}".format(listener_name))
+
+    # Define file name,remove existing, create empty indication count file
+    # line count from this file is number of indications received.
+    indication_count_file = "end2endindication_output.txt"
+    if os.path.isfile(indication_count_file):
+        os.remove(indication_count_file)
+    with open(indication_count_file, 'w', encoding='UTF-8'):
+        pass
+
+    if verbose:
+        print("Create listener name={} port={} scheme={} indi-file={}".
+              format(listener_name, listener_port, listener_scheme,
+                     indication_count_file))
+
+    exec_pywbemlistener_cmd(['start', listener_name,
+                             '--port', str(listener_port),
+                             '--scheme', listener_scheme,
+                             '--bind-addr', listener_bind_addr,
+                             '--indi-file', indication_count_file],
+                            verbose=verbose)
+
+    exec_pywbemlistener_cmd(['list'], verbose=verbose)
+
+    if verbose:
+        print("Debug Send invoke method for {} instances".
+              format(indication_send_count))
+    result = exec_pywbemcli_cmd(
+        ['-s', svr_url, '--no-verify', '--log', 'all', 'class',
+         'invokemethod',
+         'Test_IndicationProviderClass', 'SendTestIndicationsCount',
+         '--namespace', source_namespaces,
+         '--parameter', "indicationSendCount={}".
+         format(indication_send_count)])
+
+    if verbose:
+        print("Debug: invoke method result {}".format(result))
+
+    test_result = wait_for_indications(indication_send_count,
+                                       indication_count_file,
+                                       verbose)
+
+    # Close listener
+    if verbose:
+        print('Debug Close listener')
+    exec_pywbemlistener_cmd(['stop', listener_name], verbose=verbose)
+
+    # Remove subscriptions
+    if verbose:
+        print("Remove subscription")
+    remove_subscription(svr_url, dest_id, filter_id)
+
+    if test_result:
+        assert False, test_result
+
+
+def wait_for_indications(indication_send_count, indication_count_file,
+                         verbose):
+    """
+    Wait and count indications received. Exactly the required number of
+    indications must be returned and counted in a time period determined
+    by the indication_send_count.
+
+    Returns None if successful or fail message if indication
+    """
+    # Wait for indications to be received with timeout.
+    # This counts the number of loops with nothing received and with
+    # less than requested received. This accounts for possibility of too many
+    # indications sent by waiting for at least 2 seconds extended by number
+    # if indications expected
+    max_loop_count = int(2 + (indication_send_count / 50))
+
+    rcvd_indication_count = 0
+    loop_counter = 0  # Set to zero each time indications received.
+
+    test_result = None
+    while loop_counter <= max_loop_count:
+        loop_counter += 1
+        time.sleep(1)
+
+        # Count indications received in file by counting lines
+        with open(indication_count_file, 'r', encoding='UTF-8') as fp:
+            rcvd_lines = len(fp.readlines())
+            if verbose:
+                print("rcvd {} indications, loop {}".format(rcvd_lines,
+                                                            loop_counter))
+
+        # Restart loop counter when any indications received
+        if rcvd_indication_count < rcvd_lines:
+            rcvd_indication_count = rcvd_lines
+            if verbose:
+                print("Rcvd {} indications  loop_counter {}".
+                      format(rcvd_indication_count, loop_counter))
+            loop_counter = 0
+
+        if rcvd_lines == indication_send_count:
+            if verbose:
+                print("Received expected number of indications {0}".
+                      format(rcvd_lines))
+            break
+        # If requested number of indications received, break loop
+        if rcvd_lines > indication_send_count:
+            test_result = "Received too many indications rcvd={0}, " \
+                          "expected={1}". \
+                          format(rcvd_lines, indication_send_count)
+            break
+
+    else:
+        test_result = "Waited too long for indications. Rcvd {} \
+                      indications, expected {}. ".format(
+                      rcvd_indication_count, indication_send_count)
+        if verbose:
+            print("Loop counter {} max_loop_count {}".format(loop_counter,
+                                                             max_loop_count))
+    return test_result or None
+
+
+def test_indications(server_url):  # pylint: disable=redefined-outer-name
+    """
+    The indication test.  This function is called because server_url is a pytest
+    fixture.
+    """
+    # issue #3022, the container not returning all of the indications.
+    # This appears to be much more consistent with python 3.7 and 3.7
+    # PACKAGE_LEVEL=minimum
+    if sys.version_info[0:2] in ((2, 7), (3, 7)):
+        skip("Skipping test_indications for python 2.7 and 3.7")
+
+    verbose = False
+
+    # Get a real IP address for the machine to insert into the
+    # indication_destination_host variable. This must be an address available
+    # to both the test machine/vm/etc. and the container in which OpenPegasus
+    # is running so OpenPegasus can route indications to the listener.
+    # cannot be localhost, etc.
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.connect(("8.8.8.8", 80))
+    indication_dest_host = sock.getsockname()[0]
+    sock.close()
+
+    if verbose:
+        print("Indication_dest_host {}".format(indication_dest_host))
+
+    interop = validate_namespace_exists(server_url, 'interop', 'root/interop')
+
+    validate_indication_profile(server_url, ('SNIA', 'Indication', '1.2.0'))
+
+    required_classes = {interop: ['CIM_ListenerDestinationCIMXML',
+                                  'CIM_IndicationFilter',
+                                  'CIM_IndicationSubscription', ], }
+
+    validate_required_classes(server_url, required_classes)
+
+    # Two network addresses are associated with the listener:
+    # 1. The destination url for indications that is part of the Destination
+    #    instance of the subscription.  This must be a real public destination
+    #    URL for indications created by the server. In this code that is the
+    #    ind_dest_scheme, ind_dest_addr and listener_port.
+    # 2. The bind address for the indication listener that defines the
+    #    the network interfaces on which the listener will accept indications
+    #    This is the listener_scheme either a specific public IP address or a
+    #    wildcard address and the listener port.
+
+    # Subscription destination URL parameters
+    ind_dest_scheme = 'http'
+    ind_dest_addr = indication_dest_host
+
+    # TODO: Extend to include both http and https listener ports.
+    # listener bind url parameters
+    listener_scheme = 'http'
+    # tests parameters for bind to IP and wildcard bind.
+    listener_bind_addr_ip = indication_dest_host
+    listener_bind_addr_wc = "0.0.0.0"
+
+    # listener and indication_dest port are the same
+    listener_port = 5000
+
+    # Sending only a single indication because we have issues with losing
+    # indications. They get stuck in the WBEM Server See pywbem issue.
+    indication_send_count = 1
+
+    # Execute the test.  If successful, will return. If fail, the
+    # test asserts. Test1, with bind IP, test2 wildcard bind
+    execute_indication_test(server_url, ind_dest_scheme, ind_dest_addr,
+                            listener_scheme, listener_bind_addr_wc,
+                            listener_port, indication_send_count, verbose)
+
+    execute_indication_test(server_url, ind_dest_scheme, ind_dest_addr,
+                            listener_scheme, listener_bind_addr_ip,
+                            listener_port, indication_send_count, verbose)

--- a/tests/end2endtest/test_instance_count.py
+++ b/tests/end2endtest/test_instance_count.py
@@ -21,9 +21,8 @@ from __future__ import absolute_import, print_function
 import re
 
 # pylint: disable=unused-import
-from .utils import server_url  # noqa: F401
+from .utils import server_url, exec_pywbemcli_cmd  # noqa: F401
 # pylint: enable=unused-import
-from ..unit.utils import execute_command
 
 
 def create_table(stdout):
@@ -49,12 +48,9 @@ def test_instance_count(server_url):
 
     # Check the instance count operation that will return a success and
     # valid data
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
+    stdout = exec_pywbemcli_cmd(
         ['-s', server_url, '--no-verify', '-o', 'simple', 'instance', 'count',
          '-n', 'root/cimv2'])
-    assert rc == 0
-    assert stderr == ''
 
     table_lines = create_table(stdout)
     # Why this not in rslt assert ('Namespace', 'Class', 'count') in table_lines
@@ -64,15 +60,11 @@ def test_instance_count(server_url):
     # Test instance count against OpenPegasus with option that produces
     # CIMError from the server but from which pywbemcli should simply
     # produce a line in a report.
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
+    stdout = exec_pywbemcli_cmd(
         ['-s', server_url, '--verbose', '--no-verify', '-o', 'simple',
          'instance', 'count', '-n', 'test/TestProvider',
-         '--ignore-class', 'TST_FaultyInstance,TST_FaultyInstanceSub'])
-
-    if rc != 0:
-        print("instance count stderr: {}".format(stderr))
-    assert rc == 0
+         '--ignore-class', 'TST_FaultyInstance,TST_FaultyInstanceSub'],
+        ignore_stderr=True)
 
     table_lines = create_table(stdout)
     assert ('test/TestProvider', 'TEST_Family', 'CIMError CIM_ERR_NOT_FOUND') \

--- a/tests/end2endtest/test_server.py
+++ b/tests/end2endtest/test_server.py
@@ -21,9 +21,8 @@ from __future__ import absolute_import, print_function
 import re
 
 # pylint: disable=unused-import
-from .utils import server_url  # noqa: F401
+from .utils import server_url, exec_pywbemcli_cmd  # noqa: F401
 # pylint: enable=unused-import
-from ..unit.utils import execute_command
 
 
 def test_server_is_pegasus(server_url):
@@ -40,39 +39,27 @@ def test_server_is_pegasus(server_url):
     """
 
     # Check the server brand
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
+    stdout = exec_pywbemcli_cmd(
         ['-s', server_url, '--no-verify', 'server', 'brand'])
-    assert rc == 0
-    assert stderr == ''
     brand = stdout.strip('\n')
     assert brand == 'OpenPegasus'
 
     # Check the expected Interop namespace
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
+    stdout = exec_pywbemcli_cmd(
         ['-s', server_url, '--no-verify', 'namespace', 'interop'])
-    assert rc == 0
-    assert stderr == ''
     interop = stdout.strip('\n')
     assert interop == 'root/interop'
 
     # Check the namespaces our tests will use
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
+    stdout = exec_pywbemcli_cmd(
         ['-s', server_url, '--no-verify', 'namespace', 'list'])
-    assert rc == 0
-    assert stderr == ''
     namespaces = stdout.strip('\n').split('\n')[2:]
     assert 'root/interop' in namespaces
     assert 'test/TestProvider' in namespaces
 
     # Check the profiles our tests will use
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
+    stdout = exec_pywbemcli_cmd(
         ['-s', server_url, '--no-verify', 'profile', 'list'])
-    assert rc == 0
-    assert stderr == ''
     profile_lines = stdout.strip('\n').split('\n')[3:]
     profiles = []
     for line in profile_lines:

--- a/tests/end2endtest/test_subscriptions.py
+++ b/tests/end2endtest/test_subscriptions.py
@@ -23,9 +23,11 @@ from __future__ import absolute_import, print_function
 import re
 
 # pylint: disable=unused-import
-from .utils import server_url  # noqa: F401
+from .utils import server_url, validate_namespace_exists, \
+    validate_indication_profile, validate_required_classes, \
+    create_indication_subscription, remove_subscription, \
+    exec_pywbemcli_cmd  # noqa: F401
 # pylint: enable=unused-import
-from ..unit.utils import execute_command
 
 
 def test_subscriptions(server_url):
@@ -34,138 +36,33 @@ def test_subscriptions(server_url):
     The test.  This function is called because server_url is a pytest
     fixture.
     """
-    # Get Interop Namespace
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
-        ['-s', server_url, '--no-verify', 'namespace', 'interop'])
-    assert rc == 0
-    assert stderr == ''
-    interop = stdout.strip('\n')
-    assert interop == 'root/interop'
+    interop = validate_namespace_exists(server_url, 'interop', 'root/interop')
 
-    # Determine if Indication profile exists
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
-        ['-s', server_url, '--no-verify', 'profile', 'list'])
-    assert rc == 0
-    assert stderr == ''
-    profile_lines = stdout.strip('\n').split('\n')[3:]
-    profiles = []
-    for line in profile_lines:
-        m = re.match(r'^(.+?) {2,}(.+?) {2,}(.+)$', line)
-        assert m, "Cannot parse 'profile list' output line: {!r}".format(line)
-        profiles.append(m.groups())
-    # validate versions of indication profile
-    assert ('SNIA', 'Indication', '1.2.0') in profiles
+    validate_indication_profile(server_url, ('SNIA', 'Indication', '1.2.0'))
 
-    # Determine if required classes are in interop
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
-        ['-s', server_url, '--no-verify', 'class', 'get',
-         'CIM_ListenerDestinationCIMXML', '-n', interop])
-    assert rc == 0
-    assert stderr == ''
+    required_classes = {interop: ['CIM_ListenerDestinationCIMXML',
+                                  'CIM_IndicationFilter',
+                                  'CIM_IndicationSubscription', ], }
 
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
-        ['-s', server_url, '--no-verify', 'class', 'get',
-         'CIM_IndicationFilter', '-n', interop])
-    assert rc == 0
-    assert stderr == ''
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
-        ['-s', server_url, '--no-verify', 'class', 'get',
-         'CIM_IndicationSubscription', '-n', interop])
-    assert rc == 0
-    assert stderr == ''
+    validate_required_classes(server_url, required_classes)
 
-    # Create a destination
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
-        ['-s', server_url, '--no-verify', 'subscription', 'add-destination',
-         'odest1', '-l', 'http://localhost:5000'])
-    assert rc == 0
-    assert stderr == ''
-    good_response = stdout.strip('\n')
-    assert good_response == 'Added owned destination: ' \
-        'Name=pywbemdestination:defaultpywbemcliSubMgr:odest1'
+    filter_id = 'ofilter1'
+    dest_id = 'odest1'
 
-    # Create a filter
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
-        ['-s', server_url, '--no-verify', 'subscription', 'add-filter',
-         'ofilter1', '--query', 'Select * from CIM_AlertIndication'])
-    assert rc == 0
-    assert stderr == ''
-    good_response = stdout.strip('\n')
-    assert good_response == 'Added owned filter: Name=pywbemfilter:' \
-        'defaultpywbemcliSubMgr:ofilter1'
-
-    # Test filter creation that returns CIMError since we cannot test
-    # this with mock. Server should return exception because of bad filter
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
-        ['-s', server_url, '--no-verify', 'subscription', 'add-filter',
-         'ofilter2', '--query', 'blah'])
-    assert rc == 1
-    err_response = stderr.strip('\n')
-    assert re.search("CIM_ERR_INVALID_PARAMETER", err_response)
-
-    # Create a subscription
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
-        ['-s', server_url, '--no-verify', 'subscription', 'add-subscription',
-         'odest1', 'ofilter1', '--owned'])
-    assert rc == 0
-    assert stderr == ''
-    good_response = stdout.strip('\n')
-    assert re.search("Added owned subscription:", good_response)
-    assert re.search('pywbemdestination:defaultpywbemcliSubMgr:odest1',
-                     good_response)
+    create_indication_subscription(server_url, 'http', 'localhost', '5000',
+                                   dest_id, filter_id,
+                                   'Select * from CIM_AlertIndication',
+                                   'root/cimv2')
 
     # General list command
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
+    stdout = exec_pywbemcli_cmd(
         ['-s', server_url, '--no-verify', '-o', 'simple',
          'subscription', 'list'])
-    assert rc == 0
-    assert stderr == ''
+
     good_response = stdout.strip('\n')
     pattern = r"TOTAL INSTANCES +3 +0 +3"
     assert re.search(pattern, good_response)
 
     # Remove the subscription
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
-        ['-s', server_url, '--no-verify', 'subscription', 'remove-subscription',
-         'odest1', 'ofilter1'])
-    assert rc == 0
-    assert stderr == ''
-    good_response = stdout.strip('\n')
-    assert good_response == \
-        'Removed 1 subscription(s) for destination-id: odest1, filter-id: ' \
-        'ofilter1.'
 
-    # Remove the filter
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
-        ['-s', server_url, '--no-verify', 'subscription', 'remove-filter',
-         'ofilter1'])
-    assert rc == 0
-    assert stderr == ''
-    good_response = stdout.strip('\n')
-    assert good_response == \
-        'Removed owned indication filter: identity=ofilter1, ' \
-        'Name=pywbemfilter:defaultpywbemcliSubMgr:ofilter1.'
-
-    # Remove the destination
-    rc, stdout, stderr = execute_command(
-        'pywbemcli',
-        ['-s', server_url, '--no-verify', 'subscription', 'remove-destination',
-         'odest1'])
-    assert rc == 0
-    assert stderr == ''
-    good_response = stdout.strip('\n')
-    assert good_response == \
-        'Removed owned indication destination: identity=odest1, ' \
-        'Name=pywbemdestination:defaultpywbemcliSubMgr:odest1.'
+    remove_subscription(server_url, dest_id, filter_id)

--- a/tests/end2endtest/utils.py
+++ b/tests/end2endtest/utils.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 
 """
-Utilities for end2end testing.
+Utilities for end2end testing. Includes both fixtures and non-fixture common
+functions.
 """
 
 from __future__ import absolute_import, print_function
 
 import os
+import re
+
 from subprocess import call, check_call
 try:
     from subprocess import DEVNULL  # Python 3
@@ -26,6 +29,8 @@ except ImportError:
     DEVNULL = open(os.devnull, 'wb')  # pylint: disable=consider-using-with
 
 import pytest
+
+from ..unit.utils import execute_command
 
 # Server nickname or server group nickname in WBEM server definition file
 TEST_SERVER_IMAGE = os.getenv('TEST_SERVER_IMAGE', None)
@@ -42,6 +47,9 @@ def server_url(request):
     The TCP ports used on the host side are 15988 and 15989 so that they do
     not conflict with a WBEM server the user may have set up manually, which
     typically would use the standard ports 5988 and 5989.
+
+    Yields the url of the WBEM server started including port number with
+    scheme == HTTPS. Stops the container on return from the yield so
     """
     image = request.param
     if image is None:
@@ -54,18 +62,210 @@ def server_url(request):
     host_port_http = '15988'
     host_port_https = '15989'
 
-    call(['docker', 'rm', container, '--force'],
-         stdout=DEVNULL, stderr=DEVNULL)
+    host_uri = 'https://localhost:{}'.format(host_port_https)
 
-    check_call(['docker', 'create',
-                '--name', container,
-                '--publish', '{}:5988'.format(host_port_http),
-                '--publish', '{}:5989'.format(host_port_https),
-                image],
-               stdout=DEVNULL)
+    # Flag to use an existing running container for the test.  This is
+    # a debug mechanism in that the WBEM Server must be already running in
+    # an existing container before the test and the container is not stoppe
+    # at the end of the test.  This allows debugging the test in the container
+    # and setting the flags to capture server information from the container
+    # when the test is over
+    # TODO: Change following to False before commit
+    use_running_container = False
 
-    check_call(['docker', 'start', container], stdout=DEVNULL)
+    if use_running_container:
+        yield host_uri
 
-    yield 'https://localhost:15989'
+    else:
+        # Remove, create and start a new container before yield to the test
+        call(['docker', 'rm', container, '--force'],
+             stdout=DEVNULL, stderr=DEVNULL)
 
-    check_call(['docker', 'rm', container, '--force'], stdout=DEVNULL)
+        check_call(['docker', 'create',
+                    '--name', container,
+                    '--publish', '{}:5988'.format(host_port_http),
+                    '--publish', '{}:5989'.format(host_port_https),
+                    '--net', 'bridge',
+                    image],
+                   stdout=DEVNULL)
+
+        check_call(['docker', 'start', container], stdout=DEVNULL)
+
+        yield host_uri
+
+        check_call(['docker', 'rm', container, '--force'], stdout=DEVNULL)
+
+
+def exec_pywbemcli_cmd(request_params, expected_rc=0, ignore_stderr=False):
+    """
+    Execute a pywbemcli request with the list of parameters provided in
+    request_params and assert if rc != 0. When ignore_stderr is set, the test
+    ignores values in the stderr returned.
+
+    If expected_rc == 0
+        Returns stdout if rc = 0 or asserts if rc != 0
+    if expected_rc != 0
+        Returns stderr if expected_rc == rc or asserts if expected_rc != rc
+
+    There is a case in the code where a non-zero stderr is returned when
+    rc == 0. the ingore_stderr parameter allows bypassing this.
+    """
+    # print("debug: exec_pywbemcli_cmd {}".format(" ".join(request_params)))
+    rc, stdout, stderr = execute_command('pywbemcli', request_params)
+    # print("debug: rc={}, stderr={}".format(rc, stderr))
+
+    if expected_rc == 0:
+        assert rc == 0, "pywbemcli failed: params={}, rc={}, stderr={}" \
+                        .format(request_params, rc, stderr)
+        if not ignore_stderr:
+            assert stderr == '', "pywbemcli stderr={}, rc={}".format(stderr, rc)
+        return stdout
+
+    # expected rc not 0
+    assert rc == expected_rc, "pywbemcli failed: params={} failed rc={}, " \
+                              "stderr={} " \
+                              .format(request_params, rc, stderr)
+    return stderr
+
+
+def validate_namespace_exists(server_url, namespace, namespace_full_name):
+    # pylint: disable=redefined-outer-name
+    """
+    Validate that the namespace defined by namespace  ex. interop exists.  The
+    parameter namespace_full_name is the full namespace name (ex root/interop)
+
+    Returns the namespace if successful
+    """
+    # Get Interop Namespace
+    stdout = exec_pywbemcli_cmd(
+        ['-s', server_url, '--no-verify', 'namespace', namespace])
+    namespace = stdout.strip('\n')
+    assert namespace == namespace_full_name
+    return namespace
+
+
+def validate_indication_profile(server_url, expected_profile):
+    # pylint: disable=redefined-outer-name
+    """
+    Validate that the expected profile defined by the tuple expected_profile
+    exists.
+    """
+    # Determine if Indication profile exists
+    stdout = exec_pywbemcli_cmd(
+        ['-s', server_url, '--no-verify', 'profile', 'list'])
+
+    profile_lines = stdout.strip('\n').split('\n')[3:]
+    profiles = []
+    for line in profile_lines:
+        m = re.match(r'^(.+?) {2,}(.+?) {2,}(.+)$', line)
+        assert m, "Cannot parse 'profile list' output line: {!r}".format(line)
+        profiles.append(m.groups())
+
+    # validate versions of indication profile
+    assert expected_profile in profiles, "Expected profile {0} not found in " \
+        "{1}".format(expected_profile, profiles)
+
+
+def validate_required_classes(server_url, required_classes_dict):
+    # pylint: disable=redefined-outer-name
+    """
+    Test that the classed defined in the namespaces in the input dictionary
+    actually exist.
+    """
+    for namespace, classnames in required_classes_dict.items():
+        for classname in classnames:
+            exec_pywbemcli_cmd(
+                ['-s', server_url, '--no-verify', 'class', 'get',
+                 classname, '-n', namespace])
+
+
+def create_indication_subscription(server_url, listener_scheme, listener_host,
+                                   listener_port, dest_id, filter_id,
+                                   query, source_namespaces):
+    # pylint: disable=redefined-outer-name
+    """
+    Create the 3 instances required for a complete  indication subscription
+    in the WBEM server defined by server_url
+
+    The bind_address must include both the host name/IP and scheme.
+
+    Source namespaces which is a parameter for the filter is optional
+    """
+    # Create a destination
+    listener_url = "{}://{}:{}".format(listener_scheme, listener_host,
+                                       listener_port)
+
+    stdout = exec_pywbemcli_cmd(
+        ['-s', server_url, '--no-verify', 'subscription', 'add-destination',
+         dest_id, '-l', listener_url])
+
+    good_response = stdout.strip('\n')
+    assert good_response == 'Added owned destination: ' \
+        'Name=pywbemdestination:defaultpywbemcliSubMgr:{}'.format(dest_id)
+
+    # Create a filter
+    cmd = ['-s', server_url, '--no-verify', 'subscription', 'add-filter',
+           filter_id,
+           '--query', query,
+           '--source-namespaces', source_namespaces]
+
+    stdout = exec_pywbemcli_cmd(cmd)
+
+    good_response = stdout.strip('\n')
+    assert good_response == 'Added owned filter: Name=pywbemfilter:' \
+        'defaultpywbemcliSubMgr:{}'.format(filter_id)
+
+    # Test filter creation that returns CIMError since we cannot test
+    # this with mock. Server should return exception because of bad filter
+    stderr = exec_pywbemcli_cmd(
+        ['-s', server_url, '--no-verify', 'subscription', 'add-filter',
+         'ofilter2', '--query', 'blah', '--source-namespaces', 'root/cimv2'],
+        expected_rc=1, )
+
+    err_response = stderr.strip('\n')
+    assert re.search("CIM_ERR_INVALID_PARAMETER", err_response)
+
+    # Create a subscription
+    stdout = exec_pywbemcli_cmd(
+        ['-s', server_url, '--no-verify', 'subscription', 'add-subscription',
+         'odest1', 'ofilter1', '--owned'])
+    good_response = stdout.strip('\n')
+    assert re.search("Added owned subscription:", good_response)
+    assert re.search(
+        'pywbemdestination:defaultpywbemcliSubMgr:{}'.format(dest_id),
+        good_response)
+
+
+def remove_subscription(server_url, dest_id, filter_id):
+    # pylint: disable=redefined-outer-name
+    """
+    Remove an existing indication defined by dest_id and filter_id from the
+    WBEM server defined by server_url
+    """
+    # pylint: disable=redefined-outer-name
+    stdout = exec_pywbemcli_cmd(
+        ['-s', server_url, '--no-verify', 'subscription', 'remove-subscription',
+         dest_id, filter_id])
+    good_response = stdout.strip('\n')
+    assert good_response == \
+        'Removed 1 subscription(s) for destination-id: {}, filter-id: ' \
+        '{}.'.format(dest_id, filter_id)
+
+    # Remove the filter
+    stdout = exec_pywbemcli_cmd(
+        ['-s', server_url, '--no-verify', 'subscription', 'remove-filter',
+         filter_id])
+    good_response = stdout.strip('\n')
+    assert good_response == \
+        'Removed owned indication filter: identity={0}, ' \
+        'Name=pywbemfilter:defaultpywbemcliSubMgr:{0}.'.format(filter_id)
+
+    # Remove the destination
+    stdout = exec_pywbemcli_cmd(
+        ['-s', server_url, '--no-verify', 'subscription', 'remove-destination',
+         dest_id])
+
+    good_response = stdout.strip('\n')
+    assert good_response == \
+        'Removed owned indication destination: identity={0}, ' \
+        'Name=pywbemdestination:defaultpywbemcliSubMgr:{0}.'.format(dest_id)


### PR DESCRIPTION
This adds a new end2end test for indications. I creates an indication subscription in the container web server, creates a listener, calls a specific class/method that is only in OpenPegasus to send a defined number of indications and waits a defined time for those indications to be sent.  

NOTE: Depends on PR #1305, container indications which modifies the listener so that it will accept indications from other than localhost.  

PR #1305 was rebased into this PR to allow testing of the end2end indication code.

Note that this PR changed the container version in test.yaml since that was missed in the previous change of the container to version 0.1.3.

This PR requests a very small quantity of indications because there is an issue  in generating a multiple indications.  They do not all get sent by OpenPegasus.  We generated a separate issue (issue #1342)  for this problem.

This Pr establishes that the path is open and that we can create the subscriptions in the container, request the indications, receive the indication(s) and close the subscription both with a real IP listener bind address and with the IPV4 wildcard bind address.


