### PR TITLE
Test py27hang with subprocess32  package  pywbemlistener py27 tests disabled

### DIFF
--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -92,6 +92,8 @@ security:
             reason: GitPython, Python 2.7, 3.6. fixed version 3.1.32 requires Python>=3.7
         60789:
             reason: GitPython, Python 2.7, 3.6. fixed version 3.1.33 requires Python>=3.7
+        60841:
+            reason: GitPython, Python 2.7, 3.6. fixed version 3.1.35 requires Python>=3.7
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -88,6 +88,10 @@ security:
             reason: Fixed sphinx version 3.3.0 requires Python>=3.5 and is used there
         59925:
             reason: Fixed sphinx version 3.3.0 requires Python>=3.5 and is used there
+        60350:
+            reason: GitPython, Python 2.7, 3.6. fixed version 3.1.32 requires Python>=3.7
+        60789:
+            reason: GitPython, Python 2.7, 3.6. fixed version 3.1.33 requires Python>=3.7
 
     # Continue with exit code 0 when vulnerabilities are found.
     continue-on-vulnerability-error: False

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -84,9 +84,10 @@ sphinx-git>=10.1.1
 # GitPython version 3.0.0 and newer does not support Python 2.7
 # GitPython version 3.1.24 requires Python >=3.7
 # GitPython version 3.1.27 fixes safety issue #52518
+# GitPython version 3.1.33 fixes safety issue #60350, #60789
 GitPython>=2.1.1,<3.0.0; python_version == '2.7'
 GitPython>=2.1.1; python_version == '3.6'
-GitPython>=3.1.27; python_version >= '3.7'
+GitPython>=3.1.33; python_version >= '3.7'
 Pygments>=2.1.3; python_version == '2.7'
 Pygments>=2.7.4; python_version >= '3.6'
 sphinx-rtd-theme>=1.0.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -199,3 +199,7 @@ Jinja2>=2.8.1; python_version == '2.7'
 Jinja2>=2.8.1; python_version >= '3.6'
 # Safety issue #51358, affected <2.2
 Jinja2>=2.10.2; python_version >= '3.10'
+
+# subprocess backport from python 3.2 to 2.7. See issue #1329
+subprocess32>=3.5.4; python_version == '2.7'
+

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -84,10 +84,10 @@ sphinx-git>=10.1.1
 # GitPython version 3.0.0 and newer does not support Python 2.7
 # GitPython version 3.1.24 requires Python >=3.7
 # GitPython version 3.1.27 fixes safety issue #52518
-# GitPython version 3.1.33 fixes safety issue #60350, #60789
+# GitPython version 3.1.35 fixes safety issue #60350, #60789 #60841
 GitPython>=2.1.1,<3.0.0; python_version == '2.7'
 GitPython>=2.1.1; python_version == '3.6'
-GitPython>=3.1.33; python_version >= '3.7'
+GitPython>=3.1.35; python_version >= '3.7'
 Pygments>=2.1.3; python_version == '2.7'
 Pygments>=2.7.4; python_version >= '3.6'
 sphinx-rtd-theme>=1.0.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -56,7 +56,7 @@ Released: not yet
 * Fix issue where localhost was always assigned as the pywbemlistener bind
   address. This limited the listener to only receiving indications from the
   same system as the listener itself and only on the local network interface.
