### PR TITLE
Fix issue with tests hiding default connection file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,14 @@ doc_dependent_files := \
 # the help in test cases.
 pywbemtools_termwidth := 120
 
+# PYWBEMCLI_ALT_HOME_DIR; Env var defining alternate directory where default
+# pywbemcli connection file will be placed for tests rather than the deault '~'
+# connection file ane mock caches are placed in this directory.
+# This env var value used in pywbemcli/_connection_file_names.py to build these
+# filenames with value of directory where pywbemcli files stored during unit
+# tests. This is set in this makefile for all tests.
+PYWBEMCLI_ALT_HOME_DIR=tmp_tst_pywbemcli_alt_home
+
 # PyLint config file
 pylint_rc_file := pylintrc
 
@@ -714,9 +722,9 @@ endif
 test: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done $(doc_utility_help_files)
 	@echo "Makefile: Running unit and function tests"
 ifeq ($(PLATFORM),Windows_native)
-	cmd /c "set PYWBEMTOOLS_TERMWIDTH=$(pywbemtools_termwidth) & py.test --color=yes $(pytest_cov_opts) $(pytest_warning_opts) $(pytest_opts) tests/unit -s"
+	cmd /c "set PYWBEMTOOLS_TERMWIDTH=$(pywbemtools_termwidth) & set PYWBEMCLI_ALT_HOME_DIR=$(PYWBEMCLI_ALT_HOME_DIR) & py.test --color=yes $(pytest_cov_opts) $(pytest_warning_opts) $(pytest_opts) tests/unit -s"
 else
-	PYWBEMTOOLS_TERMWIDTH=$(pywbemtools_termwidth) py.test --color=yes $(pytest_cov_opts) $(pytest_warning_opts) $(pytest_opts) tests/unit -s
+	PYWBEMTOOLS_TERMWIDTH=$(pywbemtools_termwidth) PYWBEMCLI_ALT_HOME_DIR=$(PYWBEMCLI_ALT_HOME_DIR) py.test --color=yes $(pytest_cov_opts) $(pytest_warning_opts) $(pytest_opts) tests/unit -s
 endif
 	@echo "Makefile: Done running tests"
 
@@ -734,9 +742,9 @@ endif
 end2endtest: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done
 	@echo "Makefile: Running end2end tests"
 ifeq ($(PLATFORM),Windows_native)
-	cmd /c "set TEST_SERVER_IMAGE=$(TEST_SERVER_IMAGE) & py.test --color=yes $(pytest_end2end_warning_opts) $(pytest_end2end_opts) tests/end2endtest -s"
+	cmd /c "set TEST_SERVER_IMAGE=$(TEST_SERVER_IMAGE) & set PYWBEMCLI_ALT_HOME_DIR=$(PYWBEMCLI_ALT_HOME_DIR) & py.test --color=yes $(pytest_end2end_warning_opts) $(pytest_end2end_opts) tests/end2endtest -s"
 else
