### PR TITLE
Fixes to simplifiy doc of tab-completion

### DIFF
--- a/changes/1524.feature.3.rst
+++ b/changes/1524.feature.3.rst
@@ -12,3 +12,6 @@ Clarify that this does not actually activate tab-completion.
 
 Simplify a definition of where the activation script must be relative to the
 pywbemtools command.
+
+Updated the text for the pywbemcli help activate and pywbemtools help activate
+to match the other tab-activation documentation changes.

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -982,7 +982,7 @@ Help text for ``pywbemcli help`` (see :ref:`help command`):
 
       Show help for specific pywbemcli subjects.  This is in addition to the help messages that are available with the -h or
       --help option for every command group and command in pywbemcli. It helps document pywbemcli subjects that are more
-      general than specific commands and configuration subjects that do not have specific commands
+      general than specific commands and configuration subjects that do not have specific commands.
 
       If there is no argument provided, outputs a list and summary of the existing help subjects.
 

--- a/docs/pywbemlistener/cmdshelp.rst
+++ b/docs/pywbemlistener/cmdshelp.rst
@@ -105,7 +105,7 @@ Help text for ``pywbemlistener help`` (see :ref:`pywbemlistener help command`):
 
       Show help for specific pywbemlistener subjects.  This is in addition to the help messages that are available with the
       -h or --help option for every command group and command in pywbemlistener. It helps document pywbemlistener subjects
-      that are more general than specific commands and configuration subjects that do not have specific commands
+      that are more general than specific commands and configuration subjects that do not have specific commands.
 
       If there is no argument provided, outputs a list and summary of the existing help subjects.
 

--- a/docs/settingsandconfiguration.rst
+++ b/docs/settingsandconfiguration.rst
@@ -21,7 +21,8 @@ Settings and Configuration
 
 Both pywbemtools (pywbemcli and pywbemlistener) execute after installation
 without any configuration except for the use of tab-completion (using <TAB> on
-the shell command line) to attempt to complete parameters.
+the shell command line) to attempt to complete parameters. The tab-completion
+is not active after initialzation and must be activated separately.
 
 
 .. _`Activating shell tab-completion`:
@@ -33,7 +34,7 @@ Activating shell tab-completion
 .. index:: pair: zsh shell; tab-completion
 .. index:: pair: fish shell; tab-completion
 
-Tab-completion is supported for pywbemlistener and  of pywbemcli in the
+Tab-completion is supported for pywbemlistener and pywbemcli in the
 :ref:`command mode`, for the following shells:
 
   * **bash shell** - (bash version 4.4 or greater). Not all Linux implementations
@@ -71,69 +72,47 @@ pywbemtools installation.
 .. index:: tab-completion
 .. index:: Activating tab-completion
 
-To activate shell tab-completion, the  script *magic variable*  (``<PROG-NAME>_COMPLETE``) must
-be defined for the shell defining the shell name and the pywbemtools name
+To activate shell tab-completion, the  script *magic variable*
+(``<PROG-NAME>_COMPLETE``) must be defined in the shell initialization for the
+shell defining the shell name and the pywbemtools name as follows:
 
-    _<PROG-NAME>_COMPLETE=<SHELL-NAME>_source  <prog-name>
+.. code-block:: text
+
+    * The shell magic variable    _<PROG-NAME>_COMPLETE=<SHELL-NAME>_source  <prog-name>
 
 where:
 
     * `<PROG-NAME>` - pywbemtools command name in uppercase(i.e. PYWBEMCLI or PYWBEMLISTENER).
     * `<SHELL-NAME>` - shell name (i.e. bash, zsh, or fish).
     * `<prog-name>` - pywbemtools command name in lower case (pywbemcli or pywbemlistener).
+                      The commands must be publicly available.
 
