### PR TITLE
Remove unneeded python 2.7 functionality and configuration info.

### DIFF
--- a/pywbemtools/_click_extensions.py
+++ b/pywbemtools/_click_extensions.py
@@ -2,8 +2,6 @@
 This file contains extensions to Click for pywbemtools.
 """
 
-import sys
-from collections import OrderedDict
 import packaging.version
 
 import click
@@ -43,9 +41,6 @@ class PywbemtoolsGroup(click.Group):
         """
         super().__init__(name, commands, **attrs)
 
-        if sys.version_info < (3, 6):
-            self.commands = commands or OrderedDict()
-
         # Replace Click.Command.format_usage with local version
         click.core.Command.format_usage = pywbemtools_format_usage
         click.core.Command.format_options = pywbemtools_format_options
@@ -64,10 +59,10 @@ class PywbemtoolsTopGroup(click.Group):
     Extend Click Group class to:
 
     1.  Order the display of the commands and command groups in the top level
-        help output to sort and then put names defined in the predefined_list
-        at the end of the list of commands/groups. Since ordering of the top
-        level cannot be tied to order commands are inserted in list, we elected
-        to just move the generic ones to the end of the list.
+        help output to sort and then put names defined in the __init__ argument
+        move_to_end at the end of the list of commands/groups. Since ordering
+        of the top level cannot be tied to order commands are inserted in list,
+        we elected to just move the generic ones to the end of the list.
 
     This class is used by specifying it for the 'cls' argument on the top
     level group, for example:
@@ -197,42 +192,11 @@ def pywbemtools_format_options(self, ctx, formatter):
             formatter.write_dl(opts)
 
 
-class TabCompleteArgument(click.Argument):
-    """
-    click.argument subclass to be used wherever shell_complete is part of the
-    attributes. Removes the shell_complete attribute if Click version less that
-    version 8 since it is not defined for Click 7
-    """
-    def __init__(self, *args, **kwargs):
-        # Remove the shell_complete option which is not defined in click 7
-        if CLICK_VERSION[0] < 8:
-            kwargs.pop('shell_complete', [])
-
-        super().__init__(*args, **kwargs)
-
-
-class TabCompleteOption(click.Option):
-    """
-    click.Option subclass to override Option for any option that sets the
-    shell_complete attribute. If click version 7, remove the click8 only
-    attribute since that attribute does not exist in Click 7
-    """
-    def __init__(self, *args, **kwargs):
-        """
-        Remove shell_complete option and pass other args and kwargs to
-        superclass
-        """
-        # Remove the shell_complete option which is not defined in click 7
-        if CLICK_VERSION[0] < 8:
-            kwargs.pop('shell_complete', [])
-        super().__init__(*args, **kwargs)
-
-
 # The following MutuallyExclusiveOption originated with a number of
 # discussions on stack overflow and a github gist at
 # https://gist.github.com/stanchan/bce1c2d030c76fe9223b5ff6ad0f03db
 
-class MutuallyExclusiveOption(TabCompleteOption):
+class MutuallyExclusiveOption(click.Option):
     """
     This class subclasses Click option to allow defining mutually exclusive
     options.
@@ -307,12 +271,6 @@ def click_completion_item(name):
         object.  This is the click class that must be returned by user
         tab-completion functions for each string that is proposed as a
         tab completion.
-
-        Click does not include shell_completion in click versions less that
-        v 8 so this method should not be called when click versions lt 8 are
-        used.
     """
-    assert CLICK_VERSION[0] >= 8
-
     # pylint: disable=no-member
     return click.shell_completion.CompletionItem(name)

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -40,7 +40,7 @@ from ._common import pick_one_from_list, pywbem_error_exception, \
 from ._connection_repository import ConnectionsFileError
 from ._context_obj import ContextObj
 from .._click_extensions import PywbemtoolsGroup, PywbemtoolsCommand, \
-    CMD_OPTS_TXT, GENERAL_OPTS_TXT, SUBCMD_HELP_TXT, TabCompleteArgument
+    CMD_OPTS_TXT, GENERAL_OPTS_TXT, SUBCMD_HELP_TXT
 
 from .._options import add_options, help_option
 from .._output_formatting import output_format_is_table, \
@@ -153,8 +153,7 @@ def connection_show(context, name, **options):
 @connection_group.command('delete', cls=PywbemtoolsCommand,
                           options_metavar=CMD_OPTS_TXT)
 @click.argument('name', type=str, metavar='NAME', required=False,
-                shell_complete=connection_name_completer,
-                cls=TabCompleteArgument)
+                shell_complete=connection_name_completer)
 @add_options(help_option)
 @click.pass_obj
 def connection_delete(context, name):

--- a/pywbemtools/pywbemcli/_cmd_help.py
+++ b/pywbemtools/pywbemcli/_cmd_help.py
@@ -26,7 +26,7 @@ with the particular subject.
 
 import click
 