-	TEST_SERVER_IMAGE=$(TEST_SERVER_IMAGE) py.test --color=yes $(pytest_end2end_warning_opts) $(pytest_end2end_opts) tests/end2endtest -s
+	TEST_SERVER_IMAGE=$(TEST_SERVER_IMAGE) PYWBEMCLI_ALT_HOME_DIR=$(PYWBEMCLI_ALT_HOME_DIR) py.test --color=yes $(pytest_end2end_warning_opts) $(pytest_end2end_opts) tests/end2endtest -s
 endif
 	@echo "Makefile: Done running end2end tests"
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,14 @@ Released: not yet
   on differences between pywbem 1.0.0 and earlier versions of python.
   (issue #1405)
 
+* Refactor pywbemcli tests to avoid hiding the default connection file and
+  the names for the connection file and mock cache by moving as part of tests.
+  EnvVar PYWBEMCLI_ALT_HOME_DIR defines alternate directory for connection file
+  and mockcache and is set for all pywbemcli tests. The definition of file
+  names for default connection file and mock cache managed by pywbemcli moved
+  from  pywbemtools/pywbemcli/_utils.py to pywbemcli/_connection_file_names.py.
+  (issue # 1423)
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/pywbemtools/_utils.py
+++ b/pywbemtools/_utils.py
@@ -42,25 +42,6 @@ USE_TERMINAL_WIDTH = True
 # are output with no limit on width.
 DEFAULT_TABLE_WIDTH = 150
 
-# Keep the following connections file definitions in sync with help text of
-# the "--connections-file" option in pywbemcli.py and generaloptions.rst, and
-# with the use of the base file name in several other .rst and .py files.
-
-# Base file name of the connections file
-# The B08_* file name was used before pywbemcli 0.8.
-CONNECTIONS_FILENAME = '.pywbemcli_connections.yaml'
-B08_CONNECTIONS_FILENAME = 'pywbemcli_connection_definitions.yaml'
-
-# Path name of default connections file directory.
-DEFAULT_CONNECTIONS_DIR = os.path.expanduser("~")
-
-# Path name of default connections file
-# The B08_* path name was used before pywbemcli 0.8.
-DEFAULT_CONNECTIONS_FILE = os.path.join(DEFAULT_CONNECTIONS_DIR,
-                                        CONNECTIONS_FILENAME)
-B08_DEFAULT_CONNECTIONS_FILE = os.path.join(DEFAULT_CONNECTIONS_DIR,
-                                            B08_CONNECTIONS_FILENAME)
-
 
 def ensure_bytes(obj):
     """

--- a/pywbemtools/pywbemcli/__init__.py
+++ b/pywbemtools/pywbemcli/__init__.py
@@ -31,6 +31,7 @@ from ._common import *                # noqa: F403,F401
 from ._pywbem_server import *         # noqa: F403,F401
 from ._warnings import *              # noqa: F403,F401
 
+from ._connection_file_names import *  # noqa: F403,F401
 from ._cmd_class import *             # noqa: F403,F401
 from ._cmd_instance import *          # noqa: F403,F401
 from ._cmd_qualifier import *         # noqa: F403,F401

--- a/pywbemtools/pywbemcli/_cmd_connection.py
+++ b/pywbemtools/pywbemcli/_cmd_connection.py
@@ -251,7 +251,7 @@ def connection_test(context, **options):
 @click.pass_obj
 def connection_save(context, name, **options):
     """
-    Save the current connection parameters to a named WBEM connection.
+    Save the current connection parameters to a named connection.
 
     Save the current connection to the connections file as a connection
     definition named NAME. The NAME argument is required.
@@ -824,7 +824,6 @@ def cmd_connection_save(context, name, options):
     connection must exist.
     The save function allows overwriting existing names
     """
-
     current_connection = context.pywbem_server
     if not current_connection:
         raise click.ClickException('No current connection connection. Use '
@@ -845,6 +844,11 @@ def cmd_connection_save(context, name, options):
 
     if options['set_default']:
         _set_default_connection(context.connections_repo, name, verify=False)
+    if context.verbose:
+        click.echo(f"Connection name: {name} added to named connections in "
+                   f"connections file {connections.connections_file}")
+        if options['set_default']:
+            click.echo(f"Default connection name set to {name}")
 
 
 def cmd_connection_list(context, options):

--- a/pywbemtools/pywbemcli/_connection_file_names.py
+++ b/pywbemtools/pywbemcli/_connection_file_names.py
@@ -1,0 +1,98 @@
+# (C) Copyright 2024 IBM Corp.
+# (C) Copyright 2024 Inova Development Inc.
+# All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Path for the directory containing the connections file and
+mock cache directory.  This is setup dynamically using an environment
+variable for the name of the toplevel directory for these files or the
+user home directory.
+"""
+
+import os
+from click import Abort
+
+# file suffix to be used for backup files for connection files when they
+# are updated.
+BAK_FILE_SUFFIX = '.bak'
+
+# Env var that defines an alternate directory in which will be the home
+# directory for the default connection file and mock cache directory.
+# If env var PYWBEMCLI_ALT_HOME_DIR_ENVVAR is empty
+# or does not exist user home directory (i.e. '~') is used
+PYWBEMCLI_ALT_HOME_DIR_ENVVAR = 'PYWBEMCLI_ALT_HOME_DIR'
+
+# Keep the following connections file definitions in sync with help text of
+# the "--connections-file" option in pywbemcli.py and generaloptions.rst, and
+# with the use of the base file name in several other .rst and .py files.
+
+# Base file name of the default connections file
+# The B08_* file name was used before pywbemcli 0.8.
+CONNECTIONS_FILENAME = '.pywbemcli_connections.yaml'
+B08_CONNECTIONS_FILENAME = 'pywbemcli_connection_definitions.yaml'
+
+# Path name of default connections file directory.
+# Dynamically builds the directory name for the directory that contains the
+# default connections file and the mockcache directory based on an environment
+# variable. Savea the result in variable DEFAULT_CONNECTIONS_DIR.
+# Directory name is from the environment variable value or if the env var
+# does not exist, the user home directory.
+#
+# This environment variable provides a tool to define an alternate
+# location for the directory containing the default connection file and
+# connection mockcache directory and is used in pywbemcli unit test.
+# If no directory exists it builds an empty directory.
+DEFAULT_CONNECTIONS_DIR = None
+
+if os.getenv(PYWBEMCLI_ALT_HOME_DIR_ENVVAR):
+    alt_home_dir_path = os.path.normpath(
+        os.getenv(PYWBEMCLI_ALT_HOME_DIR_ENVVAR))
+    # Windows makefile pads end of env var string.
+    while alt_home_dir_path[-1] == " ":
+        alt_home_dir_path = alt_home_dir_path[:-1]
+    if os.path.exists(alt_home_dir_path):
+        if os.path.isfile(alt_home_dir_path):
+            raise Abort(
+                f'Alternate files home path create: {alt_home_dir_path} '
+                f'defined by envvar: {PYWBEMCLI_ALT_HOME_DIR_ENVVAR} failed. '
+                "File with same name exists")
+        DEFAULT_CONNECTIONS_DIR = alt_home_dir_path
+    else:
+        try:
+            os.mkdir(alt_home_dir_path)
+            DEFAULT_CONNECTIONS_DIR = alt_home_dir_path
+        except OSError as oe:
+            raise Abort(
+                f'Alternate files home path create: {alt_home_dir_path} '
+                f'defined by envvar: {PYWBEMCLI_ALT_HOME_DIR_ENVVAR} failed. '
+                f'Exception: {oe}')
+else:
+    DEFAULT_CONNECTIONS_DIR = os.path.expanduser("~")
+
+assert DEFAULT_CONNECTIONS_DIR is not None  # Future rmve after testing complete
+
+
+# Path name of default connections file
+# The B08_* path name was used before pywbemcli 0.8.
+DEFAULT_CONNECTIONS_FILE = os.path.join(DEFAULT_CONNECTIONS_DIR,
+                                        CONNECTIONS_FILENAME)
+B08_DEFAULT_CONNECTIONS_FILE = os.path.join(DEFAULT_CONNECTIONS_DIR,
+                                            B08_CONNECTIONS_FILENAME)
+
+# Directory where mock cache files for named connections defined in the
+# default connection file as mock connections (--mock-server general
+# argument) are saved. In the same directory as default connection file.
+MOCKCACHE_ROOT_DIR = os.path.join(DEFAULT_CONNECTIONS_DIR,
+                                  '.pywbemcli_mockcache')

--- a/pywbemtools/pywbemcli/_connection_repository.py
+++ b/pywbemtools/pywbemcli/_connection_repository.py
@@ -27,13 +27,12 @@ import os
 from contextlib import contextmanager
 import yaml
 import yamlloader
-import click
+from click import echo
 
 from ._pywbem_server import PywbemServer
 from ._pywbemcli_operations import delete_mock_cache
-from .._utils import DEFAULT_CONNECTIONS_FILE, B08_DEFAULT_CONNECTIONS_FILE
-
-BAK_FILE_SUFFIX = 'bak'
+from ._connection_file_names import DEFAULT_CONNECTIONS_FILE, \
+    B08_DEFAULT_CONNECTIONS_FILE, BAK_FILE_SUFFIX
 
 
 class ConnectionsFileError(Exception):
@@ -457,9 +456,9 @@ class ConnectionRepository:
                     f'Error migrating old connections file '
                     f'"{B08_DEFAULT_CONNECTIONS_FILE}": {exc}')
 
-            click.echo(f"Migrated old connections file "
-                       f"{B08_DEFAULT_CONNECTIONS_FILE!r} to "
-                       f"{DEFAULT_CONNECTIONS_FILE!r}")
+            echo(f"Migrated old connections file "
+                 f"{B08_DEFAULT_CONNECTIONS_FILE!r} to "
+                 f"{DEFAULT_CONNECTIONS_FILE!r}")
 
         # If the file does not exist, the connection repo still has the
         # initial state at this point, and it remains empty.
@@ -521,7 +520,7 @@ class ConnectionRepository:
                     self._pywbemcli_servers[name] = server
                 self._loaded = True
                 if self._verbose:
-                    click.echo(
+                    echo(
                         f"Connections file loaded: {self._connections_file}")
 
         except OSError as exc:
@@ -634,7 +633,7 @@ class ConnectionRepository:
         # Create bak file and then rename tmp file
         try:
             if os.path.isfile(self._connections_file):
-                bakfile = f'{self._connections_file}.{BAK_FILE_SUFFIX}'
+                bakfile = self._connections_file + BAK_FILE_SUFFIX
                 if os.path.isfile(bakfile):
                     os.remove(bakfile)
                 if os.path.isfile(self._connections_file):
@@ -654,4 +653,4 @@ class ConnectionRepository:
                 f'Error renaming temporary file "{tmpfile}" to connections '
                 f'file "{self._connections_file}": {exc}')
         if self._verbose:
-            click.echo(f"Connections file saved: {self._connections_file}")
+            echo(f"Connections file saved: {self._connections_file}")

--- a/pywbemtools/pywbemcli/_pywbem_server.py
+++ b/pywbemtools/pywbemcli/_pywbem_server.py
@@ -26,10 +26,12 @@ import click
 import pywbem
 from pywbem import WBEMServer, configure_loggers_from_string
 
-from . import mockscripts
 from .config import DEFAULT_URL_SCHEME, DEFAULT_CONNECTION_TIMEOUT, \
     DEFAULT_NAMESPACE, MAX_TIMEOUT, DEFAULT_MAXPULLCNT
-from ._pywbemcli_operations import PYWBEMCLIConnection, PYWBEMCLIFakedConnection
+from ._pywbemcli_operations import PYWBEMCLIConnection, \
+    PYWBEMCLIFakedConnection
+
+from . import mockscripts
 
 WBEM_SERVER_OBJ = None
 

--- a/pywbemtools/pywbemcli/_pywbemcli_operations.py
+++ b/pywbemtools/pywbemcli/_pywbemcli_operations.py
@@ -36,8 +36,10 @@ import packaging.version
 import pywbem
 import pywbem_mock
 
+from ._connection_file_names import DEFAULT_CONNECTIONS_FILE, \
+    MOCKCACHE_ROOT_DIR
 from .config import DEFAULT_MAXPULLCNT
-from .._utils import ensure_bytes, ensure_unicode, DEFAULT_CONNECTIONS_FILE
+from .._utils import ensure_bytes, ensure_unicode
 from . import mockscripts
 
 PYWBEM_VERSION = packaging.version.parse(pywbem.__version__)
@@ -384,12 +386,11 @@ class BuildMockenvMixin:
         # which is required for caching.
         if connections_file == DEFAULT_CONNECTIONS_FILE:
 
-            cache_rootdir = mockcache_rootdir()
-            if not os.path.isdir(cache_rootdir):
-                os.mkdir(cache_rootdir)
+            if not os.path.isdir(MOCKCACHE_ROOT_DIR):
+                os.mkdir(MOCKCACHE_ROOT_DIR)
 
             cache_dir = mockcache_cachedir(
-                cache_rootdir, connections_file, connection_name)
+                MOCKCACHE_ROOT_DIR, connections_file, connection_name)
             if not os.path.isdir(cache_dir):
                 os.mkdir(cache_dir)
 
