### PR TITLE
Update OpenPegasus container to version 0.1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ endif
 # Docker image for end2end tests.
 # Keep the version in sync with the test.yml workflow.
 ifndef TEST_SERVER_IMAGE
-  TEST_SERVER_IMAGE := kschopmeyer/openpegasus-server:0.1.2
+  TEST_SERVER_IMAGE := kschopmeyer/openpegasus-server:0.1.3
 endif
 
 # Determine OS platform make runs on.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -43,6 +43,11 @@ Released: not yet
 * Extend tab completion to include connection show, connection delete,
   connection save. (see issue # 1315)
 
+* Changed version of OpenPegasus-wbemserver container for end2end tests
+  from version 0.1.2 to 0.1.3.  This version corrects OpenPegasus issues in 
+  requesting test indications from the wbem server and uses OpenPegasus 
+  2.14.4 or greater. This change will allow end2end indication testing.
+
 **Cleanup:**
 
 * Change to used safety-policy-file .safety-policy-yml to keep the safety issue


### PR DESCRIPTION
This updates the OpenPegasus docker container version from 0.1.2 to 0.1.3.

The primary difference for the OpenPegasus tests is that this release fixes and issue in the OpenPegasus indications test class definition so that the the class properly declares all of the parameters of the methods to include the parameters by using OpenPegasus 2.14 4 release from the github OpenPegasus\OpenPegasus repository.

Before this version all pywbemcli indication indication test requests to OpenPegasus were refused because the required parameters did not exist in the class definition.  See issue #1299