### PR TITLE
Fixed that the --nq/--no-qualifiers was ignored for class operations

### DIFF
--- a/changes/1476.fix.rst
+++ b/changes/1476.fix.rst
@@ -1,0 +1,2 @@
+Fixed that the --nq, --no-qualifiers option was ignored for class operations,
+and qualifiers were always included.

--- a/pywbemtools/pywbemcli/_cmd_class.py
+++ b/pywbemtools/pywbemcli/_cmd_class.py
@@ -60,7 +60,7 @@ from .._output_formatting import output_format_is_table, \
 
 no_qualifiers_class_option = [              # pylint: disable=invalid-name
     click.option('--nq', '--no-qualifiers', 'no_qualifiers', is_flag=True,
-                 default=True,
+                 default=False,
                  help='Do not include qualifiers in the returned class(es). '
                       'Default: Include qualifiers.')]
 
@@ -596,7 +596,7 @@ def cmd_class_get(context, classname, options):
                 classname,
                 namespace=ns,
                 LocalOnly=options['local_only'],
-                IncludeQualifiers=options['no_qualifiers'],
+                IncludeQualifiers=not options['no_qualifiers'],
                 IncludeClassOrigin=options['include_classorigin'],
                 PropertyList=resolve_propertylist(options['propertylist'])))
 
@@ -676,7 +676,7 @@ def cmd_class_references(context, classname, options):
                     cln,
                     ResultClass=options['result_class'],
                     Role=options['role'],
-                    IncludeQualifiers=options['no_qualifiers'],
+                    IncludeQualifiers=not options['no_qualifiers'],
                     IncludeClassOrigin=options['include_classorigin'],
                     PropertyList=resolve_propertylist(options['propertylist'])))
 
@@ -721,7 +721,7 @@ def cmd_class_associators(context, classname, options):
                     Role=options['role'],
                     ResultClass=options['result_class'],
                     ResultRole=options['result_role'],
-                    IncludeQualifiers=options['no_qualifiers'],
+                    IncludeQualifiers=not options['no_qualifiers'],
                     IncludeClassOrigin=options['include_classorigin'],
                     PropertyList=resolve_propertylist(options['propertylist'])))
 

--- a/pywbemtools/pywbemcli/_common_cmd_functions.py
+++ b/pywbemtools/pywbemcli/_common_cmd_functions.py
@@ -365,7 +365,7 @@ def enumerate_classes_filtered(context, namespace, classname, options):
 
     names_only = options.get('names_only', False)
 
-    iq = options.get('no_qualifiers', True)
+    iq = not options.get('no_qualifiers', False)
 
     # Force IncludeQualifier true if results are to be filtered since
     # the filter requires that qualifiers exist.


### PR DESCRIPTION
Note: The failures on macOS are subject of issue #1467.