@@ -712,14 +713,6 @@ class PYWBEMCLIFakedConnection(BuildMockenvMixin,
         super().__init__(*args, **kwargs)
 
 
-def mockcache_rootdir():
-    """
-    Return the directory path of the mock cache root directory.
-    """
-    dir_path = os.path.join(os.path.expanduser('~'), '.pywbemcli_mockcache')
-    return dir_path
-
-
 def mockcache_cachedir(rootdir, connections_file, connection_name):
     """
     Return the directory path of the mock cache directory for a connection.
@@ -758,7 +751,7 @@ def delete_mock_cache(connections_file, connection_name):
       OSError: Mock cache cannot be deleted.
     """
     cache_dir = mockcache_cachedir(
-        mockcache_rootdir(), connections_file, connection_name)
+        MOCKCACHE_ROOT_DIR, connections_file, connection_name)
     if os.path.isdir(cache_dir):
         file_list = glob.glob(os.path.join(cache_dir, '*'))
         for _file in file_list:

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -51,12 +51,13 @@ from ._pywbem_server import PywbemServer
 from .config import DEFAULT_NAMESPACE, PYWBEMCLI_PROMPT, \
     PYWBEMCLI_HISTORY_FILE, DEFAULT_MAXPULLCNT, DEFAULT_CONNECTION_TIMEOUT, \
     MAX_TIMEOUT, USE_AUTOSUGGEST
