### PR TITLE
Correct issues in tab completor for --name option

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,7 +32,14 @@ Released: not yet
 * Fixed issue with PyYAML 5.4 installation on Python>=3.10 that fails since
   the recent release of Cython 3.
 
+* Correct issue in tab completion for --name argument and option where
+  invalid co:nnection file could cause exception.  Changes messages issued
+  for error to warning. (see issue #1316)
+
 **Enhancements:**
+
+* Extend tab completion to include connection show, connection delete,
+  connection save. (see issue # 1315)
 
 **Cleanup:**
 

--- a/pywbemtools/pywbemcli/__init__.py
+++ b/pywbemtools/pywbemcli/__init__.py
@@ -27,9 +27,11 @@ from .._click_extensions import *     # noqa: F403,F401
 from .._options import *              # noqa: F403,F401
 from .._output_formatting import *    # noqa: F403,F401
 from .._common_cmd_actions import *   # noqa: F403,F401
+
 from ._cmd_namespace import *         # noqa: F403,F401
 from ._common import *                # noqa: F403,F401
 from ._pywbem_server import *         # noqa: F403,F401
+from ._warnings import *              # noqa: F403,F401
 
 from ._cmd_class import *             # noqa: F403,F401
 from ._cmd_instance import *          # noqa: F403,F401

--- a/pywbemtools/pywbemcli/_warnings.py
+++ b/pywbemtools/pywbemcli/_warnings.py
@@ -1,0 +1,41 @@
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+#
+
+"""
+The following warnings are pywbemcli specific warnings that can be issued by
+the pywbemcli.
+"""
+
+from pywbem import Warning as pywbemwarning
+
+
+class InvalidConnectionFile(pywbemwarning):
+    """
+    Indicates that invalid connection file in startup of interactive mode.
+    Warning to user that they cannot use some commands because of the
+    lack of connection file.
+    """
+    pass
+
+
+class TabCompletionError(pywbemwarning):
+    """
+    Indicates that invalid connection file in a tab completion.
+    This warning is used in place of an exception for cmd line tab completion
+    errors because exceptions should never be issued in tab-completion
+    handling
+    """
+    pass

--- a/tests/unit/pywbemcli/test_tabcompletion_unit.py
+++ b/tests/unit/pywbemcli/test_tabcompletion_unit.py
@@ -33,6 +33,7 @@ import click
 
 from pywbemtools.pywbemcli._cmd_help import help_arg_subject_shell_completer
 from pywbemtools.pywbemcli.pywbemcli import connection_name_completer
+from pywbemtools.pywbemcli._warnings import TabCompletionError
 # pylint: disable=relative-beyond-top-level
 from ..pytest_extensions import simplified_test_function
 # pylint: enable=relative-beyond-top-level
@@ -169,25 +170,25 @@ TESTCASES_CONNECTION_NAME_COMPLETE = [
           exp_rtn=[]),
      None, None, OK),
 
-    ('Verify with  invalid connections file, generates exception',
+    ('Verify with invalid connections file, warning',
      dict(ctx="CONNECTION_REPO_TEST_FILE_PATH",
           yaml=TEST_CONNECTION_YAML,
           file=CONNECTION_REPO_TEST_FILE_PATH,
           file_exists=False,
           incomplete="",
-          exp_rtn=["testconn", 'tmp1']),
-     click.ClickException, None, CLICK_V_8),
+          exp_rtn=[]),
+     None, TabCompletionError, CLICK_V_8),
 
     # Needs click version as condition to avoid unwanted exception because
     # of the exception expected.
-    ('Verify with  invalid connections file, generates exception',
+    ('Verify with  invalid connections file, generates warning',
      dict(ctx="CONNECTION_REPO_TEST_FILE_PATH",
           yaml=TEST_CONNECTION_YAML,
           file=None,
           file_exists=False,
           incomplete="",
           exp_rtn=[]),
-     click.ClickException, None, CLICK_V_8),
+     None, TabCompletionError, CLICK_V_8),
 ]
 
 


### PR DESCRIPTION
This pr covers two issues:

1. It corrects a code issue in the completer that causes an exception if the connection file is not even defined in the ctx parameter. see issue #1315

2. It extends the use of tab completion to other places that the connection name is used in commands, in particular the remainder of the connection commands that use the connection name as argument.  It was only implemented in a subset of these commands. see issue #1316

3. Adds a new module -warnings to hold the common warning objects.