-The existence of this shell *magic variable*  (``_<PROG-NAME>_COMPLETE``) notifies the
-shell that this is a shell tab-completion variable and the shell calls
-back to `<prog-name>` with arguments containing ``_<PROG-NAME>_COMPLETE``,
-``_<SHELL-NAME>_source`` and other tab-completion information in environment
-variables.  The pywbemtools command  `prog-name` returns the correct completion
-script text specific for that shell as the call return value which the user
-must save as a script file
+The existence of this shell *magic variable*  (``_<PROG-NAME>_COMPLETE``) in
+the shell initialization file notifies the shell that this is a shell
+tab-completion variable and the shell calls back to `<prog-name>` with
+arguments containing ``_<PROG-NAME>_COMPLETE``, ``_<SHELL-NAME>_source`` and
+other tab-completion information in environment variables.  The pywbemtools
+command  `prog-name` returns the correct completion script text specific for
+that shell as the call return value.
 
-Once tab-completion is activated for a shell type , hitting <TAB> or <TAB><TAB>
-initiates tab-completion for command names, option names, and some
-option/argument values which attempts to return the completion of the word on
-the command line where <TAB> was entered. If there are multiple possible
-completions, the shell returns the list or do nothing until a second <TAB> is
-entered.
+The ``eval`` completes the initialization by making the COMPLETE script returned
+from the bash call to the pywbemtool command available within the current shell.
 
-If hitting <TAB> or <TAB><TAB> when tab-completion is active returns nothing,
-either the word at the terminal cursor is not matched with a possible
-target (ex. ``pywbemcli --name xxx<TAB>``) for pywbemcli connection name when
-there is no connection name that starts with ``xxx`` or there is no
-tab-completion (ex. for example for the class name in ``get class
-<class-name>``)
+The pywbemtools commands must be public for this initialization.Note also that
+the tab-completion script is created each time the shell is initialized
 
-Activation of tab-completion involves the following for each pywbemtools
-command but with different formats for each shell type:
-
-1. Getting from each pywbemtools command the body of a completion script for
-   the terminal's shell type as defined above using the *magic variable*. This
-   script file contains the shell-specific logic to activate tab-completion and
-   process tab-completion calls.
-
-2. Notifying the shell of this completion script by either:
-
-   * notifying the shell with a shell  ``eval`` statement or,
-   * saving the script to a completion script file and notifying the shell later
-     by sourcing the resulting completion script file.
-
-Activation with shell eval statement
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Table table:ref:`tab-complete-eval-statement` defines the ``eval`` statement
+Table table:ref:`tab-complete-eval-statement` defines an ``eval`` statement
 for the shells that pywbemcli/pywbemlistener support for tab-completion that
-would be added to a shell startup file defined in the table, for example:
+should be added to a shell startup file defined in the table, for example:
 
 .. code-block:: text
 
-    # example for tab-completion activation and bash shell
-    _PYWBEMCLI_COMPLETE=bash_source pywbemcli
-    _PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener
+    # example for tab-completion activation and bash shell, These lines
+    # are be inserted into bash initialization (.bashrc)
+    eval "$(_PYWBEMCLI>_COMPLETE=bash_source pywbemcli)"
+    eval "$(_PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener)"
 
-.. _tab-complete-eval-statement:
-
-.. table:: Eval statement and proposed startup shell startup file to use for several shells
+.. table:: Eval statement and proposed startup shell startup  eval command to use for several shells
 
   ======  =======================================  =========================================================
   Shell   File to insert eval statement            Eval command
@@ -143,15 +122,58 @@ would be added to a shell startup file defined in the table, for example:
   fish    ~/.config/fish/completions/foo-bar.fish  eval (env _<PROG-NAME>_COMPLETE=fish_source <prog-name>_COMPLETE=fish_source <prog-name>)
   ======  =======================================  =========================================================
 
-This method requires that the pywbemtools command be in the in the PATH
-since the ``eval`` statement initiates a callback to the pywbemcli/pywbemlistener and
-the location of those executables must be publicly available.
 