+from ._connection_file_names import CONNECTIONS_FILENAME, \
+    DEFAULT_CONNECTIONS_FILE
 from ._connection_repository import ConnectionRepository, \
     ConnectionsFileError
 from .._click_extensions import PywbemtoolsTopGroup, GENERAL_OPTS_TXT, \
     SUBCMD_HELP_TXT, MutuallyExclusiveOption, click_completion_item
-from .._utils import pywbemtools_warn, get_terminal_width, \
-    CONNECTIONS_FILENAME, DEFAULT_CONNECTIONS_FILE, debug_log
+from .._utils import pywbemtools_warn, get_terminal_width, debug_log
 from .._options import add_options, help_option
 from .._output_formatting import OUTPUT_FORMAT_GROUPS, OUTPUT_FORMATS
 

--- a/tests/unit/pywbemcli/test_connection_repository.py
+++ b/tests/unit/pywbemcli/test_connection_repository.py
@@ -27,11 +27,11 @@ from contextlib import contextmanager
 from unittest.mock import patch
 import pytest
 
+from pywbemtools.pywbemcli._connection_file_names import \
+    DEFAULT_CONNECTIONS_FILE, B08_DEFAULT_CONNECTIONS_FILE, BAK_FILE_SUFFIX
 import pywbemtools.pywbemcli._connection_repository
 from pywbemtools.pywbemcli._connection_repository import ConnectionRepository, \
     ConnectionsFileLoadError, ConnectionsFileWriteError