-from .._click_extensions import GENERAL_OPTS_TXT, TabCompleteArgument
+from .._click_extensions import GENERAL_OPTS_TXT
 
 from .pywbemcli import cli
 from .._options import add_options, help_option
@@ -51,7 +51,6 @@ def help_arg_subject_shell_completer(ctx, param, incomplete):
 @cli.command('help', options_metavar=GENERAL_OPTS_TXT)
 @click.argument('subject', type=str,
                 metavar='SUBJECT',
-                cls=TabCompleteArgument,
                 shell_complete=help_arg_subject_shell_completer,
                 required=False)  # pylint: disable=no-member
 @add_options(help_option)

--- a/pywbemtools/pywbemcli/_cmd_server.py
+++ b/pywbemtools/pywbemcli/_cmd_server.py
@@ -47,12 +47,6 @@ from .._output_formatting import validate_output_format, format_table, \
 # the corresponding option name, ex. 'include_qualifiers'. It should be
 # defined with underscore and not dash
 
-# Issue 224 - Exception in prompt-toolkit with python 2.7. Caused because
-# with prompt-toolkit 2 + the completer requires unicode and click_repl not
-# passing help as unicode in options as unicode
-# NOTE: Insure that all option help attributes are unicode to get around this
-#       issue
-
 #
 #   Common option definitions for server group
 #

--- a/pywbemtools/pywbemcli/_displaytree.py
+++ b/pywbemtools/pywbemcli/_displaytree.py
@@ -24,8 +24,6 @@ each classname (see show_detail parameter).
 from asciitree import LeftAligned
 import click
 
