### PR TITLE
Added new entries to minimum-constraints-develop.txt

### DIFF
--- a/changes/noissue.6.fix.rst
+++ b/changes/noissue.6.fix.rst
@@ -1,0 +1,4 @@
+Development: Fix issue with minimum-constraints-develop.txt that causing
+failure of make check_reqs. Added two pkgs to minimum-constraints-develop.txt:
+package Levenshtein used by safety and Sphinx and roman-numerals-py used by
+Sphinx. See PR 1453 for details.

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -33,6 +33,8 @@ coveralls==3.3.0
 # Safety CI by pyup.io
 safety==3.1.0
 safety-schemas==0.0.2
+# The following used by safety and Sphinx
+Levenshtein==0.25.1
 # TODO: Change to dparse 0.6.4 once released
 dparse==0.6.4b0
 ruamel.yaml==0.17.21
@@ -71,6 +73,7 @@ sphinxcontrib-serializinghtml==1.1.9; python_version >= '3.9'
 sphinxcontrib-websupport==1.2.4
 autodocsumm==0.2.12
 Babel==2.11.0
+roman-numerals-py==1.0.0 ; python_version >= '3.9'
 
 # PyLint (no imports, invoked via pylint script)
 pylint==3.0.1; python_version == '3.8'


### PR DESCRIPTION
Fails make check_reqs.

Added entries for packages python-Levenshtein, Levenshtein, and roman-numerals-py to minimum-constraings-develop.txt to eliminate errors from make check-reqs