### PR TITLE
Refactor mock scripts and documentation for old-style scripts.

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -359,6 +359,17 @@ This documentation uses a few special terms to refer to Python types:
       <ALT-f> will insert the first word of the suggestion.  This capability is
       implemented only in the interactive mode of pywbemcli.
 
+   WBEM provider
+      A WBEM provider has two possible definitions.  SNIA defines a WBEM
+      provider as a WBEM server environment that includes all the elements of a
+      WBEM server server infrastructure, server repository for CIM objects,
+      elements that generate responses for particular CIM classes, etc.).
+      However, DMTF defines a WBEM provider as a component of a WBEM server
+      that manages the objects and generates responses for a particular CIM
+      class. Thus you would have a provider for the CIM_Namespace class as a
+      component of a WBEM server. In this document a WBEM provider is
+      considered the provider for a single WBEM class.
+
 
 .. _`Profile advertisement methodologies`:
 

--- a/pywbemtools/_click_extensions.py
+++ b/pywbemtools/_click_extensions.py
@@ -98,7 +98,7 @@ class PywbemtoolsTopGroup(click.Group):
         This happens only for the top level commands/groups because this is the
         class override for click.Group ONLY with the top group.
         """
-        # Sort because thier is no particular order for the groups
+        # Sort because their is no particular order for the groups
         cmd_list = sorted(self.commands.keys())
         # Reorder commands list so the move_to_end list commands are at bottom
         #  of list. This displays them at the bottom of the list of commands in

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -244,14 +244,14 @@ def connection_test(context, **options):
 @click.argument('name', type=str, metavar='NAME', required=True)
 @click.option('-f', '--set-default', is_flag=True,
               default=False,
-              help="Set this definition as the default definition "
-              "that will be loaded upon pywbemcli startup if no server or name "
-              "is included on the command line.")
+              help="Set this definition as the default definition. "
+              "That connection will be loaded upon pywbemcli startup if no "
+              "server or name is included on the command line.")
 @add_options(help_option)
 @click.pass_obj
 def connection_save(context, name, **options):
     """
-    Save the current connection to a new WBEM connection definition.
+    Save the current connection parameters to a named WBEM connection.
 
     Save the current connection to the connections file as a connection
     definition named NAME. The NAME argument is required.

