### PR TITLE
Migrated to use towncrier for change logs

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -76,21 +76,19 @@ local clone of the `pywbem/pywbemtools` Git repo.
         git pull
         git checkout -b release_${MNU}
 
-3.  Edit the change log:
+3.  Update the change log:
 
-        vi docs/changes.rst
+    First make a dry-run to print the change log as it would be:
 
-    and make the following changes in the section of the version that is being
-    released:
+        towncrier build --draft
 
-    * Finalize the version.
-    * Change the release date to today's date.
-    * Make sure that all changes are described.
-    * Make sure the items shown in the change log are relevant for and
-      understandable by users.
-    * In the "Known issues" list item, remove the link to the issue tracker and
-      add text for any known issues you want users to know about.
-    * Remove all empty list items.
+    If you are satisfied with the change log, update the change log:
+
+        towncrier build --yes
+
+    This will update the change log file ``docs/changes.rst`` with the
+    information from the change fragment files in the ``changes`` directory, and
+    will delete these change fragment files.
 
 4.  Run the Safety tool:
 
@@ -228,60 +226,31 @@ local clone of the `pywbem/pywbemtools` Git repo.
         git pull
         git checkout -b start_${MNU}
 
-3.  Edit the change log:
-
-        vi docs/changes.rst
-
-    and insert the following section before the top-most section:
-
-        pywbemtools M.N.U.dev
-        ---------------------
-
-        This version contains all fixes up to version M.N-1.x.
-
-        Released: not yet
-
-        **Incompatible changes:**
-
-        **Deprecations:**
-
-        **Bug fixes:**
-
-        **Enhancements:**
-
-        **Cleanup:**
-
-        **Known issues:**
-
-        * See `list of open issues`_.
-
-        .. _`list of open issues`: https://github.com/pywbem/pywbemtools/issues
-
-4.  Commit your changes and push them to the remote repo:
+3.  Commit your changes and push them to the remote repo:
 
         git commit -asm "Start ${MNU}"
         git push --set-upstream origin start_${MNU}
 
-5.  On GitHub, create a Pull Request for branch ``start_M.N.U``.
+4.  On GitHub, create a Pull Request for branch ``start_M.N.U``.
 
     Important: When creating Pull Requests, GitHub by default targets the
     ``master`` branch. When starting a version based on a stable branch, you
     need to change the target branch of the Pull Request to ``stable_M.N``.
 
-6.  On GitHub, create a milestone for the new version ``M.N.U``.
+5.  On GitHub, create a milestone for the new version ``M.N.U``.
 
     You can create a milestone in GitHub via Issues -> Milestones -> New
     Milestone.
 
-7.  On GitHub, go through all open issues and pull requests that still have
+6.  On GitHub, go through all open issues and pull requests that still have
     milestones for previous releases set, and either set them to the new
     milestone, or to have no milestone.
 
-8.  On GitHub, once the checks for the Pull Request for branch ``start_M.N.U``
+7.  On GitHub, once the checks for the Pull Request for branch ``start_M.N.U``
     have succeeded, merge the Pull Request (no review is needed). This
     automatically deletes the branch on GitHub.
 
-9.  Add release start tag and clean up the local repo:
+8.  Add release start tag and clean up the local repo:
 
     Note: An initial tag is necessary because the automatic version calculation
     done by setuptools-scm uses the most recent tag in the commit history and

--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ dist_dependent_files_all := \
 dist_dependent_files := $(filter-out $(version_file), $(dist_dependent_files_all))
 
 # Packages whose dependencies are checked using pip-missing-reqs
-check_reqs_packages := pytest coverage coveralls flake8 pylint twine safety sphinx
+check_reqs_packages := pytest coverage coveralls flake8 pylint twine safety sphinx towncrier
 
 # Scripts are required to install the OS-level components of pywbem.
 ifeq ($(PLATFORM),Windows_native)

--- a/changes/.gitignore
+++ b/changes/.gitignore
@@ -1,0 +1,2 @@
+# Keep this directory in git even if empty
+!.gitignore

--- a/changes/1390.incompatible.rst
+++ b/changes/1390.incompatible.rst
@@ -1,0 +1,1 @@
+Removed support for Python 2.7, 3.6, and 3.7.

--- a/changes/1395.feature.rst
+++ b/changes/1395.feature.rst
@@ -1,0 +1,2 @@
+Development: Changed release process to use a GitHub Actions workflow and
+documented that in DEVELOP.md.

