### PR TITLE
Increased version of safety to 3.6.2 to simplify its dependencies

### DIFF
--- a/changes/noissue.111.fix.rst
+++ b/changes/noissue.111.fix.rst
@@ -1,0 +1,1 @@
+Dev: Increased version of safety to 3.6.2 to simplify its dependencies.

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -31,7 +31,7 @@ pytest-cov==2.7.0
 coveralls==3.3.0
 
 # Safety CI by pyup.io
-safety==3.4.0
+safety==3.6.1
 safety-schemas==0.0.14
 dparse==0.6.4
 ruamel.yaml==0.17.21
@@ -40,9 +40,9 @@ Authlib==1.3.1
 marshmallow==3.15.0
 pydantic==2.8.0
 pydantic_core==2.20.0
-typer==0.12.1
-typer-cli==0.12.1
-typer-slim==0.12.1
+typer==0.16.0
+typer-cli==0.16.0
+typer-slim==0.16.0
 # psutil is handled in install
 filelock==3.16.1
 
@@ -136,7 +136,7 @@ linecache2==1.0.0
 # Jinja2 3.x requires MarkupSafe>=2.0
 MarkupSafe==2.0.0
 mistune==0.8.1
-nltk==3.9
+nltk==3.9.1
 pandocfilters==1.4.1
 pathlib2==2.2.1
 pbr==1.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,8 +42,8 @@ tabulate>=0.8.8; python_version >= '3.10'
 
 toposort>=1.6
 # psutil 6.0.0 fixes an install error on Python 3.13 on Windows
-# safety 3.4.0 depends on psutil~=6.1.0
-psutil~=6.1.0
+# safety 3.6.2 depends on psutil>=6.1.0
+psutil>=6.1.0
 
 # prompt-toolkit>=3.0 may cause WinError 995 on py38 on Windows (issue #690).
 # version 3.0.36 requirement for click-repl


### PR DESCRIPTION
No review needed.