### PR TITLE
Circumvented OSError(0) issue with sysctl(KERN_PROCARGS2) for "pywbemlistener list"

### DIFF
--- a/changes/1511.fix.rst
+++ b/changes/1511.fix.rst
@@ -1,0 +1,4 @@
+pywbemlistener: Circumvented the behavior that on macOS where "pywbemlistener list"
+could raise OSError "Errno 0 (originated from sysctl(KERN_PROCARGS2)" when
+retrieving the command line of a process when listing the processes, by
+ignoring that error.

--- a/pywbemtools/pywbemlistener/_cmd_listener.py
+++ b/pywbemtools/pywbemlistener/_cmd_listener.py
@@ -547,6 +547,18 @@ def get_listeners(name=None):
                 psutil.NoSuchProcess):
             # Ignore processes we cannot access or that ended meanwhile
             continue
+        except OSError as exc:
+            if exc.errno == 0 and "KERN_PROCARGS2" in str(exc):
+                # Ignore the following error:
+                #   [Errno 0] Undefined error: 0 (originated from
+                #   sysctl(KERN_PROCARGS2))
+                # See https://github.com/giampaolo/psutil/issues/2708
+                # Note: psutil plans to raise AccessDenied for this error in
+                # the future, see
+                # https://github.com/giampaolo/psutil/issues/2708 .
+                continue
+            raise
+
         for i, item in enumerate(cmdline):
             if item.endswith(cmdname):
                 listener_index = i


### PR DESCRIPTION
For details, see the commit message.