-Activation by directly creating the tab-completion script file
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Testing that tab-completion is activated
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This activation is useful if you have multiple implementations of pywbemtools
-active.
+The tab-completion activation of pywbemcli and pywbemlistener can be tested in
+a terminal by entering part of a known command and using the <TAB> to request
+completion. The example below shows testing:
+
+.. code-block:: text
+
+   $ pywbemcli clas<TAB>
+
+   This should complete the class statement (i.e. expand cmd line to
+   ``pywbemcli class``).
+
+   $ pywbemlistener star<TAB>
+
+   This should complete the start command name (i.e. expand command line to
+   ``pywbemlistener start``)
+
+Each shell type has one or more commands to determine the state of
+tab-completion for a particular application.  In bash it is the builtin command
+``complete`` used both to define the tab-completion for a particular command
+and to list which commands have been activated.
+
+Executing the bash builtin ``complete -p pywbemcli`` command should return the
+a line that defines the completion for pywbemcli as follows:
+
+.. code-block:: text
+
+    $ complete -p pywbemcli       < ------------ This returns the following
+                                                 if tab-completion is active
+
+    complete -o nosort -F _pywbemcli_completion pywbemcli
+
+Zsh has corresponding commands depending on the version of completion and the
+use of the bashcompinit plugin.
+
+Removing shell tab-completion activation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Bash: The command ``complete -r pywbemcli`` removes the tab-completion for
+pywbemcli.
+
+Zsh: Depends on zsh configuration
+
+
+Alternate activation by directly creating the tab-completion script file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This activation technique is useful if you have multiple implementations of
+pywbemtools active or for some reason pywbemtools is not in a public directory.
 
 Create a complete tab-completion script file using the same statement (ex.
 ``_<PROG-NAME>_COMPLETE=<shell-type>_source <prog-name>``) but save the
@@ -227,47 +249,5 @@ for example, the terminal window is opened:
     source  ~/.pywbemlistener-complete.bash
 
 
-Testing that tab-completion is activated
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The tab-completion activation of pywbemcli and pywbemlistener can be tested in
-a terminal by entering part of a known command and using the <TAB> to request
-completion. The example below shows testing:
 
-.. code-block:: text
-
-   $ pywbemcli clas<TAB>
-
-   This should complete the class statement (i.e. expand cmd line to
-   ``pywbemcli class``).
-
-   $ pywbemlistener star<TAB>
-
-   THis should complete the start command name (i.e. expand command line to
-   ``pywbemlistener start``)
-
-Each shell type has one or more commands to determine the state of
-tab-completion for a particular application.  In bash it is the builtin command
-``complete`` used both to define the tab-completion for a particular command
-and to list which commands have been activated.
-
-Executing the bash builtin ``complete -p pywbemcli`` command should return the
-a line that defines the completion for pywbemcli as follows:
-
-.. code-block:: text
-
-    $ complete -p pywbemcli       < ------------ This returns the following
-                                                 if tab-completion is active
-
-    complete -o nosort -F _pywbemcli_completion pywbemcli
-
-Zsh has corresponding commands depending on the version of completion and the
-use of the bashcompinit plugin.
-
-Removing shell tab-completion activation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Bash: The command ``complete -r pywbemcli`` removes the tab-completion for
-pywbemcli.
-
-Zsh: Depends on zsh configuration

--- a/pywbemtools/pywbemcli/_cmd_help.py
+++ b/pywbemtools/pywbemcli/_cmd_help.py
@@ -63,7 +63,7 @@ def help_subjects(ctx, subject):   # pylint: disable=unused-argument
     help messages that are available with the -h or --help option for every
     command group and command in pywbemcli. It helps document pywbemcli
     subjects that are more general than specific commands and configuration
-    subjects that do not have specific commands
+    subjects that do not have specific commands.
 
     If there is no argument provided, outputs a list and summary of the
     existing help subjects.
@@ -76,8 +76,9 @@ def help_subjects(ctx, subject):   # pylint: disable=unused-argument
 
 
 # pylint: disable=invalid-name