--- a/pywbemtools/pywbemcli/_pywbemcli_operations.py
+++ b/pywbemtools/pywbemcli/_pywbemcli_operations.py
@@ -296,7 +296,7 @@ class BuildMockenvMixin:
     """
     Mixin class for pywbem_mock.FakedWBEMConnection that adds the ability to
     build the mock environment of a connection from a connection definition in
-    a connections file.
+    a connections file and input files that define the model and mock setup.
     """
 
     def build_mockenv(self, server, file_path_list, connections_file,

--- a/pywbemtools/pywbemcli/mockscripts/__init__.py
+++ b/pywbemtools/pywbemcli/mockscripts/__init__.py
@@ -97,6 +97,9 @@ def setup_script(file_path, conn, server, verbose):
       SetupNotSupportedError (py<3.5): New-style setup in mock script not
         supported.
       NotCacheable (py<3.5): Mock environment is not cacheable.
+      DeprecatedSetupWarning: Old-style setup mock script. This is a
+        warning that this style is deprecated and will be removed in a
+        future version of pywbemtools
     """
     modpath = get_modpath(file_path)
     spec = importlib.util.spec_from_file_location(modpath, file_path)
@@ -105,6 +108,9 @@ def setup_script(file_path, conn, server, verbose):
     # We cannot find out whether the script has a setup() function before
     # executing it, so we have to set the global variables for the old
     # setup approach in any case.
+    # Deprecated: These global variables have been deprecated will be removed
+    # in a future version of pywbemtools, They are retained because users may
+    # have defined scripts that use this old-style interface.
     module.CONN = conn
     module.SERVER = server
     module.VERBOSE = verbose

--- a/tests/unit/pywbemcli/simple_mock_invokemethod_v1new.py
+++ b/tests/unit/pywbemcli/simple_mock_invokemethod_v1new.py
@@ -6,6 +6,8 @@ function.
 Note: This script and its method provider perform checks because their purpose
 is to test the provider dispatcher. A real mock script with a real method
 provider would not need to perform any of these checks.
+
+This script uses the new-style mock script interface with a setup(...) function.
 """
 
 import pywbem

--- a/tests/unit/pywbemcli/simple_mock_invokemethod_v1old.py
+++ b/tests/unit/pywbemcli/simple_mock_invokemethod_v1old.py
@@ -1,4 +1,15 @@
 """
+
+*Deprecated* - This test script uses the old-style mock script interface and
+is therefore deprecated and will be removed in a future version of
+pywbem tools.
+
+See simple_mock_invokemethod_v1new.py for a corresponding example of the
+new-style mock script interface with a setup(...) script.
+
+Do not use this old-style mock script interface in developing pywbemtools
+mock scripts as this interface will be removed in a future pywbem version.
+
 Test mock script that installs a test method provider for CIM method
 method1() in CIM class CIM_Foo, using the old-style setup approach
 with global variables. This interface is deprecated and will be removed in
@@ -9,8 +20,7 @@ is to test the provider dispatcher. A real mock script with a real method
 provider would not need to perform any of these checks.
 
 Do not use this old-style mock script interface in developing pywbemtools
-mock scripts.
-
+mock scripts as this interface will be removed in a future pywbem version.
 """
 
 import pywbem

--- a/tests/unit/pywbemcli/test_connection_cmds.py
+++ b/tests/unit/pywbemcli/test_connection_cmds.py
@@ -88,15 +88,16 @@ CONNECTION_HELP_LINES = [
     'Usage: pywbemcli [GENERAL-OPTIONS] connection COMMAND [ARGS] [COMMAND-OPTIONS]',  # noqa: E501
     'Command group for WBEM connection definitions.',
     CMD_OPTION_HELP_HELP_LINE,
-    'delete  Delete a WBEM connection definition.',
     'export  Export the current connection.',
-    'list    List the WBEM connection definitions.',
-    'save    Save the current connection to a new WBEM connection',
-    'select  Select a WBEM connection definition as current or default.',
     'show    Show a WBEM connection definition or the current connection.',
+    'delete  Delete a WBEM connection definition.',
+    'select  Select a WBEM connection definition as current or default.',
     'test    Test the current connection with a predefined WBEM request.',
+    'save    Save the current connection parameters to a named WBEM connection.',  # noqa: E501
+    'list    List the WBEM connection definitions.',
     'set-default Set a connection as the default connection.'
 ]
+
 
 CONNECTION_DELETE_HELP_LINES = [
     'Usage: pywbemcli [GENERAL-OPTIONS] connection delete NAME '
@@ -120,7 +121,7 @@ CONNECTION_LIST_HELP_LINES = [
 
 CONNECTION_SAVE_HELP_LINES = [
     'Usage: pywbemcli [GENERAL-OPTIONS] connection save NAME [COMMAND-OPTIONS]',
-    'Save the current connection to a new WBEM connection definition.',
+    'Save the current connection parameters to a named WBEM connection.',
     CMD_OPTION_HELP_HELP_LINE,
 ]
 


### PR DESCRIPTION
As part of the issue on old-style mock scripts we reviewed the mock script documentation and usage.  Note that the old-style mock script already generates a warning if used so no change was needed.

The changes were to:

1.  Significantly modified the mock script documentation.

2,.  Minor changes to the mock script code mocking 

3. Modify some test mock scripts to clarify use of old-style and new-style scripts and mark old style as deprecated.

4. In addition in modifies some code documentation to make corrections.

5. remove one of the test mock scripts as obsolete.

6. Remove the word new from the description of the connection save command since the command creates a new connection or modifies an existing one.

7. Fix tests for help cmd order and save command help. 


