### PR TITLE
1.2: Test: Upgraded GitHub Actions plugins to use node.js 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,7 +202,7 @@ jobs:
         mkdir -p ${{ env.DOCKER_CACHE_DIR }}
     - name: Set up caching for local Docker image cache directory
       if: ${{ (matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-20.04') && matrix.python-version != '2.7' }}
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ env.DOCKER_CACHE_DIR }}
         key: docker-cache-{hash}
@@ -221,12 +221,12 @@ jobs:
           docker load -i ${{ env.DOCKER_CACHE_DIR }}/${{ env.TEST_SERVER_IMAGE_TAR }}; \
         fi
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
       if: ${{ matrix.python-version != '2.7' }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Display initial Python packages

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -45,6 +45,8 @@ Released: not yet
 
 * Development: Fixed dependency issue with safety 3.0.0 by pinning it.
 
+* Test: Upgraded GitHub Actions plugins to use node.js 20.
+
 **Enhancements:**
 
 * Split safety run out of "check" make target ino a separate "safety" make target


### PR DESCRIPTION
Rolls back PR #1356 into 1.2.1