+
 activate_shell_help_msg = '''
-Pywbemcli shell tab-completion must be activated after installation by
+Pywbemcli tab-completion must be activated after installation by
 notifying the shell and pywbemcli before the <TAB> becomes active when
 entering a pywbemcli command in the shell.
 
@@ -91,9 +92,7 @@ inserting the following into the shell initialization (ex. .bashrc)
     eval "$(_PYWBEMCLI>_COMPLETE=bash_source pywbemcli)"
     eval "$(_PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener)"
 
-
-
-The activation  'eval' statement for each of the shells supported is as follows
+The activation 'eval' statement for each of the shells supported is as follows
 and can be inserted into the corresponding shell startup script defined below.
 
 =====  ============  ===========================================================
@@ -118,10 +117,10 @@ Activate pywbemcli tab-completion as follows:
           ``complete -o nosort -F _pywbemcli_completion pywbemcli``
 
 Executing ``eval`` directly in the shell startup file requires that the
-pywbemcli executable location must be known when opening a terminal . This may
-not be consistent with executing pywbemcli in virtual environments. See
-the pywbemtools documentation for more information and alternate ways to
-activate tab-completion is special circumstances.
+pywbemcli executable must be publicly available, itslocation must be known when
+opening a terminal . This may not be consistent with executing pywbemcli
+in virtual environments. See the pywbemtools documentation for more information
+and alternate ways to activate tab-completion is special circumstances.
 
 '''
 # pylint: enable=invalid-name
