### PR TITLE
Test: Circumvented a pip-check-reqs issue by excluding its version 2.5.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -168,8 +168,9 @@ pipdeptree>=2.2.0
 #   on Python 2.7.
 # pip-check-reqs 2.3.2 is needed to have proper support for pip<=21.3.
 # pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11.
-pip-check-reqs>=2.3.2; python_version >= '3.6' and python_version <= '3.10'
-pip-check-reqs>=2.4.3; python_version >= '3.11'
+# pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143
+pip-check-reqs>=2.3.2; python_version >= '3.6' and python_version <= '3.7'
+pip-check-reqs>=2.4.3,!=2.5.0; python_version >= '3.8'
 
 # safety 2.3.5 started pinning packaging to <22.0 and requires >=21.0
 packaging>=17.0; python_version == '2.7'

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -38,14 +38,16 @@ Released: not yet
 
 * Fixed safety issues as of 2023-08-27.
 
+* Test: Circumvented a pip-check-reqs issue by excluding its version 2.5.0.
+
 **Enhancements:**
 
 * Extend tab completion to include connection show, connection delete,
   connection save. (see issue # 1315)
 
 * Changed version of OpenPegasus-wbemserver container for end2end tests
-  from version 0.1.2 to 0.1.3.  This version corrects OpenPegasus issues in 
-  requesting test indications from the wbem server and uses OpenPegasus 
+  from version 0.1.2 to 0.1.3.  This version corrects OpenPegasus issues in
+  requesting test indications from the wbem server and uses OpenPegasus
   2.14.4 or greater. This change will allow end2end indication testing.
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -246,8 +246,8 @@ pkginfo==1.4.2
 
 # Package dependency management tools
 pipdeptree==2.2.0
-pip-check-reqs==2.3.2; python_version >= '3.6' and python_version <= '3.10'
-pip-check-reqs==2.4.3; python_version >= '3.11'
+pip-check-reqs==2.3.2; python_version >= '3.6' and python_version <= '3.7'
+pip-check-reqs==2.4.3; python_version >= '3.8'
 
 # pyzmq is used (at least?) by jupyter.
 #pyzmq==16.0.4


### PR DESCRIPTION
No review needed.