### PR TITLE
Fixed incorrect package version in build; Increased pipdeptree version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -742,14 +742,16 @@ $(sdist_file): pyproject.toml MANIFEST.in $(doc_utility_help_files) $(dist_depen
 	@echo "Makefile: Creating the source distribution archive: $(sdist_file)"
 	-$(call RM_FUNC,MANIFEST)
 	-$(call RMDIR_FUNC,build $(package_name).egg-info-INFO .eggs)
-	$(PYTHON_CMD) -m build --sdist --outdir $(dist_dir) .
+	$(PYTHON_CMD) -m build --no-isolation --sdist --outdir $(dist_dir) .
+	bash -c "ls -l $(sdist_file) || ls -l $(dist_dir) && echo package_level=$(package_level) && $(PYTHON_CMD) -m setuptools_scm"
 	@echo "Makefile: Done creating the source distribution archive: $(sdist_file)"
 
 $(bdist_file) $(version_file): pyproject.toml MANIFEST.in $(doc_utility_help_files) $(dist_dependent_files)
 	@echo "Makefile: Creating the normal wheel distribution archive: $(bdist_file)"
 	-$(call RM_FUNC,MANIFEST)
 	-$(call RMDIR_FUNC,build $(package_name).egg-info-INFO .eggs)
-	$(PYTHON_CMD) -m build --wheel --outdir $(dist_dir) -C--universal .
+	$(PYTHON_CMD) -m build --no-isolation --wheel --outdir $(dist_dir) -C--universal .
+	bash -c "ls -l $(bdist_file) $(version_file) || ls -l $(dist_dir) && echo package_level=$(package_level) && $(PYTHON_CMD) -m setuptools_scm"
 	@echo "Makefile: Done creating the normal wheel distribution archive: $(bdist_file)"
 
 # PyLint status codes:

--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -6,5 +6,5 @@
 
 pip>=25.0
 setuptools>=70.0.0
-setuptools-scm>=8.1.0
+setuptools-scm>=9.2.0
 wheel>=0.41.3

--- a/changes/noissue.7.fix.rst
+++ b/changes/noissue.7.fix.rst
@@ -1,0 +1,5 @@
+Dev: Fixed issue where the package version used for distribution archive file
+names were generated inconsistently between setuptools_scm (used in Makefile)
+and the 'build' module, by using no build isolation ('--no-isolation' option
+of the 'build' module) and increasing the minimum version of 'setuptools-scm'
+to 9.2.0, which fixes a number of version related issues.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -102,7 +102,7 @@ entrypoints>=0.3.0
 ruff>=0.3.5
 
 # Package dependency management tools
-pipdeptree>=2.2.0
+pipdeptree>=2.24.0
 # pip-check-reqs 2.3.2 is needed to have proper support for pip<=21.3.
 # pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11 and requires pip>=21.2.4
 # pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -101,7 +101,7 @@ entrypoints==0.3.0
 ruff==0.3.5
 
 # Package dependency management tools
-pipdeptree==2.2.0
+pipdeptree==2.24.0
 pip-check-reqs==2.4.3; python_version <= '3.11'
 pip-check-reqs==2.5.1; python_version >= '3.12'
 

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -12,7 +12,7 @@
 
 pip==25.0
 setuptools==70.0.0
-setuptools-scm==8.1.0
+setuptools-scm==9.2.0
 wheel==0.41.3
 
 
@@ -52,7 +52,7 @@ PyYAML==6.0.2
 
 yamlloader==0.5.5
 # Packaging 21.0 is required by safety 2.2.0
-packaging==22.0
+packaging==24.1
 
 mock==3.0.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 [build-system]
 requires = [
     "setuptools>=70.0.0",
-    "setuptools-scm>=8.1.0",
+    "setuptools-scm>=9.2.0",
     "wheel>=0.38.1",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ PyYAML>=6.0.2
 yamlloader>=0.5.5
 
 # safety 2.3.5 pins packaging to <22.0 and requires >=21.0
-packaging>=22.0
+packaging>=24.1
 
 # See issue #822 about issue in mock 4.0.3.
 mock>=3.0.0


### PR DESCRIPTION
For details, see the commit message.
No review needed.
A rollback to 1.3 is not needed, because that version still uses setup.py.