-# Use an ordered Nocase dictionary for the tree. Ordered dictionary creates
-# tree output that has the same order in multiple versions of python.
 from pywbem._nocasedict import NocaseDict
 
 

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -1064,14 +1064,6 @@ def cli(ctx, server, connection_name, default_namespace, user, password,
         display_click_context(ctx, msg="DIAGNOSTICS-NEWCTX: Initial context:",
                               display_attrs=True)
 
-    _python_nm = sys.version_info[0:2]
-    if _python_nm in ((2, 7),):
-        pywbemtools_warn(
-            "Pywbemcli support for Python {}.{} is deprecated and will be "
-            "removed in a future version".
-            format(_python_nm[0], _python_nm[1]),
-            DeprecationWarning)
-
     # If no invoked_subcommand, there is no command to execute this flag
     # causes us to start interactive mode
     if ctx.invoked_subcommand is None:

--- a/pywbemtools/pywbemlistener/_cmd_help.py
+++ b/pywbemtools/pywbemlistener/_cmd_help.py
@@ -26,7 +26,7 @@ with the particular subject.
 
 import click
 
-from .._click_extensions import GENERAL_OPTS_TXT, TabCompleteArgument
+from .._click_extensions import GENERAL_OPTS_TXT
 
 from .pywbemlistener import cli
 from .._options import add_options, help_option
@@ -50,7 +50,6 @@ def help_arg_subject_shell_completer(ctx, param, incomplete):
 @cli.command('help', options_metavar=GENERAL_OPTS_TXT)
 @click.argument('subject', type=str,
                 metavar='SUBJECT',
-                cls=TabCompleteArgument,
                 shell_complete=help_arg_subject_shell_completer,
                 required=False)  # pylint: disable=no-member
 @add_options(help_option)

--- a/pywbemtools/pywbemlistener/_cmd_listener.py
+++ b/pywbemtools/pywbemlistener/_cmd_listener.py
@@ -38,7 +38,7 @@ from pywbem import WBEMListener, ListenerError, CIMInstance, CIMProperty, \
     Uint16, WBEMConnection, Error
 
 from .._click_extensions import PywbemtoolsCommand, CMD_OPTS_TXT, \
-    TabCompleteArgument, click_completion_item
+    click_completion_item
 from .._options import add_options, help_option, validate_required_arg
 from .._output_formatting import format_table
 
@@ -401,7 +401,6 @@ def listener_start(context, name, **options):
 @click.argument('name',
                 type=str,
                 metavar='NAME',
-                cls=TabCompleteArgument,
                 shell_complete=listener_name_completer,
                 required=True)
 @add_options(help_option)
@@ -425,7 +424,6 @@ def listener_stop(context, name):
 @click.argument('name',
                 type=str,
                 metavar='NAME',
-                cls=TabCompleteArgument,
                 shell_complete=listener_name_completer,
                 required=True)
 @add_options(help_option)
@@ -460,7 +458,6 @@ def listener_list(context):
 @click.argument('name',
                 type=str,
                 metavar='NAME',
-                cls=TabCompleteArgument,
                 shell_complete=listener_name_completer,
                 required=False)
 @click.option('-c', '--count', type=int, metavar='INT',
@@ -760,8 +757,7 @@ arguments:
   This keyword argument can also be used for accessing its Python object
   attributes in the format specifier (e.g. '{dt.hour}').
 
-* 'tz' - Timezone name of the local timezone. On Python versions before 3.6,
-  the empty string.
+* 'tz' - Timezone name of the local timezone.
 
 * 'h' - Host name or IP address of the host that sent the indication.
 

--- a/pywbemtools/pywbemlistener/pywbemlistener.py
+++ b/pywbemtools/pywbemlistener/pywbemlistener.py
@@ -17,8 +17,6 @@
 The main function of the pywbemlistener command.
 """
 
-
-import sys
 import warnings
 import click
 
@@ -28,7 +26,7 @@ from ._context_obj import ContextObj
 from . import _config
 from .._click_extensions import PywbemtoolsTopGroup, GENERAL_OPTS_TXT, \
     SUBCMD_HELP_TXT
-from .._utils import pywbemtools_warn, get_terminal_width
+from .._utils import get_terminal_width
 from .._options import add_options, help_option
 from .._output_formatting import OUTPUT_FORMAT_GROUPS, OUTPUT_FORMATS
 
@@ -138,11 +136,3 @@ def cli(ctx, output_format, logdir, verbose, pdb, warn):
     # Since there is no interactive mode, there is never a context object.
     assert ctx.obj is None
     ctx.obj = ContextObj(output_format, logdir, verbose, pdb, warn)
-
-    _python_nm = sys.version_info[0:2]
-    if _python_nm in ((2, 7),):
-        pywbemtools_warn(
-            "Pywbemlistener support for Python {}.{} is deprecated and will be "
-            "removed in a future version".
-            format(_python_nm[0], _python_nm[1]),
-            DeprecationWarning)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,10 +15,9 @@ pywbem>=1.7.2
 
 nocaselist>=1.0.3
 nocasedict>=1.0.1
-# Click 7.0 has issue #1231 on Windows which we circumvent in the test code
-# Click 7.1 has a bug with output capturing
-# Click 8.0 is incompatible with python <3.0. See issues #816 (python 2.7 not
-#     supported) and #819 (click-repl incompatible)
+
+# Click 8.0 is incompatible with python <3.0. See issue  #819
+# (click-repl incompatible)
 # The Click requirements were copied into dev-requirements.txt in order not to
 # have the safety package upgrade it. Keep them in sync.
 # Safety package requires click 8.0.2 minimum

--- a/tests/unit/pytest_extensions.py
+++ b/tests/unit/pytest_extensions.py
@@ -9,29 +9,11 @@ that code.
 import functools
 from collections import namedtuple
 import warnings
-from inspect import Signature, Parameter
+from inspect import signature
 
 import pytest
 
 __all__ = ['simplified_test_function']
-
-
-# Pytest determines the signature of the test function by unpacking any
-# wrapped functions (this is the default of the signature() function it
-# uses. We correct this behavior by setting the __signature__ attribute of
-# the wrapper function to its correct signature. To do that, we cannot use
-# signature() because its follow_wrapped parameter was introduced only in
-# Python 3.5. Instead, we build the signature manually.
-# TODO: Simplify this.
-TESTFUNC_SIGNATURE = Signature(
-    parameters=[
-        Parameter('desc', Parameter.POSITIONAL_OR_KEYWORD),
-        Parameter('kwargs', Parameter.POSITIONAL_OR_KEYWORD),
-        Parameter('exp_exc_types', Parameter.POSITIONAL_OR_KEYWORD),
-        Parameter('exp_warn_types', Parameter.POSITIONAL_OR_KEYWORD),
-        Parameter('condition', Parameter.POSITIONAL_OR_KEYWORD),
-    ]
-)
 
 
 def simplified_test_function(test_func):
@@ -185,7 +167,11 @@ def simplified_test_function(test_func):
                         raise AssertionError(msg)
         return ret
 
-    # Needed because the decorator is signature-changin
-    wrapper_func.__signature__ = TESTFUNC_SIGNATURE
+    # Pytest determines the signature of the test function by unpacking any
+    # wrapped functions (this is the default of the signature() function it
+    # uses. We correct this behavior by setting the __signature__ attribute of
+    # the wrapper function to its correct signature.
+    # Needed because the decorator is signature-changing
+    wrapper_func.__signature__ = signature(wrapper_func, follow_wrapped=False)
 
     return functools.update_wrapper(wrapper_func, test_func)


### PR DESCRIPTION
Removes some items that were required for older versions of python (pre 3.8 min version) but that were not caught in the initial removal:

* _click_extensions.py (TabCompletion class and TabCompletionArgument) Remove ref to TabCompletionClass from code
* _displaytree.py -  just a comment removed
* pywbemcli.py - Remove some python 2.7 tests in repl _cmd_listener - commane about tz parameter
* pywbemlistener.py - Python 2.7 test
* requirements.txt - some python 2.7 comments
* Pytest_extensions.py - Manual setup of simplified test signature.


While this pr could be considered a response to issue 1405, it was put together and tested before I started on that issue. Therefore it is submitted as an independent pr