-from pywbemtools._utils import B08_DEFAULT_CONNECTIONS_FILE, \
-    DEFAULT_CONNECTIONS_FILE
 from pywbemtools.pywbemcli._pywbem_server import PywbemServer
 
 from ..pytest_extensions import simplified_test_function
@@ -45,8 +45,8 @@ from ..pytest_extensions import simplified_test_function
 CLICK_ISSUE_1590 = sys.platform == 'win32'
 
 SCRIPT_DIR = os.path.dirname(__file__)
-CONNECTION_REPO_TEST_FILE_PATH = os.path.join(SCRIPT_DIR,
-                                              'tst_connection_repository.yaml')
+CONNECTION_REPO_TEST_FILE_PATH = os.path.join(
+    SCRIPT_DIR, 'tmp_tst_connection_repository.yaml')
 
 YAML_GOOD_TWO_DEFS = """connection_definitions:
     tst1:
@@ -175,26 +175,26 @@ def remove_file_before_after():
     Remove the connections file at beginning and end of test.
     """
     file = CONNECTION_REPO_TEST_FILE_PATH
+    bakfilesuffix = f"'.' + {BAK_FILE_SUFFIX}"
+    bakfile = CONNECTION_REPO_TEST_FILE_PATH + bakfilesuffix
+    tmpfile = CONNECTION_REPO_TEST_FILE_PATH + '.tmp'
+
     if os.path.isfile(file):
         os.remove(file)
-    file = CONNECTION_REPO_TEST_FILE_PATH + '.bak'
-    if os.path.isfile(file):
-        os.remove(file)
-    file = CONNECTION_REPO_TEST_FILE_PATH + '.tmp'
-    if os.path.isfile(file):
-        os.remove(file)
+    if os.path.isfile(bakfile):
+        os.remove(bakfile)
+    if os.path.isfile(tmpfile):
+        os.remove(tmpfile)
     # The yield causes the remainder of this fixture to be executed at the
     # end of the test.
     yield
     file = CONNECTION_REPO_TEST_FILE_PATH
     if os.path.isfile(file):
         os.remove(file)
-    file = CONNECTION_REPO_TEST_FILE_PATH + '.bak'
-    if os.path.isfile(file):
-        os.remove(file)
-    file = CONNECTION_REPO_TEST_FILE_PATH + '.tmp'
-    if os.path.isfile(file):
-        os.remove(file)
+    if os.path.isfile(bakfile):
+        os.remove(bakfile)
+    if os.path.isfile(tmpfile):
+        os.remove(tmpfile)
 
 
 # The real functions before they get patched

--- a/tests/unit/pywbemcli/test_general_options.py
+++ b/tests/unit/pywbemcli/test_general_options.py
@@ -25,7 +25,7 @@ import os
 import sys
 import pytest
 
-from pywbemtools._utils import CONNECTIONS_FILENAME
+from pywbemtools.pywbemcli._connection_file_names import CONNECTIONS_FILENAME
 
 from .cli_test_extensions import CLITestsBase
 from .common_options_help_lines import CMD_OPTION_HELP_HELP_LINE
@@ -82,20 +82,15 @@ TEST_CONNECTIONS_FILE_DICT_SERVER = {
     'default_connection_name': None,
 }
 
-
-def GET_TEST_PATH_STR(filename):  # pylint: disable=invalid-name
-    """
-    Return the string representing the relative path of the file name provided.
-    """
-    return (str(os.path.join(TEST_DIR, filename)))
+EMPTY_CONNECTIONS_FILE_PATH = 'empty_connections_file.yaml'
 
 
-SIMPLE_MOCK_MODEL_FILE = "simple_mock_model.mof"
 MOCK_DEFINITION_ENVVAR = 'PYWBEMCLI_STARTUP_SCRIPT'
 BAD_PY_ERR_STRTUP_FILE = 'error/py_err_processatstartup.py'
-MOCK_PW_PROMPT_FILE = 'mock_password_prompt.py'
+BAD_PY_ERR_STRTUP_FILE_PATH = os.path.join(TEST_DIR, BAD_PY_ERR_STRTUP_FILE)
+MOCK_PW_PROMPT_FILE_PATH = os.path.join(TEST_DIR, 'mock_password_prompt.py')
 
-SIMPLE_MOCK_FILE_PATH = os.path.join(TEST_DIR, SIMPLE_MOCK_MODEL_FILE)
+SIMPLE_MOCK_MODEL_FILE_PATH = os.path.join(TEST_DIR, "simple_mock_model.mof")
 PYTHON_MOCK_FILE_PATH = os.path.join(TEST_DIR, 'simple_python_mock_script.py')
 BAD_MOF_FILE_PATH = os.path.join(TEST_DIR, 'mof_with_error.mof')
 BAD_PY_FILE_PATH = os.path.join(TEST_DIR, 'py_with_error.py')
