### PR TITLE
Fixed 'socket.gaierror' exception when --bind-addr option was not specified

### DIFF
--- a/changes/noissue.120.fix.rst
+++ b/changes/noissue.120.fix.rst
@@ -1,0 +1,1 @@
+Fixed 'socket.gaierror' exception when --bind-addr option was not specified.

--- a/tests/unit/pywbemlistener/test_list_cmd.py
+++ b/tests/unit/pywbemlistener/test_list_cmd.py
@@ -93,7 +93,7 @@ LIST_TESTCASES = [
         dict(
             stdout=[
                 r"^Name +Port +Scheme +Bind addr +PID +Created$",
-                r"^lis1 +50001 +http +none +[0-9]+ +[0-9\- :\.]+$",
+                r"^lis1 +50001 +http +\(any\) +[0-9]+ +[0-9\- :\.]+$",
             ],
             test='all',
         ),
@@ -113,8 +113,8 @@ LIST_TESTCASES = [
         dict(
             stdout=[
                 r"^Name +Port +Scheme +Bind addr +PID +Created$",
-                r"^lis1 +50001 +http +none +[0-9]+ +[0-9\- :\.]+$",
-                r"^lis2 +50002 +http +none +[0-9]+ +[0-9\- :\.]+$",
+                r"^lis1 +50001 +http +\(any\) +[0-9]+ +[0-9\- :\.]+$",
+                r"^lis2 +50002 +http +\(any\) +[0-9]+ +[0-9\- :\.]+$",
                 r"^lis3 +50003 +http +localhost +[0-9]+ +[0-9\- :\.]+$",
             ],
             test='all',

--- a/tests/unit/pywbemlistener/test_show_cmd.py
+++ b/tests/unit/pywbemlistener/test_show_cmd.py
@@ -98,7 +98,7 @@ SHOW_TESTCASES = [
                 r"^Name +lis1$",
                 r"^Port +50001$",
                 r"^Scheme +http$",
-                r"^Bind addr +none",
+                r"^Bind addr +\(any\)",
                 r"^Certificate file *$",
                 r"^Key file *$",
                 r"^Indication call *$",


### PR DESCRIPTION
For details, see the commit message.