--- a/changes/1405.cleanup.rst
+++ b/changes/1405.cleanup.rst
@@ -1,0 +1,2 @@
+Removed code and tests that depend on the differences between Python 3.8+ and
+on differences between pywbem 1.0.0 and earlier versions of Python.

--- a/changes/1423.cleanup.rst
+++ b/changes/1423.cleanup.rst
@@ -1,0 +1,6 @@
+Refactored pywbemcli tests to avoid hiding the default connection file and
+the names for the connection file and mock cache by moving as part of tests.
+EnvVar PYWBEMCLI_ALT_HOME_DIR defines alternate directory for connection file
+and mockcache and is set for all pywbemcli tests. The definition of file
+names for default connection file and mock cache managed by pywbemcli moved
+from  pywbemtools/pywbemcli/_utils.py to pywbemcli/_connection_file_names.py.

--- a/changes/1429.feature.rst
+++ b/changes/1429.feature.rst
@@ -1,0 +1,1 @@
+Added support for and testing on Python 3.13.

--- a/changes/1432.fix.rst
+++ b/changes/1432.fix.rst
@@ -1,0 +1,2 @@
+Development: Increased minimum versions of PyYAML to 6.0.2 and psutil to 6.0.0,
+to fix install errors with Python 3.13 on Windows.

--- a/changes/1436.feature.rst
+++ b/changes/1436.feature.rst
@@ -1,0 +1,2 @@
+Development: Migrated to use towncrier for change logs.
+See docs/development.rst for details and usage.

--- a/changes/1441.cleanup.rst
+++ b/changes/1441.cleanup.rst
@@ -1,0 +1,3 @@
+Used click-repl version 3 forked. Currently this is using a forked version
+since the proposed changes to fix issues have not been incorporated into a
+released version of click-repl.