@@ -185,8 +184,8 @@ Example:
 
 # pylint: disable=invalid-name
 tab_completion_help_msg = """
-Tab completion is not supported in the interactive mode.
-Tab completion is supported in the command mode, when activated.
+Tab completion is supported in the command mode, when activated but it is not
+available in the repl mode (interactive mode)
 
 Tab completion for option values and arguments exists when the data is local.
 It is not provided for option values and arguments where access to a WBEM
@@ -194,9 +193,9 @@ server is required.
 
 Tab completion is available for:
 
-* the command group names
-* the command names
-* the option names
+* The command group names
+* The command names
+* The option names
 * The values of some general options including:
     * --name
     * --mock-server
@@ -205,7 +204,7 @@ Tab completion is available for:
     * --keyfile
     * --certfile
     * --outputformat
-* the values of some arguements
+* The values of some arguements
     * help <subject> argument
 
 When tab completion is not available for an argument or option value, entering

--- a/pywbemtools/pywbemcli/_cmd_help.py
+++ b/pywbemtools/pywbemcli/_cmd_help.py
@@ -85,22 +85,16 @@ Tab-completion is only available for certain shells including: bash (version
 4.4 or greater), zsh, and fish shells since pywbemcli defines the completer
 script specifically for each shell.
 
-Activation of pywbemcli involves the following but with different formats for
-each shell type:
+Tab-completion can easily be activated for both pywbemtools commnds by
+inserting the following into the shell initialization (ex. .bashrc)
 
-1. Getting from pywbemcli the body of a completion script that defines
-   activation for the shell. This is done by executing the script statement
-   '_PYWBEMCLI_COMPLETE=<shell>_source pywbemcli' where <shell> can be 'bash',
-   'zsh', or 'fish'. This causes the shell to call back to pywbemcli with
-   '_PYWBEMCLI_COMPLETE' and '<shell>_source' arguments wherein pywbemcli
-   returns the completion script.
-2. Setting up the shell of this completion script by either:
-   * an 'eval' statement in the terminal startup
-     (ex. .bashrc ) that defines the completion script or,
-   * Creating the completion script file and sourcing that file later to activate.
+    eval "$(_PYWBEMCLI>_COMPLETE=bash_source pywbemcli)"
+    eval "$(_PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener)"
 
-The 'eval' statement for each of the shells supported is as follows and can
-be inserted into the corresponding shell startup script defined below.
+
+
+The activation  'eval' statement for each of the shells supported is as follows
+and can be inserted into the corresponding shell startup script defined below.
 
 =====  ============  ===========================================================
 shell  startup file  eval command
@@ -113,41 +107,22 @@ fish  ~/.config/fish/completions/foo-bar.fish
 
 Activate pywbemcli tab-completion as follows:
 
-  1. Edit the eval command in the startup file or
-  2. Close the file and restart the terminal or
+  1. Edit the eval command in the startup file
+  2. Close the file and restart the terminal
   3. Test existence of tab-completion by:
      a. Test completion with a command such as "pywbemcli cl<TAB> which should
         complete the "class" command group name.
      b. In bash executing "complete -p pywbemcli". An entry for pywbemcli must
-        exist for pywbemcli as follows:
+        be returned for pywbemcli as follows:
 
           ``complete -o nosort -F _pywbemcli_completion pywbemcli``
 
-Executing ``eval`` directly in the shell startup file has the issue that the
+Executing ``eval`` directly in the shell startup file requires that the
 pywbemcli executable location must be known when opening a terminal . This may
-not be consistent with executing pywbemcli in virtual environments.
+not be consistent with executing pywbemcli in virtual environments. See
+the pywbemtools documentation for more information and alternate ways to
+activate tab-completion is special circumstances.
 
-To activate tab-completion using a completion file execute the command defined
-below for the desired shell to create the completion script for pywbemcli
-in  a file (ex.~/pywbemcli-complete.bash). This command requires that that
-pywbemcli be available. The file name is arbitrary.
-=====  =====================================================================
-shell  completion file creating command
-=====  =====================================================================
-bash   _PYWBEMCLI_COMPLETE=bash_source pywbemcli > ~/.pywbemcli-complete.bash
-zsh    _PYWBEMCLI_COMPLETE=zsh_source pywbemcli > ~/.pywbemcli-complete.zsh
-fish   _PYWBEMCLI_COMPLETE=fish_source pywbemcli >
-          ~/.config/fish/completions/pywbemcli.fish
-=====  =====================================================================
-
-Once the completion script file is created, pywbemcli tab-completion can be
-activated by sourcing this script (ex 'source ~/.pywbemcli-complete.bash')
-upon shell startup. This does not actually call pywbemcli.  This can be done a
-number of different ways, for example:
-
-* Include the sourcing statement in the shell startup script (ex. ~/.bashrc)
-* Execute the statement as part of the startup of a virtual envrionment.
-* Manually execute the sourcing statement when required before calling pywbemcli
 '''
 # pylint: enable=invalid-name
 

--- a/pywbemtools/pywbemlistener/_cmd_help.py
+++ b/pywbemtools/pywbemlistener/_cmd_help.py
@@ -85,20 +85,26 @@ characteristics. Further, it is only usable with those shells that include
 tab-completion as part of the shell functionality.  On Linux based systems this
 includes shells like bash (version 4.0 or greater), zsh, and fish.
 
-Activation of pywbemlistener involves the following but with different formats
-for each shell type:
+Tab-completion can easily be activated by inserting the following into the
+shell initialization (ex. .bashrc)
 
-* Getting from pywbemlistener the body of a completion script for the shell to
-  be activated. This is done by executing a script statement of form
-  ``_PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener``.
-* Notifying the shell of this completion script with an eval statement or
-  saving the script and notifying the shell later by sourcing the resulting
-  completion script file.
+    eval "$(_PYWBEMCLI>_COMPLETE=bash_source pywbemcli)"
+    eval "$(_PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener)"
 
-Tab-completion can be activated either by:
+To activate pywbemlistener and pywbemcli tab-completion:
 
-* Installing the activation script with an eval statement into .bashrc
-* Creating a completion script file and sourcing that file at a later time.
+  1. Insert the eval command for each tool in the startup file
+  2. Close the file and restart the terminal
+  3. Test existence of tab-completion by:
+     a. Test completion with a command such as "pywbemlistener cl<TAB> which
+        should complete the "pywbemlistener li<TAB>" command group name.
+     b. In bash executing "complete -p pywbemlistener". An entry for
+        pywbemlistener must exist for pywbemlistener as follows:
+        complete -o nosort -F _pywbemlistener_completion pywbemlistener
+
+Note that the pywbemtools must be publicly available for the above to
+activate tab-completion and this creates the COMPLETE script each time the
+shell is initalized.
 
 The ``eval`` statement for each of the shells supported is as follows and can
 be inserted into the corresponding shell startup script defined below.
@@ -115,50 +121,11 @@ fish  ~/.config/fish/completions/foo-bar.fish
                            fish_source pywbemlistener)"
 =====  ===========  ===========================================================
 
-To activate pywbemlistener tab-completion:
-
-  1. Edit the eval command in the startup file or
-  2. Close the file and restart the terminal or
-  3. Test existence of tab-completion by:
-     a. Test completion with a command such as "pywbemlistener cl<TAB> which
-        should complete the "pywbemlistener li<TAB>" command group name.
-     b. In bash executing "complete -p pywbemlistener". An entry for
-        pywbemlistener must exist for pywbemlistener as follows:
-        complete -o nosort -F _pywbemlistener_completion pywbemlistener
-
-Executing the eval directly in the shell startup file has the issue that the
+Executing the eval directly in the shell startup file requires that the
 pywbemlistener executable location must be known when opening a terminal . This
 may not be consistent with executing pywbemlistener in virtual environments.
-
-To activate tab-completion using a completion file execute the command defined
-below for the desired shell. This  creates the completion script for
-pywbemlistener in ``~/pywbemlistener-complete.bash``. This command requires
-that pywbemlistener is publicly available :
-
-=====  =====================================================================
-shell  completion file creating command
-=====  =====================================================================
-bash   _PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener >
-            ~/.pywbemcli-complete.bash
-zsh    _PYWBEMLISTENER_COMPLETE=zsh_source pywbemlistener >
-            ~/.pywbemcli-complete.zsh
-fish   _PYWBEMLISTENER_COMPLETE=fish_source pywbemlistener >
-          ~/.config/fish/completions/pywbemcli.fish
-=====  =====================================================================
-
-Once the completion script file is created, pywbemlistener tab-completion can
-be activated by sourcing this script:
-   (ex. ''source ~/.pywbemlistener-complete.bash'').
-This does not call pywbemlistener and can be done by, for for example:
-
-* Include the sourcing statement in the shell startup script (ex. ~/.bashrc)
-* Execute the statement as part of the startup of virtual envrionments.
-* Manually executing the sourcing statement when required.
 '''
-# pylint: enable=invalid-name
 
-
-# pylint: disable=invalid-name
 tab_completion_help_msg = """
 Tab completion (when activated) for option values and arguments exists when the
 data is local. It is not provided for option values and arguments where access

