### PR TITLE
Modify tab-completion activation doc per issue 1524

### DIFF
--- a/changes/1524.feature.3.rst
+++ b/changes/1524.feature.3.rst
@@ -12,3 +12,6 @@ Clarify that this does not actually activate tab-completion.
 
 Simplify a definition of where the activation script must be relative to the
 pywbemtools command.
+
+Updated the text for the pywbemcli help activate and pywbemtools help activate
+to match the other tab-activation documentation changes.

--- a/docs/pywbemcli/cmdlineinterface.rst
+++ b/docs/pywbemcli/cmdlineinterface.rst
@@ -27,15 +27,8 @@ within the pywbemtools package.
 
 Pywbemcli provides a command line interface(CLI) interaction with WBEM servers.
 
-The pywbemcli command is invoked with a command  and arguments/options:
-
-.. code-block:: text
-
-    $ pywbemcli [GENERAL-OPTIONS] COMMAND [COMMAND-OPTIONS] [ARGS]
-
-Where the components are:
-
-The pywbemcli command is invoked with a command and arguments/options:
+The pywbemcli command is invoked from a command line terminal with a command
+and arguments/options in the order shown here:
 
 .. code-block:: text
 
@@ -48,7 +41,7 @@ Where the components are:
 
 .. index:: pair: General Options; command components
 
-* **GENERAL-OPTIONS** - General options; they apply to all commands.
+* **GENERAL-OPTIONS** - General options apply to all commands.
   See :ref:`Using the pywbemcli command line general options` for information
   on the pywbemcli general options.
 
@@ -57,28 +50,24 @@ Where the components are:
 * **COMMAND** - A name of a command which may consist of:
    * <group name> <command name> for commands that are defined within
      groups (ex. ``class find``).
-   * <group name> (ex. ``class``) to show group help including list of  command
-     within the group.
-   * <command name> for those commands that are not part of a group. For
+
+   * <command name> for commands that are not part of a group. For
      example ``repl`` and ``help`` that are not in any command group.
 
 .. index:: pair: command arguments; command components
 