@@ -351,7 +346,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify valid --use-pull yes option returns data from mock.',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH, '--use-pull', 'yes'],
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH,
+      '--use-pull', 'yes'],
       'cmdgrp': 'class',
       'args': ['get', 'CIM_Foo']},
      {'stdout': ["class CIM_Foo"],
@@ -359,7 +355,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify valid --use-pull either option returns data from mock.',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH,
                   '--use-pull', 'either'],
       'cmdgrp': 'class',
       'args': ['get', 'CIM_Foo']},
@@ -368,7 +364,8 @@ TEST_CASES = [
      None, OK],
 
     ['Verify valid --use-pull no option returns data from mock.',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH, '--use-pull', 'no'],
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH,
+      '--use-pull', 'no'],
       'cmdgrp': 'class',
       'args': ['get', 'CIM_Foo']},
      {'stdout': ["class CIM_Foo"],
@@ -377,7 +374,7 @@ TEST_CASES = [
 
     ['Verify simultaneous --server and --mock-server on cmd line invalid.',
      {'general': ['--server', 'http://blah', '--mock-server',
-                  SIMPLE_MOCK_FILE_PATH],
+                  SIMPLE_MOCK_MODEL_FILE_PATH],
       'cmdgrp': 'connection',
       'args': ['show']},
      {'stderr': ["Conflicting options: `server` is mutually exclusive with "
@@ -387,7 +384,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify simultaneous --mock-server option and --name option fails',
-     {'general': ['-m', SIMPLE_MOCK_FILE_PATH, '--name', 'MyConnName'],
+     {'general': ['-m', SIMPLE_MOCK_MODEL_FILE_PATH, '--name', 'MyConnName'],
       'cmdgrp': 'connection',
       'args': ['show']},
      {'stderr': ["Conflicting options: `connection-name` is mutually exclusive "
@@ -526,7 +523,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify -m option one file',
-     {'general': ['-m', SIMPLE_MOCK_FILE_PATH],
+     {'general': ['-m', SIMPLE_MOCK_MODEL_FILE_PATH],
       'cmdgrp': 'connection',
       'args': ['show']},
      {'stdout': ['^name *not-saved \\(current\\)$',
@@ -538,7 +535,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify -m option, multiple files',
-     {'general': ['-m', SIMPLE_MOCK_FILE_PATH,
+     {'general': ['-m', SIMPLE_MOCK_MODEL_FILE_PATH,
                   '-m', PYTHON_MOCK_FILE_PATH],
       'cmdgrp': 'connection',
       'args': ['show']},
@@ -601,11 +598,10 @@ TEST_CASES = [
      None, OK],
 
     ['Verify -m option, file with python startup file containing syntax error',
-     {'general': ['-m', SIMPLE_MOCK_FILE_PATH],
+     {'general': ['-m', SIMPLE_MOCK_MODEL_FILE_PATH],
       'cmdgrp': 'class',
       'args': ['enumerate'],
-      'env': {MOCK_DEFINITION_ENVVAR:
-              GET_TEST_PATH_STR(BAD_PY_ERR_STRTUP_FILE)}},
+      'env': {MOCK_DEFINITION_ENVVAR: BAD_PY_ERR_STRTUP_FILE_PATH}},
      {'stderr': ['Traceback (most recent call last)',
                  'def mock?prompt(msg):',
                  'SyntaxError:'],
@@ -640,7 +636,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --mock-server and WBEMConnection only option user',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH,
                   '--user', 'fred'],
       'cmdgrp': 'connection',
       'args': ['show']},
@@ -651,7 +647,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --mock-server and WBEMConnection only options user and password',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH,
                   '--user', 'fred', '--password', 'fred'],
       'cmdgrp': 'connection',
       'args': ['show']},
@@ -662,7 +658,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --mock-server and WBEMConnection only options certfile, keyfile',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH,
                   '--certfile', 'fred', '--keyfile', 'fred'],
       'cmdgrp': 'connection',
       'args': ['show']},
@@ -674,7 +670,7 @@ TEST_CASES = [
 
 
     ['Verify --mock-server and WBEMConnection only option no-verify',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH,
                   '--no-verify'],
       'cmdgrp': 'connection',
       'args': ['show']},
@@ -686,7 +682,7 @@ TEST_CASES = [
 
 
     ['Verify --mock-server and WBEMConnection only option --verify',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH,
                   '--verify'],
       'cmdgrp': 'connection',
       'args': ['show']},
@@ -711,7 +707,7 @@ TEST_CASES = [
 
 
     ['Verify --timestats',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH, '--timestats'],
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH, '--timestats'],
       'cmdgrp': 'class',
       'args': ['enumerate']},
      {'stdout': ['class CIM_Foo {',
@@ -723,7 +719,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify uses pull operation with option --use-pull either',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH, '--timestats',
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH, '--timestats',
                   '--use-pull', 'either', '--pull-max-cnt', '1'],
       'cmdgrp': 'instance',
       'args': ['enumerate', 'CIM_Foo']},
@@ -736,7 +732,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify pull fails options --use-pull either, --disable-pull-operations',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH, '--timestats',
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH, '--timestats',
                   '--use-pull', 'either', '--pull-max-cnt', '1'],
       'cmdgrp': 'instance',
       'args': ['enumerate', 'CIM_Foo']},
@@ -776,7 +772,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify uses pull operation with option --use-pull yes',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH, '--timestats',
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH, '--timestats',
                   '--use-pull', 'yes', '--pull-max-cnt', '1'],
       'cmdgrp': 'instance',
       'args': ['enumerate', 'CIM_Foo']},
@@ -790,7 +786,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify uses traditional operation with option --use-pull no',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH, '--timestats',
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH, '--timestats',
                   '--use-pull', 'no'],
       'cmdgrp': 'instance',
       'args': ['enumerate', 'CIM_Foo']},
@@ -804,7 +800,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify --mock-server and -server not allowed',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH,
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH,
                   '--server', 'http://blah'],
       'cmdgrp': 'instance',
       'args': ['enumerate', 'CIM_Foo']},