--- a/pywbemtools/pywbemlistener/_cmd_help.py
+++ b/pywbemtools/pywbemlistener/_cmd_help.py
@@ -62,7 +62,7 @@ def help_subjects(ctx, subject):   # pylint: disable=unused-argument
     help messages that are available with the -h or --help option for every
     command group and command in pywbemlistener. It helps document
     pywbemlistener subjects that are more general than specific commands and
-    configuration subjects that do not have specific commands
+    configuration subjects that do not have specific commands.
 
     If there is no argument provided, outputs a list and summary of the
     existing help subjects.
@@ -74,40 +74,25 @@ def help_subjects(ctx, subject):   # pylint: disable=unused-argument
                                     PYWBEMLISTENER_HELP_SUBJECTS_DICT))
 
 
-# pylint: disable=invalid-name,
+# pylint: disable=invalid-name
+
 activate_shell_help_msg = '''
-Pywbemlistener includes tab-completion capability for all commands for certain
-shell types program being used by the command line terminal.
+Pywbemlistener tab-completion must be activated after installation by
+notifying the shell and pywbemlistener before the <TAB> becomes active when
+entering a pywbemlistener command in the shell.
 
-Tab-completion is active only when it is activated by
-notifying the command shell of the pywbemlistener tab-completion
-characteristics. Further, it is only usable with those shells that include
-tab-completion as part of the shell functionality.  On Linux based systems this
-includes shells like bash (version 4.0 or greater), zsh, and fish.
+Tab-completion is only available for certain shells including: bash (version
+4.4 or greater), zsh, and fish shells since pywbemlistener defines the completer
+script specifically for each shell.
 
-Tab-completion can easily be activated by inserting the following into the
-shell initialization (ex. .bashrc)
+Tab-completion can easily be activated for both pywbemtools commnds by
+inserting the following into the shell initialization (ex. .bashrc)
 
     eval "$(_PYWBEMCLI>_COMPLETE=bash_source pywbemcli)"
     eval "$(_PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener)"
 
-To activate pywbemlistener and pywbemcli tab-completion:
-
-  1. Insert the eval command for each tool in the startup file
-  2. Close the file and restart the terminal
-  3. Test existence of tab-completion by:
-     a. Test completion with a command such as "pywbemlistener cl<TAB> which
-        should complete the "pywbemlistener li<TAB>" command group name.
-     b. In bash executing "complete -p pywbemlistener". An entry for
-        pywbemlistener must exist for pywbemlistener as follows:
-        complete -o nosort -F _pywbemlistener_completion pywbemlistener
-
-Note that the pywbemtools must be publicly available for the above to
-activate tab-completion and this creates the COMPLETE script each time the
-shell is initalized.
-
-The ``eval`` statement for each of the shells supported is as follows and can
-be inserted into the corresponding shell startup script defined below.
+The activation 'eval' statement for each of the shells supported is as follows
+and can be inserted into the corresponding shell startup script defined below.
 
 =====  ============  ===========================================================
 shell  startup file  eval command
@@ -121,9 +106,23 @@ fish  ~/.config/fish/completions/foo-bar.fish
                            fish_source pywbemlistener)"
 =====  ===========  ===========================================================
 
-Executing the eval directly in the shell startup file requires that the
-pywbemlistener executable location must be known when opening a terminal . This
-may not be consistent with executing pywbemlistener in virtual environments.
+Activate pywbemlistener tab-completion as follows:
+
+  1. Edit the eval command in the startup file
+  2. Close the file and restart the terminal
+  3. Test existence of tab-completion by:
+     a. Test completion with a command such as "pywbemlistener li<TAB> which should
+        complete the "list" command group name.
+     b. In bash executing "complete -p pywbemlistener". An entry for pywbemlistener must
+        be returned for pywbemlistener as follows:
+
+          ``complete -o nosort -F _pywbemlistener_completion pywbemlistener``
+
+Executing ``eval`` directly in the shell startup file requires that the
+pywbemlistener executable location must be known when opening a terminal . This may
+not be consistent with executing pywbemlistener in virtual environments. See
+the pywbemtools documentation for more information and alternate ways to
+activate tab-completion is special circumstances.
 '''
 
 tab_completion_help_msg = """

--- a/tests/unit/pywbemcli/test_help_cmd.py
+++ b/tests/unit/pywbemcli/test_help_cmd.py
@@ -114,6 +114,7 @@ TEST_CASES = [
      None, OK],
 ]
 
+
 # pylint: disable=too-few-public-methods
 class TestPywbemcliCmdHelp(CLITestsBase):
     """

