### PR TITLE
1.3: Fixed coveralls not found on MacOS with py39-311

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,6 +175,11 @@ jobs:
               }, \
               { \
                 \"os\": \"macos-latest\", \
+                \"python-version\": \"3.11\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
                 \"python-version\": \"3.12\", \
                 \"package_level\": \"latest\" \
               }, \
@@ -350,7 +355,6 @@ jobs:
       run: |
         make end2endtest
     - name: Send coverage result to coveralls.io
-      shell: bash -l {0}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_PARALLEL: true

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ else
   RMDIR_R_FUNC = find . -type d -name '$(1)' | xargs -n 1 rm -rf
   CP_FUNC = cp -r $(1) $(2)
   ENV = env | sort
-  WHICH = which
+  WHICH = which -a
 endif
 
 # Name of this Python package on Pypi

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -20,6 +20,10 @@ Released: not yet
 
 * Fixed new issues reported by Pylint 3.2.
 
+* Test: Fixed the issue that coveralls was not found in the test workflow on MacOS
+  with Python 3.9-3.11, by running it without login shell. Added Python 3.11 on
+  MacOS to the normal tests.
+
 * For Python 3.6 and 3.7, changed macos-latest back to macos-12 because
   macos-latest got upgraded from 12 to 14 and no longer supports Python 3.6
   and 3.7.


### PR DESCRIPTION
Rolls back PR #1418 into 1.3.1.