### PR TITLE
1.3: Adjusted to changed OS versions in GitHub Actions; Added twine deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,16 @@ jobs:
                 \"package_level\": \"minimum\" \
               }, \
               { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
                 \"os\": \"macos-latest\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"latest\" \
@@ -99,22 +109,32 @@ jobs:
                 \"package_level\": \"minimum\" \
               }, \
               { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-12\", \
+                \"os\": \"ubuntu-22.04\", \
                 \"python-version\": \"3.7\", \
                 \"package_level\": \"latest\" \
               }, \
               { \
-                \"os\": \"macos-12\", \
+                \"os\": \"ubuntu-22.04\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-13\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-13\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-13\", \
+                \"python-version\": \"3.7\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-13\", \
                 \"python-version\": \"3.7\", \
                 \"package_level\": \"minimum\" \
               } \
@@ -149,7 +169,7 @@ jobs:
                 \"package_level\": \"minimum\" \
               }, \
               { \
-                \"os\": \"ubuntu-latest\", \
+                \"os\": \"ubuntu-22.04\", \
                 \"python-version\": \"3.7\", \
                 \"package_level\": \"minimum\" \
               }, \
@@ -159,12 +179,12 @@ jobs:
                 \"package_level\": \"latest\" \
               }, \
               { \
-                \"os\": \"macos-12\", \
+                \"os\": \"macos-13\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"minimum\" \
               }, \
               { \
-                \"os\": \"macos-12\", \
+                \"os\": \"macos-13\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"latest\" \
               }, \

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,10 @@ Released: not yet
   macos-latest got upgraded from 12 to 14 and no longer supports Python 3.6
   and 3.7.
 
+* Test: Changed macos-12 to macos-13 since macos-12 was removed in GitHub Actions.
+  Changed ubuntu-latest for Python 3.7 to ubuntu-22.04 because GitHub Actions
+  upgraded ubuntu-latest to be ubuntu-24.04.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -165,6 +165,7 @@ gitdb2==2.0.0; python_version == '2.7'
 gitdb2==2.0.0; python_version == '3.6'
 gitdb==4.0.8; python_version >= '3.7'
 html5lib==0.999999999
+id==1.5.0
 imagesize==1.3.0
 jsonschema==2.6.0
 keyring==18.0.0


### PR DESCRIPTION
For details, see the commit message.
This also rolls back PR #1449 into 1.3.1, but differently.
No review needed.