@@ -835,7 +831,7 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],
 
-    ['Verify --namen option with non-existent connection file fails',
+    ['Verify --name option with non-existent connection file fails',
      {'general': ['--name', 'namedoesnotexist'],
       'cmdgrp': 'connection',
       'args': ['show']},
@@ -888,7 +884,7 @@ TEST_CASES = [
                   '--user', 'john'],
       'cmdgrp': 'connection',
       'args': ['test'],
-      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_PW_PROMPT_FILE)}},
+      'env': {MOCK_DEFINITION_ENVVAR: MOCK_PW_PROMPT_FILE_PATH}},
      {'stdout': ["MOCK_CLICK_PROMPT Enter password (user john)"],
       'stderr': ["ConnectionError: Failed to establish"],
       'rc': 1,
@@ -896,10 +892,10 @@ TEST_CASES = [
      None, OK],
 
     #
-    #   Verify password prompt. This is a sequence
+    #   Verify password prompt. This is a sequence using a connections file
     #
-    ['Create a mock serve with user but no password. Sequence 0,1.',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH],
+    ['Create a mock server with user but no password. Sequence 0,1.',
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH, ],
       'args': ['save', 'mocktestVerifyPWPrompt'],
       'cmdgrp': 'connection', },
      {'stdout': "",
@@ -908,20 +904,19 @@ TEST_CASES = [
 
     # TODO: This test is worthless the prompt is not called
     ['Verify server in repository.  Sequence 0,2.',
-     {'general': [],
-      'cmdgrp': 'connection',
+     {'cmdgrp': 'connection',
       'args': ['list'],
-      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_PW_PROMPT_FILE)}},
+      'env': {MOCK_DEFINITION_ENVVAR: MOCK_PW_PROMPT_FILE_PATH}},
      {'stdout': ['mocktestVerifyPWPrompt', 'WBEM server connections(brief)'],
       'test': 'innows'},
      None, OK],
 
     ['Verify load of this server and class enumerate triggers password prompt. '
      ' Sequence 0,3.',
-     {'general': ['--name', 'mocktestVerifyPWPrompt'],
+     {'general': ['--name', 'mocktestVerifyPWPrompt', ],
       'cmdgrp': 'class',
       'args': ['enumerate'],
-      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_PW_PROMPT_FILE)}},
+      'env': {MOCK_DEFINITION_ENVVAR: MOCK_PW_PROMPT_FILE_PATH}},
      {'stdout': ['CIM_Foo'],
       'test': 'innows'},
      None, OK],
@@ -940,7 +935,7 @@ TEST_CASES = [
      {'general': ['--server', "http://blahblah",
                   '--user', 'john'],
       'stdin': ['class enumerate'],
-      'env': {MOCK_DEFINITION_ENVVAR: GET_TEST_PATH_STR(MOCK_PW_PROMPT_FILE)}},
+      'env': {MOCK_DEFINITION_ENVVAR: MOCK_PW_PROMPT_FILE_PATH}},
      {'stdout': ['MOCK_CLICK_PROMPT Enter password',
                  '(user john)'],
       'test': 'innows'},
