### PR TITLE
Fixed use of pytest.warns(None)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -54,6 +54,9 @@ Released: not yet
 
 * Test: Upgraded GitHub Actions plugins to use node.js 20.
 
+* Test: Fixed issues resulting from removal of support for pytest.warns(None)
+  in pytest version 8.
+
 **Enhancements:**
 
 * Added support for Python 3.12.

--- a/tests/unit/pytest_extensions.py
+++ b/tests/unit/pytest_extensions.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import
 
 import functools
 from collections import namedtuple
+import warnings
 import six
 import pytest
 if six.PY3:
@@ -132,7 +133,7 @@ def simplified_test_function(test_func):
                                   condition)
 
         if exp_warn_types:
-            with pytest.warns(exp_warn_types) as rec_warnings:
+            with warnings.catch_warnings(record=True) as rec_warnings:
                 if exp_exc_types:
                     with pytest.raises(exp_exc_types):
                         if condition == 'pdb':
@@ -155,7 +156,7 @@ def simplified_test_function(test_func):
                     ret = None  # Debugging hint
                     assert len(rec_warnings) >= 1
         else:
-            with pytest.warns(None) as rec_warnings:
+            with warnings.catch_warnings(record=True) as rec_warnings:
                 if exp_exc_types:
                     with pytest.raises(exp_exc_types):
                         if condition == 'pdb':
@@ -177,7 +178,7 @@ def simplified_test_function(test_func):
                     # Verify that no warnings have occurred
                     if exp_warn_types is None and rec_warnings:
                         lines = []
-                        for w in rec_warnings.list:
+                        for w in rec_warnings:
                             tup = (w.filename, w.lineno, w.category.__name__,
                                    str(w.message))
                             line = "{t[0]}:{t[1]}: {t[2]}: {t[3]}".format(t=tup)


### PR DESCRIPTION
For details, see the commit message.
No review needed.