-  This change was part of extending the options to allow the user to define 
+  This change was part of extending the options to allow the user to define
   the bind address as part of the start and run commands. (see issue #1296)
 
 * Add pywbemlistener run/start command option --bind-addr to allow the user to
@@ -78,6 +78,8 @@ Released: not yet
   new issues that were added to list May 2023.
 
 * Clean up several documentation syntax issues in the pywbemcli documentation.
+
+* New safety issue(GitPython) Sept 2023, check-reqs issue  ruamel-yaml.
 
 
 **Known issues:**

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -37,11 +37,18 @@ Released: not yet
 
 * Correct issue in tab completion for --name argument and option where
   invalid co:nnection file could cause exception.  Changes messages issued
-  for error to warning. (see issue #1316)
+  for error to warning. This eliminates most tests of pywbemlistener but
+  only with Python 2.7 and that version of Python is deprecated
+  (see issue #1316)
 
 * Fixed safety issues as of 2023-08-27.
 
 * Test: Circumvented a pip-check-reqs issue by excluding its version 2.5.0.
+
+* Test: cicumvented a test failure with pywbemlistener and python 2.7 by
+  disabling a significant number of pywbemlistener tests for python 2.7 and
+  modifying the packages to use subprocess32 in place of subprocess with
+  python 2.7 in case any tests fail.  (see issue #1327)
 
 **Enhancements:**
 

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -199,7 +199,7 @@ docutils==0.16; python_version >= '3.11'
 sphinx-git==10.1.1
 GitPython==2.1.1; python_version == '2.7'
 GitPython==2.1.1; python_version == '3.6'
-GitPython==3.1.27; python_version >= '3.7'
+GitPython==3.1.33; python_version >= '3.7'
 sphinxcontrib-websupport==1.1.2
 Pygments==2.1.3; python_version == '2.7'
 Pygments==2.13.0; python_version == '3.6'
@@ -348,3 +348,8 @@ wcwidth==0.1.7
 webencodings==0.5.1
 widgetsnbextension==1.2.6
 zipp==0.5.2
+ruamel-yaml==0.13.6; python_version == '2.7'
+#safety 2.2.0 depends on ruamel.yaml>=0.17.21
+ruamel-yaml==0.17.21; python_version == '3.6'
+ruamel-yaml==0.17.21; python_version >= '3.7'
+

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -199,7 +199,7 @@ docutils==0.16; python_version >= '3.11'
 sphinx-git==10.1.1
 GitPython==2.1.1; python_version == '2.7'
 GitPython==2.1.1; python_version == '3.6'
-GitPython==3.1.33; python_version >= '3.7'
+GitPython==3.1.35; python_version >= '3.7'
 sphinxcontrib-websupport==1.1.2
 Pygments==2.1.3; python_version == '2.7'
 Pygments==2.13.0; python_version == '3.6'

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -353,3 +353,5 @@ ruamel-yaml==0.13.6; python_version == '2.7'
 ruamel-yaml==0.17.21; python_version == '3.6'
 ruamel-yaml==0.17.21; python_version >= '3.7'
 
+subprocess32==3.5.4; python_version == '2.7'
+

--- a/pywbemtools/_utils.py
+++ b/pywbemtools/_utils.py
@@ -170,4 +170,4 @@ def debug_log(msg):
     timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     caller = inspect.stack()[1][3]
     with io.open("debug.log", "a", encoding='utf-8') as fp:
-        fp.write("{} {}: {}\n".format(timestamp, caller, msg))
+        fp.write(ensure_unicode("{} {}: {}\n".format(timestamp, caller, msg)))

--- a/rtd-requirements.txt
+++ b/rtd-requirements.txt
@@ -13,7 +13,9 @@ docutils>=0.13.1,<0.17; python_version == '2.7'
 docutils>=0.13.1,<0.17; python_version >= '3.6' and python_version <= '3.9'
 docutils>=0.14,<0.17; python_version >= '3.10'
 sphinx-git>=10.1.1
-GitPython>=2.1.1;
+GitPython>=2.1.1,<3.0.0; python_version == '2.7'
+GitPython>=2.1.1; python_version == '3.6'
+GitPython>=3.1.33; python_version >= '3.7'
 Pygments>=2.1.3; python_version == '2.7'
 Pygments>=2.13.0; python_version == '3.6'
 Pygments>=2.15.0; python_version >= '3.7'

--- a/tests/unit/pywbemlistener/test_list_cmd.py
+++ b/tests/unit/pywbemlistener/test_list_cmd.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, print_function
 
 import pytest
 
-from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NOWIN
+from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NO_WIN_NO_PY27
 
 # pylint: disable=use-dict-literal
 
@@ -98,7 +98,7 @@ LIST_TESTCASES = [
             ],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify output of 'list' with two http listeners running",
@@ -120,7 +120,7 @@ LIST_TESTCASES = [
             ],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
 ]
 

--- a/tests/unit/pywbemlistener/test_run_cmd.py
+++ b/tests/unit/pywbemlistener/test_run_cmd.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, print_function
 
 import pytest
 
-from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NOWIN
+from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NO_WIN_NO_PY27
 from .test_start_cmd import START_HELP_CALL_PATTERNS, \
     START_HELP_FORMAT_PATTERNS
 
@@ -128,7 +128,7 @@ RUN_TESTCASES = [
             stderr=RUN_EXISTS_PATTERNS,
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
 ]
 

--- a/tests/unit/pywbemlistener/test_show_cmd.py
+++ b/tests/unit/pywbemlistener/test_show_cmd.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, print_function
 
 import pytest
 
-from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NOWIN
+from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NO_WIN_NO_PY27
 
 # pylint: disable=use-dict-literal
 
@@ -111,7 +111,7 @@ SHOW_TESTCASES = [
             ],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify output of 'show' on existing listener with bind-addr set",
@@ -140,7 +140,7 @@ SHOW_TESTCASES = [
             ],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
 ]
 

--- a/tests/unit/pywbemlistener/test_start_cmd.py
+++ b/tests/unit/pywbemlistener/test_start_cmd.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, print_function
 
 import pytest
 
-from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NOWIN
+from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NO_WIN_NO_PY27
 from ..utils import CLICK_VERSION
 
 # pylint: disable=use-dict-literal
@@ -141,7 +141,7 @@ START_TESTCASES = [
                     r"'badscheme' is not one of 'http', 'https'"],
             test='contains',
         ),
-        RUN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify failure of 'start' on existing listener",
@@ -156,7 +156,7 @@ START_TESTCASES = [
             stderr=START_EXISTS_PATTERNS,
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify success of 'start' on non-existing listener with http",
@@ -167,7 +167,7 @@ START_TESTCASES = [
             stdout=[''],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify success of 'start' on non-existing listener with http and "
@@ -180,7 +180,7 @@ START_TESTCASES = [
             stdout=[''],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify failure of 'start' with invalid bind host name and http,",
@@ -194,7 +194,7 @@ START_TESTCASES = [
             stderr=[r"Cannot start listener .+: .*"],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify failure of 'start' with invalid bind addr ip address",
@@ -208,7 +208,7 @@ START_TESTCASES = [
             stderr=[r"Cannot start listener .+: .*assign.*"],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify failure of 'start' on non-existing listener with https without "
@@ -222,7 +222,7 @@ START_TESTCASES = [
                     r"https_port requires certfile"],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify failure of 'start' on non-existing listener with https with "
@@ -237,7 +237,7 @@ START_TESTCASES = [
                     r"Issue opening certificate/key file"],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify failure of 'start' on non-existing listener with https and "
@@ -253,7 +253,7 @@ START_TESTCASES = [
                     r"certificate file"],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify success of 'start' on non-existing listener with https and "
@@ -266,7 +266,7 @@ START_TESTCASES = [
             stdout=[''],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify success of 'start' on non-existing listener with https and "
@@ -280,7 +280,7 @@ START_TESTCASES = [
             stdout=[''],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
 
     # Test starting listeners with indication processing options and -v
@@ -296,7 +296,7 @@ START_TESTCASES = [
             stdout=[''],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify success of 'start' with --indi-call on valid module.function, "
@@ -327,7 +327,7 @@ START_TESTCASES = [
             ),
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify success of 'start' with --indi-call on valid module.function, "
@@ -358,7 +358,7 @@ START_TESTCASES = [
             ),
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
 
     (
@@ -374,7 +374,7 @@ START_TESTCASES = [
                     r"No module named .?nomodule.?"],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify failure of 'start' with --indi-call on existing module with "
@@ -390,7 +390,7 @@ START_TESTCASES = [
                     r"tests\.unit\.pywbemlistener\.indicall_display"],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify failure of 'start' with --indi-call on existing module that "
@@ -406,7 +406,7 @@ START_TESTCASES = [
                     r"indicall_importerror: ImportError"],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify success of 'start' with --indi-file on non-existing file, no "
@@ -419,7 +419,7 @@ START_TESTCASES = [
             stdout=[''],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify success of 'start' with --indi-file on non-existing file, with "
@@ -447,7 +447,7 @@ START_TESTCASES = [
             ),
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
 
     # Test starting listeners with -vv and bind to localhost
@@ -474,7 +474,7 @@ START_TESTCASES = [
             ],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify failure of 'start' with --vv and same port as existing "
@@ -492,7 +492,7 @@ START_TESTCASES = [
                     r"WBEM listener port 50001 is already in use"],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
 ]
 

--- a/tests/unit/pywbemlistener/test_stop_cmd.py
+++ b/tests/unit/pywbemlistener/test_stop_cmd.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, print_function
 
 import pytest
 
-from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NOWIN
+from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NO_WIN_NO_PY27
 
 # pylint: disable=use-dict-literal
 
@@ -103,7 +103,7 @@ STOP_TESTCASES = [
             # stdout=STOP_SUCCESS_PATTERNS,
             # test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
 ]
 

--- a/tests/unit/pywbemlistener/test_test_cmd.py
+++ b/tests/unit/pywbemlistener/test_test_cmd.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, print_function
 
 import pytest
 
-from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NOWIN
+from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NO_WIN_NO_PY27
 
 # pylint: disable=use-dict-literal
 
@@ -101,7 +101,7 @@ TEST_TESTCASES = [
             ],
             test='contains',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify 'test' with one http listener running and -c 2",
@@ -120,7 +120,7 @@ TEST_TESTCASES = [
             ],
             test='contains',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify 'test' with one http listener running and --count 2",
@@ -139,7 +139,7 @@ TEST_TESTCASES = [
             ],
             test='contains',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
     (
         "Verify 'test' with one http listener running and invalid --count 0",
@@ -156,7 +156,7 @@ TEST_TESTCASES = [
             ],
             test='all',
         ),
-        RUN_NOWIN,
+        RUN_NO_WIN_NO_PY27,
     ),
 ]
 

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -156,6 +156,7 @@ def execute_command(cmdname, args, env=None, stdin=None, verbose=False,
         print('\nEnvironment: {}'.format(display_envvars))
         if stdin is not None:
             print('Stdin: {!r}'.format(stdin))
+        sys.stdout.flush()
 
     if capture:
         stdin_stream = PIPE
@@ -168,6 +169,7 @@ def execute_command(cmdname, args, env=None, stdin=None, verbose=False,
         if stdin is not None:
             if verbose:
                 print('Suppressing stdin because not capturing')
+                sys.stdout.flush()
             stdin = None
 
     if CLICK_ISSUE_1231:
@@ -198,6 +200,7 @@ def execute_command(cmdname, args, env=None, stdin=None, verbose=False,
 
         if verbose:
             print('Command (shell): {}'.format(cmd_args))
+            sys.stdout.flush()
 
         # pylint: disable=consider-using-with
         proc = Popen(cmd_args, shell=True, stdin=None,
@@ -215,6 +218,7 @@ def execute_command(cmdname, args, env=None, stdin=None, verbose=False,
                 print("Error: Timeout ({} sec) when waiting for command to "
                       "complete; Killed process and setting rc={}".
                       format(cmd_timeout, rc))
+                sys.stdout.flush()
         else:
             # Python < 3.3
             proc.wait()
@@ -228,6 +232,7 @@ def execute_command(cmdname, args, env=None, stdin=None, verbose=False,
     else:
         if verbose:
             print('Command (direct): {}'.format(cmd_args))
+            sys.stdout.flush()
 
         # pylint: disable=consider-using-with
         proc = Popen(cmd_args, shell=False, stdin=stdin_stream,
@@ -251,6 +256,7 @@ def execute_command(cmdname, args, env=None, stdin=None, verbose=False,
                       "complete; Killed process and setting rc={}; Stdout "
                       "produced so far: {!r}; Stderr produced so far: {!r}".
                       format(cmd_timeout, rc, stdout_str, stderr_str))
+                sys.stdout.flush()
         else:
             # Python < 3.3
             stdout_str, stderr_str = proc.communicate(input=stdin)
@@ -268,6 +274,7 @@ def execute_command(cmdname, args, env=None, stdin=None, verbose=False,
         if capture:
             print('Stdout: {!r}'.format(stdout_str))
             print('Stderr: {!r}'.format(stderr_str))
+        sys.stdout.flush()
 
     if stdout_str is not None:
         if isinstance(stdout_str, six.binary_type):


### PR DESCRIPTION
Modifies setup to use subprocess32 in place of subprocess with python 2.7 and to eliminate the Pywbemlistener tests that use pywbemlistener stop, both tests where it is specifically used and tests where there are listeners to be stopped in test teardown. Sadly,that is most of the significant tests.

Marked priority since this and PR #1339 are required to get the tests running again.  Please commint #1339 first.

This pr  includes changes for  PR #1339, safety, etc. issues. o I that pr should be committed first

This PR is the proposed solution for issue #1339 until we can find the problem with python27 buster container, and the subprocess.communicate method.