@@ -1122,7 +1117,7 @@ TEST_CASES = [
      None, OK],
 
     ['Verify Change --mock-server to --server in interactive mode.',
-     {'general': ['--mock-server', SIMPLE_MOCK_FILE_PATH, ],
+     {'general': ['--mock-server', SIMPLE_MOCK_MODEL_FILE_PATH, ],
       # args not allowed in interactive mode
       'stdin': ['connection show',
                 '--server  http://blah connection show',
@@ -1155,6 +1150,7 @@ TEST_CASES = [
       'test': 'innows'},
      None, OK],  # TODO: this test fails on windows. Outputs don't compare'
 
+    # TODO: This one now fails because we added test for default conn file.
     ['Verify Change --name invalid in interactive mode. command no connections '
      'file',
      {'general': ['--name', 'NAMEDOESNOTEXIST'],
@@ -1166,7 +1162,7 @@ TEST_CASES = [
                  'Aborted!'],
       'rc': 1,
       'test': 'innows'},
-     None, OK],
+     None, FAIL],
 
     ['Verify Change --name invalid in interactive mode . stdin. Connection '
      'file exists and we delete',
@@ -1513,7 +1509,7 @@ TEST_CASES = [
                 'connection show']},
      {'stdout': ['default-namespace root/cimv2'],
       'test': 'innows'},
-     SIMPLE_MOCK_MODEL_FILE, OK],
+     SIMPLE_MOCK_MODEL_FILE_PATH, OK],
 
     ['Verify simple pywbem command against file works and verbose connect and '
      'disconnect work.',

--- a/tests/unit/pywbemcli/test_pywbemcli_operations.py
+++ b/tests/unit/pywbemcli/test_pywbemcli_operations.py
@@ -18,7 +18,6 @@
 Unit tests for _pywbemcli_operations module.
 """
 
-
 import sys
 import os
 import glob
@@ -30,8 +29,10 @@ import pytest
 import pywbem
 
 from pywbemtools.pywbemcli._pywbemcli_operations import PYWBEMCLIFakedConnection
-from pywbemtools._utils import ensure_unicode, \
-    DEFAULT_CONNECTIONS_FILE
+from pywbemtools._utils import ensure_unicode
+from pywbemtools.pywbemcli._connection_file_names import \
+    MOCKCACHE_ROOT_DIR, DEFAULT_CONNECTIONS_DIR, DEFAULT_CONNECTIONS_FILE, \
+    BAK_FILE_SUFFIX
 from pywbemtools.pywbemcli.mockscripts import DeprecatedSetupWarning, \
     SetupNotSupportedError
 
@@ -61,8 +62,7 @@ SCRIPT_DIR = os.path.dirname(__file__)
 USER_CONNECTIONS_FILE = os.path.join(SCRIPT_DIR, '.user_connections_file.yaml')
 
 # Backup of default connections file
-DEFAULT_CONNECTIONS_FILE_BAK = DEFAULT_CONNECTIONS_FILE + \
-    '.test_pywbemcli_operations.bak'
+DEFAULT_CONNECTIONS_FILE_BAK = DEFAULT_CONNECTIONS_FILE + BAK_FILE_SUFFIX
 
 # Flag indicating that the new-style setup approach() with a setup() function
 # is supported.
@@ -111,12 +111,12 @@ def get_mockcache_dir(connection_name):
 
     We assume the connection name is unique across all connection files.
     """
-    mockcache_rootdir = os.path.join(os.path.expanduser('~'),
-                                     '.pywbemcli_mockcache')
-    if os.path.isdir(mockcache_rootdir):
-        for _dir in os.listdir(mockcache_rootdir):
+    if not os.path.isdir(MOCKCACHE_ROOT_DIR):
+        os.mkdir(MOCKCACHE_ROOT_DIR)
+    if os.path.isdir(DEFAULT_CONNECTIONS_DIR):
+        for _dir in os.listdir(MOCKCACHE_ROOT_DIR):
             if _dir.endswith('.' + connection_name):
-                dir_path = os.path.join(mockcache_rootdir, _dir)
+                dir_path = os.path.join(MOCKCACHE_ROOT_DIR, _dir)
                 return dir_path
     raise ValueError
 

--- a/tests/unit/pywbemcli/testmock/wbemserver_mock_script.py
+++ b/tests/unit/pywbemcli/testmock/wbemserver_mock_script.py
@@ -21,9 +21,8 @@ in pywbemcli so that other dictionary definitions of the mock can be created.
 
 This script has the DMTF model itself as a dependent but we are not
 registering the pieces of the model as a dependent because we don't really
-know what changes in the model.
+know what changes are in the model.
 """
-
 
 import os
 


### PR DESCRIPTION
Fix issue with tests hiding default connection file. Solution is to use an alternate definition for the location of the CONNECTION_FILES_DIR,   

See commit messages for more details  since I did a couple of other things to simplify the whole testing of these files.