--- a/tests/unit/pywbemcli/test_help_cmd.py
+++ b/tests/unit/pywbemcli/test_help_cmd.py
@@ -45,12 +45,12 @@ INSTANCENAME_HELP_LINES = [
 ]
 
 TABCOMPLETION_HELP_LINES = [
-    "Tab completion is not supported in the interactive mode.",
-    "Tab completion is supported in the command mode, when activated."
+    "Tab completion is supported in the command mode, when activated",
+    "Tab completion is available for:"
 ]
 
 ACTIVATE_HELP_LINES = [
-    "Pywbemcli includes tab-completion capability for all commands for certain"
+    "Pywbemcli tab-completion must be activated after installation by"
 ]
 
 
@@ -114,8 +114,8 @@ TEST_CASES = [
      None, OK],
 ]
 
-
-class TestCmdHelp(CLITestsBase):  # pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods
+class TestPywbemcliCmdHelp(CLITestsBase):
     """
     Test the help command
     """

--- a/tests/unit/pywbemlistener/test_help_cmd.py
+++ b/tests/unit/pywbemlistener/test_help_cmd.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Test the help command that displays help text on specific pywbemcli
+Test the help command that displays help text on specific pywbemlistener
 subjects.
 
 """
@@ -51,9 +51,7 @@ SHOW_HELP_SUMMARY_PATTERNS = [
 ]
 
 SHOW_HELP_ACTIVATE_PATTERNS = [
-    r"activate - Activating shell tab completion",
-    r"Pywbemlistener includes tab-completion capability",
-    r"Manually executing the sourcing statement when required."
+    r"Pywbemlistener tab-completion must be activated after installation by"
 ]
 
 


### PR DESCRIPTION
Part of issue 1524.
This pr cleans up the documentation of tab-completion and makes some other minor spelling and grammar corrections.

This makes the primary instructions for tab-completion activate simply putting the eval statement in the terminal startup file.

However it does not completely remove the other technique but moves it to a separate section at the bottom of the documentation noting that is is only used in a few cases.

The changes are primarily in the docs settings file with some changes to the text for the pywbemcli help activate and pywbemlistener help activate