--- a/changes/changes.rst.j2
+++ b/changes/changes.rst.j2
@@ -1,0 +1,77 @@
+{#
+ # Jinja2 template for towncrier to generate the change log from change fragments.
+ #
+ # Input variables (as of towncrier 22.8.0):
+ # - render_title (bool): Indicates whether a title should be rendered by the
+ #   template. If False, the title is being added by towncrier to the result of
+ #   the template.
+ # - sections: The change fragments, as a dict with key: section
+ #   name, value: dict with key: category (=type) name, value: dict with key:
+ #   change fragment text, value: list of issues.
+ # - definitions: The definitions of change categories (=types), as a dict
+ #   with key: type name, value: dict with items 'name', 'showcontent'.
+ # - underlines (str): The underline characters to use for the different heading
+ #   levels (following the top heading level)
+ # - versiondata (dict): Project name and version data, as a dict with items
+ #   'name', 'version', 'date'.
+ # - top_underline (str): The underline character to be used for the title
+ #   of the change log when the template generates the title.
+ # - get_indent (func): Function to get the indentation for subsequent lines
+ #   given the first line of a multi-line change fragment text.
+ #}
+{% if render_title %}
+{%   if versiondata.name %}
+{{ versiondata.name }} {{ versiondata.version }} ({{ versiondata.date }})
+{{ top_underline * ((versiondata.name + versiondata.version + versiondata.date)|length + 4)}}
+{%   else %}
+{{ versiondata.version }} ({{ versiondata.date }})
+{{ top_underline * ((versiondata.version + versiondata.date)|length + 3)}}
+{%   endif %}
+{% endif %}
+
+Released: {{ versiondata.date }}
+
+{% for section, _ in sections.items() %}
+{%   set underline = underlines[0] %}
+{%   if section %}
+{{ section }}
+{{ underline * section|length }}
+
+{%     set underline = underlines[1] %}
+{%   endif %}
+{%   if sections[section] %}
+{%     for category, val in definitions.items() if category in sections[section] and category != 'notshown' %}
+**{{ definitions[category]['name'] }}:**
+
+{%       if definitions[category]['showcontent'] %}
+{%         for text, values in sections[section][category].items() %}
+{%           set issue_values = [] %}
+{%           for v in values if 'noissue' not in v %}
+{%             set _ = issue_values.append(v) %}
+{%           endfor %}
+{%           set issue_values_str = ' (' + issue_values|join(', ') + ')' if issue_values else '' %}
+* {{ text }}{{ issue_values_str }}
+
+{%         endfor %}
+{%       else %}
+{%         set issue_values = [] %}
+{%         for v in sections[section][category][''] if 'noissue' not in v %}
+{%           set _ = issue_values.append(v) %}
+{%         endfor %}
+{%         if issue_values %}
+* {{ issue_values|join(', ') }}
+
+{%         endif %}
+{%       endif %}
+{%       if sections[section][category]|length == 0 %}
+No significant changes.
+
+{%       endif %}
+{%     endfor %}
+{%   else %}
+No significant changes.
+
+{%   endif %}
+{% endfor %}
+{{ '' }}
+{{ '' }}

--- a/changes/noissue.1.feature.rst
+++ b/changes/noissue.1.feature.rst
@@ -1,0 +1,10 @@
+Development: Migrated from setup.py to pyproject.toml since that is the
+recommended direction for Python packages. The make targets have not changed.
+The content of the wheel and source distribution archives has not changed.
+
+Some files have been renamed:
+- minimum-constraints.txt to minimum-constraints-develop.txt
+- .safety-policy-all.yml to .safety-policy-develop.yml
+
+Removed pywbem/_version_scm.py from git tracking, because it is now
+dynamically created when building the distribution.

--- a/changes/noissue.1.fix.rst
+++ b/changes/noissue.1.fix.rst
@@ -1,0 +1,1 @@
+Development: Fixed new issues reported by Pylint 3.2 and 3.3.

--- a/changes/noissue.1.incompatible.rst
+++ b/changes/noissue.1.incompatible.rst
@@ -1,0 +1,4 @@
+The migration from setup.py to pyproject.toml removed the possibility to run
+setup.py as a command, for example to install or test pywbemtools. Note that
+running setup.py as a command has been deprecated by the Python setuptools
+team.

--- a/changes/noissue.2.feature.rst
+++ b/changes/noissue.2.feature.rst
@@ -1,0 +1,5 @@
+Development: The pywbem version during development now uses an automatically
+calculated dev number and the git commit hash, e.g. '1.4.0a1.dev9+gad875911'.
+The pywbem version numbers for packages released to Pypi are unchanged: 'M.N.U'.
+Updated the release description in DEVELOP.md to no longer edit the version
+file.

--- a/changes/noissue.2.fix.rst
+++ b/changes/noissue.2.fix.rst
@@ -1,0 +1,3 @@
+Test: Fixed the issue that coveralls was not found in the test workflow on MacOS
+with Python 3.9-3.11, by running it without login shell. Added Python 3.11 on
+MacOS to the normal tests.

--- a/changes/noissue.3.fix.rst
+++ b/changes/noissue.3.fix.rst
@@ -1,0 +1,2 @@
+Development: Fixed pydantic install issue on Python 3.13 by excluding
+safety-schemas version 0.0.7.

--- a/changes/noissue.4.fix.rst
+++ b/changes/noissue.4.fix.rst
@@ -1,0 +1,2 @@
+Test: Python 3.13 was pinned to 3.13.0 to work around a pylint issue on
+Python 3.13.1.

--- a/changes/noissue.safety.fix.rst
+++ b/changes/noissue.safety.fix.rst
@@ -1,0 +1,1 @@
+Fixed safety issues up to 2024-11-30.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,9 @@
 # Build distribution archive
 build>=1.1.1
 
+# Change log
+towncrier>=22.8.0
+
 # Unit test (imports into testcases):
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
 pytest>=4.3.1

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,93 +4,12 @@
 Change log
 ==========
 
-
-pywbemtools 1.4.0.dev1
-----------------------
-
-This version contains all fixes up to version 1.3.x.
-
-Released: not yet
-
-**Incompatible changes:**
-
-* Removed support for Python 2.7, 3.6, and 3.7. (issue #1390)
-
-* The migration from setup.py to pyproject.toml removed the possibility to run
-  setup.py as a command, for example to install or test pywbemtools. Note that
-  running setup.py as a command has been deprecated by the Python setuptools
-  team.
-
-**Deprecations:**
-
-**Bug fixes:**
-
-* Addressed safety issues up to 2024-11-30.
-
-* Fixed new issues reported by Pylint 3.2 and 3.3.
-
-* Test: Fixed the issue that coveralls was not found in the test workflow on MacOS
-  with Python 3.9-3.11, by running it without login shell. Added Python 3.11 on
-  MacOS to the normal tests.
-
-* Increased minimum versions of PyYAML to 6.0.2 and psutil to 6.0.0, to fix
-  install errors with Python 3.13 on Windows. (related to issue #3225)
-
-* Dev: Fixed pydantic install issue on Pyhton 3.13 by excluding safety-schemas
-  version 0.0.7
-
-* Test: Python 3.13 was pinned to 3.13.0 to work around a pylint issue on
-  Python 3.13.1.
-
-**Enhancements:**
-
-* Added support for and testing on Python 3.13. (issue #1429)
-
-* Development: Changed release process to use a GitHub Actions workflow
-  add as documented in DEVELOP.md. (issue #1395)
-
-* Development: Migrated from setup.py to pyproject.toml since that is the
-  recommended direction for Python packages. The make targets have not changed.
-  The content of the wheel and source distribution archives has not changed.
-
-  Some files have been renamed:
-  - minimum-constraints.txt to minimum-constraints-develop.txt
-  - .safety-policy-all.yml to .safety-policy-develop.yml
-
-  Removed pywbem/_version_scm.py from git tracking, because it is now
-  dynamically created when building the distribution.
-
-* Development: The pywbem version during development now uses an automatically
-  calculated dev number and the git commit hash, e.g. ``1.4.0a1.dev9+gad875911``.
-  The pywbem version numbers for packages released to Pypi are unchanged: M.N.U.
-  Updated the release description in DEVELOP.md to no longer edit the version
-  file.
-
-**Cleanup:**
-
-* Remove code and tests that depends on the differences between python 3.8+ and
-  on differences between pywbem 1.0.0 and earlier versions of python.
-  (issue #1405)
-
-* Refactor pywbemcli tests to avoid hiding the default connection file and
-  the names for the connection file and mock cache by moving as part of tests.
-  EnvVar PYWBEMCLI_ALT_HOME_DIR defines alternate directory for connection file
-  and mockcache and is set for all pywbemcli tests. The definition of file
-  names for default connection file and mock cache managed by pywbemcli moved
-  from  pywbemtools/pywbemcli/_utils.py to pywbemcli/_connection_file_names.py.
-  (issue # 1423)
-
-* Use click-repl version 3 forked. Currently this is using a forked version since the
-  proposed changes to fix issues (see issue #1441) have not been incorporated
-  into a released version of click-repl.
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/pywbem/pywbemtools/issues
-
-
+.. ============================================================================
+..
+.. Do not add change records here directly, but create fragment files instead!
+..
+.. ============================================================================
+.. towncrier start
 pywbemtools 1.3.0
 -----------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,8 +98,8 @@ language = 'en'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = ["testsuite", ".tox", ".git", "attic", "dist", "irecv",
-                    "tools", "packaging", "build_doc", "pywbemtools.egg-info",
-                    ".eggs"]
+                    "tools", "changes", "packaging", "build_doc",
+                    "pywbemtools.egg-info", ".eggs"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents. None means it is rendered in italic, without a link.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -282,6 +282,112 @@ For further discussion of good and bad practices regarding commits, see:
 .. _How to Get Your Change Into the Linux Kernel: https://www.kernel.org/doc/Documentation/SubmittingPatches
 
 
+.. _`Creating and submitting a change to pywbemtools`:
+
+Creating and submitting a change to pywbemtools
+-----------------------------------------------
+
+All changes to pywbemtools are made through Github with PRs created on topic
+branches and merged with the current master after successful group review.
+
+To make a change, create a topic branch. You can assume that you are the only
+one using that branch, so force-pushes to that branch and rebasing that branch
+is fine.
+
+When you are ready to push your change, describe the change for users of the
+package in a change fragment file. That is a small file in RST format with just
+a single change. For more background, read the
+[towncrier concept](https://towncrier.readthedocs.io/en/stable/markdown.html)
+(which uses Markdown format in that description and calls these files
+'news fragment files').
+
+To create a change fragment file, execute:
+
+For changes that have a corresponding issue:
+
+.. code-block:: sh
+
+    towncrier create <issue>.<type>.rst --edit
+
+For changes that have no corresponding issue:
+
+.. code-block:: sh
+
+    towncrier create noissue.<number>.<type>.rst --edit
+
+For changes where you do not want to create a change log entry:
+
+.. code-block:: sh
+
+    towncrier create noissue.<number>.notshown.rst --edit
+    # The file content will be ignored - it can also be empty
+
+where:
+
+* ``<issue>`` - The issue number of the issue that is addressed by the change.
+  If the change addresses more than one issue, copy the new change fragment file
+  after its content has been edited, using the other issue number in the file
+  name. It is important that the file content is exactly the same, so that
+  towncrier can create a single change log entry from the two (or more) files.
+
+  If the change has no related issue, use the ``noissue.<number>.<type>.rst``
+  file name format, where ``<number>`` is any number that results in a file name
+  that does not yet exist in the ``changes`` directory.
+
+* ``<type>`` - The type of the change, using one of the following values:
+
+  - ``incompatible`` - An incompatible change. This will show up in the
+    "Incompatible Changes" section of the change log. The text should include
+    a description of the incompatibility from a user perspective and if
+    possible, how to mitigate the change or what replacement functionality
+    can be used instead.
+
+  - ``deprecation`` - An externally visible functionality is being deprecated
+    in this release.
+    This will show up in the "Deprecations" section of the change log.
+    The deprecated functionality still works in this release, but may go away
+    in a future release. If there is a replacement functionality, the text
+    should mention it.
+
+  - ``fix`` - A bug fix in the code, documentation or development environment.
+    This will show up in the "Bug fixes" section of the change log.
+
+  - ``feature`` - A feature or enhancement in the code, documentation or
+    development environment.
+    This will show up in the "Enhancements" section of the change log.
+
+  - ``cleanup`` - A cleanup in the code, documentation or development
+    environment, that does not fix a bug and is not an enhanced functionality.
+    This will show up in the "Cleanup" section of the change log.
+
+  - ``notshown`` - The change will not be shown in the change log.
+
+This command will create a new change fragment file in the ``changes``
+directory and will bring up your editor (usually vim).
+
+If your change does multiple things of different types listed above, create
+a separate change fragment file for each type.
+
+If you need to modify an existing change log entry as part of your change,
+edit the existing corresponding change fragment file.
+
+Add the new or changed change fragment file(s) to your commit. The test
+workflow running on your Pull Request will check whether your change adds or
+modifies change fragment files.
+
+You can review how your changes will show up in the final change log for
+the upcoming release by running:
+
+.. code-block:: sh
+
+    towncrier build --draft
+
+Always make sure that your pushed branch has either just one commit, or if you
+do multiple things, one commit for each logical change. What is not OK is to
+submit for review a PR with the multiple commits it took you to get to the final
+result for the change.
+
+
 .. _`Core Development Team`:
 
 Core Development Team

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -12,6 +12,11 @@
 # Build distribution archive
 build==1.1.1
 
+# Change log
+towncrier==22.8.0
+incremental==22.10.0
+click-default-group==1.2.4
+
 # Unit test (imports into testcases):
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
 pytest==4.4.0; python_version <= '3.9'
@@ -120,6 +125,8 @@ future==0.18.3
 gitdb==4.0.8
 html5lib==0.999999999
 imagesize==1.3.0
+# importlib-resources is used by keyring 3.13+ on py<=3.8, towncrier 23.6+ on py<=3.9
+importlib-resources==5.6.0; python_version <= '3.9'
 jsonschema==2.6.0
 keyring==18.0.0
 linecache2==1.0.0

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,46 @@
+# Config file for towncrier change log tool
+
+[tool.towncrier]
+directory = "changes"
+package = "pywbemtools"
+# package_dir = "."
+filename = "docs/changes.rst"
+template = "changes/changes.rst.j2"
+start_string = ".. towncrier start"
+title_format = "pywbemtools {version}"
+underlines = "^~"
+issue_format = "`#{issue} <https://github.com/pywbem/pywbemtools/issues/{issue}>`_"
+
+# The following array defines the allowable change types, in order
+
+[[tool.towncrier.type]]
+directory = "incompatible"
+name = "Incompatible changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecation"
+name = "Deprecations"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fix"
+name = "Bug fixes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "Enhancements"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "cleanup"
+name = "Cleanup"
+showcontent = true
+
+# Type that is not shown in the change log at all, because the towncrier template
+# is skipping this change type. The 'showcontent' flag is not strong enough for that.
+[[tool.towncrier.type]]
+directory = "notshown"
+name = "Changes not shown"
+showcontent = false


### PR DESCRIPTION
You can display the change log for the upcoming version 1.4.0 by running:
```
make develop
towncrier build --draft
```
with this branch checked out.