### PR TITLE
Fixed start program timeouts and other issues in listener tests; Enabled tests again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,7 +246,8 @@ jobs:
       env:
         PACKAGE_LEVEL: ${{ matrix.package_level }}
         RUN_TYPE: ${{ steps.set-run-type.outputs.result }}
-        # TESTCASES: test_class_cmds.py
+        # TESTCASES: pywbemlistener
+        # TESTOPTS: -vv
       run: |
         make test
     - name: Run end2end test with WBEM server Docker image

--- a/Makefile
+++ b/Makefile
@@ -836,8 +836,9 @@ $(done_dir)/todo_$(pymn)_$(PACKAGE_LEVEL).done: Makefile $(done_dir)/develop_$(p
 .PHONY: check_reqs
 check_reqs: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done minimum-constraints-install.txt requirements.txt
 	@echo "Makefile: Checking missing dependencies of the package"
-	pip-missing-reqs $(package_name) --requirements-file=requirements.txt
-	pip-missing-reqs $(package_name) --requirements-file=minimum-constraints-install.txt
+# TODO(RELEASE): Enable again once pywbem 1.9.0 is released.
+# pip-missing-reqs $(package_name) --requirements-file=requirements.txt
+# pip-missing-reqs $(package_name) --requirements-file=minimum-constraints-install.txt
 	@echo "Makefile: Done checking missing dependencies of the package"
 ifeq ($(PLATFORM),Windows_native)
 # Reason for skipping on Windows is https://github.com/r1chardj0n3s/pip-check-reqs/issues/67

--- a/changes/1492.fix.rst
+++ b/changes/1492.fix.rst
@@ -1,0 +1,2 @@
+Fixed the timeout errors when test programs run the pywbemlistener 'start'
+command.

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -18,7 +18,8 @@ wheel==0.41.3
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
-pywbem==1.8.0
+# TODO(RELEASE): Enable again once pywbem 1.9.0 is released.
+# pywbem==1.9.0
 # When using the GitHub master branch of pywbem, simply comment out the line
 # above, since links are not allowed in constraint files - the minimum will be
 # ensured by requirements.txt then.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dynamic = ["version", "dependencies"]
 
 [project.scripts]
 pywbemcli = "pywbemtools.pywbemcli.pywbemcli:cli"
-pywbemlistener = "pywbemtools.pywbemlistener.pywbemlistener:cli"
+pywbemlistener = "pywbemtools.pywbemlistener.pywbemlistener:main"
 
 [project.urls]
 Homepage = "https://github.com/pywbem/pywbemtools"

--- a/pywbemtools/pywbemlistener/_context_obj.py
+++ b/pywbemtools/pywbemlistener/_context_obj.py
@@ -64,6 +64,12 @@ class ContextObj:
         self._spinner_enabled = None  # Deferred init in getter
         self._spinner_obj = click_spinner.Spinner()
 
+        # Data for stdout/stderr redirection, used by start command
+        self.saved_stdout = None
+        self.saved_stderr = None
+        self.stdout_fp = None
+        self.stderr_fp = None
+
     def __repr__(self):
         return f'ContextObj(at {id(self):08x}, ' \
                'output_format={s.output_format}, ' \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,13 @@
 
 # Direct dependencies for install (must be consistent with minimum-constraints-install.txt)
 
-pywbem>=1.8.0
+# TODO(RELEASE): Enable again once pywbem 1.9.0 is released.
+# pywbem>=1.9.0
 # When using the GitHub master branch of pywbem, comment out the line above,
 # activate the GitHub link based dependency below.
 # In that case, some of the install tests need to be disabled by setting
 # the 'PYWBEM_FROM_REPO' variable in in tests/install/test_install.sh.
-# git+https://github.com/pywbem/pywbem.git@master#egg=pywbem
+pywbem@git+https://github.com/pywbem/pywbem.git@master
 
 nocaselist>=1.0.3
 nocasedict>=1.0.1

--- a/tests/install/test_install.sh
+++ b/tests/install/test_install.sh
@@ -34,7 +34,8 @@ VERBOSE="true"
 # Indicates that pywbem is installed from a repository. This will disable
 # some install tests because they don't support this. Keep in sync with
 # the installation of pywbem from repo vs package in requirements.txt.
-PYWBEM_FROM_REPO="false"
+# TODO(RELEASE): Set to false again once pywbem 1.9.0 is released.
+PYWBEM_FROM_REPO="true"
 
 MYNAME=$(basename "$0")
 MYDIR=$(abspath $(dirname "$0")) # Absolute path of directory of this script

--- a/tests/unit/pywbemlistener/cli_test_extensions.py
+++ b/tests/unit/pywbemlistener/cli_test_extensions.py
@@ -24,6 +24,8 @@ import os
 import glob
 from collections.abc import Sequence
 import subprocess
+import tempfile
+import pathlib
 
 import pytest
 
@@ -122,8 +124,7 @@ def pywbemlistener_test(desc, inputs, exp_results, condition):
     args.extend(input_args)
 
     if verbose:
-        print(f"\nExecuting testcase: {desc}")
-        sys.stdout.flush()
+        print(f"\nExecuting testcase: {desc}", flush=True)
 
     ensure_no_listeners(verbose, 'test setup')
     start_listeners(input_listeners, verbose, 'test setup')
@@ -163,7 +164,8 @@ def pywbemlistener_test(desc, inputs, exp_results, condition):
     if 'log' in exp_results:
         assert os.path.isfile(exp_log_file)
         with open(exp_log_file, encoding='utf-8') as log_fp:
-            log_lines = log_fp.readlines()
+            log = log_fp.read()
+        log_lines = log.rstrip('\n').split('\n')
         assert 'test' in exp_results
         test = exp_results['test']
         assert_output(test, exp_log_lines, log_lines, 'log', desc)
@@ -176,18 +178,18 @@ def ensure_no_listeners(verbose, situation):
     This function relies on the 'pywbemlistener list' and 'stop' commands
     working.
     """
-    cmd_args = 'pywbemlistener -o plain list'
+    cmd_args = ["pywbemlistener", "-o", "plain", "list"]
     if verbose:
-        print(f"{situation}: Listing listeners: {cmd_args}")
-        sys.stdout.flush()
+        print(f"{situation}: Listing listeners: {cmd_args!r}", flush=True)
     out = check_output(cmd_args, situation, "Listing listeners failed", verbose)
-    lis_lines = out.decode('utf-8').rstrip('\n').split('\n')
+    lis_lines = out.rstrip('\n').split('\n')
     for lis_line in lis_lines[1:]:
         lis_name = lis_line.split(' ')[0]
-        cmd_args = f'pywbemlistener stop {lis_name}'
+        cmd_args = ["pywbemlistener", "stop", lis_name]
         if verbose:
-            print(f"{situation}: Stopping listener: {cmd_args}")
-            sys.stdout.flush()
+            cmd_args.insert(1, "-vv")
+        if verbose:
+            print(f"{situation}: Stopping listener: {cmd_args!r}", flush=True)
         check_output(cmd_args, situation, "Stopping listener failed", verbose)
 
 
@@ -206,68 +208,186 @@ def start_listeners(input_listeners, verbose, situation):
     """
     for lis_args in input_listeners:
         assert isinstance(lis_args, Sequence)
-        verbose_opts = '-vv' if verbose else ''
-        cmd_args = f"pywbemlistener {verbose_opts} start {' '.join(lis_args)}"
+        cmd_args = ["pywbemlistener", "start"]
         if verbose:
-            print(f"{situation}: Starting listener: {cmd_args}")
+            cmd_args.insert(1, "-vv")
+        cmd_args.extend(lis_args)
+        if verbose:
+            print(f"{situation}: Starting listener: {cmd_args!r}", flush=True)
         check_output(cmd_args, situation, "Starting listener failed", verbose)
 
 
 def check_output(cmd_args, situation, msg, verbose):
     """
-    Improved replacement for subprocess.check_output() with a reduced interface.
+    Execute a pywbemlistener command and capture its stdout/stderr.
 
-    The improvements are:
-    - Prints command output (stdout+stderr) in case the command fails.
+    If the command succeeds, its stdout is returned.
+    If the command fails (rc!=0) or a timeout happens, AssertionError is raised.
+
+    A pywbemlistener 'start' command is executed by capturing its stdout/stderr
+    via files, by using its hidden options --stdout-file and --stderr-file.
+    This avoids the use of pipes and that is one element in
+    avoiding (short-lived) pywbemlistener 'start' command timeouts
+    when launching the (long-lived) pywbemlistener 'run' command.
+
+    Any other pywbemlistener command is executed by capturing its stdout/stderr
+    via pipes.
+
+    Parameters:
+      cmd_args (list of str): List of complete command line args, including
+        the pywbemlistener command name.
+      situation (str): Short text describing the situation (eg. test setup).
+      msg (str): Error message to be used if the command fails.
+      verbose (bool): Print listener log files, if they exist.
+
+    Returns:
+      str: Standard output of the command, as a Unicode string.
+
+    Raises:
+      AssertionError: The command failed or timed out.
+    """
+    timeout = 30  # seconds
+
+    try:
+        start_pos = cmd_args.index("start")  # 0-based index
+    except ValueError:
+        start_pos = None
+
+    tmp_dir = None
+    try:
+        if start_pos is not None:
+            # This is the start command. That is the only command where we
+            # need to make sure that no file handles are inherited by the
+            # run command launched by the start command. If file handles
+            # from the (short-lived) start command are inherited into the
+            # (long-lived) run command, the start command hangs when exiting,
+            # and the subprocess.run() call below times out.
+            # To achieve that, the capturing of stdout/stderr of the start
+            # command is implemented via files rather than pipes by
+            # specifying the --stdout-file / --stderr-file options so that the
+            # start command writes its stdout/stderr to these files.
+
+            # pylint: disable=consider-using-with
+            tmp_dir = tempfile.TemporaryDirectory()
+            stdout_file = pathlib.Path(tmp_dir.name) / "stdout.log"
+            stderr_file = pathlib.Path(tmp_dir.name) / "stderr.log"
+
+            cmd_args_pt1 = cmd_args[:start_pos + 1]  # including "start"
+            cmd_args_pt2 = cmd_args[start_pos + 1:]  # after "start"
+            cmd_args = cmd_args_pt1
+            cmd_args.extend([
+                "--stdout-file", str(stdout_file),
+                "--stderr-file", str(stderr_file)])
+            cmd_args.extend(cmd_args_pt2)
+
+            cmd_stdin = subprocess.DEVNULL
+            cmd_stdout = subprocess.DEVNULL
+            cmd_stderr = subprocess.DEVNULL
+
+        else:
+            # This is any other command but the start command.
+            # In that case, we can use pipes to capture its stdout/stderr,
+            # because none of the other commands starts a long-lived process.
+            cmd_stdin = subprocess.PIPE
+            cmd_stdout = subprocess.PIPE
+            cmd_stderr = subprocess.PIPE
+
+        try:
+            cp = subprocess.run(
+                cmd_args, shell=False, text=True, check=False, close_fds=True,
+                stdin=cmd_stdin, stdout=cmd_stdout, stderr=cmd_stderr,
+                timeout=timeout)
+        except subprocess.TimeoutExpired as exc:
+            if start_pos is not None:
+                out, err = get_out_err(stdout_file, stderr_file)
+            else:
+                out = ""
+                err = ""
+            exc_out, exc_err = get_exc_out_err(exc)
+            if verbose:
+                log_data = get_listener_logdata()
+            else:
+                log_data = None
+
+            raise AssertionError(
+                f"{msg}: The command {cmd_args!r} timed out after "
+                f"{timeout} s.\n"
+                f"Situation: {situation}\n"
+                f"Standard output:\n{out}\n"
+                f"Standard error:\n{err}\n"
+                f"Exception standard output:\n{exc_out}\n"
+                f"Exception standard error:\n{exc_err}\n"
+                f"{log_data}") from exc
+
+        if start_pos is not None:
+            out, err = get_out_err(stdout_file, stderr_file)
+        else:
+            out = cp.stdout
+            err = cp.stderr
+        rc = cp.returncode
+        if rc != 0:
+            if verbose:
+                log_data = get_listener_logdata()
+            else:
+                log_data = None
+            raise AssertionError(
+                f"{msg}: The command {cmd_args!r} failed with rc={rc}.\n"
+                f"Situation: {situation}\n"
+                f"Standard output:\n{out}\n"
+                f"Standard error:\n{err}\n"
+                f"{log_data}")
+    finally:
+        if tmp_dir:
+            tmp_dir.cleanup()
+
+    return out
+
+
+def get_out_err(stdout_file, stderr_file):
+    """
+    Return stdout and stderr from the stdout/stderr files.
     """
     try:
-        # pylint: disable=consider-using-with
-        p = subprocess.Popen(cmd_args, shell=True, stdout=subprocess.PIPE)
-        try:
-            out, err = p.communicate(timeout=30)
-        except subprocess.TimeoutExpired:
-            p.kill()
-            p.wait()
-            raise
-        rc = p.poll()
-        if rc:
-            raise subprocess.CalledProcessError(
-                rc, cmd_args, output=out, stderr=err)
-    except Exception as exc:
-        # Note: The exception message contains the command line
-        print(f"{situation}: Error: {msg}: {exc}")
-        sys.stdout.flush()
-        if hasattr(exc, 'output'):
-            out = exc.output
-            if isinstance(out, bytes):
-                out = out.decode('utf-8')
-            print("Begin of command output (stdout):")
-            print(out)
-            print("End of command output")
-            sys.stdout.flush()
-        if hasattr(exc, 'stderr'):
-            err = exc.stderr
-            if isinstance(err, bytes):
-                err = err.decode('utf-8')
-            print("Begin of command output (stderr):")
-            print(err)
-            print("End of command output")
-            sys.stdout.flush()
-        if verbose:
-            # We do not have the listener name at this point, but there
-            # should be only one log file, if any.
-            log_files = 'pywbemlistener_*.log'
-            for log_file in glob.glob(log_files):
-                with open(log_file, encoding='utf-8') as log_fp:
-                    log_data = log_fp.read()
-                if isinstance(log_data, bytes):
-                    log_data = log_data.decode('utf-8')
-                print(f"Begin of log file {log_file}:")
-                print(log_data)
-                print("End of log file")
-                sys.stdout.flush()
-        raise
-    return out
+        out = stdout_file.read_text()
+    except FileNotFoundError:
+        out = ""
+    try:
+        err = stderr_file.read_text()
+    except FileNotFoundError:
+        err = ""
+    return out, err
+
+
+def get_exc_out_err(exc):
+    """
+    Return stdout/stderr attached to a subprocess.TimeoutExpired exception.
+    """
+    exc_out = exc.output
+    if isinstance(exc_out, bytes):
+        exc_out = exc_out.decode('utf-8')
+    exc_err = exc.stderr
+    if isinstance(exc_err, bytes):
+        exc_err = exc_err.decode('utf-8')
+    return exc_out, exc_err
+
+
+def get_listener_logdata():
+    """
+    Return the data in the listener log files.
+
+    We do not have the listener name at this point, but there
+    should be only one log file, if any.
+    """
+    log_files = 'pywbemlistener_*.log'
+    result = []
+    for log_file in glob.glob(log_files):
+        with open(log_file, encoding='utf-8') as log_fp:
+            log_data = log_fp.read()
+        if isinstance(log_data, bytes):
+            log_data = log_data.decode('utf-8')
+        result.append(f"Log file {log_file}:")
+        result.append(log_data)
+    return "\n".join(result)
 
 
 def assert_output(test, exp_patterns, act_lines, source, desc):

--- a/tests/unit/pywbemlistener/test_list_cmd.py
+++ b/tests/unit/pywbemlistener/test_list_cmd.py
@@ -17,10 +17,11 @@
 Test the 'pywbemlistener list' command.
 """
 
-
+import os
 import pytest
 
-from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NO_WIN
+from .cli_test_extensions import pywbemlistener_test, RUN, RUN_NO_WIN, \
+    check_output
 
 # pylint: disable=use-dict-literal
 
@@ -124,13 +125,107 @@ LIST_TESTCASES = [
 ]
 
 
-@pytest.mark.skip()  # TODO: Disabled to circumvent failure on GitHub Actions
 @pytest.mark.parametrize(
     "desc, inputs, exp_results, condition",
     LIST_TESTCASES
 )
 def test_lis_list(desc, inputs, exp_results, condition):
     """
-    Test general options of pywbemlistener.
+    Test 'list' command of pywbemlistener.
     """
     pywbemlistener_test(desc, inputs, exp_results, condition)
+
+
+def cleanup_logfile(logdir, name):
+    """
+    Remove the log file for the listener with that name if it exists.
+    """
+    logfile = os.path.join(logdir, f'pywbemlistener_{name}.log')
+    if os.path.exists(logfile):
+        os.remove(logfile)
+
+
+@pytest.mark.skip("Debug function disabled")
+def test_lis_debug(capsys):
+    """
+    Test function for debugging the stdout/stderr redirection.
+
+    This function is normally skipped and can be executed by commenting out
+    the skip decorator, when debugging is intended.
+    """
+    name = "lis1"
+    logdir = "."
+
+    with capsys.disabled():
+
+        print("--------------------------", flush=True)
+        cmd_args = ["pywbemlistener", "-vv", "stop", name]
+        print(f"test_lis_debug: Stopping listener: {cmd_args!r}", flush=True)
+        try:
+            out = check_output(
+                cmd_args, "test_lis_debug", "Stopping listeners failed",
+                verbose=True)
+            print(f"test_lis_debug: Success - stdout:\n{out}", flush=True)
+        except AssertionError as exc:
+            print(f"test_lis_debug: Failed - AssertionError: {exc}", flush=True)
+
+        print("--------------------------", flush=True)
+        cleanup_logfile(logdir, name)
+        cmd_args = ["pywbemlistener", "-vv", "-l", logdir, "start", name,
+                    "--scheme", "http", "--port", "50001"]
+        print(f"test_lis_debug: Starting listener: {cmd_args!r}", flush=True)
+        try:
+            out = check_output(
+                cmd_args, "test_lis_debug", "Starting listeners failed",
+                verbose=True)
+            print(f"test_lis_debug: Success - stdout:\n{out}", flush=True)
+        except AssertionError as exc:
+            print(f"test_lis_debug: Failed - AssertionError: {exc}", flush=True)
+
+        print("--------------------------", flush=True)
+        cleanup_logfile(logdir, name)
+        cmd_args = ["pywbemlistener", "-vv", "start", name, "--scheme",
+                    "http", "--port", "50001"]
+        print(f"test_lis_debug: Starting listener: {cmd_args!r}", flush=True)
+        try:
+            out = check_output(
+                cmd_args, "test_lis_debug", "Starting listeners failed",
+                verbose=True)
+            print(f"test_lis_debug: Success - stdout:\n{out}", flush=True)
+        except AssertionError as exc:
+            print(f"test_lis_debug: Failed - AssertionError: {exc}", flush=True)
+
+        print("--------------------------", flush=True)
+        cmd_args = ["pywbemlistener", "-o", "plain", "list"]
+        print(f"test_lis_debug: Listing listeners: {cmd_args!r}", flush=True)
+        try:
+            out = check_output(
+                cmd_args, "test_lis_debug", "Listing listeners failed",
+                verbose=True)
+            print(f"test_lis_debug: Success - stdout:\n{out}", flush=True)
+        except AssertionError as exc:
+            print(f"test_lis_debug: Failed - AssertionError: {exc}", flush=True)
+
+        print("--------------------------", flush=True)
+        cmd_args = ["pywbemlistener", "-vv", "stop", name]
+        print(f"test_lis_debug: Stopping listener: {cmd_args!r}", flush=True)
+        try:
+            out = check_output(
+                cmd_args, "test_lis_debug", "Stopping listeners failed",
+                verbose=True)
+            print(f"test_lis_debug: Success - stdout:\n{out}", flush=True)
+        except AssertionError as exc:
+            print(f"test_lis_debug: Failed - AssertionError: {exc}", flush=True)
+
+        print("--------------------------", flush=True)
+        cmd_args = ["pywbemlistener", "-vv", "stop", name]
+        print(f"test_lis_debug: Stopping listener: {cmd_args!r}", flush=True)
+        try:
+            out = check_output(
+                cmd_args, "test_lis_debug", "Stopping listeners failed",
+                verbose=True)
+            print(f"test_lis_debug: Success - stdout:\n{out}", flush=True)
+        except AssertionError as exc:
+            print(f"test_lis_debug: Failed - AssertionError: {exc}", flush=True)
+
+        cleanup_logfile(logdir, name)

--- a/tests/unit/pywbemlistener/test_run_cmd.py
+++ b/tests/unit/pywbemlistener/test_run_cmd.py
@@ -49,12 +49,7 @@ RUN_HELP_FORMAT_PATTERNS = START_HELP_FORMAT_PATTERNS
 
 # Output patterns for 'run' command when the listener already exists
 RUN_EXISTS_PATTERNS = [
-    r"Listener .+ already running at ",
-]
-
-# Output patterns for 'run' command when the listener was successfully started
-RUN_SUCCESS_PATTERNS = [
-    r"Running listener .+ at ",
+    r"Listener .+ already running at",
 ]
 
 RUN_TESTCASES = [
@@ -132,7 +127,6 @@ RUN_TESTCASES = [
 ]
 
 
-@pytest.mark.skip()  # TODO: Disabled to circumvent failure on GitHub Actions
 @pytest.mark.parametrize(
     "desc, inputs, exp_results, condition",
     RUN_TESTCASES

--- a/tests/unit/pywbemlistener/test_show_cmd.py
+++ b/tests/unit/pywbemlistener/test_show_cmd.py
@@ -144,7 +144,6 @@ SHOW_TESTCASES = [
 ]
 
 
-@pytest.mark.skip()  # TODO: Disabled to circumvent failure on GitHub Actions
 @pytest.mark.parametrize(
     "desc, inputs, exp_results, condition",
     SHOW_TESTCASES

--- a/tests/unit/pywbemlistener/test_start_cmd.py
+++ b/tests/unit/pywbemlistener/test_start_cmd.py
@@ -58,12 +58,20 @@ START_HELP_FORMAT_PATTERNS = [
 
 # Output patterns for 'start' command when the listener already exists
 START_EXISTS_PATTERNS = [
-    r"Listener .+ already running at ",
+    r"Listener .+ already running at",
 ]
 
 # Output patterns for 'start' command when the listener was successfully started
+# with log
 START_SUCCESS_LOG_PATTERNS = [
-    r"Run process( [0-9]+)?: Output is logged",
+    r"Run process( [0-9]+)?: Output is appended to log file:",
+    r"Started listener .+ at"
+]
+
+# Output patterns for 'start' command when the listener was successfully started
+# without log
+START_SUCCESS_NOLOG_PATTERNS = [
+    r"Started listener .+ at"
 ]
 
 START_TESTCASES = [
@@ -159,7 +167,7 @@ START_TESTCASES = [
             args=['start', 'lis1', '--scheme', 'http', '--port', '50001'],
         ),
         dict(
-            stdout=[''],
+            stdout=START_SUCCESS_NOLOG_PATTERNS,
             test='all',
         ),
         RUN_NO_WIN,
@@ -172,7 +180,7 @@ START_TESTCASES = [
                   '--port', '50001'],
         ),
         dict(
-            stdout=[''],
+            stdout=START_SUCCESS_NOLOG_PATTERNS,
             test='all',
         ),
         RUN_NO_WIN,
@@ -213,7 +221,7 @@ START_TESTCASES = [
         ),
         dict(
             rc=1,
-            stderr=[r"Cannot create listener .+: "
+            stderr=[r"Cannot create WBEMListener for listener .+: "
                     r"https_port requires certfile"],
             test='all',
         ),
@@ -258,7 +266,7 @@ START_TESTCASES = [
                   '--certfile', 'tests/certs/server_cert_key.pem'],
         ),
         dict(
-            stdout=[''],
+            stdout=START_SUCCESS_NOLOG_PATTERNS,
             test='all',
         ),
         RUN_NO_WIN,
@@ -272,7 +280,7 @@ START_TESTCASES = [
                   '--keyfile', 'tests/certs/server_key.pem'],
         ),
         dict(
-            stdout=[''],
+            stdout=START_SUCCESS_NOLOG_PATTERNS,
             test='all',
         ),
         RUN_NO_WIN,
@@ -288,14 +296,21 @@ START_TESTCASES = [
                   'tests.unit.pywbemlistener.indicall_display.display'],
         ),
         dict(
-            stdout=[''],
+            stdout=[
+                r"Inserting current directory into front of Python module "
+                r"search path",
+                r"Added indication handler for calling function "
+                r"display\(\) in module tests\.unit\.pywbemlistener\."
+                r"indicall_display",
+                r"Started listener lis1 at http://localhost:50001",
+            ],
             test='all',
         ),
         RUN_NO_WIN,
     ),
     (
         "Verify success of 'start' with --indi-call on valid module.function, "
-        "with log and localhost bint addr",
+        "with log and localhost bind addr",
         dict(
             args=['-v', '-l', '.', 'start', 'lis1', '--scheme', 'http',
                   '--bind-addr', 'localhost', '--port', '50001', '--indi-call',
@@ -307,16 +322,29 @@ START_TESTCASES = [
                 'pywbemlistener_lis1.log',
                 [
                     r"Opening 'run' output log file at .+",
-
-                    r"Inserting current directory into front of Python module "
-                    r"search path",
-                    r"Added indication handler for calling function "
-                    r"display\(\) in module tests\.unit\.pywbemlistener\."
-                    r"indicall_display",
-
-                    r"Running listener lis1 at http://localhost:50001",
-                    r"Shut down listener lis1 running at "
-                    r"http://localhost:50001",
+                    r"Creating indication queue with max size: ",
+                    r"Starting callback thread",
+                    r"Entering callback processing loop",
+                    r"Creating threaded HTTP server for host 'localhost' on ",
+                    r"Resolving address of host localhost using AF_INET",
+                    r"Successfully resolved address of host localhost to:",
+                    r"Creating HTTPServer for family 2 and sockaddr",
+                    r"Successfully created HTTPServer for family 2",
+                    r"Starting HTTP listener thread to run threaded HTTP "
+                    r"server",
+                    r"Run process: Inserting current directory into front of "
+                    r"Python module search path",
+                    r"Adding callback function 'display'",
+                    r"Run process: Added indication handler for calling "
+                    r"function display\(\) in module "
+                    r"tests\.unit\.pywbemlistener\.indicall_display",
+                    r"Stopping threaded HTTP server and its listener thread",
+                    r"Stopped threaded HTTP server and its listener thread",
+                    r"Waiting for indication queue to be empty",
+                    r"Indication queue is now empty",
+                    r"Stopping callback thread",
+                    r"Leaving callback processing loop",
+                    r"Stopped callback thread",
                     r"Closing 'run' output log file at .+",
                 ],
             ),
@@ -338,16 +366,29 @@ START_TESTCASES = [
                 'pywbemlistener_lis1.log',
                 [
                     r"Opening 'run' output log file at .+",
-
-                    r"Inserting current directory into front of Python module "
-                    r"search path",
-                    r"Added indication handler for calling function "
-                    r"display\(\) in module tests\.unit\.pywbemlistener\."
-                    r"indicall_display",
-
-                    r"Running listener lis1 at http://:50001",
-                    r"Shut down listener lis1 running at "
-                    r"http://:50001",
+                    r"Creating indication queue with max size: ",
+                    r"Starting callback thread",
+                    r"Entering callback processing loop",
+                    r"Creating threaded HTTP server for host None on ",
+                    r"Resolving address of host None using AF_INET",
+                    r"Successfully resolved address of host None to:",
+                    r"Creating HTTPServer for family 2 and sockaddr",
+                    r"Successfully created HTTPServer for family 2",
+                    r"Starting HTTP listener thread to run threaded HTTP "
+                    r"server",
+                    r"Run process: Inserting current directory into front of "
+                    r"Python module search path",
+                    r"Adding callback function 'display'",
+                    r"Run process: Added indication handler for calling "
+                    r"function display\(\) in module "
+                    r"tests\.unit\.pywbemlistener\.indicall_display",
+                    r"Stopping threaded HTTP server and its listener thread",
+                    r"Stopped threaded HTTP server and its listener thread",
+                    r"Waiting for indication queue to be empty",
+                    r"Indication queue is now empty",
+                    r"Stopping callback thread",
+                    r"Leaving callback processing loop",
+                    r"Stopped callback thread",
                     r"Closing 'run' output log file at .+",
                 ],
             ),
@@ -411,35 +452,29 @@ START_TESTCASES = [
                   '--port', '50001', '--indi-file', 'new.log'],
         ),
         dict(
-            stdout=[''],
+            stdout=[
+                r"Run process: Added indication handler for appending to file "
+                fr"new\.log with format .{DEFAULT_INDI_FORMAT}.",
+                r"Started listener lis1 at http://\(any\):50001",
+            ],
             test='all',
         ),
         RUN_NO_WIN,
     ),
     (
-        "Verify success of 'start' with --indi-file on non-existing file, with "
-        "log bind to localhost",
+        "Verify success of 'start' with --indi-file on non-existing file, no "
+        "log, bind to localhost",
         dict(
-            args=['-v', '-l', '.', 'start', 'lis1', '--scheme', 'http',
+            args=['-v', 'start', 'lis1', '--scheme', 'http',
                   '--bind-addr', 'localhost', '--port', '50001', '--indi-file',
                   'new.log'],
         ),
         dict(
-            stdout=START_SUCCESS_LOG_PATTERNS,
-            log=(
-                'pywbemlistener_lis1.log',
-                [
-                    r"Opening 'run' output log file at .+",
-
-                    r"Added indication handler for appending to file new\.log "
-                    fr"with format .{DEFAULT_INDI_FORMAT}.",
-
-                    r"Running listener lis1 at http://localhost:50001",
-                    r"Shut down listener lis1 running at "
-                    r"http://localhost:50001",
-                    r"Closing 'run' output log file at .+",
-                ],
-            ),
+            stdout=[
+                r"Run process: Added indication handler for appending to file "
+                fr"new\.log with format .{DEFAULT_INDI_FORMAT}.",
+                r"Started listener lis1 at http://localhost:50001",
+            ],
             test='all',
         ),
         RUN_NO_WIN,
@@ -454,18 +489,19 @@ START_TESTCASES = [
         ),
         dict(
             stdout=[
-                r"Start process( [0-9]+)?: Starting run process as: "
-                r"\['pywbemlistener', '-vv', 'run', u?'lis1', '--port', "
-                r"'50001', '--scheme', 'http', "
-                r"'--start-pid', '[0-9]+', "
-                r"'--bind-addr', u?'localhost', "
-                fr"'--indi-format', u?'{DEFAULT_INDI_FORMAT}'\]",
+                r"Start process( [0-9]+)?: Starting run process: .*",
                 r"Start process( [0-9]+)?: Waiting for run process [0-9]+ to "
                 r"complete startup",
+                r"Run process: Starting listener thread for listener lis1",
+                r"Run process: Started listener thread for listener lis1",
+                r"Run process: Running listener lis1 at http://localhost:50001",
+                r"Run process: Sending success signal \([0-9]+\) to start "
+                r"process",
                 r"Start process( [0-9]+)?: Handling success signal .+ from "
                 r"run process",
                 r"Start process( [0-9]+)?: Startup of run process [0-9]+ "
                 r"succeeded",
+                r"Started listener lis1 at http://localhost:50001",
             ],
             test='all',
         ),
@@ -492,7 +528,6 @@ START_TESTCASES = [
 ]
 
 
-@pytest.mark.skip()  # TODO: Disabled to circumvent failure on GitHub Actions
 @pytest.mark.parametrize(
     "desc, inputs, exp_results, condition",
     START_TESTCASES

--- a/tests/unit/pywbemlistener/test_stop_cmd.py
+++ b/tests/unit/pywbemlistener/test_stop_cmd.py
@@ -107,7 +107,6 @@ STOP_TESTCASES = [
 ]
 
 
-@pytest.mark.skip()  # TODO: Disabled to circumvent failure on GitHub Actions
 @pytest.mark.parametrize(
     "desc, inputs, exp_results, condition",
     STOP_TESTCASES

--- a/tests/unit/pywbemlistener/test_tabcompletion_unit.py
+++ b/tests/unit/pywbemlistener/test_tabcompletion_unit.py
@@ -72,7 +72,6 @@ TESTCASES_LISTENER_NAME_COMPLETE = [
 ]
 
 
-@pytest.mark.skip()  # TODO: Disabled to circumvent failure on GitHub Actions
 @pytest.mark.parametrize(
     "desc, kwargs, exp_exc_types, exp_warn_types, condition",
     TESTCASES_LISTENER_NAME_COMPLETE)

--- a/tests/unit/pywbemlistener/test_test_cmd.py
+++ b/tests/unit/pywbemlistener/test_test_cmd.py
@@ -160,7 +160,6 @@ TEST_TESTCASES = [
 ]
 
 
-@pytest.mark.skip()  # TODO: Disabled to circumvent failure on GitHub Actions
 @pytest.mark.parametrize(
     "desc, inputs, exp_results, condition",
     TEST_TESTCASES


### PR DESCRIPTION
This PR includes some redesign. For details, see the commit message.

I don't think that the PR should be rolled back into 1.3, because it is too large of a change.

I have run the following standalone tests with these commands:

* `pywbemlistener start lis1 --scheme http --bind_addr nosuchserver --port 50001` -> rc=2, No such option (error not shown with co_run script).
* `pywbemlistener start lis1 --scheme http --bind-addr nosuchserver --port 50001` -> rc=1, no such server
* `pywbemlistener start lis1 --scheme http --port 50001` -> rc=0, started
* `pywbemlistener show lis1` -> rc=0, shows lis1
* `pywbemlistener list` -> rc=0, shows lis1
* `pywbemlistener stop lis2` -> rc=1, no such listener
* `pywbemlistener stop lis1` -> rc=0, stopped

Each of these commands was run in different ways regarding its stdout/stderr:

* Run from terminal without redirection
* Run from terminal with stdout & stderr redirection
* Run with (local) co_run script (runs a command like the unit tests do, using `check_output()`)