### PR TITLE
Discuss effects of pywbem 1.7.0 changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ system as background processes. It provides functionality to:
 
 Requirements:
 
-1.  Python 2.7, 3.4 and higher
+1.  Python 2.7, 3.6 and higher
 2.  Operating Systems: Linux, OS-X, native Windows, UNIX-like
     environments on Windows (e.g. Cygwin)
 3.  On Python 2, the following OS-level packages are needed:

--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -471,6 +471,34 @@ path can often be determined from the class diagram in the specification for
 the profile.
 Many times, ``CIM_System`` or ``CIM_ComputerSystem`` is the scoping class.
 
+.. _`Troubleshooting`:
+
+Troubleshooting
+---------------
+
+.. index:: pair; installation fail: troubleshooting
+
+This section describes some trouble shooting hints for the installation and
+execution of pywbemtools.  See also the
+`pywbem troubleshooting documentation. <https://pywbem.readthedocs.io/en/latest/appendix.html#troubleshooting>`_
+for information on specific pywbem issues.
+
+Issues with pywbemtools verson 1.3+, Urllib3 package version 2, and SSL
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. index:: pair; SSL fail: troubleshooting
+.. index:: pair; TLS fail: troubleshooting
+.. index:: pair; urllib fail: troubleshooting
+
+Pywbemtools version 1.3.0 introduces the possibility of TLS protocol version
+issues with pywbemtools or between pywbemtools and WBEM severs. These can be
+introduced with the pywbem package version 1.7.0 which allows change of the minimum
+TLS protocol version required to TLS >= 1.2.
+
+Support for  understanding the issues and correcting a number of these possible
+installation and run exceptions involving SSL and TLS is in the
+`pywbem SSL troubleshooting documentation. <https://pywbem.readthedocs.io/en/latest/appendix.html#troubleshooting/Issues with pywbem verson 1.7+, Urllib3 package version 2, and SSL>`_
+
 
 .. _`References`:
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -19,6 +19,17 @@ Released: not yet
 * Installation of this package using "setup.py" is no longer supported.
   Use "pip" instead.
 
+* Update to pywbemtools version 1.3.0 requires pywbem version >= 1.7.2
+  which allows urllib3 version >= 2.0. This may result in issues with SSL because
+  urllib3 may require support of TLS protocol version >= 1.2 possibly
+  resulting in exceptions such as the following:
+
+    SSLError(1, '[SSL: UNSUPPORTED_PROTOCOL] unsupported protocol . . .)  or
+    NotOpenSSLWarning: urllib3 v2.0 only supports OpenSSL 1.1.1+
+
+  See `pywbem troubleshooting documentation. <https://pywbem.readthedocs.io/en/latest/appendix.html#troubleshooting>`_
+  for help resolving such issues.
+
 **Deprecations:**
 
 **Bug fixes:**
@@ -104,6 +115,8 @@ Released: not yet
   in the test workflow which allowed removing the step to update it.
 
 * Added support for running 'ruff', a new lint tool.
+
+* Indroduces a troubleshooting section to the pywbemtools documentation.
 
 **Cleanup:**
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -202,6 +202,12 @@ NOTE: pywbemtools may also be installed for development and to include the
 pywbemtools test environment by cloning the pywbemtools git repository as
 documented in :ref:`Pywbemtools development`.
 
+.. index:: pair; troubleshooting: pywbem
+
+Support for correcting a number of installation issues can be found in the
+`pywbem troubleshooting documentation. <https://pywbem.readthedocs.io/en/latest/appendix.html#troubleshooting>`_
+
+
 .. _`Verification of the installation`:
 
 Verification of the installation


### PR DESCRIPTION
Discuss the issues with change to pywbem 1.7.0.  We concluded that there are no required code chénges to pywbemtools.  This includes:

1. Documentation to help. Resolve any ssl issues .

Note that this pr adds a troubleshooting section to the documentation appendix