-* **ARGUMENTS** - Arguments may be defineda specific command. Arguments
-  are not individually
-  documented in the help and do not have preceeding dashes. In pywbemcli
-  arguments are only used in commands. There are no general arguments.
-  Specifically they are used to specify request object names (ex. class namme
-  or instance name for specifice commands.
+* **ARGUMENTS** - Arguments may be defined for specific commands. Arguments
+  do not have preceeding dashes. In pywbemcli arguments are only used in
+  commands; here are no general arguments. For pywbemcli they are used to
+  specify request object names (ex. class namme or instance name for specific
+  commands.
 
 .. index:: pair: command interface; Command Options
 
 * **COMMAND-OPTIONS** - Options that apply only to a particular
-  COMMAND.
-
-Options are prefixed with the characters ``-`` for the short form or ``--`` for
-the long form (ex. ``-n`` or ``--namespace``). The other command line components
-do not begin with ``-``.
+  COMMAND. Options are prefixed with the characters ``-`` for the short form or
+  ``--`` for the long form (ex. ``-n`` or ``--namespace``). The other command
+  line components do not begin with ``-``.
 
 .. index:: pair: command groups; command interface
 
@@ -119,17 +108,19 @@ and ``--namespace`` is a command option.
    single: auto-suggestion
 
 Pywbemcli supports  :term:`tab-completion` and :term:`auto-suggestion`
-depending on whether it is in command mode or interactive mode.
+depending on whether it is in command mode or interactive mode:
 
-  * :ref:`interactive mode` - both tab-completion and auto-suggestion are always
-    available.
   * :ref:`command mode` - tab-completion is available with some command shells
-    and only when activated for the shell type.  Auto-suggestion is not
-    available.
+    and only when activated for the shell type. It is available for bash,
+    zsh, and fish shells.  Auto-suggestion is not enabled at installation. To enable
+    tab-completion see :ref:`Activating shell tab-completion`.
+  * :ref:`interactive mode` - auto-suggestions are always available.
+
+.. index:: tab-completion
 
 Tab-completion is available in pywbemcli for:
     * All comand group and command names
-    * All option names
+    * All general and command specific option names
     * At least the following general options values:
         * --name
         * --mock-server - The completion uses the default connection file
@@ -160,15 +151,17 @@ Tab-completion is available in pywbemcli for:
     $ pywbemcli class <TAB><TAB>
     ... <shows the class commands to select from>
 
-    $ pywbemcli -n moc <TAB><TAB>  (Only only with Python 3)
-    ... returns connection names in the default connection file that start
-    ... with moc
+    $ pywbemcli -n moc <TAB><TAB>
+    ... returns ``mock``
+    $ pywbemcli -n mock a<TAB><TAB>
+    ... returns list of defined connection names that start with ``a``.
 
-Tab-completion for ``pywbemcli`` is used like any other tab-completion by
+
+Tab-completion for ``pywbemcli`` is used like bash tab-completion by
 hitting <TAB> or <TAB><TAB> where completion is possible. Generally <TAB>
 returns a complete response completion if there is only one available while
 <TAB><TAB> returns a list if there are multiple possible completions but the
-exact behavior depends on the shell and any number of shell flags, extensions
+exact behavior depends on the shell, any number of shell flags, and extensions
 that are particular to each shell.
 
 .. index::
@@ -236,10 +229,11 @@ activating shell completion.
 Interactive mode
 ----------------
 
-In interactive mode (also known as :term:`REPL` mode), pywbem provides an
-interactive shell environment that allows typing pywbemcli commands, internal
-commands (for operating the pywbemcli shell), and external commands (that are
-executed in the standard shell of the user).
+In interactive mode (also known as :term:`REPL` mode), pywbemcli provides an
+interactive shell environment within an executing pywbemcli instance that
+allows typing pywbemcli commands, internal commands (for operating the
+pywbemcli shell), and external commands (that are executed in the standard
+shell of the user).
 
 The pywbemcli shell uses the prompt ``pywbemcli>``. The cursor is shown in
 the examples as an underscore (``_``) in the following examples in this document.
@@ -399,11 +393,10 @@ The pywbemcli shell in the interactive mode always supports tab-completion and
 usually with popup help text for commands, arguments, and options typing, where
 the valid choices are shown based upon what was typed so far, and where an item
 from the popup list can be picked with <TAB> or with the cursor keys. It can be
-used to select from the list of general options. Interacitve
-mode tab-completion may differ from command mode tab-completion because the
-support is provided by a python package and not the shell. The following
-examples show interactive mode tab-completion; an
-underscore ``_`` is shown as the cursor:
+used to select from the list of general options. Interactive mode
+tab-completion may differ from command mode tab-completion because the support
+is provided by a python package and not the shell. The following examples show
+interactive mode tab-completion; an underscore ``_`` is shown as the cursor:
 
 .. code-block:: text
 
@@ -417,7 +410,7 @@ underscore ``_`` is shown as the cursor:
                   class
 
 Interactive mode uses a combination of tab-completion and auto-suggestion  for
-aut completion which are both always active:
+auto-completion which are both always active:
 
   * :term:`tab-completion` - In this mode, a single <TAB> enables the display of
     available completion possibilities for command groups, commands, options

--- a/docs/pywbemcli/cmdlineinterface.rst
+++ b/docs/pywbemcli/cmdlineinterface.rst
@@ -59,7 +59,7 @@ Where the components are:
 * **ARGUMENTS** - Arguments may be defined for specific commands. Arguments
   do not have preceeding dashes. In pywbemcli arguments are only used in
   commands; here are no general arguments. For pywbemcli they are used to
-  specify request object names (ex. class namme or instance name for specific
+  specify request object names (ex. class name or instance name for specific
   commands.
 
 .. index:: pair: command interface; Command Options
@@ -119,18 +119,18 @@ depending on whether it is in command mode or interactive mode:
 .. index:: tab-completion
 
 Tab-completion is available in pywbemcli for:
-    * All comand group and command names
+    * All command group and command names
     * All general and command specific option names
     * At least the following general options values:
-        * --name
-        * --mock-server - The completion uses the default connection file
+        * ``--name``
+        * ``--mock-server`` - The completion uses the default connection file
           unless the --connection-file general option has already been defined
           for an alternate connection file on the command line.
-        * --connection-file
-        * --keyfile
-        * --certfile
-        * --use-pull
-        * --output-format
+        * ``--connection-file``
+        * ``--keyfile``
+        * ``--certfile``
+        * ``--use-pull``
+        * ``--output-format``
     * At least the following command arguments
         * help <subject-argument>
     * At least the following command options
@@ -146,7 +146,7 @@ Tab-completion is available in pywbemcli for:
     ... <shows the command groups to select from>
 
     $ pywbemcli clas<TAB>
-    ... completes the command group class
+    ... completes the command group command ``class``
 
     $ pywbemcli class <TAB><TAB>
     ... <shows the class commands to select from>
@@ -157,12 +157,17 @@ Tab-completion is available in pywbemcli for:
     ... returns list of defined connection names that start with ``a``.
 
 
-Tab-completion for ``pywbemcli`` is used like bash tab-completion by
+Tab-completion for ``pywbemcli`` is used like any other shell tab-completion by
 hitting <TAB> or <TAB><TAB> where completion is possible. Generally <TAB>
 returns a complete response completion if there is only one available while
 <TAB><TAB> returns a list if there are multiple possible completions but the
 exact behavior depends on the shell, any number of shell flags, and extensions
-that are particular to each shell.
+that are particular the shell running.
+
+Tab-completion is available for several shells including bash, zsh and fish.
+
+Upon installation, shell tab-completion is not active. It can be activated post
+installation as defined in section :ref:`Activating shell tab-completion`.
 
 .. index::
     pair: Modes of operation; Command mode

--- a/docs/pywbemcli/cmdshelp.rst
+++ b/docs/pywbemcli/cmdshelp.rst
@@ -137,7 +137,7 @@ Help text for ``pywbemcli``:
       subscription  Command group to manage WBEM indication subscriptions.
       connection    Command group for WBEM connection definitions.
       repl          Enter interactive mode (default).
-      help          Show help for pywbemcli subjects.
+      help          Show help for specific pywbemcli subjects.
       docs          Get pywbemtools documentation in web browser.
 
 
@@ -978,15 +978,13 @@ Help text for ``pywbemcli help`` (see :ref:`help command`):
 
     Usage: pywbemcli [GENERAL-OPTIONS] help SUBJECT
 
-      Show help for pywbemcli subjects.
+      Show help for specific pywbemcli subjects.
 
-      Show help for specific pywbemcli subjects.  This is in addition to the help messages that are available with the -h or
-      --help option for every command group and command in pywbemcli. It helps document pywbemcli subjects that are more
-      general than specific commands and configuration subjects that do not have specific commands
+      This is in addition to the help messages that are available with the -h or --help option for every command group and
+      command in pywbemcli. It helps document pywbemcli subjects that are more general than specific commands and
+      configuration subjects that do not have specific commands.
 
-      If there is no argument provided, outputs a list and summary of the existing help subjects.
-
-      If an argument is provided, it outputs the help for the subject(s) defined by the argument.
+      If there is no argument provided, a list and summary of the existing help subjects is displayed.
 
     Command Options:
       -h, --help  Show this help message.

--- a/docs/pywbemcli/commands.rst
+++ b/docs/pywbemcli/commands.rst
@@ -412,7 +412,7 @@ using :term:`CIM object output formats`.
 
 If the ``--deep-inheritance``/``--di`` command option is set, all direct and
 indirect subclasses are included in the result. Otherwise, only one level of
-the class hierarchy is in the result.
+the class hierarchy is included in the result.
 
 .. index:: pair: result filters; class enumerate command
 
@@ -1012,7 +1012,7 @@ The command options are:
 *  ``--object-order`` - This option modifies the order of the display of
    instances when there are multiple namespaces displayed to order by classname
    and then namespace where the normal display order is  to order by
-   namespace and then classname
+   namespace and then classname.
 
 index:
     pair --namespace option; command option --namespace
@@ -1023,7 +1023,7 @@ index:
    :term:`current connection`. This option accepts single or multiple namespaces
    and displays the results for the list of namespaces supplied.
    See :ref: `Pywbemcli special command line features` for more information
-   on using multiple namespaces
+   on using multiple namespaces.
 
 *  ``-s``/``--summary`` - Show only a summary (count) of the objects.
 
@@ -1034,9 +1034,9 @@ index:
 *  ``--fql``/``--filter-query-language QUERY-LANGUAGE`` = The filter query
    language to be used with ``--filter-query``. Default: DMTF:FQL.
 
-*  ``--show-null`` -In the TABLE output formats, show propertieswith no value
+*  ``--show-null`` -In the TABLE output formats, show properties with no value
    (i.e. Null) in all of the instances to be displayed. Otherwise only
-   properties at least one instance has a non- Null property are displayed
+   properties at least one instance has a non-Null property are displayed
 
 *  ``--help-instancename``/``--hi`` -  Show help message for specifying
    ``INSTANCENAME`` including use of the ``--key`` and ``--namespace``
@@ -1422,7 +1422,7 @@ The command options are:
    to when pull operations are used. Default: DMTF:FQL. This parameter is
    ignored if traditional operations are executed.
 
-*  ``--show-null`` - In the TABLE output formats, show propertieswith no value
+*  ``--show-null`` - In the TABLE output formats, show properties with no value
    (i.e. Null) in all of the instances to be displayed. Otherwise only
    properties at least one instance has a non- Null property are displayed
 
@@ -2110,7 +2110,7 @@ The ``-namespace``/``-n`` command option option defines the term:`Namespace` to
 use for this command, instead of the default namespace of the :term:`current
 connection`.  This option accepts single or multiple namespaces and displays
 the results for the list of namespaces supplied. See :ref: `Pywbemcli special
-command line features` for more information on using multiple namespaces
+command line features` for more information on using multiple namespaces.
 
 The qualifier declaration is displayed using :term:`CIM object output formats`
 or :term:`Table output formats`.
@@ -2646,7 +2646,7 @@ statistics gathering and reporting in pywbemcli:
     interactive mode with the ``statistics show`` command.
 
     For mock environments, artificial operations on the MOF compile time
-    needed for setting up the mock respository are included in the client
+    needed for setting up the mock repository are included in the client
     maintained statistics.
 
 2.  WBEM servers may support two capabilities for managing statistics on WBEM
@@ -2954,7 +2954,7 @@ implementations of WBEM servers such as the implementation of OpenPegasus.
 
 The ``connection`` command group includes commands that manage named :term:`connection
 definitions <connection definition>` that are persisted in a :term:`connections file`.
-This allows maintaining multiple connection :term:`connection definitionss <connection definition>` and then using any
+This allows maintaining multiple connection :term:`connection definitions <connection definition>` and then using any
 one via the :ref:`--name general option`. Only a single connection is
 active (selected) at any point in time but the connection connection can
 be selected on the pywbemcli command line (:ref:`--name general option`) or
@@ -3057,7 +3057,7 @@ The format of this command is:
     pywbemcli [GENERAL-OPTIONS] connection export [COMMAND-OPTIONS]
 
 This is done by displaying the commands to set the environment variables to
-stdout.
+stdout:
 
 .. code-block:: text
 
@@ -3677,7 +3677,7 @@ list by executing subscription list-filters, subscription list_destinations(), o
 subscription list-subscriptions().
 
 **NOTE:** Pywbem_mock used in testing does not remember any of subscription
-instances between  non-interactive commands so that most pywbemcli mock testing
+instances between non-interactive commands so that most pywbemcli mock testing
 is done in interactive mode.
 
 Identifying destinations, filters, and subscriptions on the command line
@@ -4109,7 +4109,7 @@ The ``subscription ``list-destinations`` command displays the existing
 destination instances ((CIM class ``CIM_ListenerDestinationCIMXML``)) on
 the current WBEM server.
 
-**NOTE:** pywbemcli works only with the  ``CIM_ListenerDestinationCIMXML``
+**NOTE:** pywbemcli works only with the ``CIM_ListenerDestinationCIMXML``
 class so that any indication destination instances defined with the superclass
 ``CIM_ListenerDestination`` are not visible.
 
@@ -4538,7 +4538,6 @@ the filter is part of an existing subscription.
 See :ref:`pywbemcli subscription remove-filter --help` for the help output
 of the command.
 
-
 .. index::
     pair: subscription commands; subscription remove-subscription
     pair: remove-subscription command; subscription command group
@@ -4567,7 +4566,7 @@ where the two required arguments:
 
 * ``DESTINATIONID`` is the ``IDENTITY`` for the listener destination instance to be
   attached to the subscription. See :ref:`subscription add-destination
-  command`: for the definition of ``DESTINATIONID``
+  command`: for the definition of ``DESTINATIONID``.
 * ``FILTERID`` is the ``IDENTITY`` for the indication filter instance to be
   attached to the subscription.  See :ref:`subscription add-filter command`:
   for the definition of ``FILTERID``.
@@ -4662,7 +4661,7 @@ of the command.
 ``Subscription remove-server`` command
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This command unregisters owned listeners from the WBEM server and removes
+This command deregisters owned listeners from the WBEM server and removes
 all owned indication subscriptions, owned indication filters, and owned
 listener destinations for this currently active pywbemcli WBEM server from
 that WBEM server.
@@ -4681,10 +4680,10 @@ The currently active WBEM server is the WBEM server to which pywbemcli is
 currently attached; the WBEM server defined by  the :ref:`--name general option`,
 :ref:`--server general option`, or :ref:`--mock-server general option`.
 
-The identity of the current wbem server id visible in the title of
+The identity of the current WBEM server id visible in the title of
 each of the subscription list table outputs.
 
-Thus, for example current server is defined by svr_id and is actually
+Thus, for example the current server is defined by svr_id and is actually
 the fixed name ``http://FakedUrl:5988`` of the mock server.
 
 .. code-block:: text
@@ -4820,14 +4819,14 @@ Thus, for example:
 ----------------
 
 .. index::
-    single: docs command
+    single: docs command``
     pair: docs; command
 
 The ``docs`` command provides a simple way to access the pywbemtools
-documentation  publically available on the WEB.  This command calls the
+documentation  publicly available on the WEB.  This command calls the
 system default WEB browser with the URL of the pywbemtools documentation
 to open a new browser window with the top level page of that documentation and
-immediatly terminates or returns to the repl command line.
+immmediately terminates or returns to the ``repl`` command line.
 
 This is ``experimental`` as of pywbemtools 1.2.0.
 

--- a/docs/pywbemcli/generaloptions.rst
+++ b/docs/pywbemcli/generaloptions.rst
@@ -286,7 +286,7 @@ the following arguments :
 
     defines the use of the pywbemcli mock WBEM server script ``myscript.py`` and
     executes the pywbem command ``class enumerate`` to show the first level
-    of the class hiearchy class names in the default namespace.
+    of the class hierarchy class names in the default namespace.
 
 2. Define connection characteristics for a WBEM server by using the
 
@@ -950,12 +950,12 @@ for details.
 """"""""""""""""""""""""
 
 The ``--pdb`` general option is a boolean option that enables debugging
-with the built-in pdb debugger.
+with the built-in Python pdb debugger.
 
 If debugging is enabled, execution of each pywbemcli command will pause just
 before the command within pywbemcli is executed, and the pdb debugger prompt
 will appear. See `pdb debugger commands`_ for details on how to operate the
-built-in pdb debugger.
+built-in Python pdb debugger.
 
 In addition to the ``--pdb`` option,
 
@@ -1060,7 +1060,7 @@ shell commands to set all of the environment variables:
 This can be used to set those environment variables and thus to persist
 the connection name in the shell environment, from where it will be used in
 any subsequent pywbemcli commands until removed. The following shows the
-display of the pywbbemcli environment variables that are set :
+display of the pywbemcli environment variables that are set :
 
 .. code-block:: text
 
@@ -1199,7 +1199,7 @@ The output formats fall into the following groups:
   format.  The tree format is not supported by any other command today.
 
 * **TEXT format** - The :ref:`Text formats` is used for commands that output
-  small quantites of text (ex. the interop namespace name) and that could be
+  small quantities of text (ex. the interop namespace name) and that could be
   used as part of a command line redirection.
 
 When an unsupported output format is specified for a command response, it is
@@ -1237,7 +1237,7 @@ class      get           'mof'    objects        See Note 1 below
 class      invokemethod  'mof'    objects        See Note 1 below
 class      references    'mof'    objects        See Note 1 below
 class      tree          None     None           Only outputs as ascii tree
-instance   associators   'mof'    objects, table Output as cim object or table of properties
+instance   associators   'mof'    objects, table Output as CIM object or table of properties
 instance   count         'simple' table
 instance   create        None     None           Nothing returned
 instance   delete        None     None           Nothing returned

--- a/docs/pywbemcli/index.rst
+++ b/docs/pywbemcli/index.rst
@@ -18,8 +18,8 @@
 Pywbemcli command
 =================
 
-Pywbemcli provides access to WBEM servers from the command line.
-It provides functionality to:
+Pywbemcli provides access to WBEM servers from the terminal command line.
+It provides functionality using the WBEM protocol to:
 
 * Explore the CIM data of WBEM servers. It can manage/inspect the CIM model
   components including CIM classes, CIM instances, and CIM qualifiers and

--- a/docs/pywbemcli/index.rst
+++ b/docs/pywbemcli/index.rst
@@ -18,8 +18,8 @@
 Pywbemcli command
 =================
 
-Pywbemcli provides access to WBEM servers from the terminal command line.
-It provides functionality using the WBEM protocol to:
+Pywbemcli provides access to WBEM servers from the terminal command line
+using the WBEM protocol to:
 
 * Explore the CIM data of WBEM servers. It can manage/inspect the CIM model
   components including CIM classes, CIM instances, and CIM qualifiers and
@@ -41,7 +41,8 @@ It provides functionality using the WBEM protocol to:
   can access multiple WBEM servers by name.
 
 * Provide both a command line mode and an interactive mode where multiple
-  pywbemcli commands can be executed within the context of a WBEM server.
+  pywbemcli commands can be executed within the context of a WBEM server in a
+  single execution of pywbemcli.
 
 * Use an integrated mock WBEM server to try out commands. The mock server
   can be loaded with CIM objects defined in MOF files or via Python scripts.

--- a/docs/pywbemcli/mock_support.rst
+++ b/docs/pywbemcli/mock_support.rst
@@ -12,10 +12,10 @@ Mock WBEM server overview
 
 `pywbemcli` implements an in-process mock WBEM Server using the pywbem
 :ref:`pywbem:Mock WBEM server` which defines a local mock WBEM server
-environment. The mock sever provides WBEM server request responses to pywbmcli
+environment. The mock sever provides WBEM server request responses to pywbemcli
 commands. The configuration and contents of the mock server are defined by the
 pywbemcli :ref:`--mock-server general option` which defines a mock script
-mof or python file that defines the CIM model and functional characteristics
+MOF or python file that defines the CIM model and functional characteristics
 of the mock WBEM server.
 
 .. index:: pair: mock server; start
@@ -501,7 +501,7 @@ For example:
         for fn in dependent_file_names:
             dep_path = os.path.join(os.path.dirname(this_file_path), fn)
             conn.provider_dependent_registry.add_dependents(this_file_path,
-                                                        dep_path)
+                                                            dep_path)
 
     def _setup(conn, server, verbose):
 
@@ -577,7 +577,6 @@ should operate on depending on the Python version:
    in several ways including:
 
    * prevents caching of the mock environment.
-   * TODO
 
    Old-style mock scripts are executed as Python scripts in Python namespace
    ``__builtin__``, with the following Python global variables made available:
@@ -1134,8 +1133,6 @@ Caching mock WBEM servers connection definitions
 .. index:: pair: mock-server cache; cache mock-server
 .. index:: pair: mock-server cache; connection definition
 
-TODO: add index entries for connection definition
-
 Pywbemcli automatically attempts to cache the contents of a mock WBEM server
 definition when:
 
@@ -1179,8 +1176,8 @@ The caches for the connection definitions are maintained in the
 ``.pywbemcli_mockcache`` directory in the user's home directory in separate
 files with names of the form <guid>.<connection name>.
 
-If a connection definition is used as the wbem server (:ref:`--name general
-option`) , pywbemcli verifies whether its mock WBEM server has been cached, and
+If a connection definition is used as the wbem server (:ref:`--name general option`),
+pywbemcli verifies whether its mock WBEM server has been cached, and
 if so, whether the cache is up to date. If it is not up to date, it is not used
 but re-generated.
 
@@ -1199,5 +1196,3 @@ are also used to determine whether the mock cache is up to date.
 See :ref:`pywbem:Registry for provider dependent files` for more details on how
 to register dependent files. Generally all the files used in the setup script
 and the script itself should be registered as dependent files.
-
-# TODO: Why in pywbem

--- a/docs/pywbemlistener/cmdshelp.rst
+++ b/docs/pywbemlistener/cmdshelp.rst
@@ -103,9 +103,11 @@ Help text for ``pywbemlistener help`` (see :ref:`pywbemlistener help command`):
 
       Show help for pywbemlistener subjects.
 
+      If an argument is provided, it outputs the help for the subject(s) defined by the argument.
+
       Show help for specific pywbemlistener subjects.  This is in addition to the help messages that are available with the
       -h or --help option for every command group and command in pywbemlistener. It helps document pywbemlistener subjects
-      that are more general than specific commands and configuration subjects that do not have specific commands
+      that are more general than specific commands and configuration subjects that do not have specific commands.
 
       If there is no argument provided, outputs a list and summary of the existing help subjects.
 

--- a/docs/pywbemlistener/commands.rst
+++ b/docs/pywbemlistener/commands.rst
@@ -79,7 +79,7 @@ indication listener on the local system, by specifying the listener name.
 
 The running listeners are identified as the processes executing the
 ``pywbemlistener run`` command. The listener name is also identified from
-the process command line.
+the command argument in the process command line.
 
 Example:
 
@@ -115,20 +115,22 @@ See :ref:`pywbemlistener show --help` for the exact help output of the command.
 The ``pywbemlistener start`` command starts a new WBEM indication listener on
 the local system.
 
-The listener is running as a normal user process in the background, inheriting
+The listener is run as a normal user process in the background, inheriting
 the group and user context from the process that runs the ``pywbemlistener start``
 command (usually the shell process in a terminal session).
 
 Example:
 
 .. code-block:: text
-
     $ pywbemlistener start lis1 --cert-file .../certs/server_cert.pem --key-file .../certs/server_key.pem
     Running listener lis1 at https://localhost:25989
 
-The previous example started a listener for HTTPS (the default) on the default
+The previous example started a listener named lis1 for HTTPS (the default) on the default
 port 25989. Because HTTPS was used, it was necessary to specify an X.509 server
 certificate and its key file.
+
+The listener name must be unique as it defines the listener target for other
+commands (ex. ``show listener lis1``)
 
 The ``-p, --port`` option specifies the port on which the listener will
 receive indicaitons.
@@ -238,9 +240,9 @@ Example:
     $ pywbemlistener stop lis1
     Shut down listener lis1 running at http://localhost:25989
 
-On Windows, the listener process is stopped immediately without giving the
-process control to clean up. On other platforms, the listener process is stopped
-gracefully, giving the process control to clean up.
+On Windows, the listener process named ``lis1`` is stopped immediately without
+giving the process control to clean up. On other platforms, the listener
+process is stopped gracefully, giving the process control to clean up.
 
 See :ref:`pywbemlistener stop --help` for the exact help output of the command.
 
@@ -335,7 +337,7 @@ command groups, and commands.
     $ pywbemcli help
 
     Help subjects:
-    Subject name    ubject description
+    Subject name    Subject description
     --------------  --------------------------------------------
     activate        How to activate tab-completion
     tab-completion  Using tab-completion

--- a/docs/pywbemlistener/commands.rst
+++ b/docs/pywbemlistener/commands.rst
@@ -122,8 +122,9 @@ command (usually the shell process in a terminal session).
 Example:
 
 .. code-block:: text
+
     $ pywbemlistener start lis1 --cert-file .../certs/server_cert.pem --key-file .../certs/server_key.pem
-    Running listener lis1 at https://localhost:25989
+    # Running listener lis1 at https://localhost:25989
 
 The previous example started a listener named lis1 for HTTPS (the default) on the default
 port 25989. Because HTTPS was used, it was necessary to specify an X.509 server

--- a/docs/pywbemlistener/index.rst
+++ b/docs/pywbemlistener/index.rst
@@ -32,6 +32,49 @@ Instead, the currently running processes executing the
 listeners. Because of this, there is no notion of a stopped listener nor
 does a listener have an operational status.
 
+This section describes the command line interface of the pywbemlistener
+terminal command.
+
+The pywbemlistener command is invoked from a command line terminal with a command
+and arguments/options as shown here:
+
+.. code-block:: text
+
+    $ pywbemlistener [GENERAL-OPTIONS] COMMAND [COMMAND-OPTIONS] [ARGUMENTS]
+    or
+    $ pywbemlistener [GENERAL-OPTIONS] COMMAND [ARGUMENTS] [COMMAND-OPTIONS]
+
+
+Where the components are:
+
+.. index:: pair: General Options; command components
+
+* **GENERAL-OPTIONS** - General options apply to all pywbemlistener commands.
+  They start with ``-`` or ``--``. See :ref:`Pywbemlistener general options`
+
+* **COMMAND** - A name of a command to be executed. See :ref:`Pywbemlistener commands`
+
+* **ARGUMENTS** - Arguments may be defined for specific commands. Arguments
+  do not have preceeding dashes. Arguments name the target listener
+  for commands that execute against a single listener (ex. ``start lis1``)
+
+* **COMMAND-OPTIONS** - Options that apply only to a particular
+  COMMAND. Options are prefixed with the characters ``-`` for the short form or
+  ``--`` for the long form (ex. ``-n`` or ``--namespace``).
+
+.. index::
+   pair: tab-completion; auto-suggestion
+   single: auto-suggestion
+
+Pywbemistener supports  :term:`tab-completion`. Tab-completion is available
+with some command shells and only when activated for the shell type after
+pywbemlistener installation. It is available for bash, zsh, and fish shells.
+
+Tab-completion is available in pywbemcli for:
+    * All command names
+    * All general and command specific option names
+    * command arguments (i.e. listener names)
+
 .. The maxdepth attribute overrides the maxdepth attribute of the
 .. mastertoc if used.
 .. The numbered attribute intentionally is not set, because the numbering

--- a/docs/settingsandconfiguration.rst
+++ b/docs/settingsandconfiguration.rst
@@ -21,7 +21,8 @@ Settings and Configuration
 
 Both pywbemtools (pywbemcli and pywbemlistener) execute after installation
 without any configuration except for the use of tab-completion (using <TAB> on
-the shell command line) to attempt to complete parameters.
+the shell command line) to attempt to complete parameters. The tab-completion
+is not active after installation and must be activated separately.
 
 
 .. _`Activating shell tab-completion`:
@@ -33,7 +34,7 @@ Activating shell tab-completion
 .. index:: pair: zsh shell; tab-completion
 .. index:: pair: fish shell; tab-completion
 
-Tab-completion is supported for pywbemlistener and  of pywbemcli in the
+Tab-completion is supported for pywbemlistener and pywbemcli in the
 :ref:`command mode`, for the following shells:
 
   * **bash shell** - (bash version 4.4 or greater). Not all Linux implementations
@@ -71,69 +72,47 @@ pywbemtools installation.
 .. index:: tab-completion
 .. index:: Activating tab-completion
 
-To activate shell tab-completion, the  script *magic variable*  (``<PROG-NAME>_COMPLETE``) must
-be defined for the shell defining the shell name and the pywbemtools name
+To activate shell tab-completion, the  script *magic variable*
+(``<PROG-NAME>_COMPLETE``) must be defined in the shell initialization for the
+shell defining the shell name and the pywbemtools name as follows:
 
-    _<PROG-NAME>_COMPLETE=<SHELL-NAME>_source  <prog-name>
+.. code-block:: text
+
+    * The shell magic variable    _<PROG-NAME>_COMPLETE=<SHELL-NAME>_source  <prog-name>
 
 where:
 
     * `<PROG-NAME>` - pywbemtools command name in uppercase(i.e. PYWBEMCLI or PYWBEMLISTENER).
     * `<SHELL-NAME>` - shell name (i.e. bash, zsh, or fish).
     * `<prog-name>` - pywbemtools command name in lower case (pywbemcli or pywbemlistener).
+                      The commands must be publicly available.
 
-The existence of this shell *magic variable*  (``_<PROG-NAME>_COMPLETE``) notifies the
-shell that this is a shell tab-completion variable and the shell calls
-back to `<prog-name>` with arguments containing ``_<PROG-NAME>_COMPLETE``,
-``_<SHELL-NAME>_source`` and other tab-completion information in environment
-variables.  The pywbemtools command  `prog-name` returns the correct completion
-script text specific for that shell as the call return value which the user
-must save as a script file
+The existence of this shell *magic variable*  (``_<PROG-NAME>_COMPLETE``) in
+the shell initialization file notifies the shell that this is a shell
+tab-completion variable and the shell calls back to `<prog-name>` with
+arguments containing ``_<PROG-NAME>_COMPLETE``, ``_<SHELL-NAME>_source`` and
+other tab-completion information in environment variables.  The pywbemtools
+command  `prog-name` returns the correct completion script text specific for
+that shell as the call return value.
 
-Once tab-completion is activated for a shell type , hitting <TAB> or <TAB><TAB>
-initiates tab-completion for command names, option names, and some
-option/argument values which attempts to return the completion of the word on
-the command line where <TAB> was entered. If there are multiple possible
-completions, the shell returns the list or do nothing until a second <TAB> is
-entered.
+The ``eval`` completes the initialization by making the COMPLETE script returned
+from the bash call to the pywbemtool command available within the current shell.
 
-If hitting <TAB> or <TAB><TAB> when tab-completion is active returns nothing,
-either the word at the terminal cursor is not matched with a possible
-target (ex. ``pywbemcli --name xxx<TAB>``) for pywbemcli connection name when
-there is no connection name that starts with ``xxx`` or there is no
-tab-completion (ex. for example for the class name in ``get class
-<class-name>``)
+The pywbemtools commands must be public for this initialization.Note also that
+the tab-completion script is created each time the shell is initialized
 
-Activation of tab-completion involves the following for each pywbemtools
-command but with different formats for each shell type:
-
-1. Getting from each pywbemtools command the body of a completion script for
-   the terminal's shell type as defined above using the *magic variable*. This
-   script file contains the shell-specific logic to activate tab-completion and
-   process tab-completion calls.
-
-2. Notifying the shell of this completion script by either:
-
-   * notifying the shell with a shell  ``eval`` statement or,
-   * saving the script to a completion script file and notifying the shell later
-     by sourcing the resulting completion script file.
-
-Activation with shell eval statement
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Table table:ref:`tab-complete-eval-statement` defines the ``eval`` statement
+Table table:ref:`tab-complete-eval-statement` defines an ``eval`` statement
 for the shells that pywbemcli/pywbemlistener support for tab-completion that
-would be added to a shell startup file defined in the table, for example:
+should be added to a shell startup file defined in the table, for example:
 
 .. code-block:: text
 
-    # example for tab-completion activation and bash shell
-    _PYWBEMCLI_COMPLETE=bash_source pywbemcli
-    _PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener
+    # example for tab-completion activation and bash shell, These lines
+    # are be inserted into bash initialization (.bashrc)
+    eval "$(_PYWBEMCLI>_COMPLETE=bash_source pywbemcli)"
+    eval "$(_PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener)"
 
-.. _tab-complete-eval-statement:
-
-.. table:: Eval statement and proposed startup shell startup file to use for several shells
+.. table:: Eval statement and proposed startup shell startup  eval command to use for several shells
 
   ======  =======================================  =========================================================
   Shell   File to insert eval statement            Eval command
@@ -143,15 +122,58 @@ would be added to a shell startup file defined in the table, for example:
   fish    ~/.config/fish/completions/foo-bar.fish  eval (env _<PROG-NAME>_COMPLETE=fish_source <prog-name>_COMPLETE=fish_source <prog-name>)
   ======  =======================================  =========================================================
 
-This method requires that the pywbemtools command be in the in the PATH
-since the ``eval`` statement initiates a callback to the pywbemcli/pywbemlistener and
-the location of those executables must be publicly available.
 
-Activation by directly creating the tab-completion script file
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Testing that tab-completion is activated
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This activation is useful if you have multiple implementations of pywbemtools
-active.
+The tab-completion activation of pywbemcli and pywbemlistener can be tested in
+a terminal by entering part of a known command and using the <TAB> to request
+completion. The example below shows testing:
+
+.. code-block:: text
+
+   $ pywbemcli clas<TAB>
+
+   This should complete the class statement (i.e. expand cmd line to
+   ``pywbemcli class``).
+
+   $ pywbemlistener star<TAB>
+
+   This should complete the start command name (i.e. expand command line to
+   ``pywbemlistener start``)
+
+Each shell type has one or more commands to determine the state of
+tab-completion for a particular application.  In bash it is the builtin command
+``complete`` used both to define the tab-completion for a particular command
+and to list which commands have been activated.
+
+Executing the bash builtin ``complete -p pywbemcli`` command should return the
+a line that defines the completion for pywbemcli as follows:
+
+.. code-block:: text
+
+    $ complete -p pywbemcli       < ------------ This returns the following
+                                                 if tab-completion is active
+
+    complete -o nosort -F _pywbemcli_completion pywbemcli
+
+Zsh has corresponding commands depending on the version of completion and the
+use of the bashcompinit plugin.
+
+Removing shell tab-completion activation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Bash: The command ``complete -r pywbemcli`` removes the tab-completion for
+pywbemcli.
+
+Zsh: Depends on zsh configuration
+
+
+Alternate activation by directly creating the tab-completion script file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This activation technique is useful if you have multiple implementations of
+pywbemtools active or for some reason pywbemtools is not in a public directory.
 
 Create a complete tab-completion script file using the same statement (ex.
 ``_<PROG-NAME>_COMPLETE=<shell-type>_source <prog-name>``) but save the
@@ -227,47 +249,3 @@ for example, the terminal window is opened:
     source  ~/.pywbemlistener-complete.bash
 
 
-Testing that tab-completion is activated
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The tab-completion activation of pywbemcli and pywbemlistener can be tested in
-a terminal by entering part of a known command and using the <TAB> to request
-completion. The example below shows testing:
-
-.. code-block:: text
-
-   $ pywbemcli clas<TAB>
-
-   This should complete the class statement (i.e. expand cmd line to
-   ``pywbemcli class``).
-
-   $ pywbemlistener star<TAB>
-
-   THis should complete the start command name (i.e. expand command line to
-   ``pywbemlistener start``)
-
-Each shell type has one or more commands to determine the state of
-tab-completion for a particular application.  In bash it is the builtin command
-``complete`` used both to define the tab-completion for a particular command
-and to list which commands have been activated.
-
-Executing the bash builtin ``complete -p pywbemcli`` command should return the
-a line that defines the completion for pywbemcli as follows:
-
-.. code-block:: text
-
-    $ complete -p pywbemcli       < ------------ This returns the following
-                                                 if tab-completion is active
-
-    complete -o nosort -F _pywbemcli_completion pywbemcli
-
-Zsh has corresponding commands depending on the version of completion and the
-use of the bashcompinit plugin.
-
-Removing shell tab-completion activation
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Bash: The command ``complete -r pywbemcli`` removes the tab-completion for
-pywbemcli.
-
-Zsh: Depends on zsh configuration

--- a/docs/settingsandconfiguration.rst
+++ b/docs/settingsandconfiguration.rst
@@ -33,25 +33,9 @@ Activating shell tab-completion
 .. index:: pair: bash shell; tab-completion
 .. index:: pair: zsh shell; tab-completion
 .. index:: pair: fish shell; tab-completion
+.. index:: pair: shell tab completion; tab completion
 
-Tab-completion is supported for pywbemlistener and pywbemcli in the
-:ref:`command mode`, for the following shells:
-
-  * **bash shell** - (bash version 4.4 or greater). Not all Linux implementations
-    include the bash_complete addon so that the user may be required to install
-    the add-on. A simple test with a utility like ``ls`` will indicate if
-    tab-completion is available  in bash(ex. enter ``ls <TAB>`` to test for the
-    existence of the bash_complete addon).
-
-  * **zsh shell** - Tab-completion is available for all versions of zsh but
-    may need to be activated in the zsh config file. Furthermore there are two
-    different completion systems for zsh.
-
-  * **fish shell** - Available for all versions of this shell.
-
-Tab-completion is not supported in the pywbemcli :ref:`Interactive mode`.
-
-Tab-completion allows the terminal user to:
+Shell tab-completion, when activated, allows the terminal user to:
 
 * Complete the static elements of the command line including:
 
@@ -66,53 +50,74 @@ Tab-completion allows the terminal user to:
   But the value of the class in ``class get`` does not support tab-completion
   because that involves a connection to the WBEM server.
 
-Tab-completion for pywbemlistener and pywbemcli must be manually activated after
-pywbemtools installation.
+Tab-completion for the pywbemtool commands (pywbemlistener and pywbemcli) must
+be manually activated after pywbemtools installation.
+
+Shell tab-completion is supported for pywbemlistener and pywbemcli in the
+:ref:`command mode`, for the following shells:
+
+  * **bash shell** - (bash version 4.4 or greater). Not all Linux implementations
+    include the bash_complete addon so that the user may be required to install
+    the add-on. A simple test with a utility like ``ls`` will indicate if
+    tab-completion is available  in bash(ex. enter ``ls <TAB>`` to test for the
+    existence of the bash_complete addon).
+
+  * **zsh shell** - Tab-completion is available for all versions of zsh but
+    may need to be activated in the zsh config file. Furthermore there are two
+    different completion systems for zsh.
+
+  * **fish shell** - Available for all versions of this shell.
 
 .. index:: tab-completion
 .. index:: Activating tab-completion
 
-To activate shell tab-completion, the  script *magic variable*
-(``<PROG-NAME>_COMPLETE``) must be defined in the shell initialization for the
-shell defining the shell name and the pywbemtools name as follows:
+To activate shell tab-completion, the shell magic variable
+(``_<PROG-NAME>_COMPLETE``) must be defined in the shell initialization for the
+shell, defining the shell name and the pywbemtools name as follows:
 
 .. code-block:: text
 
-    * The shell magic variable    _<PROG-NAME>_COMPLETE=<SHELL-NAME>_source  <prog-name>
+    * _<PROG-NAME>_COMPLETE=<SHELL-NAME>_source  <prog-name>
 
 where:
 
     * `<PROG-NAME>` - pywbemtools command name in uppercase(i.e. PYWBEMCLI or PYWBEMLISTENER).
     * `<SHELL-NAME>` - shell name (i.e. bash, zsh, or fish).
     * `<prog-name>` - pywbemtools command name in lower case (pywbemcli or pywbemlistener).
-                      The commands must be publicly available.
+      pywbemcli and pywbemlistener must be publicly available.
 
-The existence of this shell *magic variable*  (``_<PROG-NAME>_COMPLETE``) in
-the shell initialization file notifies the shell that this is a shell
-tab-completion variable and the shell calls back to `<prog-name>` with
-arguments containing ``_<PROG-NAME>_COMPLETE``, ``_<SHELL-NAME>_source`` and
-other tab-completion information in environment variables.  The pywbemtools
-command  `prog-name` returns the correct completion script text specific for
-that shell as the call return value.
+The existence of this shell variable (``_<PROG-NAME>_COMPLETE``) when the
+shell is started indicates that this is a shell tab-completion variable and the
+shell calls back to `<prog-name>` oon terminal startup with arguments containing
+``_<PROG-NAME>_COMPLETE``, ``_<SHELL-NAME>_source`` and other tab-completion
+information in environment variables.  The pywbemtools command  `prog-name`
+returns the correct completion script text specific for that shell as the call
+return value.
 
-The ``eval`` completes the initialization by making the COMPLETE script returned
-from the bash call to the pywbemtool command available within the current shell.
+The ``eval`` statement defined in the table below contains the ``eval``
+statement in the shell startup script for supported shells that activates the
+tab-completion initialization by making the script returned from the shell call
+to the pywbemtools command available within the current shell instantiation.
 
-The pywbemtools commands must be public for this initialization.Note also that
-the tab-completion script is created each time the shell is initialized
+The pywbemtools commands must be public for this initialization to work. The
+tab-completion script is created each time the shell is initialized and is
+placed in the user root directory.
 
-Table table:ref:`tab-complete-eval-statement` defines an ``eval`` statement
-for the shells that pywbemcli/pywbemlistener support for tab-completion that
-should be added to a shell startup file defined in the table, for example:
+An ``eval` command specific for each supported shell should be added to the
+shell started up file for that shell type  to activate shell tab-completion
+of that particular shell, and each of the pywbemtools commands. For example
+the following example activates the bash shell tab-completion for pywbemcli
+each time a bash terminal shell is started. :
 
 .. code-block:: text
 
-    # example for tab-completion activation and bash shell, These lines
-    # are be inserted into bash initialization (.bashrc)
-    eval "$(_PYWBEMCLI>_COMPLETE=bash_source pywbemcli)"
+    eval "$(_PYWBEMCLI_COMPLETE=bash_source pywbemcli)"
     eval "$(_PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener)"
 
-.. table:: Eval statement and proposed startup shell startup  eval command to use for several shells
+The following table defines the shell tab-activation ``eval`` command for each
+of the shell types supported by pywbemtools.
+
+.. table::
 
   ======  =======================================  =========================================================
   Shell   File to insert eval statement            Eval command
@@ -121,6 +126,12 @@ should be added to a shell startup file defined in the table, for example:
   zsh     ~/.zshrc                                 eval "$(_<PROG-NAME>_COMPLETE=zsh_source <prog-name>_COMPLETE=zsh_source <prog-name>)"
   fish    ~/.config/fish/completions/foo-bar.fish  eval (env _<PROG-NAME>_COMPLETE=fish_source <prog-name>_COMPLETE=fish_source <prog-name>)
   ======  =======================================  =========================================================
+
+
+This `eval` statement defines the shell variable and the pywbemtool tool in a
+shell variable(_<prog_name>_COMPLETE) and notifies the the defined shell that
+the pywbemtool is to be activated. The shell both the pywbemtool to create the
+required script.
 
 
 Testing that tab-completion is activated
@@ -173,9 +184,10 @@ Alternate activation by directly creating the tab-completion script file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This activation technique is useful if you have multiple implementations of
-pywbemtools active or for some reason pywbemtools is not in a public directory.
+pywbemtools installed or for some reason pywbemtools is not in a public
+directory.
 
-Create a complete tab-completion script file using the same statement (ex.
+Create a complete tab-completion script file using the statement (ex.
 ``_<PROG-NAME>_COMPLETE=<shell-type>_source <prog-name>``) but save the
 resulting complete script in a file (ex: ``~/.pywbemcli-complete.bash``).  This
 file contains the shell-specific logic to activate tab-completion and process
@@ -185,13 +197,13 @@ whether pywbemcli and pywbemlistener are public.
 
 The following table defines the shell command for supported shells to create the
 complete script file.  The naming and exact location of the file is arbitrary and
-the locations shown in the table are examples.  However, the file is different
-for each shell.
+the locations shown in the table are examples.  However, the script file created
+is different for each shell. The following table defines the line to be executed
+to create the COMPLETE shell script for each supported shell type. This can be
+executed one time after pywbemtools is installed since that script is fixed
+by the code in the pywbemtool.
 
-.. _shell-completion-script:
-
-.. table:: Creation of the complete script file as the tab-completion initialization
-   :name: shell-completion-script
+.. table::
 
   =====  ===========================================================================
   Shell  Script creation command
@@ -202,50 +214,41 @@ for each shell.
          ~/.config/fish/completions/<prog-name>.fish
   =====  ===========================================================================
 
-Once the complete script file has been created, tab-completion activation is completed
-by sourcing the complete script file to notify the shell of the complete file
-each time a terminal is opened. For example as follows:
+
+The activation is completed by sourcing the script before the pywbemtool is
+executed in an active shell. For example to complete activation for bash where
+the script is in ~/blah execute :
 
 .. code-block:: text
 
-    # example for bash and pywbemcli
+    $ source ~/blah/pywbemcli-complete.bash
+
+    The pywbemtool should now have shell tab completion active for bash
+
+For example the following creates the shell tab-completion script for bash and
+pywbemcli in directory ./blah and can be executed once after pywbemcli
+installation:
+
+.. code-block:: text
+
+    # example for bash and pywbemcli where the script is placed in  directory ./blah
     $ _PYWBEMCLI_COMPLETE=bash_source pywbemcli > ./blah/pywbemcli-complete.bash
+
+The second step can be executed any time before pywbemcli is executed and
+activates shell tab-completion for the current shell execution by sourcing the
+COMPLETE script created in the first step:
+
+
+.. code-block:: text
+
     $ source  ~/blah.pywbemcli-complete.bash
 
 This step can be executed automatically:
 
-* by including the sourcing statement in a terminal startup script
-  (ex. in ``.bashrc``).
-* or including sourcing statement as part of a virtual environment startup
+* by including sourcing statement as part of a virtual environment startup
 
-Or the sourcing statement can be executed when a terminal is open simply by
-executing the script itself(ex. ``source  ~/.pywbemcli-complete.bash``).
+* or executing the sourcing statement when a terminal is opened by
+  executing the script itself (ex. ``source  ~/.pywbemcli-complete.bash``).
 
-Thus in summary, for bash, pywbemcli and pywbemlisteer can be activated by
-inserting the following evaluation script into .bashrc if
-pywbemcli/pywbemlistener are publicly available whenever the terminal is
-started:
-
-.. code-block::
-
-    eval "$(_PYWBEMCLI_COMPLETE=bash_source pywbemcli)"
-    eval "$(_PYWBEMLISTENER_COMPLETE=bash_source pywbelistener)"
-
-or by creating a completion script file one time as follows when pywbemlistener
-and pywbemcli are publicly available and then sourcing the script when,
-for example, the terminal window is opened:
-
-.. code-block::
-
-    # Execute once when pywbemcli is in the path:
-
-    _PYWBEMCLI_COMPLETE=bash_source pywbemcli > ~/.pywbemcli-complete.bash
-    _PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener > ~/.pywbemlistener-complete.bash
-
-
-    # Source the resulting file each time a terminal is started (ex edit into .bashrc):
-
-    source  ~/.pywbemcli-complete.bash
-    source  ~/.pywbemlistener-complete.bash
-
+* or executing in the shell before using pywbemcli in a single terminal session.
 

--- a/pywbemtools/pywbemcli/_cmd_help.py
+++ b/pywbemtools/pywbemcli/_cmd_help.py
@@ -57,27 +57,24 @@ def help_arg_subject_shell_completer(ctx, param, incomplete):
 @click.pass_context
 def help_subjects(ctx, subject):   # pylint: disable=unused-argument
     """
-    Show help for pywbemcli subjects.
+    Show help for specific pywbemcli subjects.
 
-    Show help for specific pywbemcli subjects.  This is in addition to the
-    help messages that are available with the -h or --help option for every
-    command group and command in pywbemcli. It helps document pywbemcli
-    subjects that are more general than specific commands and configuration
-    subjects that do not have specific commands
+    This is in addition to the help messages that are available with the -h or
+    --help option for every command group and command in pywbemcli. It helps
+    document pywbemcli subjects that are more general than specific commands
+    and configuration subjects that do not have specific commands.
 
-    If there is no argument provided, outputs a list and summary of the
-    existing help subjects.
-
-    If an argument is provided, it outputs the help for the subject(s) defined
-    by the argument.
+    If there is no argument provided, a list and summary of the
+    existing help subjects is displayed.
     """
     click.echo(help_subjects_action(ctx.obj, subject,
                                     PYWBEMCLI_HELP_SUBJECTS_DICT))
 
 
 # pylint: disable=invalid-name
+
 activate_shell_help_msg = '''
-Pywbemcli shell tab-completion must be activated after installation by
+Pywbemcli tab-completion must be activated after installation by
 notifying the shell and pywbemcli before the <TAB> becomes active when
 entering a pywbemcli command in the shell.
 
@@ -85,22 +82,14 @@ Tab-completion is only available for certain shells including: bash (version
 4.4 or greater), zsh, and fish shells since pywbemcli defines the completer
 script specifically for each shell.
 
-Activation of pywbemcli involves the following but with different formats for
-each shell type:
+Tab-completion can easily be activated for both pywbemtools commnds by
+inserting the following into the shell startup script (ex. .bashrc)
 
-1. Getting from pywbemcli the body of a completion script that defines
-   activation for the shell. This is done by executing the script statement
-   '_PYWBEMCLI_COMPLETE=<shell>_source pywbemcli' where <shell> can be 'bash',
-   'zsh', or 'fish'. This causes the shell to call back to pywbemcli with
-   '_PYWBEMCLI_COMPLETE' and '<shell>_source' arguments wherein pywbemcli
-   returns the completion script.
-2. Setting up the shell of this completion script by either:
-   * an 'eval' statement in the terminal startup
-     (ex. .bashrc ) that defines the completion script or,
-   * Creating the completion script file and sourcing that file later to activate.
+    eval "$(_PYWBEMCLI>_COMPLETE=bash_source pywbemcli)"
+    eval "$(_PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener)"
 
-The 'eval' statement for each of the shells supported is as follows and can
-be inserted into the corresponding shell startup script defined below.
+The activation 'eval' statement for each of the shells supported is as follows
+and can be inserted into the corresponding shell startup script defined below.
 
 =====  ============  ===========================================================
 shell  startup file  eval command
@@ -113,41 +102,22 @@ fish  ~/.config/fish/completions/foo-bar.fish
 
 Activate pywbemcli tab-completion as follows:
 
-  1. Edit the eval command in the startup file or
-  2. Close the file and restart the terminal or
+  1. Edit the eval command in the script startup file (ex. .bashrc)
+  2. Close the file and restart the terminal
   3. Test existence of tab-completion by:
      a. Test completion with a command such as "pywbemcli cl<TAB> which should
         complete the "class" command group name.
      b. In bash executing "complete -p pywbemcli". An entry for pywbemcli must
-        exist for pywbemcli as follows:
+        be returned for pywbemcli as follows:
 
           ``complete -o nosort -F _pywbemcli_completion pywbemcli``
 
-Executing ``eval`` directly in the shell startup file has the issue that the
-pywbemcli executable location must be known when opening a terminal . This may
-not be consistent with executing pywbemcli in virtual environments.
+Executing ``eval`` directly in the shell startup file requires that the
+pywbemcli executable must be publicly available, its location must be known when
+opening a terminal. This may not be consistent with executing pywbemcli
+in virtual environments. See the pywbemtools documentation for more information
+and alternate ways to activate tab-completion is special circumstances.
 
-To activate tab-completion using a completion file execute the command defined
-below for the desired shell to create the completion script for pywbemcli
-in  a file (ex.~/pywbemcli-complete.bash). This command requires that that
-pywbemcli be available. The file name is arbitrary.
-=====  =====================================================================
-shell  completion file creating command
-=====  =====================================================================
-bash   _PYWBEMCLI_COMPLETE=bash_source pywbemcli > ~/.pywbemcli-complete.bash
-zsh    _PYWBEMCLI_COMPLETE=zsh_source pywbemcli > ~/.pywbemcli-complete.zsh
-fish   _PYWBEMCLI_COMPLETE=fish_source pywbemcli >
-          ~/.config/fish/completions/pywbemcli.fish
-=====  =====================================================================
-
-Once the completion script file is created, pywbemcli tab-completion can be
-activated by sourcing this script (ex 'source ~/.pywbemcli-complete.bash')
-upon shell startup. This does not actually call pywbemcli.  This can be done a
-number of different ways, for example:
-
-* Include the sourcing statement in the shell startup script (ex. ~/.bashrc)
-* Execute the statement as part of the startup of a virtual envrionment.
-* Manually execute the sourcing statement when required before calling pywbemcli
 '''
 # pylint: enable=invalid-name
 
@@ -210,8 +180,8 @@ Example:
 
 # pylint: disable=invalid-name
 tab_completion_help_msg = """
-Tab completion is not supported in the interactive mode.
-Tab completion is supported in the command mode, when activated.
+Tab completion is supported in the command mode, when activated but it is not
+available in the repl mode (interactive mode)
 
 Tab completion for option values and arguments exists when the data is local.
 It is not provided for option values and arguments where access to a WBEM
@@ -219,9 +189,9 @@ server is required.
 
 Tab completion is available for:
 
-* the command group names
-* the command names
-* the option names
+* The command group names
+* The command names
+* The option names
 * The values of some general options including:
     * --name
     * --mock-server
@@ -230,7 +200,7 @@ Tab completion is available for:
     * --keyfile
     * --certfile
     * --outputformat
-* the values of some arguements
+* The values of some arguements
     * help <subject> argument
 
 When tab completion is not available for an argument or option value, entering

--- a/pywbemtools/pywbemlistener/_cmd_help.py
+++ b/pywbemtools/pywbemlistener/_cmd_help.py
@@ -58,11 +58,14 @@ def help_subjects(ctx, subject):   # pylint: disable=unused-argument
     """
     Show help for pywbemlistener subjects.
 
+    If an argument is provided, it outputs the help for the subject(s) defined
+    by the argument.
+
     Show help for specific pywbemlistener subjects.  This is in addition to the
     help messages that are available with the -h or --help option for every
     command group and command in pywbemlistener. It helps document
     pywbemlistener subjects that are more general than specific commands and
-    configuration subjects that do not have specific commands
+    configuration subjects that do not have specific commands.
 
     If there is no argument provided, outputs a list and summary of the
     existing help subjects.
@@ -70,38 +73,30 @@ def help_subjects(ctx, subject):   # pylint: disable=unused-argument
     If an argument is provided, it outputs the help for the subject(s) defined
     by the argument.
     """
+
     click.echo(help_subjects_action(ctx.obj, subject,
                                     PYWBEMLISTENER_HELP_SUBJECTS_DICT))
 
 
-# pylint: disable=invalid-name,
+# pylint: disable=invalid-name
+
 activate_shell_help_msg = '''
-Pywbemlistener includes tab-completion capability for all commands for certain
-shell types program being used by the command line terminal.
+Pywbemlistener tab-completion must be activated after installation by
+notifying the shell and pywbemlistener before the <TAB> becomes active when
+entering a pywbemlistener command in the shell.
 
-Tab-completion is active only when it is activated by
-notifying the command shell of the pywbemlistener tab-completion
-characteristics. Further, it is only usable with those shells that include
-tab-completion as part of the shell functionality.  On Linux based systems this
-includes shells like bash (version 4.0 or greater), zsh, and fish.
+Tab-completion is only available for certain shells including: bash (version
+4.4 or greater), zsh, and fish shells since pywbemlistener defines the completer
+script specifically for each shell.
 
-Activation of pywbemlistener involves the following but with different formats
-for each shell type:
+Tab-completion can easily be activated for both pywbemtools commnds by
+inserting the following into the shell initialization (ex. .bashrc)
 
-* Getting from pywbemlistener the body of a completion script for the shell to
-  be activated. This is done by executing a script statement of form
-  ``_PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener``.
-* Notifying the shell of this completion script with an eval statement or
-  saving the script and notifying the shell later by sourcing the resulting
-  completion script file.
+    eval "$(_PYWBEMCLI>_COMPLETE=bash_source pywbemcli)"
+    eval "$(_PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener)"
 
-Tab-completion can be activated either by:
-
-* Installing the activation script with an eval statement into .bashrc
-* Creating a completion script file and sourcing that file at a later time.
-
-The ``eval`` statement for each of the shells supported is as follows and can
-be inserted into the corresponding shell startup script defined below.
+The activation 'eval' statement for each of the shells supported is as follows
+and can be inserted into the corresponding shell startup script defined below.
 
 =====  ============  ===========================================================
 shell  startup file  eval command
@@ -115,45 +110,23 @@ fish  ~/.config/fish/completions/foo-bar.fish
                            fish_source pywbemlistener)"
 =====  ===========  ===========================================================
 
-To activate pywbemlistener tab-completion:
+Activate pywbemlistener tab-completion as follows:
 
-  1. Edit the eval command in the startup file or
-  2. Close the file and restart the terminal or
+  1. Edit the eval command in the startup file
+  2. Close the file and restart the terminal
   3. Test existence of tab-completion by:
-     a. Test completion with a command such as "pywbemlistener cl<TAB> which
-        should complete the "pywbemlistener li<TAB>" command group name.
-     b. In bash executing "complete -p pywbemlistener". An entry for
-        pywbemlistener must exist for pywbemlistener as follows:
-        complete -o nosort -F _pywbemlistener_completion pywbemlistener
+     a. Test completion with a command such as "pywbemlistener li<TAB> which should
+        complete the "list" command group name.
+     b. In bash executing "complete -p pywbemlistener". An entry for pywbemlistener must
+        be returned for pywbemlistener as follows:
 
-Executing the eval directly in the shell startup file has the issue that the
-pywbemlistener executable location must be known when opening a terminal . This
-may not be consistent with executing pywbemlistener in virtual environments.
+          ``complete -o nosort -F _pywbemlistener_completion pywbemlistener``
 
-To activate tab-completion using a completion file execute the command defined
-below for the desired shell. This  creates the completion script for
-pywbemlistener in ``~/pywbemlistener-complete.bash``. This command requires
-that pywbemlistener is publicly available :
-
-=====  =====================================================================
-shell  completion file creating command
-=====  =====================================================================
-bash   _PYWBEMLISTENER_COMPLETE=bash_source pywbemlistener >
-            ~/.pywbemcli-complete.bash
-zsh    _PYWBEMLISTENER_COMPLETE=zsh_source pywbemlistener >
-            ~/.pywbemcli-complete.zsh
-fish   _PYWBEMLISTENER_COMPLETE=fish_source pywbemlistener >
-          ~/.config/fish/completions/pywbemcli.fish
-=====  =====================================================================
-
-Once the completion script file is created, pywbemlistener tab-completion can
-be activated by sourcing this script:
-   (ex. ''source ~/.pywbemlistener-complete.bash'').
-This does not call pywbemlistener and can be done by, for for example:
-
-* Include the sourcing statement in the shell startup script (ex. ~/.bashrc)
-* Execute the statement as part of the startup of virtual envrionments.
-* Manually executing the sourcing statement when required.
+Executing ``eval`` directly in the shell startup file requires that the
+pywbemlistener executable location must be known when opening a terminal . This may
+not be consistent with executing pywbemlistener in virtual environments. See
+the pywbemtools documentation for more information and alternate ways to
+activate tab-completion is special circumstances.
 '''
 # pylint: enable=invalid-name
 

--- a/pywbemtools/pywbemlistener/_cmd_help.py
+++ b/pywbemtools/pywbemlistener/_cmd_help.py
@@ -86,8 +86,8 @@ notifying the shell and pywbemlistener before the <TAB> becomes active when
 entering a pywbemlistener command in the shell.
 
 Tab-completion is only available for certain shells including: bash (version
-4.4 or greater), zsh, and fish shells since pywbemlistener defines the completer
-script specifically for each shell.
+4.4 or greater), zsh, and fish shells since pywbemlistener defines the
+completer script specifically for each shell.
 
 Tab-completion can easily be activated for both pywbemtools commnds by
 inserting the following into the shell initialization (ex. .bashrc)
@@ -112,8 +112,8 @@ fish  ~/.config/fish/completions/foo-bar.fish
 
 Activate pywbemlistener tab-completion as follows:
 
-  1. Edit the eval command in the startup file
-  2. Close the file and restart the terminal
+  1. Edit the eval command in the startup file.
+  2. Close the file and restart the terminal.
   3. Test existence of tab-completion by:
      a. Test completion with a command such as "pywbemlistener li<TAB> which should
         complete the "list" command group name.
@@ -123,9 +123,9 @@ Activate pywbemlistener tab-completion as follows:
           ``complete -o nosort -F _pywbemlistener_completion pywbemlistener``
 
 Executing ``eval`` directly in the shell startup file requires that the
-pywbemlistener executable location must be known when opening a terminal . This may
-not be consistent with executing pywbemlistener in virtual environments. See
-the pywbemtools documentation for more information and alternate ways to
+pywbemlistener executable location must be known when opening a terminal . This
+may not be consistent with executing pywbemlistener in virtual environments.
+See the pywbemtools documentation for more information and alternate ways to
 activate tab-completion is special circumstances.
 '''
 # pylint: enable=invalid-name

--- a/tests/unit/pywbemcli/test_general_options.py
+++ b/tests/unit/pywbemcli/test_general_options.py
@@ -171,7 +171,7 @@ GENERAL_HELP_LINES = [
       subscription  Command group to manage WBEM indication subscriptions.
       connection  Command group for WBEM connection definitions.
       repl        Enter interactive mode (default).
-      help        Show help for pywbemcli subjects.
+      help        Show help for specific pywbemcli subjects.
       docs        Get pywbemtools documentation in web browser."""
 ]
 
@@ -220,19 +220,15 @@ Command Options:
 
 SUBJECT_HELP = """Usage: pywbemcli [GENERAL-OPTIONS] help SUBJECT
 
-  Show help for pywbemcli subjects.
+    Show help for specific pywbemcli subjects.
 
-  Show help for specific pywbemcli subjects.  This is in addition to the help
-  messages that are available with the -h or --help option for every command
-  group and command in pywbemcli. It helps document pywbemcli subjects that are
-  more general than specific commands and configuration subjects that do not
-  have specific commands
+    This is in addition to the help messages that are available with the -h or
+    --help option for every command group and command in pywbemcli. It helps
+    document pywbemcli subjects that are more general than specific commands
+    and configuration subjects that do not have specific commands.
 
-  If there is no argument provided, outputs a list and summary of the existing
-  help subjects.
-
-  If an argument is provided, it outputs the help for the subject(s) defined by
-  the argument.
+    If there is no argument provided, a list and summary of the
+    existing help subjects is displayed.
 
 Command Options:
   -h, --help  Show this help message.

--- a/tests/unit/pywbemcli/test_help_cmd.py
+++ b/tests/unit/pywbemcli/test_help_cmd.py
@@ -45,12 +45,12 @@ INSTANCENAME_HELP_LINES = [
 ]
 
 TABCOMPLETION_HELP_LINES = [
-    "Tab completion is not supported in the interactive mode.",
-    "Tab completion is supported in the command mode, when activated."
+    "Tab completion is supported in the command mode, when activated",
+    "Tab completion is available for:"
 ]
 
 ACTIVATE_HELP_LINES = [
-    "Pywbemcli includes tab-completion capability for all commands for certain"
+    "Pywbemcli tab-completion must be activated after installation by"
 ]
 
 
@@ -115,7 +115,8 @@ TEST_CASES = [
 ]
 
 
-class TestCmdHelp(CLITestsBase):  # pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods
+class TestPywbemcliCmdHelp(CLITestsBase):
     """
     Test the help command
     """

--- a/tests/unit/pywbemlistener/test_help_cmd.py
+++ b/tests/unit/pywbemlistener/test_help_cmd.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Test the help command that displays help text on specific pywbemcli
+Test the help command that displays help text on specific pywbemlistener
 subjects.
 
 """
@@ -51,9 +51,7 @@ SHOW_HELP_SUMMARY_PATTERNS = [
 ]
 
 SHOW_HELP_ACTIVATE_PATTERNS = [
-    r"activate - Activating shell tab completion",
-    r"Pywbemlistener includes tab-completion capability",
-    r"Manually executing the sourcing statement when required."
+    r"Pywbemlistener tab-completion must be activated after installation by"
 ]
 
 


### PR DESCRIPTION
Simplifies the documentation for activation of tab-completion for both pywbemcli and pywbemlistener to document only the eval method.

Note that this does not remove the other method but creates an extra section at the bottom of the tab-completion section noting that this is only for special circumstances.  i.e. that alternative is buried but available if necessary.

Also the activation of both pywbemcli and pywbemlistener eval statements is shown together in both pywbemcli and pywbemlistener documentation just to be sure users understand that each has a separate statement.

Modifies the pywbemcli help activate and pywbemlistener help activate commands to simplify this documentation and describe only the eval based method.

Consists of two commits.  The second was added 18 April to improve documentation of the command line.

Modify pywbemcli / pywbemlistener help command help text to simplify it.

