### PR TITLE
Fixed package conflict between pylint and mccabe on py 3.10 minimum

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -98,10 +98,10 @@ Babel>=2.9.1; python_version >= '3.6'
 # Pylint 2.7-2.9 had issue https://github.com/PyCQA/pylint/issues/4118 (issues #2672, #2673)
 # Pylint 2.14 / astroid 2.11 support wrapt 1.14 which is required for Python 3.11
 # Pylint 2.15 / astroid 2.12 is needed to circumvent issue https://github.com/PyCQA/pylint/issues/7972 on Python 3.11
-pylint>=2.10.0; python_version >= '3.6' and python_version <= '3.10'
+pylint>=2.13.0; python_version >= '3.6' and python_version <= '3.10'
 pylint>=2.15.0; python_version == '3.11'
 pylint>=3.0.1; python_version >= '3.12'
-astroid>=2.7.2; python_version >= '3.6' and python_version <= '3.10'
+astroid>=2.11.0; python_version >= '3.6' and python_version <= '3.10'
 astroid>=2.12.4; python_version == '3.11'
 astroid>=3.0.1; python_version >= '3.12'
 # astroid 2.13.0 uses typing-extensions on Python<3.11 but misses to require it on 3.10. See https://github.com/PyCQA/astroid/issues/1942

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -79,10 +79,10 @@ Babel==2.7.0; python_version == '2.7'
 Babel==2.9.1; python_version >= '3.6'
 
 # PyLint (no imports, invoked via pylint script)
-pylint==2.10.0; python_version >= '3.6' and python_version <= '3.10'
+pylint==2.13.0; python_version >= '3.6' and python_version <= '3.10'
 pylint==2.15.0; python_version == '3.11'
 pylint==3.0.1; python_version >= '3.12'
-astroid==2.7.2; python_version >= '3.6' and python_version <= '3.10'
+astroid==2.11.0; python_version >= '3.6' and python_version <= '3.10'
 astroid==2.12.4; python_version == '3.11'
 astroid==3.0.1; python_version >= '3.12'
 typing-extensions==3.10; python_version <= '3.10'
@@ -195,7 +195,8 @@ sphinxcontrib-serializinghtml==1.1.5; python_version >= '3.6'
 terminado==0.6
 testpath==0.3
 toml==0.10.0
-tomli==2.0.1; python_version >= '3.6'
+tomli==1.1.0; python_version == '3.6'
+tomli==2.0.1; python_version >= '3.7'
 tornado==4.4.2; python_version == '2.7'
 tornado==6.1; python_version == '3.6'
 tornado==6.2; python_version == '3.7'


### PR DESCRIPTION
No review needed.