### PR TITLE
Ks/#1441 test crepl fork

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -80,6 +80,10 @@ Released: not yet
   from  pywbemtools/pywbemcli/_utils.py to pywbemcli/_connection_file_names.py.
   (issue # 1423)
 
+* Use click-repl version 3 forked. Currently this is using a forked version since the
+  proposed changes to fix issues (see issue #1441) have not been incorporated
+  into a released version of click-repl.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -29,7 +29,16 @@ nocasedict==1.0.1
 Click==8.0.2
 click-spinner==0.1.8; python_version <= '3.11'
 click-spinner==0.1.10; python_version >= '3.12'
-click-repl==0.2
+
+# TODO: The version specified in requirements.txt is a fork of
+# click=repl. When that fork is integrated and a new version of click-repl
+# is released that should be the new minimum because that fork changes the
+# repl function interface by adding a new parameter that pywbemcli uses.
+# Version 0.3.0 does not work for us because of issue #1441 so in requirements
+# we are currently using a forked version of the click-repl master.
+# Probably: click-repl==0.3.1
+click-repl @ git+https://github.com/pywbem/click-repl.git@allow-general-options
+
 asciitree==0.3.3
 tabulate==0.8.2; python_version <= '3.9'
 tabulate==0.8.8; python_version >= '3.10'
@@ -37,7 +46,7 @@ tabulate==0.8.8; python_version >= '3.10'
 toposort==1.6
 psutil==6.0.0
 
-prompt-toolkit==3.0.13
+prompt-toolkit==3.0.36
 
 PyYAML==6.0.2
 

--- a/pywbemtools/pywbemcli/pywbemcli.py
+++ b/pywbemtools/pywbemcli/pywbemcli.py
@@ -1115,4 +1115,7 @@ def repl(ctx):
     if USE_AUTOSUGGEST:
         prompt_kwargs['auto_suggest'] = AutoSuggestFromHistory()
 
-    click_repl.repl(ctx, prompt_kwargs=prompt_kwargs)
+    # set option allow_general_options=True to enable use of general options
+    # in pywbemcli
+    click_repl.repl(ctx, prompt_kwargs=prompt_kwargs,
+                    allow_general_options=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,9 +25,16 @@ nocasedict>=1.0.1
 Click>=8.0.2
 click-spinner>=0.1.8; python_version <= '3.11'
 click-spinner>=0.1.10; python_version >= '3.12'
+
 # click-repl 0.2 is needed for compatibility with Click 8.0.
-# click-repl version 3.0 causes test failures. See issue #1312
-click-repl>=0.2,<0.3.0
+# click-repl version 3.0 causes test failures. See issues #1312 and #1441
+# Fix for click repl in forked repo issue #1441. Use our fork of click-repl
+# below which fixes the issue defined in issue #1441
+click-repl @ git+https://github.com/pywbem/click-repl.git@allow-general-options
+# TODO: Update click-repl version when our changes accepted probably
+#       to click-repl>=0.3.1. When this changes, minimum-constraints-install.txt
+#       must also be updated
+
 asciitree>=0.3.3
 # tabulate 0.8.8 fixes ImportError on Python 3.10.
 tabulate>=0.8.2; python_version <= '3.9'
@@ -38,7 +45,8 @@ toposort>=1.6
 psutil>=6.0.0
 
 # prompt-toolkit>=3.0 may cause WinError 995 on py38 on Windows (issue #690).
-prompt-toolkit>=3.0.13
+# version 3.0.36 requirement for click-repl
+prompt-toolkit>=3.0.36
 
 # PyYAML is also pulled in by dparse and python-coveralls
 # PyYAML 6.0 has wheel archives for Python 3.6 - 3.11


### PR DESCRIPTION
Changes to use a version of click-repl version 3 with changes made to allow use of click general options  (options and arguments on the command line before the subcommand name) within a subcommand  (options and arguments on the command line before the subcommand name).  In click-repl version 2 the general options and arguments were allowed as part of the repl input in addition to the arguments and options of the subcommand.  However in click-repl version 3.0, this capability was eliminated so only the subcommand and its arguments are options were allowed.

**Note:** we fail about 80 tests if we use the current click-rep 0.3.0 because it refuses all general options input in the repl mode.

Thus, for example in pywbemcli with click-repl 2 the following repl input is accepted and may be used by the subcommand class get:
    > --verbose class get cimThing

In click-repl 3 that command is rejected because the --verbose is refused by the repl parser.

This PR restores the original capability but as an option with a new input parameter ("allow_general_options") in the repl function.  The default behavior with this option not set is the same as click_rep; 3.0. 

However we realize that the process of getting prs approved and committed within the click-repl project is very slow and so propose to use out fork of click-repl which is located in the pywbemtools repository as the basis for click-repl until the change is accepted by the click-repl community.